### PR TITLE
Normalize API assignment objects before storing in state

### DIFF
--- a/frontend/src/app/calendar/page.tsx
+++ b/frontend/src/app/calendar/page.tsx
@@ -321,6 +321,19 @@ function CalendarGrid({ assignments }: { assignments: Assignment[] }) {
   );
 }
 
+
+function normalizeAssignments(items: any[]): Assignment[] {
+  return (items ?? []).map((a: any) => ({
+    id: a.id ?? '',
+    title: a.title ?? '',
+    course_name: a.course_name ?? '',
+    due_date: a.due_date ?? '',
+    assignment_type: a.assignment_type ?? 'other',
+    notes: a.notes ?? null,
+    google_event_id: a.google_event_id ?? null,
+  }));
+}
+
 function CalendarInner() {
   const { userId: USER_ID, userReady } = useUser();
   const searchParams = useSearchParams();
@@ -351,7 +364,7 @@ function CalendarInner() {
   useEffect(() => {
     if (!userReady) return;
     getAllAssignments(USER_ID)
-      .then(data => setAssignments(data.assignments ?? []))
+      .then(data => setAssignments(normalizeAssignments(data.assignments ?? [])))
       .catch(console.error);
     getCalendarStatus(USER_ID)
       .then(res => setGoogleConnected(res.connected))
@@ -410,7 +423,7 @@ function CalendarInner() {
     try {
       await saveAssignments(USER_ID, extractedAssignments);
       const data = await getAllAssignments(USER_ID);
-      setAssignments(data.assignments ?? []);
+      setAssignments(normalizeAssignments(data.assignments ?? []));
       setExtractedAssignments([]);
       setFileProcessed(false);
       setWarnings([]);
@@ -443,7 +456,7 @@ function CalendarInner() {
       setSyncedCount(res.synced_count);
       // Refresh so google_event_id values are up to date
       getAllAssignments(USER_ID)
-        .then(data => setAssignments(data.assignments ?? []))
+        .then(data => setAssignments(normalizeAssignments(data.assignments ?? [])))
         .catch(console.error);
     } catch (e: any) {
       alert(e.message);


### PR DESCRIPTION
### Motivation
- Ensure assignments returned from the API always have the expected shape and default values to prevent undefined fields causing UI issues.

### Description
- Add `normalizeAssignments(items: any[]): Assignment[]` to map/normalize incoming assignment objects with defaults and use it when handling `getAllAssignments` responses during initial load, after `saveAssignments`, and after `syncToGoogleCalendar` refresh.

### Testing
- Ran a local TypeScript typecheck (`tsc`) and `yarn build`/`yarn lint`, and they completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda6b9c9348327b2fc4063fc6e57b1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of assignment data handling in the calendar to ensure consistent display of all assignment fields when syncing from external sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->