### PR TITLE
Refactor: Migrate from course_name strings to course_id FKs

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -9,6 +9,7 @@ class StartSessionBody(BaseModel):
     topic: str = ""
     mode: str = "socratic"
     use_shared_context: bool = True
+    course_id: Optional[str] = None  # Direct course_id lookup instead of resolving from topic
 
 
 class ChatBody(BaseModel):
@@ -56,7 +57,7 @@ class SubmitQuizBody(BaseModel):
 
 class AssignmentItem(BaseModel):
     title: str
-    course_name: str = ""
+    course_id: str = ""  # Changed from course_name to course_id
     due_date: str
     assignment_type: str = "other"
     notes: Optional[str] = None
@@ -82,6 +83,20 @@ class ImportSaveBody(BaseModel):
     AssignmentItem shape before posting here.
     """
     assignments: list[AssignmentItem]
+
+
+# ── Graph (Courses) ─────────────────────────────────────────────────────────
+
+class AddCourseBody(BaseModel):
+    """Body for enrolling a user in a course (creating a user_courses record)."""
+    course_id: str
+    color: Optional[str] = None
+    nickname: Optional[str] = None
+
+
+class UpdateCourseColorBody(BaseModel):
+    """Body for updating a course enrollment's color."""
+    color: str
 
 
 # ── Social ────────────────────────────────────────────────────────────────────
@@ -154,3 +169,11 @@ class SubmitIssueReportBody(BaseModel):
     topic: str
     description: str
     screenshot_urls: list[str] = []
+
+
+# ── Documents ──────────────────────────────────────────────────────────────────
+
+class UploadDocumentBody(BaseModel):
+    """Body for document upload."""
+    course_id: str
+    user_id: str

--- a/backend/routes/calendar.py
+++ b/backend/routes/calendar.py
@@ -101,7 +101,7 @@ def save_assignments(body: SaveAssignmentsBody):
     payload = [
         {
             "title": a.title,
-            "course_name": a.course_name,
+            "course_id": a.course_id,
             "due_date": a.due_date,
             "assignment_type": a.assignment_type,
             "notes": a.notes,
@@ -115,44 +115,79 @@ def save_assignments(body: SaveAssignmentsBody):
 @router.get("/upcoming/{user_id}")
 def get_upcoming(user_id: str):
     today = datetime.utcnow().strftime("%Y-%m-%d")
+    # Join with courses to get course_code and course_name
     rows = table("assignments").select(
-        "*",
+        "*,courses!inner(course_code,course_name)",
         filters={"user_id": f"eq.{user_id}", "due_date": f"gte.{today}"},
         order="due_date.asc",
         limit=20,
     )
-    return {"assignments": rows}
+    # Transform to include course info at top level
+    assignments = []
+    for r in rows:
+        course = r.get("courses", {}) if isinstance(r.get("courses"), dict) else {}
+        assignments.append({
+            "id": r["id"],
+            "user_id": r["user_id"],
+            "title": r["title"],
+            "due_date": r["due_date"],
+            "assignment_type": r.get("assignment_type"),
+            "notes": r.get("notes"),
+            "google_event_id": r.get("google_event_id"),
+            "course_id": r.get("course_id"),
+            "course_code": course.get("course_code", ""),
+            "course_name": course.get("course_name", ""),
+        })
+    return {"assignments": assignments}
 
 
 @router.get("/all/{user_id}")
 def get_all_assignments(user_id: str):
     """Return all assignments for a user (past and future) for the calendar view."""
+    # Join with courses to get course_code and course_name
     rows = table("assignments").select(
-        "*",
+        "*,courses!inner(course_code,course_name)",
         filters={"user_id": f"eq.{user_id}"},
         order="due_date.asc",
     )
-    return {"assignments": rows}
+    # Transform to include course info at top level
+    assignments = []
+    for r in rows:
+        course = r.get("courses", {}) if isinstance(r.get("courses"), dict) else {}
+        assignments.append({
+            "id": r["id"],
+            "user_id": r["user_id"],
+            "title": r["title"],
+            "due_date": r["due_date"],
+            "assignment_type": r.get("assignment_type"),
+            "notes": r.get("notes"),
+            "google_event_id": r.get("google_event_id"),
+            "course_id": r.get("course_id"),
+            "course_code": course.get("course_code", ""),
+            "course_name": course.get("course_name", ""),
+        })
+    return {"assignments": assignments}
 
 
 @router.post("/suggest-study-blocks")
 def suggest_study_blocks(body: StudyBlockBody):
     today = datetime.utcnow().strftime("%Y-%m-%d")
     assignments = table("assignments").select(
-        "*",
+        "*,courses!inner(course_code,course_name)",
         filters={"user_id": f"eq.{body.user_id}", "due_date": f"gte.{today}"},
         order="due_date.asc",
     )
-    blocks = [
-        {
+    blocks = []
+    for a in assignments:
+        course = a.get("courses", {}) if isinstance(a.get("courses"), dict) else {}
+        course_label = f"[{course.get('course_code', '')}] " if course.get('course_code') else ""
+        blocks.append({
             "topic": a["title"],
             "suggested_date": a["due_date"],
             "duration_minutes": 60,
             "reason": f"Due {a['due_date']}",
             "related_assignment_id": a["id"],
-        }
-        for a in assignments
-    ]
+        })
     return {"study_blocks": blocks[:5]}
 
 
@@ -223,7 +258,7 @@ def sync_to_google(body: SyncBody):
     service = build("calendar", "v3", credentials=creds)
 
     unsynced = table("assignments").select(
-        "*",
+        "*,courses!inner(course_code,course_name)",
         filters={
             "user_id": f"eq.{body.user_id}",
             "google_event_id": "is.null",
@@ -231,7 +266,7 @@ def sync_to_google(body: SyncBody):
     )
     # Also catch empty-string google_event_id
     unsynced += table("assignments").select(
-        "*",
+        "*,courses!inner(course_code,course_name)",
         filters={
             "user_id": f"eq.{body.user_id}",
             "google_event_id": "eq.",
@@ -242,8 +277,14 @@ def sync_to_google(body: SyncBody):
     for a in unsynced:
         if not a.get("due_date"):
             continue
+            
+        course = a.get("courses", {}) if isinstance(a.get("courses"), dict) else {}
+        course_code = course.get("course_code", "")
+        course_name = course.get("course_name", "")
+        course_label = f"[{course_code}] " if course_code else ""
+        
         event = {
-            "summary": f"[{a['course_name']}] {a['title']}" if a.get("course_name") else a["title"],
+            "summary": f"{course_label}{a['title']}" if course_label else a["title"],
             "description": a.get("notes") or "",
             "start": {"date": a["due_date"]},
             "end": {"date": a["due_date"]},
@@ -268,7 +309,7 @@ def export_to_google(body: ExportBody):
     exported = 0
     skipped = 0
     for aid in body.assignment_ids:
-        rows = table("assignments").select("*", filters={"id": f"eq.{aid}"})
+        rows = table("assignments").select("*,courses!inner(course_code,course_name)", filters={"id": f"eq.{aid}"})
         if not rows:
             continue
         a = rows[0]
@@ -277,8 +318,13 @@ def export_to_google(body: ExportBody):
             skipped += 1
             continue
 
+        course = a.get("courses", {}) if isinstance(a.get("courses"), dict) else {}
+        course_code = course.get("course_code", "")
+        course_name = course.get("course_name", "")
+        course_label = f"[{course_code}] " if course_code else ""
+
         event = {
-            "summary": f"[{a['course_name']}] {a['title']}" if a.get("course_name") else a["title"],
+            "summary": f"{course_label}{a['title']}" if course_label else a["title"],
             "description": a.get("notes") or "",
             "start": {"date": a["due_date"]},
             "end": {"date": a["due_date"]},

--- a/backend/routes/graph.py
+++ b/backend/routes/graph.py
@@ -23,8 +23,9 @@ def get_user_recommendations(user_id: str):
 # ── Course endpoints ──────────────────────────────────────────────────────────
 
 class AddCourseBody(BaseModel):
-    course_name: str
+    course_id: str
     color: Optional[str] = None
+    nickname: Optional[str] = None
 
 
 class UpdateCourseColorBody(BaseModel):
@@ -38,14 +39,14 @@ def list_courses(user_id: str):
 
 @router.post("/{user_id}/courses")
 def create_course(user_id: str, body: AddCourseBody):
-    return add_course(user_id, body.course_name, body.color)
+    return add_course(user_id, body.course_id, body.color, body.nickname)
 
 
-@router.patch("/{user_id}/courses/{course_name}/color")
-def set_course_color(user_id: str, course_name: str, body: UpdateCourseColorBody):
-    return update_course_color(user_id, course_name, body.color)
+@router.patch("/{user_id}/courses/{course_id}/color")
+def set_course_color(user_id: str, course_id: str, body: UpdateCourseColorBody):
+    return update_course_color(user_id, course_id, body.color)
 
 
-@router.delete("/{user_id}/courses/{course_name}")
-def remove_course(user_id: str, course_name: str):
-    return delete_course(user_id, course_name)
+@router.delete("/{user_id}/courses/{course_id}")
+def remove_course(user_id: str, course_id: str):
+    return delete_course(user_id, course_id)

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -39,58 +39,81 @@ MODE_PROMPTS = {
 }
 
 
-def _resolve_course(topic: str, user_id: str) -> str:
-    """Return the subject/course the topic belongs to, or '' if unknown."""
+def _get_course_id_for_topic(topic: str, user_id: str) -> str:
+    """
+    Find the course_id associated with a topic/concept for a user.
+    First checks if topic matches a course_code or course_name,
+    then falls back to finding via graph_nodes.
+    """
     if not topic:
         return ""
     topic_trim = topic.strip()
     if not topic_trim:
         return ""
-    subject_match = table("graph_nodes").select(
-        "subject", filters={"user_id": f"eq.{user_id}", "subject": f"eq.{topic_trim}"}, limit=1
-    )
-    if subject_match:
-        return topic_trim
-    concept_match = table("graph_nodes").select(
-        "subject", filters={"user_id": f"eq.{user_id}", "concept_name": f"eq.{topic_trim}"}, limit=1
-    )
-    if concept_match:
-        return concept_match[0].get("subject") or ""
-    course_match = table("courses").select(
-        "course_name", filters={"user_id": f"eq.{user_id}", "course_name": f"eq.{topic_trim}"}, limit=1
-    )
-    if course_match:
-        return topic_trim
+    
+    # First, check if topic matches a course code or name in user's enrolled courses
     try:
-        course_rows = table("courses").select(
-            "course_name",
+        enrolled = table("user_courses").select(
+            "course_id,courses!inner(course_code,course_name)",
             filters={"user_id": f"eq.{user_id}"},
         )
+        for row in enrolled:
+            course = row.get("courses", {}) if isinstance(row.get("courses"), dict) else {}
+            course_code = course.get("course_code", "")
+            course_name = course.get("course_name", "")
+            
+            # Match on course_code (exact or case-insensitive)
+            if topic_trim.upper() == course_code.upper():
+                return row["course_id"]
+            # Match on course_name
+            if topic_trim.lower() == course_name.lower():
+                return row["course_id"]
     except Exception:
-        course_rows = []
-    for row in course_rows or []:
-        cn = row.get("course_name") or ""
-        if cn.lower() == topic_trim.lower():
-            return cn
+        pass
+    
+    # Fallback: find via graph_nodes - look for nodes matching topic
+    # that have a course_id
+    node_rows = table("graph_nodes").select(
+        "course_id",
+        filters={
+            "user_id": f"eq.{user_id}",
+            "concept_name": f"eq.{topic_trim}",
+        },
+        limit=10,
+    )
+    for row in (node_rows or []):
+        if row.get("course_id"):
+            return row["course_id"]
+    
+    # Try matching on subject field (legacy support)
+    subject_rows = table("graph_nodes").select(
+        "course_id",
+        filters={
+            "user_id": f"eq.{user_id}",
+            "subject": f"eq.{topic_trim}",
+        },
+        limit=1,
+    )
+    for row in (subject_rows or []):
+        if row.get("course_id"):
+            return row["course_id"]
+    
     return ""
 
 
-def _get_session_topic(session_id: str) -> str:
-    rows = table("sessions").select("topic", filters={"id": f"eq.{session_id}"}, limit=1)
-    return rows[0]["topic"] if rows else ""
+def _get_session_course_id(session_id: str) -> str:
+    """Get the course_id from a session if it exists."""
+    rows = table("sessions").select("course_id", filters={"id": f"eq.{session_id}"}, limit=1)
+    if rows and rows[0].get("course_id"):
+        return rows[0]["course_id"]
+    return ""
 
 
-def _get_course_documents(user_id: str, course_name: str) -> list:
+def _get_course_documents(user_id: str, course_id: str) -> list:
     """Fetch uploaded document summaries and key takeaways for a user's course."""
-    if not course_name:
+    if not course_id:
         return []
     try:
-        course_rows = table("courses").select(
-            "id", filters={"user_id": f"eq.{user_id}", "course_name": f"eq.{course_name}"}, limit=1
-        )
-        if not course_rows:
-            return []
-        course_id = course_rows[0]["id"]
         docs = table("documents").select(
             "file_name,category,summary,key_takeaways",
             filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
@@ -100,12 +123,32 @@ def _get_course_documents(user_id: str, course_name: str) -> list:
         return []
 
 
+def _get_course_info(course_id: str) -> dict:
+    """Get course info (code and name) for a course_id."""
+    if not course_id:
+        return {"course_code": "", "course_name": ""}
+    try:
+        rows = table("courses").select(
+            "course_code,course_name",
+            filters={"id": f"eq.{course_id}"},
+            limit=1,
+        )
+        if rows:
+            return {
+                "course_code": rows[0].get("course_code", ""),
+                "course_name": rows[0].get("course_name", ""),
+            }
+    except Exception:
+        pass
+    return {"course_code": "", "course_name": ""}
+
+
 def build_system_prompt(
     mode: str,
     student_name: str,
     graph_json: str,
     last_summary: str = "",
-    course_name: str = "",
+    course_id: str = "",
     use_shared_context: bool = True,
     documents: list | None = None,
 ) -> str:
@@ -133,12 +176,14 @@ def build_system_prompt(
                 + "\n\n---\n\n".join(doc_blocks)
             )
 
-    if use_shared_context and course_name:
-        ctx = get_course_context(course_name)
+    if use_shared_context and course_id:
+        ctx = get_course_context(course_id)
         if ctx:
+            course_info = _get_course_info(course_id)
+            course_label = f"{course_info['course_code']} - {course_info['course_name']}" if course_info['course_code'] else course_info['course_name']
             shared_block = (
                 SHARED_CONTEXT_TEMPLATE
-                .replace("{course_name}", course_name)
+                .replace("{course_name}", course_label)
                 .replace("{shared_context_json}", json.dumps(ctx, indent=2))
             )
             parts.append(shared_block)
@@ -179,12 +224,18 @@ def _consume_pending(session_id: str, user_id: str) -> None:
     pending = PENDING_SESSIONS.pop(session_id)
     if pending["user_id"] != user_id:
         raise HTTPException(status_code=403, detail="Session user mismatch")
-    table("sessions").insert({
+    
+    # Include course_id in session creation
+    session_data = {
         "id": session_id,
         "user_id": user_id,
         "mode": pending["mode"],
         "topic": pending["topic"],
-    })
+    }
+    if pending.get("course_id"):
+        session_data["course_id"] = pending["course_id"]
+    
+    table("sessions").insert(session_data)
     save_message(session_id, "assistant", pending["assistant_reply"], pending["graph_update"])
 
 
@@ -199,11 +250,14 @@ def start_session(body: StartSessionBody):
 
     student_name = get_user_name(body.user_id)
     graph_data = get_graph(body.user_id)
-    course_name = _resolve_course(body.topic, body.user_id)
-    documents = _get_course_documents(body.user_id, course_name)
+    
+    # Use course_id from body, or try to resolve from topic
+    course_id = body.course_id or _get_course_id_for_topic(body.topic, body.user_id)
+    documents = _get_course_documents(body.user_id, course_id)
+    
     system_prompt = build_system_prompt(
         body.mode, student_name, json.dumps(graph_data, indent=2),
-        course_name=course_name, use_shared_context=body.use_shared_context,
+        course_id=course_id, use_shared_context=body.use_shared_context,
         documents=documents,
     )
     user_message = (
@@ -217,11 +271,13 @@ def start_session(body: StartSessionBody):
         raise HTTPException(status_code=502, detail=f"Gemini error: {e}")
 
     reply, graph_update = extract_graph_update(raw)
-    apply_graph_update(body.user_id, graph_update)
+    apply_graph_update(body.user_id, graph_update, course_id=course_id)
+    
     PENDING_SESSIONS[session_id] = {
         "user_id": body.user_id,
         "mode": body.mode,
         "topic": body.topic,
+        "course_id": course_id,
         "use_shared_context": body.use_shared_context,
         "assistant_reply": reply,
         "graph_update": graph_update,
@@ -243,12 +299,14 @@ def chat(body: ChatBody):
     graph_data = get_graph(body.user_id)
     # Exclude the just-saved user message so history is prior turns only
     history = get_conversation_history(body.session_id)[:-1]
-    topic = _get_session_topic(body.session_id)
-    course_name = _resolve_course(topic, body.user_id)
-    documents = _get_course_documents(body.user_id, course_name)
+    
+    # Get course_id from session if available
+    course_id = _get_session_course_id(body.session_id)
+    documents = _get_course_documents(body.user_id, course_id)
+    
     system_prompt = build_system_prompt(
         body.mode, student_name, json.dumps(graph_data, indent=2),
-        course_name=course_name, use_shared_context=body.use_shared_context,
+        course_id=course_id, use_shared_context=body.use_shared_context,
         documents=documents,
     )
 
@@ -259,7 +317,7 @@ def chat(body: ChatBody):
 
     reply, graph_update = extract_graph_update(raw)
     save_message(body.session_id, "assistant", reply, graph_update)
-    mastery_changes = apply_graph_update(body.user_id, graph_update)
+    mastery_changes = apply_graph_update(body.user_id, graph_update, course_id=course_id)
 
     return {"reply": reply, "graph_update": graph_update, "mastery_changes": mastery_changes}
 
@@ -270,7 +328,7 @@ def end_session(body: EndSessionBody):
         pending = PENDING_SESSIONS[body.session_id]
         if body.user_id and pending["user_id"] != body.user_id:
             raise HTTPException(status_code=403, detail="Session user mismatch")
-        PENDING_SESSIONS.pop(body.session_id, None)
+        PENDING_SESSIONS.pop(session_id, None)
         empty = {
             "concepts_covered": [],
             "mastery_changes": [],
@@ -349,6 +407,7 @@ def list_sessions(user_id: str, limit: int = 10):
             "id": s["id"],
             "topic": s["topic"],
             "mode": s["mode"],
+            "course_id": s.get("course_id"),
             "started_at": s["started_at"],
             "ended_at": s.get("ended_at"),
             "message_count": len(msgs),
@@ -381,6 +440,7 @@ def resume_session(session_id: str):
                 "user_id": p["user_id"],
                 "topic": p["topic"],
                 "mode": p["mode"],
+                "course_id": p.get("course_id"),
                 "started_at": now,
                 "ended_at": None,
             },
@@ -395,7 +455,7 @@ def resume_session(session_id: str):
         }
 
     session_rows = table("sessions").select(
-        "id,user_id,topic,mode,started_at,ended_at",
+        "id,user_id,topic,mode,started_at,ended_at,course_id",
         filters={"id": f"eq.{session_id}"},
     )
     if not session_rows:
@@ -424,12 +484,14 @@ def action(body: ActionBody):
     student_name = get_user_name(body.user_id)
     graph_data = get_graph(body.user_id)
     history = get_conversation_history(body.session_id)
-    topic = _get_session_topic(body.session_id)
-    course_name = _resolve_course(topic, body.user_id)
-    documents = _get_course_documents(body.user_id, course_name)
+    
+    # Get course_id from session
+    course_id = _get_session_course_id(body.session_id)
+    documents = _get_course_documents(body.user_id, course_id)
+    
     system_prompt = build_system_prompt(
         body.mode, student_name, json.dumps(graph_data, indent=2),
-        course_name=course_name, use_shared_context=body.use_shared_context,
+        course_id=course_id, use_shared_context=body.use_shared_context,
         documents=documents,
     )
     action_message = f"[ACTION: {action_prompts.get(body.action_type, '')}]"
@@ -441,7 +503,7 @@ def action(body: ActionBody):
 
     reply, graph_update = extract_graph_update(raw)
     save_message(body.session_id, "assistant", reply, graph_update)
-    apply_graph_update(body.user_id, graph_update)
+    apply_graph_update(body.user_id, graph_update, course_id=course_id)
     return {"reply": reply, "graph_update": graph_update}
 
 
@@ -449,7 +511,12 @@ def action(body: ActionBody):
 def mode_switch(body: ModeSwitchBody):
     _ensure_session_ready(body.session_id, body.user_id)
     student_name = get_user_name(body.user_id).split()[0]
-    topic = _get_session_topic(body.session_id)
+    topic = table("sessions").select(
+        "topic", filters={"id": f"eq.{body.session_id}"}, limit=1
+    )[0]["topic"] if table("sessions").select(
+        "topic", filters={"id": f"eq.{body.session_id}"}, limit=1
+    ) else "this topic"
+    
     mode_label = MODE_DISPLAY_NAMES.get(body.new_mode, body.new_mode)
 
     reply = (

--- a/backend/services/calendar_service.py
+++ b/backend/services/calendar_service.py
@@ -41,7 +41,7 @@ def insert_new_assignments(user_id: str, assignments: list[dict]) -> int:
             "id": str(uuid.uuid4()),
             "user_id": user_id,
             "title": title,
-            "course_name": a.get("course_name") or "",
+            "course_id": a.get("course_id") or "",  # Changed from course_name to course_id
             "due_date": key[1],
             "assignment_type": a.get("assignment_type") or "other",
             "notes": a.get("notes"),

--- a/backend/services/course_context_service.py
+++ b/backend/services/course_context_service.py
@@ -1,170 +1,320 @@
 """
 services/course_context_service.py
 
-Builds and caches a shared course-level context from real DB data.
-No Gemini calls — pure aggregation of graph_nodes and quiz_context.
+Builds and caches shared course-level context from real DB data.
+Aggregates graph_nodes mastery data and quiz_context across all students in a course.
 
-The context is stored in the course_context table and refreshed every time
-any student's graph is updated (via apply_graph_update in graph_service.py).
+Stores data in:
+- course_concept_stats: per-concept aggregated metrics
+- course_summary: course-wide summary with Gemini-generated text
 """
 
+import json
+import hashlib
 from datetime import datetime, timezone
 
 from db.connection import table
+from services.gemini_service import call_gemini
 
 
-def get_course_context(course_name: str) -> dict:
-    """Return the cached context_json for a course, or {} if not yet built."""
-    if not course_name:
-        return {}
+def _generate_data_hash(stats_rows: list) -> str:
+    """Generate a hash of the stats data to detect changes."""
+    data_str = json.dumps(stats_rows, sort_keys=True, default=str)
+    return hashlib.sha256(data_str.encode()).hexdigest()
+
+
+def _generate_summary_with_gemini(
+    course_code: str,
+    course_name: str,
+    avg_class_mastery: float,
+    top_struggling: list,
+    top_mastered: list,
+    student_count: int,
+) -> str:
+    """Generate a natural language summary using Gemini."""
+    prompt = f"""You are an expert education analyst summarizing a course for instructors.
+
+Course: {course_code} - {course_name}
+Students enrolled: {student_count}
+Average class mastery: {avg_class_mastery:.1%}
+
+Top struggling concepts (needs attention):
+{chr(10).join(f"- {c}" for c in top_struggling) if top_struggling else "None identified"}
+
+Top mastered concepts (students doing well):
+{chr(10).join(f"- {c}" for c in top_mastered) if top_mastered else "None identified"}
+
+Write a concise 2-3 paragraph summary that:
+1. Describes the overall class performance
+2. Highlights specific areas where students are struggling and may need intervention
+3. Notes areas where students are excelling
+4. Provides actionable recommendations for the instructor
+
+Write in a professional but approachable tone. Be specific and data-driven."""
+
     try:
-        rows = table("course_context").select(
-            "context_json",
-            filters={"course_name": f"eq.{course_name}"},
+        return call_gemini(prompt, retries=1)
+    except Exception:
+        # Fallback summary if Gemini fails
+        return (
+            f"Class average mastery: {avg_class_mastery:.1%}. "
+            f"Students are struggling with: {', '.join(top_struggling[:3]) if top_struggling else 'No major areas identified'}. "
+            f"Students have mastered: {', '.join(top_mastered[:3]) if top_mastered else 'No areas identified yet'}."
         )
-        return rows[0]["context_json"] if rows else {}
+
+
+def get_course_context(course_id: str) -> dict:
+    """
+    Return the cached course context including summary and concept stats.
+    Returns dict with course_summary + course_concept_stats, or {} if not found.
+    """
+    if not course_id:
+        return {}
+    
+    try:
+        # Get course summary
+        summary_rows = table("course_summary").select(
+            "*",
+            filters={"course_id": f"eq.{course_id}"},
+        )
+        if not summary_rows:
+            return {}
+        
+        summary = summary_rows[0]
+        
+        # Get concept stats for this course
+        stats_rows = table("course_concept_stats").select(
+            "*",
+            filters={"course_id": f"eq.{course_id}"},
+        )
+        
+        return {
+            "course_summary": {
+                "course_id": summary["course_id"],
+                "semester": summary["semester"],
+                "student_count": summary["student_count"],
+                "avg_class_mastery": summary["avg_class_mastery"],
+                "top_struggling_concepts": summary.get("top_struggling_concepts", []),
+                "top_mastered_concepts": summary.get("top_mastered_concepts", []),
+                "summary_text": summary.get("summary_text", ""),
+                "updated_at": summary["updated_at"],
+            },
+            "concept_stats": stats_rows or [],
+        }
     except Exception:
         return {}
 
 
-def update_course_context(course_name: str) -> None:
+def update_course_context(course_id: str, semester: str = "Spring 2026") -> None:
     """
-    Aggregate mastery + quiz data for all students in course_name and upsert
-    into the course_context table. Called automatically after any graph update.
+    Aggregate mastery + quiz data for all students enrolled in the course and upsert
+    into course_concept_stats and course_summary tables.
+    Called automatically after any graph update.
     """
-    if not course_name:
+    if not course_id:
         return
 
-    # ── 1. All graph nodes for this course across every user ─────────────────
+    # ── 1. Get all students enrolled in this course via user_courses ───────────
+    enrollment_rows = table("user_courses").select(
+        "user_id",
+        filters={"course_id": f"eq.{course_id}"},
+    )
+    if not enrollment_rows:
+        return  # No students enrolled, nothing to aggregate
+    
+    user_ids = [r["user_id"] for r in enrollment_rows]
+    student_count = len(user_ids)
+
+    # ── 2. Get course info for the summary ────────────────────────────────────
+    course_rows = table("courses").select(
+        "course_code,course_name",
+        filters={"id": f"eq.{course_id}"},
+    )
+    course_info = course_rows[0] if course_rows else {"course_code": "", "course_name": ""}
+
+    # ── 3. All graph nodes for this course across every enrolled student ──────
+    # Build user_id filter for PostgREST
+    user_filter = ",".join(user_ids)
     node_rows = table("graph_nodes").select(
         "id,concept_name,mastery_score,mastery_tier,user_id",
-        filters={"subject": f"eq.{course_name}"},
+        filters={"course_id": f"eq.{course_id}", "user_id": f"in.({user_filter})"},
     )
     if not node_rows:
-        return
+        return  # No graph data yet for this course
 
-    # ── 2. Group by concept_name, track per-user scores ──────────────────────
+    # ── 4. Group by concept_name, track per-user scores ───────────────────────
     concept_data: dict = {}
-    user_ids: set = set()
     node_id_set: set = set()
 
     for n in node_rows:
-        user_ids.add(n["user_id"])
         node_id_set.add(n["id"])
         name = n["concept_name"]
         if name not in concept_data:
-            concept_data[name] = {"scores": [], "tiers": []}
+            concept_data[name] = {"scores": [], "tiers": [], "node_ids": []}
         concept_data[name]["scores"].append(float(n["mastery_score"] or 0.0))
         concept_data[name]["tiers"].append(n["mastery_tier"] or "unexplored")
+        concept_data[name]["node_ids"].append(n["id"])
 
-    student_count = len(user_ids)
-
-    # ── 3. Compute per-concept metrics ────────────────────────────────────────
+    # ── 5. Compute per-concept metrics ────────────────────────────────────────
     concept_metrics: dict = {}
+    all_scores: list = []
+    
     for name, data in concept_data.items():
         scores = data["scores"]
         tiers = data["tiers"]
         n_s = len(scores)
+        
+        if n_s == 0:
+            continue
+            
         avg_mastery = sum(scores) / n_s
-        struggling_pct = sum(1 for t in tiers if t == "struggling") / n_s
-        mastered_pct = sum(1 for t in tiers if t == "mastered") / n_s
+        all_scores.extend(scores)
+        
+        struggling_count = sum(1 for t in tiers if t == "struggling")
+        mastered_count = sum(1 for t in tiers if t == "mastered")
+        unexplored_count = sum(1 for t in tiers if t == "unexplored")
+        
         concept_metrics[name] = {
-            "avg_mastery": round(avg_mastery, 3),
-            "struggling_pct": round(struggling_pct, 2),
-            "mastered_pct": round(mastered_pct, 2),
+            "avg_mastery_score": round(avg_mastery, 4),
+            "pct_struggling": round(struggling_count / n_s, 4),
+            "pct_mastered": round(mastered_count / n_s, 4),
+            "pct_unexplored": round(unexplored_count / n_s, 4),
+            "student_count": n_s,
+            "node_ids": data["node_ids"],
         }
 
-    struggling_concepts = sorted(
-        [
-            {
-                "concept": name,
-                "avg_mastery": m["avg_mastery"],
-                "struggling_pct": m["struggling_pct"],
-            }
-            for name, m in concept_metrics.items()
-            if m["struggling_pct"] > 0.2
-        ],
-        key=lambda x: x["avg_mastery"],
-    )
+    # ── 6. Pull quiz_context data for aggregated insights ────────────────────
+    node_id_list = list(node_id_set)
+    common_misconceptions: list = []
+    effective_explanations: list = []
+    prerequisite_gaps: list = []
+    
+    if node_id_list:
+        node_filter = ",".join(node_id_list[:100])  # Limit to avoid URL length issues
+        try:
+            ctx_rows = table("quiz_context").select(
+                "concept_node_id,context_json",
+                filters={"concept_node_id": f"in.({node_filter})"},
+            )
+        except Exception:
+            ctx_rows = []
 
-    mastered_concepts = sorted(
-        [
+        seen_misconceptions: set = set()
+        seen_explanations: set = set()
+        seen_prereqs: set = set()
+
+        for ctx in ctx_rows:
+            cj = ctx.get("context_json") or {}
+            if isinstance(cj, str):
+                try:
+                    cj = json.loads(cj)
+                except Exception:
+                    cj = {}
+
+            # Extract common mistakes as misconceptions
+            for m in cj.get("common_mistakes", []):
+                m = (m or "").strip()
+                if m and m.lower() not in seen_misconceptions:
+                    seen_misconceptions.add(m.lower())
+                    common_misconceptions.append(m)
+
+            # Extract weak areas as prerequisite gaps
+            for w in cj.get("weak_areas", []):
+                w = (w or "").strip()
+                if w and w.lower() not in seen_prereqs:
+                    seen_prereqs.add(w.lower())
+                    prerequisite_gaps.append(w)
+                    
+            # Look for effective explanations in any field
+            for exp in cj.get("effective_explanations", []):
+                exp = (exp or "").strip()
+                if exp and exp.lower() not in seen_explanations:
+                    seen_explanations.add(exp.lower())
+                    effective_explanations.append(exp)
+
+    # ── 7. Upsert into course_concept_stats ───────────────────────────────────
+    for name, metrics in concept_metrics.items():
+        table("course_concept_stats").upsert(
             {
-                "concept": name,
-                "avg_mastery": m["avg_mastery"],
-                "mastered_pct": m["mastered_pct"],
-            }
-            for name, m in concept_metrics.items()
-            if m["mastered_pct"] > 0.6
-        ],
-        key=lambda x: x["avg_mastery"],
+                "course_id": course_id,
+                "concept_name": name,
+                "semester": semester,
+                "student_count": metrics["student_count"],
+                "avg_mastery_score": metrics["avg_mastery_score"],
+                "pct_mastered": metrics["pct_mastered"],
+                "pct_struggling": metrics["pct_struggling"],
+                "pct_unexplored": metrics["pct_unexplored"],
+                "common_misconceptions": common_misconceptions[:20],  # Limit array size
+                "effective_explanations": effective_explanations[:20],
+                "prerequisite_gaps": prerequisite_gaps[:20],
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            },
+            on_conflict="course_id,concept_name,semester",
+        )
+
+    # ── 8. Compute course-wide summary metrics ────────────────────────────────
+    avg_class_mastery = round(sum(all_scores) / len(all_scores), 4) if all_scores else 0.0
+    
+    # Sort for top struggling (highest pct_struggling) and top mastered
+    sorted_by_struggling = sorted(
+        [(name, m) for name, m in concept_metrics.items()],
+        key=lambda x: x[1]["pct_struggling"],
         reverse=True,
     )
-
-    concept_difficulty_ranking = sorted(
-        [
-            {"concept": name, "avg_mastery": m["avg_mastery"]}
-            for name, m in concept_metrics.items()
-        ],
-        key=lambda x: x["avg_mastery"],  # lowest mastery = hardest
+    top_struggling_concepts = [name for name, _ in sorted_by_struggling[:5]]
+    
+    sorted_by_mastered = sorted(
+        [(name, m) for name, m in concept_metrics.items()],
+        key=lambda x: x[1]["pct_mastered"],
+        reverse=True,
     )
+    top_mastered_concepts = [name for name, _ in sorted_by_mastered[:5]]
 
-    # ── 4. Pull quiz_context for this course's students, filter by node ───────
-    user_id_list = list(user_ids)
-    try:
-        ctx_rows_all = table("quiz_context").select(
-            "concept_node_id,context_json",
-            filters={"user_id": f"in.({','.join(user_id_list)})"},
-        )
-    except Exception:
-        ctx_rows_all = []
-
-    # Keep only contexts for concepts that belong to this course
-    ctx_rows = [r for r in ctx_rows_all if r["concept_node_id"] in node_id_set]
-
-    # ── 5. Deduplicate misconceptions and weak areas (case-insensitive) ───────
-    seen: set = set()
-    common_misconceptions: list = []
-    seen2: set = set()
-    weak_areas: list = []
-
-    for ctx in ctx_rows:
-        cj = ctx.get("context_json") or {}
-        if isinstance(cj, str):
-            import json as _json
-            try:
-                cj = _json.loads(cj)
-            except Exception:
-                cj = {}
-
-        for m in cj.get("common_mistakes", []):
-            m = (m or "").strip()
-            if m and m.lower() not in seen:
-                seen.add(m.lower())
-                common_misconceptions.append(m)
-
-        for w in cj.get("weak_areas", []):
-            w = (w or "").strip()
-            if w and w.lower() not in seen2:
-                seen2.add(w.lower())
-                weak_areas.append(w)
-
-    # ── 6. Upsert into course_context ─────────────────────────────────────────
-    context = {
-        "struggling_concepts": struggling_concepts,
-        "mastered_concepts": mastered_concepts,
-        "concept_difficulty_ranking": concept_difficulty_ranking,
-        "common_misconceptions": common_misconceptions,
-        "weak_areas": weak_areas,
-        "student_count": student_count,
-    }
-
-    table("course_context").upsert(
+    # Generate data hash to detect changes
+    stats_for_hash = [
         {
-            "course_name": course_name,
-            "context_json": context,
+            "concept": name,
+            "avg_mastery": m["avg_mastery_score"],
+            "pct_struggling": m["pct_struggling"],
+            "pct_mastered": m["pct_mastered"],
+        }
+        for name, m in concept_metrics.items()
+    ]
+    current_hash = _generate_data_hash(stats_for_hash)
+
+    # ── 9. Check if summary needs regeneration ─────────────────────────────────
+    existing_summary_rows = table("course_summary").select(
+        "summary_hash,summary_text",
+        filters={"course_id": f"eq.{course_id}", "semester": f"eq.{semester}"},
+    )
+    
+    existing_hash = existing_summary_rows[0]["summary_hash"] if existing_summary_rows else None
+    
+    # Regenerate summary only if data changed or no existing summary
+    if current_hash != existing_hash or not existing_summary_rows:
+        summary_text = _generate_summary_with_gemini(
+            course_info.get("course_code", ""),
+            course_info.get("course_name", ""),
+            avg_class_mastery,
+            top_struggling_concepts,
+            top_mastered_concepts,
+            student_count,
+        )
+    else:
+        summary_text = existing_summary_rows[0].get("summary_text", "")
+
+    # ── 10. Upsert into course_summary ────────────────────────────────────────
+    table("course_summary").upsert(
+        {
+            "course_id": course_id,
+            "semester": semester,
             "student_count": student_count,
+            "avg_class_mastery": avg_class_mastery,
+            "top_struggling_concepts": top_struggling_concepts,
+            "top_mastered_concepts": top_mastered_concepts,
+            "summary_text": summary_text,
+            "summary_hash": current_hash,
             "updated_at": datetime.now(timezone.utc).isoformat(),
         },
-        on_conflict="course_name",
+        on_conflict="course_id,semester",
     )

--- a/backend/services/graph_service.py
+++ b/backend/services/graph_service.py
@@ -5,27 +5,24 @@ from config import get_mastery_tier
 from db.connection import table
 
 
-def _user_course_titles(user_id: str) -> set[str]:
+def _user_enrolled_courses(user_id: str) -> list[dict]:
+    """Get all courses a user is enrolled in via user_courses join."""
     try:
-        rows = table("courses").select(
-            "course_name",
+        rows = table("user_courses").select(
+            "id,course_id,color,nickname,enrolled_at,courses!inner(course_code,course_name,department,school)",
             filters={"user_id": f"eq.{user_id}"},
         )
     except Exception:
-        return set()
-    return {r["course_name"] for r in (rows or []) if r.get("course_name")}
+        return []
+    return rows or []
 
 
-def _filter_course_title_seed_nodes(nodes: list, course_titles: set[str]) -> list:
-    """Remove rows that only duplicated the course hub (concept_name == subject == registered course)."""
-    out = []
-    for n in nodes:
-        subj = (n.get("subject") or "").strip()
-        concept = (n.get("concept_name") or "").strip()
-        if subj and concept == subj and subj in course_titles:
-            continue
-        out.append(n)
-    return out
+def _get_course_nodes(user_id: str, course_id: str) -> list:
+    """Get graph nodes for a specific course."""
+    return table("graph_nodes").select(
+        "*",
+        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
+    ) or []
 
 
 def ensure_user_exists(user_id: str) -> None:
@@ -89,9 +86,14 @@ def _compute_velocity(events: list) -> float:
 
 def get_graph(user_id: str) -> dict:
     ensure_user_exists(user_id)
-    course_titles = _user_course_titles(user_id)
+    
+    # Get all enrolled courses for this user
+    enrolled_courses = _user_enrolled_courses(user_id)
+    course_id_map = {r["course_id"]: r for r in enrolled_courses}
+    
+    # Get all graph nodes for this user
     nodes_raw = table("graph_nodes").select("*", filters={"user_id": f"eq.{user_id}"})
-    nodes = _filter_course_title_seed_nodes(nodes_raw or [], course_titles)
+    nodes = nodes_raw or []
     node_ids = {n["id"] for n in nodes}
 
     edges_raw = table("graph_edges").select("*", filters={"user_id": f"eq.{user_id}"})
@@ -134,33 +136,40 @@ def get_graph(user_id: str) -> dict:
         "avg_learning_velocity": avg_velocity,
     }
 
-    subject_map: dict = {}
-    for n in nodes:
-        subj = n.get("subject") or "General"
-        subject_map.setdefault(subj, []).append(n)
-
-    for title in course_titles:
-        subject_map.setdefault(title, [])
-
+    # Build subject root hubs from enrolled courses
     subject_nodes = []
     subject_edges = []
-    for subj, subj_nodes in subject_map.items():
-        root_id = f"subject_root__{subj}"
+    
+    for enrollment in enrolled_courses:
+        course_id = enrollment["course_id"]
+        course = enrollment.get("courses", {}) if isinstance(enrollment.get("courses"), dict) else {}
+        course_code = course.get("course_code", "")
+        course_name = course.get("course_name", "")
+        
+        # Use "Course Code - Course Name" as the subject label
+        subject_label = f"{course_code} - {course_name}" if course_code else course_name
+        
+        # Find all nodes belonging to this course
+        subj_nodes = [n for n in nodes if n.get("course_id") == course_id]
+        
+        root_id = f"subject_root__{course_id}"
         if subj_nodes:
             avg_mastery = sum(n["mastery_score"] for n in subj_nodes) / len(subj_nodes)
         else:
             avg_mastery = 0.0
+            
         subject_nodes.append({
             "id": root_id,
             "user_id": user_id,
-            "concept_name": subj,
+            "concept_name": subject_label,
             "mastery_score": round(avg_mastery, 4),
             "mastery_tier": "subject_root",
-            "subject": subj,
+            "course_id": course_id,
             "times_studied": sum(n.get("times_studied", 0) for n in subj_nodes),
             "last_studied_at": None,
             "is_subject_root": True,
         })
+        
         for n in subj_nodes:
             subject_edges.append({
                 "id": f"subject_edge__{root_id}__{n['id']}",
@@ -176,91 +185,123 @@ def get_graph(user_id: str) -> dict:
 # ── Course management ──────────────────────────────────────────────────────────
 
 def get_courses(user_id: str) -> list:
+    """
+    Return user's enrolled courses joined with canonical course data.
+    Returns list of dicts with: enrollment_id, course_id, course_code, course_name, 
+    school, department, color, nickname, node_count, enrolled_at
+    """
     try:
-        rows = table("courses").select(
-            "id,course_name,color,created_at",
+        rows = table("user_courses").select(
+            "id,course_id,color,nickname,enrolled_at,courses!inner(course_code,course_name,school,department)",
             filters={"user_id": f"eq.{user_id}"},
-            order="created_at.asc",
+            order="enrolled_at.asc",
         )
     except Exception:
         return []
+    
     result = []
     for r in rows:
+        course = r.get("courses", {}) if isinstance(r.get("courses"), dict) else {}
+        course_id = r["course_id"]
+        
+        # Count nodes for this course
         node_rows = table("graph_nodes").select(
             "id",
-            filters={"user_id": f"eq.{user_id}", "subject": f"eq.{r['course_name']}"},
+            filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
         )
+        
         result.append({
-            "id": r["id"],
-            "course_name": r["course_name"],
-            "color": r["color"],
+            "enrollment_id": r["id"],
+            "course_id": course_id,
+            "course_code": course.get("course_code", ""),
+            "course_name": course.get("course_name", ""),
+            "school": course.get("school", ""),
+            "department": course.get("department", ""),
+            "color": r.get("color"),
+            "nickname": r.get("nickname"),
             "node_count": len(node_rows),
-            "created_at": r["created_at"],
+            "enrolled_at": r["enrolled_at"],
         })
     return result
 
 
-def add_course(user_id: str, course_name: str, color: str | None = None) -> dict:
-    existing = table("courses").select(
+def add_course(user_id: str, course_id: str, color: str | None = None, nickname: str | None = None) -> dict:
+    """
+    Enroll a user in a course (insert into user_courses).
+    course_id refers to the canonical courses table.
+    """
+    # Check if already enrolled
+    existing = table("user_courses").select(
         "id",
-        filters={"user_id": f"eq.{user_id}", "course_name": f"eq.{course_name}"},
+        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
     )
     if existing:
-        return {"course_name": course_name, "already_existed": True}
-    table("courses").insert({
+        return {"course_id": course_id, "already_existed": True}
+    
+    # Verify the course exists in canonical courses
+    course_check = table("courses").select("id", filters={"id": f"eq.{course_id}"})
+    if not course_check:
+        return {"course_id": course_id, "error": "Course not found in catalog"}
+    
+    table("user_courses").insert({
         "id": str(uuid.uuid4()),
         "user_id": user_id,
-        "course_name": course_name,
+        "course_id": course_id,
         "color": color,
+        "nickname": nickname,
     })
-    return {"course_name": course_name, "already_existed": False}
+    return {"course_id": course_id, "already_existed": False}
 
 
-def update_course_color(user_id: str, course_name: str, color: str) -> dict:
-    table("courses").update(
+def update_course_color(user_id: str, course_id: str, color: str) -> dict:
+    """Update the color for a user's course enrollment."""
+    table("user_courses").update(
         {"color": color},
-        filters={"user_id": f"eq.{user_id}", "course_name": f"eq.{course_name}"},
+        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
     )
     return {"updated": True}
 
 
-def delete_course(user_id: str, course_name: str) -> dict:
-    node_rows = table("graph_nodes").select(
-        "id",
-        filters={"user_id": f"eq.{user_id}", "subject": f"eq.{course_name}"},
+def update_course_nickname(user_id: str, course_id: str, nickname: str) -> dict:
+    """Update the nickname for a user's course enrollment."""
+    table("user_courses").update(
+        {"nickname": nickname},
+        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
     )
-    node_ids = [n["id"] for n in node_rows]
+    return {"updated": True}
 
-    if node_ids:
-        ids_str = ",".join(node_ids)
-        # Delete all tables that FK-reference graph_nodes before deleting nodes
-        table("quiz_context").delete({"concept_node_id": f"in.({ids_str})"})
-        table("quiz_attempts").delete({"concept_node_id": f"in.({ids_str})"})
-        table("graph_edges").delete({"source_node_id": f"in.({ids_str})"})
-        table("graph_edges").delete({"target_node_id": f"in.({ids_str})"})
-        table("graph_nodes").delete(
-            {"user_id": f"eq.{user_id}", "subject": f"eq.{course_name}"}
-        )
 
-    table("courses").delete(
-        {"user_id": f"eq.{user_id}", "course_name": f"eq.{course_name}"}
+def delete_course(user_id: str, course_id: str) -> dict:
+    """
+    Unenroll a user from a course (delete from user_courses).
+    Note: We don't delete the graph nodes - they remain for potential re-enrollment.
+    """
+    # Just delete the enrollment, not the nodes
+    table("user_courses").delete(
+        {"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"}
     )
     return {"deleted": True}
 
 
-def apply_graph_update(user_id: str, graph_update: dict) -> list:
-    """Apply a graph_update dict to the DB. Returns mastery_changes list."""
+def apply_graph_update(user_id: str, graph_update: dict, course_id: str | None = None) -> list:
+    """
+    Apply a graph_update dict to the DB. Returns mastery_changes list.
+    If course_id is provided, all new/updated nodes will be associated with that course.
+    """
     mastery_changes = []
-    touched_subjects: set = set()
+    touched_courses: set = set()
 
     for new_node in graph_update.get("new_nodes", []):
         name = new_node.get("concept_name", "")
-        subject = new_node.get("subject", "General")
+        node_course_id = course_id or new_node.get("course_id")
         init_m = float(new_node.get("initial_mastery", 0.0))
+        
+        # Check for existing node by concept_name for this user
         existing = table("graph_nodes").select(
             "id",
             filters={"user_id": f"eq.{user_id}", "concept_name": f"eq.{name}"},
         )
+        
         if not existing:
             table("graph_nodes").insert({
                 "id": str(uuid.uuid4()),
@@ -268,17 +309,17 @@ def apply_graph_update(user_id: str, graph_update: dict) -> list:
                 "concept_name": name,
                 "mastery_score": init_m,
                 "mastery_tier": get_mastery_tier(init_m),
-                "subject": subject,
+                "course_id": node_course_id,
                 "mastery_events": [],
             })
-        if subject and subject != "General":
-            touched_subjects.add(subject)
+            if node_course_id:
+                touched_courses.add(node_course_id)
 
     for upd in graph_update.get("updated_nodes", []):
         name = upd.get("concept_name", "")
         delta = float(upd.get("mastery_delta", 0.0))
         rows = table("graph_nodes").select(
-            "id,mastery_score,times_studied,subject,mastery_events",
+            "id,mastery_score,times_studied,course_id,mastery_events",
             filters={"user_id": f"eq.{user_id}", "concept_name": f"eq.{name}"},
         )
         if rows:
@@ -306,9 +347,11 @@ def apply_graph_update(user_id: str, graph_update: dict) -> list:
                 filters={"id": f"eq.{row['id']}"},
             )
             mastery_changes.append({"concept": name, "before": before, "after": after})
-            subj = row.get("subject", "")
-            if subj and subj != "General":
-                touched_subjects.add(subj)
+            
+            cid = row.get("course_id")
+            if cid:
+                touched_courses.add(cid)
+                
     if mastery_changes:
         update_streak(user_id)
 
@@ -344,12 +387,12 @@ def apply_graph_update(user_id: str, graph_update: dict) -> list:
                     "relationship_type": relationship_type,
                 })
 
-    # Refresh shared course context for every subject touched in this update
-    if touched_subjects:
+    # Refresh shared course context for every course touched in this update
+    if touched_courses:
         from services.course_context_service import update_course_context
-        for subj in touched_subjects:
+        for cid in touched_courses:
             try:
-                update_course_context(subj)
+                update_course_context(cid)
             except Exception:
                 pass  # never block the main response for a context refresh
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -27,35 +27,54 @@ export const getGraph = (userId: string) =>
 export const getRecommendations = (userId: string) =>
   fetchJSON<{ recommendations: any[] }>(`/api/graph/${userId}/recommendations`);
 
-export const getCourses = (userId: string) =>
-  fetchJSON<{ courses: { id: string; course_name: string; color: string | null; node_count: number; created_at: string }[] }>(
-    `/api/graph/${userId}/courses`
-  );
+export interface EnrolledCourse {
+  enrollment_id: string;
+  course_id: string;
+  course_code: string;
+  course_name: string;
+  school: string;
+  department: string;
+  color: string | null;
+  nickname: string | null;
+  node_count: number;
+  enrolled_at: string;
+}
 
-export const addCourse = (userId: string, courseName: string, color?: string) =>
-  fetchJSON<{ course_name: string; already_existed: boolean }>(`/api/graph/${userId}/courses`, {
+export const getCourses = (userId: string) =>
+  fetchJSON<{ courses: EnrolledCourse[] }>(`/api/graph/${userId}/courses`);
+
+export const addCourse = (userId: string, courseId: string, color?: string, nickname?: string) =>
+  fetchJSON<{ course_id: string; already_existed: boolean; error?: string }>(`/api/graph/${userId}/courses`, {
     method: 'POST',
-    body: JSON.stringify({ course_name: courseName, ...(color ? { color } : {}) }),
+    body: JSON.stringify({ course_id: courseId, ...(color ? { color } : {}), ...(nickname ? { nickname } : {}) }),
   });
 
-export const updateCourseColor = (userId: string, courseName: string, color: string) =>
+export const updateCourseColor = (userId: string, courseId: string, color: string) =>
   fetchJSON<{ updated: boolean }>(
-    `/api/graph/${userId}/courses/${encodeURIComponent(courseName)}/color`,
+    `/api/graph/${userId}/courses/${encodeURIComponent(courseId)}/color`,
     { method: 'PATCH', body: JSON.stringify({ color }) }
   );
 
-export const deleteCourse = (userId: string, courseName: string) =>
+export const deleteCourse = (userId: string, courseId: string) =>
   fetchJSON<{ deleted: boolean }>(
-    `/api/graph/${userId}/courses/${encodeURIComponent(courseName)}`,
+    `/api/graph/${userId}/courses/${encodeURIComponent(courseId)}`,
     { method: 'DELETE' }
   );
 
 // ── Learn ─────────────────────────────────────────────────────────────────────
 
-export const startSession = (userId: string, topic: string, mode: string, useSharedContext = true) =>
+export interface StartSessionRequest {
+  user_id: string;
+  topic: string;
+  mode: string;
+  use_shared_context?: boolean;
+  course_id?: string;
+}
+
+export const startSession = (userId: string, topic: string, mode: string, courseId?: string, useSharedContext = true) =>
   fetchJSON<{ session_id: string; initial_message: string; graph_state: any }>('/api/learn/start-session', {
     method: 'POST',
-    body: JSON.stringify({ user_id: userId, topic, mode, use_shared_context: useSharedContext }),
+    body: JSON.stringify({ user_id: userId, topic, mode, use_shared_context: useSharedContext, course_id: courseId }),
   });
 
 export const sendChat = (sessionId: string, userId: string, message: string, mode: string, useSharedContext = true) =>
@@ -76,18 +95,19 @@ export const endSession = (sessionId: string, userId: string) =>
     body: JSON.stringify({ session_id: sessionId, user_id: userId }),
   });
 
+export interface Session {
+  id: string;
+  topic: string;
+  mode: string;
+  course_id: string | null;
+  started_at: string;
+  ended_at: string | null;
+  message_count: number;
+  is_active: boolean;
+}
+
 export const getSessions = (userId: string, limit = 10) =>
-  fetchJSON<{
-    sessions: {
-      id: string;
-      topic: string;
-      mode: string;
-      started_at: string;
-      ended_at: string | null;
-      message_count: number;
-      is_active: boolean;
-    }[];
-  }>(`/api/learn/sessions/${userId}?limit=${limit}`);
+  fetchJSON<{ sessions: Session[] }>(`/api/learn/sessions/${userId}?limit=${limit}`);
 
 export const switchMode = (sessionId: string, userId: string, newMode: string) =>
   fetchJSON<{ reply: string }>('/api/learn/mode-switch', {
@@ -103,7 +123,7 @@ export const deleteSession = (sessionId: string, userId: string) =>
 
 export const resumeSession = (sessionId: string) =>
   fetchJSON<{
-    session: { id: string; topic: string; mode: string; started_at: string; ended_at: string | null };
+    session: { id: string; user_id: string; topic: string; mode: string; course_id: string | null; started_at: string; ended_at: string | null };
     messages: { id: string; role: string; content: string; created_at: string }[];
   }>(`/api/learn/sessions/${sessionId}/resume`);
 
@@ -146,19 +166,40 @@ export const extractSyllabus = (formData: FormData, userId?: string): Promise<an
           .join('; ');
       }
       if (!msg && typeof data.error === 'string') msg = data.error;
-      throw new Error(msg || `Request failed (HTTP ${r.status}).`);
+      throw new Error(msg || `Request failed (HTTP ${res.status}).`);
     }
     return data;
   });
 };
 
+export interface Assignment {
+  id: string;
+  user_id: string;
+  title: string;
+  due_date: string;
+  assignment_type?: string;
+  notes?: string;
+  google_event_id?: string;
+  course_id?: string;
+  course_code?: string;
+  course_name?: string;
+}
+
 export const getUpcomingAssignments = (userId: string) =>
-  fetchJSON<{ assignments: any[] }>(`/api/calendar/upcoming/${userId}`);
+  fetchJSON<{ assignments: Assignment[] }>(`/api/calendar/upcoming/${userId}`);
 
 export const getAllAssignments = (userId: string) =>
-  fetchJSON<{ assignments: any[] }>(`/api/calendar/all/${userId}`);
+  fetchJSON<{ assignments: Assignment[] }>(`/api/calendar/all/${userId}`);
 
-export const saveAssignments = (userId: string, assignments: any[]) =>
+export interface SaveAssignmentItem {
+  title: string;
+  course_id: string;
+  due_date: string;
+  assignment_type?: string;
+  notes?: string;
+}
+
+export const saveAssignments = (userId: string, assignments: SaveAssignmentItem[]) =>
   fetchJSON<{ saved_count: number }>('/api/calendar/save', {
     method: 'POST',
     body: JSON.stringify({ user_id: userId, assignments }),


### PR DESCRIPTION
## Summary

This PR refactors the backend and frontend to use the new database schema where courses are canonical (no user_id) and user_courses is the enrollment join table.

## Database Changes (already applied in Supabase)

- `courses` is now canonical (no user_id): id, course_code, course_name, department, school, etc.
- `user_courses` is the enrollment join table
- All dependent tables now use `course_id` FK to `courses.id`:
  - assignments, sessions, graph_nodes, documents, study_guides
- New tables: `course_concept_stats`, `course_summary`
- Removed: `course_context` table

## Backend Changes

### services/course_context_service.py (COMPLETE REWRITE)
- Aggregates graph_nodes mastery data across all students enrolled in a course
- Computes avg_mastery_score, pct_mastered, pct_struggling, pct_unexplored per concept
- Pulls common_misconceptions, effective_explanations, prerequisite_gaps from quiz_context
- Upserts into course_concept_stats keyed on (course_id, concept_name, semester)
- Maintains course_summary with top 5 struggling/mastered concepts
- Regenerates summary_text via Gemini only when data hash changes

### services/graph_service.py
- Updated to join user_courses -> courses for enrolled courses
- `get_graph`: builds subject_root hubs from canonical courses (course_code + course_name)
- `apply_graph_update`: now accepts `course_id` parameter for all node inserts/updates
- `get_courses`: returns enriched data: course_code, course_name, school, department, color, nickname

### routes/graph.py
- Course endpoints now accept `course_id` instead of `course_name`
- Returns joined data from user_courses + courses

### routes/learn.py
- Sessions now store `course_id` instead of resolving from topic strings
- `start-session` accepts optional `course_id` parameter
- Passes `course_id` through to `apply_graph_update`

### routes/calendar.py
- `save` endpoint uses `course_id` instead of `course_name`
- `upcoming`/`all` endpoints join with courses to return course_code and course_name

### models/__init__.py
- Added `course_id` fields to `StartSessionBody`, `AssignmentItem`, `AddCourseBody`

## Frontend Changes

### src/lib/api.ts
- `getCourses`: returns `EnrolledCourse` with course_code, course_name, school, department, etc.
- `addCourse`: takes `courseId` instead of `courseName`
- `updateCourseColor`, `deleteCourse`: use `courseId`
- `startSession`: accepts optional `courseId` parameter
- `saveAssignments`: uses `course_id` in `SaveAssignmentItem`

## Testing
- All backend modules import successfully
- Pydantic models validate correctly with new `course_id` fields
- Frontend TypeScript types are updated

## Migration Notes
- Frontend components that called `addCourse(userId, courseName)` need to now call `addCourse(userId, courseId)` where courseId is from the canonical courses catalog
- The enrollment flow should first show available courses, then enroll via course_id

---

**Commit:** 25dedba
**Branch:** refactor/course-id-schema