### PR TITLE
Fix post-OAuth sign-in flow: session failures and Try-again 404

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -14,6 +14,7 @@ SUPABASE_SERVICE_KEY = os.getenv("SUPABASE_SERVICE_KEY", "")
 
 PORT = int(os.getenv("PORT", "5000"))
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+SESSION_SECRET = os.getenv("SESSION_SECRET", "")
 
 GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/calendar.events",

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -8,7 +8,9 @@ Restricts sign-in to @bu.edu email accounts only.
 import json
 import base64
 import hashlib
+import hmac as _hmac
 import secrets
+import time as _time
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, HTTPException, Query
@@ -20,6 +22,7 @@ from config import (
     GOOGLE_AUTH_REDIRECT_URI,
     AUTH_SCOPES,
     FRONTEND_URL,
+    SESSION_SECRET,
 )
 from db.connection import table
 
@@ -177,11 +180,21 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
     if not is_approved:
         return RedirectResponse(f"{FRONTEND_URL}/pending")
 
-    # Redirect to frontend with user info
+    # Build a short-lived HMAC token so the frontend can verify this redirect
+    # without a second round-trip to the backend.
+    auth_token = ""
+    if SESSION_SECRET:
+        payload = json.dumps({"user_id": user_id, "exp": int(_time.time()) + 300}).encode()
+        payload_b64 = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+        sig_bytes = _hmac.new(SESSION_SECRET.encode(), payload_b64.encode(), hashlib.sha256).digest()
+        sig_b64 = base64.urlsafe_b64encode(sig_bytes).decode().rstrip("=")
+        auth_token = f"{payload_b64}.{sig_b64}"
+
     params = urlencode({
         "user_id": user_id,
         "name": name,
         "avatar": avatar_url,
         "is_approved": "true",
+        **({"auth_token": auth_token} if auth_token else {}),
     })
     return RedirectResponse(f"{FRONTEND_URL}/signin/callback?{params}")

--- a/frontend/src/app/api/auth/session/route.ts
+++ b/frontend/src/app/api/auth/session/route.ts
@@ -13,12 +13,14 @@ async function verifyAuthToken(token: string): Promise<string | null> {
   const payloadB64 = token.slice(0, dot);
   const sigB64 = token.slice(dot + 1);
   try {
-    // Re-pad base64url and convert to bytes for sig comparison
-    function b64urlToBytes(s: string): Uint8Array {
+    // Re-pad base64url and convert to bytes for sig comparison.
+    // Returns Uint8Array<ArrayBuffer> (concrete) so it satisfies BufferSource.
+    function b64urlToBytes(s: string): Uint8Array<ArrayBuffer> {
       const padded = s.replace(/-/g, '+').replace(/_/g, '/');
       const pad = '='.repeat((4 - (padded.length % 4)) % 4);
       const binary = atob(padded + pad);
-      const bytes = new Uint8Array(binary.length);
+      const buf = new ArrayBuffer(binary.length);
+      const bytes = new Uint8Array(buf);
       for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
       return bytes;
     }

--- a/frontend/src/app/api/auth/session/route.ts
+++ b/frontend/src/app/api/auth/session/route.ts
@@ -2,50 +2,106 @@ import { NextRequest, NextResponse } from 'next/server';
 import { signSession, SESSION_MAX_AGE } from '@/lib/sessionToken';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
+const SESSION_SECRET = process.env.SESSION_SECRET;
+
+// Verify an HMAC token produced by the backend's OAuth callback.
+// Returns the userId if valid and unexpired, otherwise null.
+async function verifyAuthToken(token: string): Promise<string | null> {
+  if (!SESSION_SECRET) return null;
+  const dot = token.lastIndexOf('.');
+  if (dot < 0) return null;
+  const payloadB64 = token.slice(0, dot);
+  const sigB64 = token.slice(dot + 1);
+  try {
+    // Re-pad base64url and convert to bytes for sig comparison
+    function b64urlToBytes(s: string): Uint8Array {
+      const padded = s.replace(/-/g, '+').replace(/_/g, '/');
+      const pad = '='.repeat((4 - (padded.length % 4)) % 4);
+      const binary = atob(padded + pad);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      return bytes;
+    }
+
+    const key = await crypto.subtle.importKey(
+      'raw',
+      new TextEncoder().encode(SESSION_SECRET),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['verify'],
+    );
+    const valid = await crypto.subtle.verify(
+      'HMAC',
+      key,
+      b64urlToBytes(sigB64),
+      new TextEncoder().encode(payloadB64),
+    );
+    if (!valid) return null;
+
+    const payload = JSON.parse(new TextDecoder().decode(b64urlToBytes(payloadB64)));
+    if (typeof payload.exp !== 'number' || payload.exp < Math.floor(Date.now() / 1000)) return null;
+    if (typeof payload.user_id !== 'string') return null;
+    return payload.user_id;
+  } catch {
+    return null;
+  }
+}
 
 export async function POST(request: NextRequest) {
-  if (!API_URL) {
-    return NextResponse.json({ error: 'NEXT_PUBLIC_API_URL not configured' }, { status: 500 });
-  }
+  const body = await request.json();
+  const { userId, authToken } = body as { userId?: string; authToken?: string };
 
-  const { userId } = await request.json();
-  if (!userId || typeof userId !== 'string') {
-    return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
-  }
+  let verifiedUserId: string | null = null;
 
-  // Verify with the backend that the user exists and is approved.
-  let approved = false;
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 3000);
-    let res: Response;
+  // Fast path: verify the backend-signed token (no round-trip needed).
+  if (authToken) {
+    verifiedUserId = await verifyAuthToken(authToken);
+    if (!verifiedUserId) {
+      return NextResponse.json({ error: 'Invalid or expired auth token' }, { status: 401 });
+    }
+  } else {
+    // Fallback: call backend to verify (used when SESSION_SECRET not shared yet).
+    if (!API_URL) {
+      return NextResponse.json({ error: 'NEXT_PUBLIC_API_URL not configured' }, { status: 500 });
+    }
+    if (!userId || typeof userId !== 'string') {
+      return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
+    }
     try {
-      res = await fetch(`${API_URL}/api/auth/me?user_id=${encodeURIComponent(userId)}`, { signal: controller.signal });
-    } finally {
-      clearTimeout(timeout);
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 3000);
+      let res: Response;
+      try {
+        res = await fetch(`${API_URL}/api/auth/me?user_id=${encodeURIComponent(userId)}`, { signal: controller.signal });
+      } finally {
+        clearTimeout(timeout);
+      }
+      if (!res.ok) {
+        return NextResponse.json({ error: 'User not found' }, { status: 401 });
+      }
+      const data = await res.json();
+      if (data.is_approved !== true) {
+        return NextResponse.json({ error: 'Not approved' }, { status: 403 });
+      }
+      verifiedUserId = userId;
+    } catch {
+      return NextResponse.json({ error: 'Backend unreachable' }, { status: 502 });
     }
-    if (!res.ok) {
-      return NextResponse.json({ error: 'User not found' }, { status: 401 });
-    }
-    const data = await res.json();
-    approved = data.is_approved === true;
+  }
+
+  try {
+    const token = await signSession(verifiedUserId);
+    const response = NextResponse.json({ ok: true });
+    response.cookies.set('sapling_session', token, {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: SESSION_MAX_AGE,
+    });
+    return response;
   } catch {
-    return NextResponse.json({ error: 'Backend unreachable' }, { status: 502 });
+    return NextResponse.json({ error: 'Session signing failed — SESSION_SECRET may not be configured' }, { status: 500 });
   }
-
-  if (!approved) {
-    return NextResponse.json({ error: 'Not approved' }, { status: 403 });
-  }
-
-  const token = await signSession(userId);
-  const response = NextResponse.json({ ok: true });
-  response.cookies.set('sapling_session', token, {
-    httpOnly: true,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: SESSION_MAX_AGE,
-  });
-  return response;
 }
 
 export async function DELETE() {

--- a/frontend/src/app/signin/callback/page.tsx
+++ b/frontend/src/app/signin/callback/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useUser } from '@/context/UserContext';
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
 function CallbackInner() {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -15,6 +17,7 @@ function CallbackInner() {
     const name = searchParams.get('name');
     const avatar = searchParams.get('avatar');
     const approvedParam = searchParams.get('is_approved');
+    const authToken = searchParams.get('auth_token');
     const error = searchParams.get('error');
 
     if (error === 'not_approved' || approvedParam === 'false') {
@@ -32,7 +35,7 @@ function CallbackInner() {
       fetch('/api/auth/session', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId }),
+        body: JSON.stringify({ userId, ...(authToken ? { authToken } : {}) }),
       }).then(res => {
         if (res.ok) {
           confirmApproved();
@@ -64,7 +67,7 @@ function CallbackInner() {
       }}>
         <p style={{ color: '#374151', fontSize: '15px', textAlign: 'center' }}>{errorMsg}</p>
         <a
-          href="/api/auth/google"
+          href={`${API_URL}/api/auth/google`}
           style={{
             padding: '10px 24px',
             background: '#1a5c2a',

--- a/frontend/src/app/signin/callback/page.tsx
+++ b/frontend/src/app/signin/callback/page.tsx
@@ -5,6 +5,11 @@ import { useSearchParams, useRouter } from 'next/navigation';
 import { useUser } from '@/context/UserContext';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+// If NEXT_PUBLIC_API_URL is not configured, falling back to a relative
+// "/api/auth/google" would 404 (it's a backend endpoint, not a frontend
+// route). Sending the user to "/signin" is the only safe client-resolvable
+// recovery, since the middleware handles re-launching OAuth from there.
+const TRY_AGAIN_HREF = API_URL ? `${API_URL}/api/auth/google` : '/signin';
 
 function CallbackInner() {
   const searchParams = useSearchParams();
@@ -67,7 +72,7 @@ function CallbackInner() {
       }}>
         <p style={{ color: '#374151', fontSize: '15px', textAlign: 'center' }}>{errorMsg}</p>
         <a
-          href={`${API_URL}/api/auth/google`}
+          href={TRY_AGAIN_HREF}
           style={{
             padding: '10px 24px',
             background: '#1a5c2a',


### PR DESCRIPTION
## Summary

Fixes two bugs that broke sign-in after Google OAuth completed — users saw a "Redirecting to sign in…" screen, then "Unable to complete sign-in", and then a 404 when clicking "Try again".

## Changes Made

**`frontend/src/app/signin/callback/page.tsx`**
- Removed `router.replace('/signin')` on session failure — the callback page now shows an inline error with a "Try again" link instead of bouncing users to `/signin`
- Fixed "Try again" `href` from `/api/auth/google` (relative Next.js path → 404) to `${NEXT_PUBLIC_API_URL}/api/auth/google` (the actual backend endpoint)
- Distinguish missing `is_approved` param (inline error) from explicit `is_approved=false` (redirect to `/pending`) — previously both were treated as denial
- Passes `auth_token` from the OAuth redirect to the session route when present

**`frontend/src/app/api/auth/session/route.ts`**
- Added HMAC token verification path: if the backend includes a signed `auth_token`, the session is established without a backend round-trip (eliminates the Cloudflare edge → backend call that was timing out)
- Kept the old backend round-trip as a fallback for when `SESSION_SECRET` is not shared
- Wrapped `signSession()` in try/catch so a missing `SESSION_SECRET` returns a descriptive 500 instead of an unhandled exception

**`backend/config.py` + `backend/routes/auth.py`**
- Backend now signs the OAuth redirect URL with a short-lived HMAC token (SHA-256, 5-min TTY, keyed on `SESSION_SECRET`)
- If `SESSION_SECRET` is not set on the backend, it omits the token and the frontend falls back to the old verification flow

**`frontend/src/__tests__/signinCallback.test.tsx`** (new)
- 8 tests covering all callback branches: dashboard on success, `/pending` on 403, inline error on server failure, inline error on network error, inline error on missing params, inline error on missing `is_approved`, `/pending` on explicit `false`, `/pending` on `error=not_approved`

## Environment variable required

`SESSION_SECRET` must be set to the **same value** in both:
- Cloudflare Pages environment variables (frontend)
- Backend `.env`

Minimum 32 characters. This is what enables the HMAC fast path and also what `signSession()` needs to create the session cookie.

## Related Issues

Fixes the sign-in failure reported for `@bu.edu` accounts on saplinglearn.com.

## Testing

- [x] All 162 frontend tests pass
- [x] Verified callback branches with unit tests
- [x] Inline error + Try-again link render correctly on failure

https://claude.ai/code/session_01U3mwGcNbKKXSb9P6cBEaqa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional short-lived auth tokens now enable faster, local verification for quicker sign-ins when configured.
  * Sign-in callback respects the configured API URL for "Try again" links.

* **Bug Fixes**
  * Improved session verification with a backend fallback and clearer failure handling during sign-in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->