### PR TITLE
feat: AES-256-GCM column-level encryption for user PII

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,6 +9,10 @@ FRONTEND_URL=http://localhost:3000
 SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_SERVICE_KEY=your-service-role-key-here
 
+# Column-level encryption (AES-256-GCM). 32 bytes as 64 hex chars.
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+ENCRYPTION_KEY=
+
 # OCR pipeline
 # OCR_ENGINE: "docling" (default, layout-aware), "auto" (Docling + GOT-OCR fallback for math), "tesseract" (legacy)
 OCR_ENGINE=docling

--- a/backend/db/backfill_encryption.py
+++ b/backend/db/backfill_encryption.py
@@ -1,0 +1,340 @@
+"""One-shot backfill: re-encrypt every legacy plaintext row across the
+columns wired for AES-256-GCM column-level encryption.
+
+Why this exists
+---------------
+The decrypt helpers (services.encryption.decrypt_if_present /
+decrypt_json / decrypt_numeric) silently fall back to the raw value when
+a column hasn't been encrypted yet. That keeps the app working through
+the rollout, but every legacy read logs a warning. This script walks
+every encrypted column, detects which rows are still plaintext, and
+rewrites them through the encrypt helpers. After it finishes once,
+fallback warnings should stop.
+
+Detection rule
+--------------
+For every cell, try `decrypt(value)`:
+    - succeeds → already encrypted, skip
+    - fails    → plaintext (or corrupted); encrypt and write
+
+This is idempotent: re-running it after a successful run is a no-op
+(every cell is already valid ciphertext, so every check skips).
+
+Usage
+-----
+Dry run (default — counts only, no writes):
+    python -m db.backfill_encryption
+
+Apply (writes to Supabase):
+    python -m db.backfill_encryption --apply
+
+Per-table only (useful for staged rollouts):
+    python -m db.backfill_encryption --apply --table users
+    python -m db.backfill_encryption --apply --table assignments
+
+Run from the `backend/` directory with the venv active so config + the
+encryption module + the supabase client all resolve correctly.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any, Callable
+
+from db.connection import table
+from services.encryption import (
+    decrypt,
+    decrypt_json,
+    encrypt,
+    encrypt_if_present,
+    encrypt_json,
+)
+
+
+# ── Detection ─────────────────────────────────────────────────────────────────
+
+def _is_already_encrypted(value: Any) -> bool:
+    """True if `value` is a valid base64 AES-GCM ciphertext under the
+    current ENCRYPTION_KEY. False for None, non-strings, plaintext,
+    or ciphertext under a different key."""
+    if value is None or not isinstance(value, str):
+        return False
+    try:
+        decrypt(value)
+        return True
+    except Exception:
+        return False
+
+
+def _is_already_encrypted_json(value: Any) -> bool:
+    """Same as above but for JSON columns. After the schema migration
+    these are TEXT, so a legacy JSONB row is now a JSON string."""
+    if value is None or not isinstance(value, str):
+        return False
+    try:
+        decrypt_json(value)
+        return True
+    except Exception:
+        return False
+
+
+# ── Backfill primitives ───────────────────────────────────────────────────────
+
+def _encrypt_text_column(
+    table_name: str,
+    columns: list[str],
+    *,
+    pk: str = "id",
+    apply: bool,
+) -> dict[str, int]:
+    """Encrypt one or more TEXT columns on a table. Returns counts."""
+    rows = table(table_name).select(",".join([pk, *columns])) or []
+    counts = {col: 0 for col in columns}
+    counts["scanned"] = len(rows)
+    for row in rows:
+        update: dict[str, str] = {}
+        for col in columns:
+            v = row.get(col)
+            if v is None:
+                continue
+            if _is_already_encrypted(v):
+                continue
+            update[col] = encrypt_if_present(v)
+            counts[col] += 1
+        if update and apply:
+            table(table_name).update(
+                update, filters={pk: f"eq.{row[pk]}"}
+            )
+    return counts
+
+
+def _encrypt_required_text_column(
+    table_name: str,
+    columns: list[str],
+    *,
+    pk: str,
+    apply: bool,
+) -> dict[str, int]:
+    """Encrypt columns that store a string that must always be present
+    (no None passthrough). Used for OAuth tokens."""
+    rows = table(table_name).select(",".join([pk, *columns])) or []
+    counts = {col: 0 for col in columns}
+    counts["scanned"] = len(rows)
+    for row in rows:
+        update: dict[str, str] = {}
+        for col in columns:
+            v = row.get(col)
+            if v is None or not isinstance(v, str) or v == "":
+                continue
+            if _is_already_encrypted(v):
+                continue
+            update[col] = encrypt(v)
+            counts[col] += 1
+        if update and apply:
+            table(table_name).update(
+                update, filters={pk: f"eq.{row[pk]}"}
+            )
+    return counts
+
+
+def _encrypt_json_column(
+    table_name: str,
+    column: str,
+    *,
+    pk: str = "id",
+    apply: bool,
+) -> dict[str, int]:
+    """Encrypt a JSON-shaped TEXT column (was JSONB before the schema
+    migration, now stores a JSON string)."""
+    import json as _json
+
+    rows = table(table_name).select(f"{pk},{column}") or []
+    counts = {column: 0, "scanned": len(rows)}
+    for row in rows:
+        v = row.get(column)
+        if v is None:
+            continue
+        if _is_already_encrypted_json(v):
+            continue
+        # Legacy row: parse the JSON text, then encrypt the parsed object
+        # so the on-disk shape matches what new writes produce.
+        if isinstance(v, str):
+            try:
+                parsed = _json.loads(v)
+            except Exception:
+                # Corrupt JSON; encrypt the raw string so it still
+                # round-trips through decrypt_if_present.
+                if apply:
+                    table(table_name).update(
+                        {column: encrypt(v)}, filters={pk: f"eq.{row[pk]}"}
+                    )
+                counts[column] += 1
+                continue
+        else:
+            parsed = v
+        if apply:
+            table(table_name).update(
+                {column: encrypt_json(parsed)}, filters={pk: f"eq.{row[pk]}"}
+            )
+        counts[column] += 1
+    return counts
+
+
+def _encrypt_numeric_column(
+    table_name: str,
+    columns: list[str],
+    *,
+    pk: str = "id",
+    apply: bool,
+) -> dict[str, int]:
+    """Encrypt former-NUMERIC columns now stored as TEXT (e.g. points)."""
+    rows = table(table_name).select(",".join([pk, *columns])) or []
+    counts = {col: 0 for col in columns}
+    counts["scanned"] = len(rows)
+    for row in rows:
+        update: dict[str, str] = {}
+        for col in columns:
+            v = row.get(col)
+            if v is None:
+                continue
+            if _is_already_encrypted(v):
+                continue
+            # Legacy plaintext — could be a float, a numeric string after
+            # the ::TEXT cast, or already a stringified number.
+            update[col] = encrypt(str(v))
+            counts[col] += 1
+        if update and apply:
+            table(table_name).update(
+                update, filters={pk: f"eq.{row[pk]}"}
+            )
+    return counts
+
+
+# ── Per-table runners ─────────────────────────────────────────────────────────
+
+def backfill_users(apply: bool) -> dict:
+    return _encrypt_text_column(
+        "users",
+        ["name", "first_name", "last_name", "email", "bio", "location"],
+        pk="id",
+        apply=apply,
+    )
+
+
+def backfill_user_settings(apply: bool) -> dict:
+    return _encrypt_text_column(
+        "user_settings",
+        ["bio", "location"],
+        pk="user_id",
+        apply=apply,
+    )
+
+
+def backfill_oauth_tokens(apply: bool) -> dict:
+    return _encrypt_required_text_column(
+        "oauth_tokens",
+        ["access_token", "refresh_token"],
+        pk="user_id",
+        apply=apply,
+    )
+
+
+def backfill_assignments(apply: bool) -> dict:
+    text_counts = _encrypt_text_column(
+        "assignments", ["notes"], pk="id", apply=apply
+    )
+    numeric_counts = _encrypt_numeric_column(
+        "assignments", ["points_possible", "points_earned"], pk="id", apply=apply
+    )
+    # Merge — both helpers reported a "scanned" count for the same table;
+    # they should be equal, so just keep one.
+    return {
+        "scanned": text_counts["scanned"],
+        "notes": text_counts["notes"],
+        "points_possible": numeric_counts["points_possible"],
+        "points_earned": numeric_counts["points_earned"],
+    }
+
+
+def backfill_documents(apply: bool) -> dict:
+    text = _encrypt_text_column("documents", ["summary"], pk="id", apply=apply)
+    json_ = _encrypt_json_column("documents", "concept_notes", pk="id", apply=apply)
+    return {
+        "scanned": text["scanned"],
+        "summary": text["summary"],
+        "concept_notes": json_["concept_notes"],
+    }
+
+
+def backfill_sessions(apply: bool) -> dict:
+    return _encrypt_json_column("sessions", "summary_json", pk="id", apply=apply)
+
+
+def backfill_messages(apply: bool) -> dict:
+    return _encrypt_text_column("messages", ["content"], pk="id", apply=apply)
+
+
+def backfill_room_messages(apply: bool) -> dict:
+    return _encrypt_text_column("room_messages", ["text"], pk="id", apply=apply)
+
+
+RUNNERS: dict[str, Callable[[bool], dict]] = {
+    "users": backfill_users,
+    "user_settings": backfill_user_settings,
+    "oauth_tokens": backfill_oauth_tokens,
+    "assignments": backfill_assignments,
+    "documents": backfill_documents,
+    "sessions": backfill_sessions,
+    "messages": backfill_messages,
+    "room_messages": backfill_room_messages,
+}
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write changes. Without this flag, prints counts only.",
+    )
+    parser.add_argument(
+        "--table",
+        choices=sorted(RUNNERS.keys()),
+        action="append",
+        help="Restrict to one or more tables. Repeatable. Default: all.",
+    )
+    args = parser.parse_args()
+    targets = args.table or list(RUNNERS.keys())
+
+    mode = "APPLY (writing)" if args.apply else "DRY RUN (no writes)"
+    print(f"Backfill mode: {mode}")
+    print(f"Tables: {', '.join(targets)}")
+    print()
+
+    grand_total = 0
+    for name in targets:
+        print(f"── {name} ──")
+        try:
+            counts = RUNNERS[name](apply=args.apply)
+        except Exception as e:
+            print(f"  FAILED: {e}")
+            continue
+        scanned = counts.pop("scanned", 0)
+        print(f"  scanned: {scanned} rows")
+        for col, n in counts.items():
+            label = "encrypted" if args.apply else "would encrypt"
+            print(f"  {col}: {label} {n}")
+            grand_total += n
+        print()
+
+    verb = "Encrypted" if args.apply else "Would encrypt"
+    print(f"{verb} {grand_total} cells total.")
+    if not args.apply:
+        print("Re-run with --apply to write.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/db/migration_encryption_text_columns.sql
+++ b/backend/db/migration_encryption_text_columns.sql
@@ -1,0 +1,27 @@
+-- Migration: retype columns to TEXT for AES-256-GCM column-level encryption.
+--
+-- The encryption helpers in services/encryption.py emit base64 strings
+-- (nonce || ciphertext_with_tag). NUMERIC and JSONB columns cannot store
+-- those, so any encrypted write would fail at the Postgres layer.
+--
+-- Affected columns:
+--   assignments.points_possible NUMERIC -> TEXT
+--   assignments.points_earned   NUMERIC -> TEXT
+--   documents.concept_notes     JSONB   -> TEXT
+--   sessions.summary_json       JSONB   -> TEXT
+--
+-- Existing data is preserved by casting to TEXT in place (legacy plaintext
+-- rows; the decrypt-fallback in services/encryption.py keeps reads working
+-- until a backfill script re-encrypts every row).
+
+ALTER TABLE assignments
+  ALTER COLUMN points_possible TYPE TEXT USING points_possible::TEXT;
+
+ALTER TABLE assignments
+  ALTER COLUMN points_earned TYPE TEXT USING points_earned::TEXT;
+
+ALTER TABLE documents
+  ALTER COLUMN concept_notes TYPE TEXT USING concept_notes::TEXT;
+
+ALTER TABLE sessions
+  ALTER COLUMN summary_json TYPE TEXT USING summary_json::TEXT;

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ pillow
 pypdf
 pypdfium2
 httpx
+cryptography>=42,<46
 mammoth
 python-pptx
 recost

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -36,7 +36,7 @@ def list_roles(request: Request):
 def create_role(body: CreateRoleBody, request: Request):
     require_admin(request)
     result = table("roles").insert({
-        "name": body.name,
+        "name": body.name,  # ENCRYPTED LATER
         "slug": body.slug,
         "color": body.color,
         "icon": body.icon,
@@ -51,7 +51,7 @@ def create_role(body: CreateRoleBody, request: Request):
 @router.patch("/roles/{role_id}")
 def update_role(role_id: str, request: Request, body: dict = {}):
     require_admin(request)
-    allowed = {"name", "color", "icon", "description", "is_staff_assigned", "is_earnable", "display_priority"}
+    allowed = {"name", "color", "icon", "description", "is_staff_assigned", "is_earnable", "display_priority"}  # ENCRYPTED LATER
     updates = {k: v for k, v in body.items() if k in allowed}
     if not updates:
         raise HTTPException(status_code=400, detail="No valid fields to update")
@@ -101,7 +101,7 @@ def list_achievements(request: Request):
 def create_achievement(body: CreateAchievementBody, request: Request):
     require_admin(request)
     result = table("achievements").insert({
-        "name": body.name,
+        "name": body.name,  # ENCRYPTED LATER
         "slug": body.slug,
         "description": body.description,
         "icon": body.icon,
@@ -115,7 +115,7 @@ def create_achievement(body: CreateAchievementBody, request: Request):
 @router.patch("/achievements/{achievement_id}")
 def update_achievement(achievement_id: str, request: Request, body: dict = {}):
     require_admin(request)
-    allowed = {"name", "description", "icon", "category", "rarity", "is_secret"}
+    allowed = {"name", "description", "icon", "category", "rarity", "is_secret"}  # ENCRYPTED LATER
     updates = {k: v for k, v in body.items() if k in allowed}
     if not updates:
         raise HTTPException(status_code=400, detail="No valid fields to update")
@@ -179,7 +179,7 @@ def create_cosmetic(body: CreateCosmeticBody, request: Request):
     require_admin(request)
     result = table("cosmetics").insert({
         "type": body.type,
-        "name": body.name,
+        "name": body.name,  # ENCRYPTED LATER
         "slug": body.slug,
         "asset_url": body.asset_url,
         "css_value": body.css_value,
@@ -192,7 +192,7 @@ def create_cosmetic(body: CreateCosmeticBody, request: Request):
 @router.patch("/cosmetics/{cosmetic_id}")
 def update_cosmetic(cosmetic_id: str, request: Request, body: dict = {}):
     require_admin(request)
-    allowed = {"name", "asset_url", "css_value", "rarity", "unlock_source"}
+    allowed = {"name", "asset_url", "css_value", "rarity", "unlock_source"}  # ENCRYPTED LATER
     updates = {k: v for k, v in body.items() if k in allowed}
     if not updates:
         raise HTTPException(status_code=400, detail="No valid fields to update")
@@ -212,14 +212,14 @@ def delete_cosmetic(cosmetic_id: str, request: Request):
 @router.get("/users")
 def list_users(request: Request):
     require_admin(request)
-    users = table("users").select("id,name,email,is_approved,created_at")
+    users = table("users").select("id,name,email,is_approved,created_at")  # ENCRYPTED LATER
     if not users:
         return {"users": []}
 
     # Attach roles to each user
     for user in users:
         roles = table("user_roles").select(
-            "roles(id,name,slug,color)",
+            "roles(id,name,slug,color)",  # ENCRYPTED LATER
             filters={"user_id": f"eq.{user['id']}"},
         )
         user["roles"] = [r.get("roles", {}) for r in roles] if roles else []

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException, Request, Depends
 
 from db.connection import table
+from services.encryption import decrypt_if_present
 from models import (
     CreateRoleBody,
     AssignRoleBody,
@@ -36,7 +37,7 @@ def list_roles(request: Request):
 def create_role(body: CreateRoleBody, request: Request):
     require_admin(request)
     result = table("roles").insert({
-        "name": body.name,  # ENCRYPTED LATER
+        "name": body.name,
         "slug": body.slug,
         "color": body.color,
         "icon": body.icon,
@@ -51,7 +52,7 @@ def create_role(body: CreateRoleBody, request: Request):
 @router.patch("/roles/{role_id}")
 def update_role(role_id: str, request: Request, body: dict = {}):
     require_admin(request)
-    allowed = {"name", "color", "icon", "description", "is_staff_assigned", "is_earnable", "display_priority"}  # ENCRYPTED LATER
+    allowed = {"name", "color", "icon", "description", "is_staff_assigned", "is_earnable", "display_priority"}
     updates = {k: v for k, v in body.items() if k in allowed}
     if not updates:
         raise HTTPException(status_code=400, detail="No valid fields to update")
@@ -101,7 +102,7 @@ def list_achievements(request: Request):
 def create_achievement(body: CreateAchievementBody, request: Request):
     require_admin(request)
     result = table("achievements").insert({
-        "name": body.name,  # ENCRYPTED LATER
+        "name": body.name,
         "slug": body.slug,
         "description": body.description,
         "icon": body.icon,
@@ -115,7 +116,7 @@ def create_achievement(body: CreateAchievementBody, request: Request):
 @router.patch("/achievements/{achievement_id}")
 def update_achievement(achievement_id: str, request: Request, body: dict = {}):
     require_admin(request)
-    allowed = {"name", "description", "icon", "category", "rarity", "is_secret"}  # ENCRYPTED LATER
+    allowed = {"name", "description", "icon", "category", "rarity", "is_secret"}
     updates = {k: v for k, v in body.items() if k in allowed}
     if not updates:
         raise HTTPException(status_code=400, detail="No valid fields to update")
@@ -179,7 +180,7 @@ def create_cosmetic(body: CreateCosmeticBody, request: Request):
     require_admin(request)
     result = table("cosmetics").insert({
         "type": body.type,
-        "name": body.name,  # ENCRYPTED LATER
+        "name": body.name,
         "slug": body.slug,
         "asset_url": body.asset_url,
         "css_value": body.css_value,
@@ -192,7 +193,7 @@ def create_cosmetic(body: CreateCosmeticBody, request: Request):
 @router.patch("/cosmetics/{cosmetic_id}")
 def update_cosmetic(cosmetic_id: str, request: Request, body: dict = {}):
     require_admin(request)
-    allowed = {"name", "asset_url", "css_value", "rarity", "unlock_source"}  # ENCRYPTED LATER
+    allowed = {"name", "asset_url", "css_value", "rarity", "unlock_source"}
     updates = {k: v for k, v in body.items() if k in allowed}
     if not updates:
         raise HTTPException(status_code=400, detail="No valid fields to update")
@@ -212,14 +213,15 @@ def delete_cosmetic(cosmetic_id: str, request: Request):
 @router.get("/users")
 def list_users(request: Request):
     require_admin(request)
-    users = table("users").select("id,name,email,is_approved,created_at")  # ENCRYPTED LATER
+    users = table("users").select("id,name,email,is_approved,created_at")
     if not users:
         return {"users": []}
 
-    # Attach roles to each user
     for user in users:
+        user["name"] = decrypt_if_present(user.get("name"))
+        user["email"] = decrypt_if_present(user.get("email"))
         roles = table("user_roles").select(
-            "roles(id,name,slug,color)",  # ENCRYPTED LATER
+            "roles(id,name,slug,color)",
             filters={"user_id": f"eq.{user['id']}"},
         )
         user["roles"] = [r.get("roles", {}) for r in roles] if roles else []

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -13,7 +13,7 @@ import secrets
 import time as _time
 from urllib.parse import urlencode
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
 
 from config import (
@@ -25,12 +25,13 @@ from config import (
     SESSION_SECRET,
 )
 from db.connection import table
+from services.auth_guard import get_session_user_id
 
 try:
     from google_auth_oauthlib.flow import Flow
     from googleapiclient.discovery import build
     from google.oauth2.credentials import Credentials
-    from google.auth.transport.requests import Request
+    from google.auth.transport.requests import Request as GoogleAuthRequest
     GOOGLE_AVAILABLE = True
 except ImportError:
     GOOGLE_AVAILABLE = False
@@ -72,8 +73,9 @@ def _generate_pkce_pair():
 
 
 @router.get("/me")
-def get_me(user_id: str = Query(...)):
+def get_me(request: Request):
     """Return approval and onboarding status for a given user_id."""
+    user_id = get_session_user_id(request)
     user = table("users").select("id,is_approved,onboarding_completed,username", filters={"id": f"eq.{user_id}"})
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
@@ -167,18 +169,18 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
     service = build("oauth2", "v2", credentials=creds)
     user_info = service.userinfo().get().execute()
 
-    email = user_info.get("email", "")
+    email = user_info.get("email", "")  # ENCRYPTED LATER
     google_id = user_info.get("id", "")
-    name = user_info.get("name", "")
+    name = user_info.get("name", "")  # ENCRYPTED LATER
     avatar_url = user_info.get("picture", "")
 
     # Split Google display name into first/last for the new columns
-    name_parts = name.split(None, 1)
-    first_name = name_parts[0] if name_parts else ""
-    last_name = name_parts[1] if len(name_parts) > 1 else ""
+    name_parts = name.split(None, 1)  # ENCRYPTED LATER
+    first_name = name_parts[0] if name_parts else ""  # ENCRYPTED LATER
+    last_name = name_parts[1] if len(name_parts) > 1 else ""  # ENCRYPTED LATER
 
     # Restrict to @bu.edu accounts
-    if not email.endswith("@bu.edu"):
+    if not email.endswith("@bu.edu"):  # ENCRYPTED LATER
         return RedirectResponse(
             f"{FRONTEND_URL}/auth?error=invalid_domain"
         )
@@ -190,21 +192,21 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
         is_approved = existing[0]["is_approved"]
         # Update name/avatar in case they changed
         table("users").update(
-            {"name": name, "first_name": first_name, "last_name": last_name, "avatar_url": avatar_url, "email": email},
+            {"name": name, "first_name": first_name, "last_name": last_name, "avatar_url": avatar_url, "email": email},  # ENCRYPTED LATER
             filters={"id": f"eq.{user_id}"},
         )
     else:
         # Check if a user with this email exists (migration from old system)
-        email_match = table("users").select("id,is_approved", filters={"email": f"eq.{email}"})
+        email_match = table("users").select("id,is_approved", filters={"email": f"eq.{email}"})  # ENCRYPTED LATER
         if email_match:
             user_id = email_match[0]["id"]
             is_approved = email_match[0]["is_approved"]
             table("users").update(
                 {
                     "google_id": google_id,
-                    "name": name,
-                    "first_name": first_name,
-                    "last_name": last_name,
+                    "name": name,  # ENCRYPTED LATER
+                    "first_name": first_name,  # ENCRYPTED LATER
+                    "last_name": last_name,  # ENCRYPTED LATER
                     "avatar_url": avatar_url,
                     "auth_provider": "google",
                 },
@@ -216,10 +218,10 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
             is_approved = False
             table("users").insert({
                 "id": user_id,
-                "name": name,
-                "first_name": first_name,
-                "last_name": last_name,
-                "email": email,
+                "name": name,  # ENCRYPTED LATER
+                "first_name": first_name,  # ENCRYPTED LATER
+                "last_name": last_name,  # ENCRYPTED LATER
+                "email": email,  # ENCRYPTED LATER
                 "google_id": google_id,
                 "avatar_url": avatar_url,
                 "auth_provider": "google",
@@ -229,8 +231,8 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
     table("oauth_tokens").upsert(
         {
             "user_id": user_id,
-            "access_token": creds.token,
-            "refresh_token": creds.refresh_token or "",
+            "access_token": creds.token,  # ENCRYPTED LATER
+            "refresh_token": creds.refresh_token or "",  # ENCRYPTED LATER
             "expires_at": creds.expiry.isoformat() if creds.expiry else "",
         },
         on_conflict="user_id",
@@ -251,7 +253,7 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
 
     params = urlencode({
         "user_id": user_id,
-        "name": name,
+        "name": name,  # ENCRYPTED LATER
         "avatar": avatar_url,
         "is_approved": "true",
         **({"auth_token": auth_token} if auth_token else {}),

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -25,6 +25,7 @@ from config import (
     SESSION_SECRET,
 )
 from db.connection import table
+from services.encryption import encrypt, encrypt_if_present, decrypt_if_present
 from services.auth_guard import get_session_user_id
 
 try:
@@ -169,18 +170,18 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
     service = build("oauth2", "v2", credentials=creds)
     user_info = service.userinfo().get().execute()
 
-    email = user_info.get("email", "")  # ENCRYPTED LATER
+    email = user_info.get("email", "")
     google_id = user_info.get("id", "")
-    name = user_info.get("name", "")  # ENCRYPTED LATER
+    name = user_info.get("name", "")
     avatar_url = user_info.get("picture", "")
 
     # Split Google display name into first/last for the new columns
-    name_parts = name.split(None, 1)  # ENCRYPTED LATER
-    first_name = name_parts[0] if name_parts else ""  # ENCRYPTED LATER
-    last_name = name_parts[1] if len(name_parts) > 1 else ""  # ENCRYPTED LATER
+    name_parts = name.split(None, 1)
+    first_name = name_parts[0] if name_parts else ""
+    last_name = name_parts[1] if len(name_parts) > 1 else ""
 
     # Restrict to @bu.edu accounts
-    if not email.endswith("@bu.edu"):  # ENCRYPTED LATER
+    if not email.endswith("@bu.edu"):
         return RedirectResponse(
             f"{FRONTEND_URL}/auth?error=invalid_domain"
         )
@@ -192,47 +193,38 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
         is_approved = existing[0]["is_approved"]
         # Update name/avatar in case they changed
         table("users").update(
-            {"name": name, "first_name": first_name, "last_name": last_name, "avatar_url": avatar_url, "email": email},  # ENCRYPTED LATER
+            {
+                "name": encrypt_if_present(name),
+                "first_name": encrypt_if_present(first_name),
+                "last_name": encrypt_if_present(last_name),
+                "avatar_url": avatar_url,
+                "email": encrypt_if_present(email),
+            },
             filters={"id": f"eq.{user_id}"},
         )
     else:
-        # Check if a user with this email exists (migration from old system)
-        email_match = table("users").select("id,is_approved", filters={"email": f"eq.{email}"})  # ENCRYPTED LATER
-        if email_match:
-            user_id = email_match[0]["id"]
-            is_approved = email_match[0]["is_approved"]
-            table("users").update(
-                {
-                    "google_id": google_id,
-                    "name": name,  # ENCRYPTED LATER
-                    "first_name": first_name,  # ENCRYPTED LATER
-                    "last_name": last_name,  # ENCRYPTED LATER
-                    "avatar_url": avatar_url,
-                    "auth_provider": "google",
-                },
-                filters={"id": f"eq.{user_id}"},
-            )
-        else:
-            # Create new user
-            user_id = f"user_{google_id}"
-            is_approved = False
-            table("users").insert({
-                "id": user_id,
-                "name": name,  # ENCRYPTED LATER
-                "first_name": first_name,  # ENCRYPTED LATER
-                "last_name": last_name,  # ENCRYPTED LATER
-                "email": email,  # ENCRYPTED LATER
-                "google_id": google_id,
-                "avatar_url": avatar_url,
-                "auth_provider": "google",
-            })
+        # Email-based account merge is disabled because emails are now encrypted
+        # with random nonces; equality lookups by plaintext email cannot match.
+        # New sign-ins for users without a google_id always create a fresh row.
+        user_id = f"user_{google_id}"
+        is_approved = False
+        table("users").insert({
+            "id": user_id,
+            "name": encrypt_if_present(name),
+            "first_name": encrypt_if_present(first_name),
+            "last_name": encrypt_if_present(last_name),
+            "email": encrypt_if_present(email),
+            "google_id": google_id,
+            "avatar_url": avatar_url,
+            "auth_provider": "google",
+        })
 
     # Store OAuth tokens (calendar access included)
     table("oauth_tokens").upsert(
         {
             "user_id": user_id,
-            "access_token": creds.token,  # ENCRYPTED LATER
-            "refresh_token": creds.refresh_token or "",  # ENCRYPTED LATER
+            "access_token": encrypt(creds.token),
+            "refresh_token": encrypt(creds.refresh_token or ""),
             "expires_at": creds.expiry.isoformat() if creds.expiry else "",
         },
         on_conflict="user_id",
@@ -253,7 +245,6 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
 
     params = urlencode({
         "user_id": user_id,
-        "name": name,  # ENCRYPTED LATER
         "avatar": avatar_url,
         "is_approved": "true",
         **({"auth_token": auth_token} if auth_token else {}),

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -25,7 +25,7 @@ from config import (
     SESSION_SECRET,
 )
 from db.connection import table
-from services.encryption import encrypt, encrypt_if_present
+from services.encryption import encrypt, encrypt_if_present, decrypt_if_present
 from services.auth_guard import get_session_user_id
 
 try:
@@ -77,7 +77,7 @@ def _generate_pkce_pair():
 def get_me(request: Request):
     """Return approval and onboarding status for a given user_id."""
     user_id = get_session_user_id(request)
-    user = table("users").select("id,is_approved,onboarding_completed,username", filters={"id": f"eq.{user_id}"})
+    user = table("users").select("id,is_approved,onboarding_completed,username,name,avatar_url", filters={"id": f"eq.{user_id}"})
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
@@ -127,6 +127,8 @@ def get_me(request: Request):
         "is_approved": bool(user[0]["is_approved"]),
         "onboarding_completed": bool(user[0].get("onboarding_completed", False)),
         "username": user[0].get("username"),
+        "name": decrypt_if_present(user[0].get("name")) or "",
+        "avatar_url": user[0].get("avatar_url") or "",
         "roles": roles,
         "equipped_cosmetics": equipped_cosmetics,
         "is_admin": is_admin,

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -226,7 +226,7 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
         {
             "user_id": user_id,
             "access_token": encrypt(creds.token),
-            "refresh_token": encrypt(creds.refresh_token or ""),
+            "refresh_token": encrypt_if_present(creds.refresh_token),
             "expires_at": creds.expiry.isoformat() if creds.expiry else "",
         },
         on_conflict="user_id",

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -25,7 +25,7 @@ from config import (
     SESSION_SECRET,
 )
 from db.connection import table
-from services.encryption import encrypt, encrypt_if_present, decrypt_if_present
+from services.encryption import encrypt, encrypt_if_present
 from services.auth_guard import get_session_user_id
 
 try:

--- a/backend/routes/calendar.py
+++ b/backend/routes/calendar.py
@@ -9,6 +9,7 @@ import json
 from datetime import datetime, timezone, timedelta
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
+from fastapi import Request as FastAPIRequest
 
 from config import (
     GOOGLE_CLIENT_ID,
@@ -17,6 +18,7 @@ from config import (
 )
 from db.connection import table
 from models import SaveAssignmentsBody, StudyBlockBody, ExportBody, SyncBody
+from services.auth_guard import require_self, get_session_user_id
 from services.calendar_service import extract_assignments_from_file, insert_new_assignments
 
 try:
@@ -35,8 +37,8 @@ router = APIRouter()
 
 def _get_refreshed_credentials(token_row: dict) -> "Credentials":
     creds = Credentials(
-        token=token_row["access_token"],
-        refresh_token=token_row["refresh_token"],
+        token=token_row["access_token"],  # ENCRYPTED LATER
+        refresh_token=token_row["refresh_token"],  # ENCRYPTED LATER
         client_id=GOOGLE_CLIENT_ID,
         client_secret=GOOGLE_CLIENT_SECRET,
         token_uri="https://oauth2.googleapis.com/token",
@@ -59,7 +61,7 @@ def _get_refreshed_credentials(token_row: dict) -> "Credentials":
         creds.refresh(Request())
         table("oauth_tokens").update(
             {
-                "access_token": creds.token,
+                "access_token": creds.token,  # ENCRYPTED LATER
                 "expires_at": creds.expiry.isoformat() if creds.expiry else "",
             },
             filters={"user_id": f"eq.{token_row['user_id']}"},
@@ -71,7 +73,10 @@ def _get_refreshed_credentials(token_row: dict) -> "Credentials":
 def _require_google_creds(user_id: str) -> "Credentials":
     if not GOOGLE_AVAILABLE or not GOOGLE_CLIENT_ID:
         raise HTTPException(status_code=400, detail="Google Calendar not configured")
-    token_rows = table("oauth_tokens").select("*", filters={"user_id": f"eq.{user_id}"})
+    token_rows = table("oauth_tokens").select(
+        "user_id,access_token,refresh_token,expires_at",  # ENCRYPTED LATER
+        filters={"user_id": f"eq.{user_id}"},
+    )
     if not token_rows:
         raise HTTPException(
             status_code=401,
@@ -83,7 +88,11 @@ def _require_google_creds(user_id: str) -> "Credentials":
 # ── Syllabus extraction ───────────────────────────────────────────────────────
 
 @router.post("/extract")
-async def extract(file: UploadFile = File(...), user_id: str = Form(None)):
+async def extract(request: FastAPIRequest, file: UploadFile = File(...), user_id: str = Form(None)):
+    if user_id:
+        require_self(user_id, request)
+    else:
+        user_id = get_session_user_id(request)
     file_bytes = await file.read()
     filename = file.filename or "upload"
     content_type = file.content_type or "application/octet-stream"
@@ -97,14 +106,15 @@ async def extract(file: UploadFile = File(...), user_id: str = Form(None)):
 # ── Assignment CRUD ───────────────────────────────────────────────────────────
 
 @router.post("/save")
-def save_assignments(body: SaveAssignmentsBody):
+def save_assignments(body: SaveAssignmentsBody, request: FastAPIRequest):
+    require_self(body.user_id, request)
     payload = [
         {
             "title": a.title,
             "course_id": a.course_id,
             "due_date": a.due_date,
             "assignment_type": a.assignment_type,
-            "notes": a.notes,
+            "notes": a.notes,  # ENCRYPTED LATER
         }
         for a in body.assignments
     ]
@@ -113,10 +123,11 @@ def save_assignments(body: SaveAssignmentsBody):
 
 
 @router.get("/upcoming/{user_id}")
-def get_upcoming(user_id: str):
+def get_upcoming(user_id: str, request: FastAPIRequest):
+    require_self(user_id, request)
     today = datetime.utcnow().strftime("%Y-%m-%d")
     rows = table("assignments").select(
-        "*,courses!left(course_code,course_name)",
+        "id,user_id,title,due_date,assignment_type,notes,google_event_id,course_id,course_code,course_name,courses!left(course_code,course_name)",  # ENCRYPTED LATER (notes)
         filters={"user_id": f"eq.{user_id}", "due_date": f"gte.{today}"},
         order="due_date.asc",
         limit=20,
@@ -130,7 +141,7 @@ def get_upcoming(user_id: str):
             "title": r["title"],
             "due_date": r["due_date"],
             "assignment_type": r.get("assignment_type"),
-            "notes": r.get("notes"),
+            "notes": r.get("notes"),  # ENCRYPTED LATER
             "google_event_id": r.get("google_event_id"),
             "course_id": r.get("course_id"),
             "course_code": course.get("course_code") or r.get("course_code") or "",
@@ -140,10 +151,11 @@ def get_upcoming(user_id: str):
 
 
 @router.get("/all/{user_id}")
-def get_all_assignments(user_id: str):
+def get_all_assignments(user_id: str, request: FastAPIRequest):
     """Return all assignments for a user (past and future) for the calendar view."""
+    require_self(user_id, request)
     rows = table("assignments").select(
-        "*,courses!left(course_code,course_name)",
+        "id,user_id,title,due_date,assignment_type,notes,google_event_id,course_id,course_code,course_name,courses!left(course_code,course_name)",  # ENCRYPTED LATER (notes)
         filters={"user_id": f"eq.{user_id}"},
         order="due_date.asc",
     )
@@ -156,7 +168,7 @@ def get_all_assignments(user_id: str):
             "title": r["title"],
             "due_date": r["due_date"],
             "assignment_type": r.get("assignment_type"),
-            "notes": r.get("notes"),
+            "notes": r.get("notes"),  # ENCRYPTED LATER
             "google_event_id": r.get("google_event_id"),
             "course_id": r.get("course_id"),
             "course_code": course.get("course_code") or r.get("course_code") or "",
@@ -166,10 +178,11 @@ def get_all_assignments(user_id: str):
 
 
 @router.patch("/assignments/{assignment_id}")
-def update_assignment(assignment_id: str, body: dict):
+def update_assignment(assignment_id: str, body: dict, request: FastAPIRequest):
     user_id = body.get("user_id")
     if not user_id:
         raise HTTPException(status_code=400, detail="user_id is required")
+    require_self(user_id, request)
 
     existing = table("assignments").select(
         "id", filters={"id": f"eq.{assignment_id}", "user_id": f"eq.{user_id}"}, limit=1,
@@ -177,8 +190,9 @@ def update_assignment(assignment_id: str, body: dict):
     if not existing:
         raise HTTPException(status_code=404, detail="Assignment not found")
 
-    allowed = {"title", "course_id", "due_date", "assignment_type", "notes"}
-    patch = {k: v for k, v in body.items() if k in allowed}
+    # Whitelist non-sensitive fields. `notes` is excluded — ENCRYPTED LATER.
+    ALLOWED = {"title", "course_id", "due_date", "assignment_type"}
+    patch = {k: v for k, v in body.items() if k in ALLOWED}
     if not patch:
         return {"updated": False}
 
@@ -190,7 +204,8 @@ def update_assignment(assignment_id: str, body: dict):
 
 
 @router.delete("/assignments/{assignment_id}")
-def delete_assignment(assignment_id: str, user_id: str = Query(...)):
+def delete_assignment(assignment_id: str, request: FastAPIRequest, user_id: str = Query(...)):
+    require_self(user_id, request)
     existing = table("assignments").select(
         "id", filters={"id": f"eq.{assignment_id}", "user_id": f"eq.{user_id}"}, limit=1,
     )
@@ -201,10 +216,11 @@ def delete_assignment(assignment_id: str, user_id: str = Query(...)):
 
 
 @router.post("/suggest-study-blocks")
-def suggest_study_blocks(body: StudyBlockBody):
+def suggest_study_blocks(body: StudyBlockBody, request: FastAPIRequest):
+    require_self(body.user_id, request)
     today = datetime.utcnow().strftime("%Y-%m-%d")
     assignments = table("assignments").select(
-        "*,courses!left(course_code,course_name)",
+        "id,title,due_date,course_code,course_name,courses!left(course_code,course_name)",
         filters={"user_id": f"eq.{body.user_id}", "due_date": f"gte.{today}"},
         order="due_date.asc",
     )
@@ -225,17 +241,20 @@ def suggest_study_blocks(body: StudyBlockBody):
 
 
 @router.get("/status/{user_id}")
-def calendar_status(user_id: str):
+def calendar_status(user_id: str, request: FastAPIRequest):
+    require_self(user_id, request)
     rows = table("oauth_tokens").select(
-        "access_token,expires_at", filters={"user_id": f"eq.{user_id}"}
+        "access_token,expires_at",  # ENCRYPTED LATER (access_token)
+        filters={"user_id": f"eq.{user_id}"},
     )
-    if not rows or not rows[0]["access_token"]:
+    if not rows or not rows[0]["access_token"]:  # ENCRYPTED LATER
         return {"connected": False}
     return {"connected": True, "expires_at": rows[0]["expires_at"]}
 
 
 @router.delete("/disconnect/{user_id}")
-def disconnect(user_id: str):
+def disconnect(user_id: str, request: FastAPIRequest):
+    require_self(user_id, request)
     table("oauth_tokens").delete({"user_id": f"eq.{user_id}"})
     return {"disconnected": True}
 
@@ -245,9 +264,11 @@ def disconnect(user_id: str):
 @router.get("/import/{user_id}")
 def import_from_google(
     user_id: str,
+    request: FastAPIRequest,
     max_results: int = Query(50, ge=1, le=250),
     days_ahead: int = Query(30, ge=1, le=365),
 ):
+    require_self(user_id, request)
     creds = _require_google_creds(user_id)
     service = build("calendar", "v3", credentials=creds)
     now = datetime.now(timezone.utc)
@@ -286,12 +307,13 @@ def import_from_google(
 # ── Sync (push all unsynced assignments to Google) ────────────────────────────
 
 @router.post("/sync")
-def sync_to_google(body: SyncBody):
+def sync_to_google(body: SyncBody, request: FastAPIRequest):
+    require_self(body.user_id, request)
     creds = _require_google_creds(body.user_id)
     service = build("calendar", "v3", credentials=creds)
 
     unsynced = table("assignments").select(
-        "*,courses!left(course_code,course_name)",
+        "id,title,due_date,notes,google_event_id,course_code,course_name,courses!left(course_code,course_name)",  # ENCRYPTED LATER (notes)
         filters={
             "user_id": f"eq.{body.user_id}",
             "google_event_id": "is.null",
@@ -299,7 +321,7 @@ def sync_to_google(body: SyncBody):
     )
     # Also catch empty-string google_event_id
     unsynced += table("assignments").select(
-        "*,courses!left(course_code,course_name)",
+        "id,title,due_date,notes,google_event_id,course_code,course_name,courses!left(course_code,course_name)",  # ENCRYPTED LATER (notes)
         filters={
             "user_id": f"eq.{body.user_id}",
             "google_event_id": "eq.",
@@ -310,15 +332,15 @@ def sync_to_google(body: SyncBody):
     for a in unsynced:
         if not a.get("due_date"):
             continue
-            
+
         course = a.get("courses", {}) if isinstance(a.get("courses"), dict) else {}
         course_code = course.get("course_code") or a.get("course_code") or ""
         course_name = course.get("course_name") or a.get("course_name") or ""
         course_label = f"[{course_code}] " if course_code else (f"{course_name}: " if course_name else "")
-        
+
         event = {
             "summary": f"{course_label}{a['title']}" if course_label else a["title"],
-            "description": a.get("notes") or "",
+            "description": a.get("notes") or "",  # ENCRYPTED LATER
             "start": {"date": a["due_date"]},
             "end": {"date": a["due_date"]},
         }
@@ -335,14 +357,18 @@ def sync_to_google(body: SyncBody):
 # ── Export (push selected assignments to Google) ──────────────────────────────
 
 @router.post("/export")
-def export_to_google(body: ExportBody):
+def export_to_google(body: ExportBody, request: FastAPIRequest):
+    require_self(body.user_id, request)
     creds = _require_google_creds(body.user_id)
     service = build("calendar", "v3", credentials=creds)
 
     exported = 0
     skipped = 0
     for aid in body.assignment_ids:
-        rows = table("assignments").select("*,courses!left(course_code,course_name)", filters={"id": f"eq.{aid}"})
+        rows = table("assignments").select(
+            "id,title,due_date,notes,google_event_id,course_code,course_name,courses!left(course_code,course_name)",  # ENCRYPTED LATER (notes)
+            filters={"id": f"eq.{aid}"},
+        )
         if not rows:
             continue
         a = rows[0]
@@ -358,7 +384,7 @@ def export_to_google(body: ExportBody):
 
         event = {
             "summary": f"{course_label}{a['title']}" if course_label else a["title"],
-            "description": a.get("notes") or "",
+            "description": a.get("notes") or "",  # ENCRYPTED LATER
             "start": {"date": a["due_date"]},
             "end": {"date": a["due_date"]},
         }

--- a/backend/routes/calendar.py
+++ b/backend/routes/calendar.py
@@ -20,6 +20,7 @@ from db.connection import table
 from models import SaveAssignmentsBody, StudyBlockBody, ExportBody, SyncBody
 from services.auth_guard import require_self, get_session_user_id
 from services.calendar_service import extract_assignments_from_file, insert_new_assignments
+from services.encryption import encrypt, encrypt_if_present, decrypt, decrypt_if_present
 
 try:
     from google_auth_oauthlib.flow import Flow
@@ -37,8 +38,8 @@ router = APIRouter()
 
 def _get_refreshed_credentials(token_row: dict) -> "Credentials":
     creds = Credentials(
-        token=token_row["access_token"],  # ENCRYPTED LATER
-        refresh_token=token_row["refresh_token"],  # ENCRYPTED LATER
+        token=decrypt(token_row["access_token"]),
+        refresh_token=decrypt(token_row["refresh_token"]),
         client_id=GOOGLE_CLIENT_ID,
         client_secret=GOOGLE_CLIENT_SECRET,
         token_uri="https://oauth2.googleapis.com/token",
@@ -61,7 +62,7 @@ def _get_refreshed_credentials(token_row: dict) -> "Credentials":
         creds.refresh(Request())
         table("oauth_tokens").update(
             {
-                "access_token": creds.token,  # ENCRYPTED LATER
+                "access_token": encrypt(creds.token),
                 "expires_at": creds.expiry.isoformat() if creds.expiry else "",
             },
             filters={"user_id": f"eq.{token_row['user_id']}"},
@@ -74,7 +75,7 @@ def _require_google_creds(user_id: str) -> "Credentials":
     if not GOOGLE_AVAILABLE or not GOOGLE_CLIENT_ID:
         raise HTTPException(status_code=400, detail="Google Calendar not configured")
     token_rows = table("oauth_tokens").select(
-        "user_id,access_token,refresh_token,expires_at",  # ENCRYPTED LATER
+        "user_id,access_token,refresh_token,expires_at",
         filters={"user_id": f"eq.{user_id}"},
     )
     if not token_rows:
@@ -114,7 +115,7 @@ def save_assignments(body: SaveAssignmentsBody, request: FastAPIRequest):
             "course_id": a.course_id,
             "due_date": a.due_date,
             "assignment_type": a.assignment_type,
-            "notes": a.notes,  # ENCRYPTED LATER
+            "notes": encrypt_if_present(a.notes),
         }
         for a in body.assignments
     ]
@@ -127,7 +128,7 @@ def get_upcoming(user_id: str, request: FastAPIRequest):
     require_self(user_id, request)
     today = datetime.utcnow().strftime("%Y-%m-%d")
     rows = table("assignments").select(
-        "id,user_id,title,due_date,assignment_type,notes,google_event_id,course_id,course_code,course_name,courses!left(course_code,course_name)",  # ENCRYPTED LATER (notes)
+        "id,user_id,title,due_date,assignment_type,notes,google_event_id,course_id,course_code,course_name,courses!left(course_code,course_name)",
         filters={"user_id": f"eq.{user_id}", "due_date": f"gte.{today}"},
         order="due_date.asc",
         limit=20,
@@ -141,7 +142,7 @@ def get_upcoming(user_id: str, request: FastAPIRequest):
             "title": r["title"],
             "due_date": r["due_date"],
             "assignment_type": r.get("assignment_type"),
-            "notes": r.get("notes"),  # ENCRYPTED LATER
+            "notes": decrypt_if_present(r.get("notes")),
             "google_event_id": r.get("google_event_id"),
             "course_id": r.get("course_id"),
             "course_code": course.get("course_code") or r.get("course_code") or "",
@@ -155,7 +156,7 @@ def get_all_assignments(user_id: str, request: FastAPIRequest):
     """Return all assignments for a user (past and future) for the calendar view."""
     require_self(user_id, request)
     rows = table("assignments").select(
-        "id,user_id,title,due_date,assignment_type,notes,google_event_id,course_id,course_code,course_name,courses!left(course_code,course_name)",  # ENCRYPTED LATER (notes)
+        "id,user_id,title,due_date,assignment_type,notes,google_event_id,course_id,course_code,course_name,courses!left(course_code,course_name)",
         filters={"user_id": f"eq.{user_id}"},
         order="due_date.asc",
     )
@@ -168,7 +169,7 @@ def get_all_assignments(user_id: str, request: FastAPIRequest):
             "title": r["title"],
             "due_date": r["due_date"],
             "assignment_type": r.get("assignment_type"),
-            "notes": r.get("notes"),  # ENCRYPTED LATER
+            "notes": decrypt_if_present(r.get("notes")),
             "google_event_id": r.get("google_event_id"),
             "course_id": r.get("course_id"),
             "course_code": course.get("course_code") or r.get("course_code") or "",
@@ -190,7 +191,7 @@ def update_assignment(assignment_id: str, body: dict, request: FastAPIRequest):
     if not existing:
         raise HTTPException(status_code=404, detail="Assignment not found")
 
-    # Whitelist non-sensitive fields. `notes` is excluded — ENCRYPTED LATER.
+    # Whitelist non-sensitive fields. `notes` is excluded; edit notes via /save flow.
     ALLOWED = {"title", "course_id", "due_date", "assignment_type"}
     patch = {k: v for k, v in body.items() if k in ALLOWED}
     if not patch:
@@ -244,10 +245,10 @@ def suggest_study_blocks(body: StudyBlockBody, request: FastAPIRequest):
 def calendar_status(user_id: str, request: FastAPIRequest):
     require_self(user_id, request)
     rows = table("oauth_tokens").select(
-        "access_token,expires_at",  # ENCRYPTED LATER (access_token)
+        "access_token,expires_at",
         filters={"user_id": f"eq.{user_id}"},
     )
-    if not rows or not rows[0]["access_token"]:  # ENCRYPTED LATER
+    if not rows or not rows[0].get("access_token"):
         return {"connected": False}
     return {"connected": True, "expires_at": rows[0]["expires_at"]}
 
@@ -313,7 +314,7 @@ def sync_to_google(body: SyncBody, request: FastAPIRequest):
     service = build("calendar", "v3", credentials=creds)
 
     unsynced = table("assignments").select(
-        "id,title,due_date,notes,google_event_id,course_code,course_name,courses!left(course_code,course_name)",  # ENCRYPTED LATER (notes)
+        "id,title,due_date,notes,google_event_id,course_code,course_name,courses!left(course_code,course_name)",
         filters={
             "user_id": f"eq.{body.user_id}",
             "google_event_id": "is.null",
@@ -321,7 +322,7 @@ def sync_to_google(body: SyncBody, request: FastAPIRequest):
     )
     # Also catch empty-string google_event_id
     unsynced += table("assignments").select(
-        "id,title,due_date,notes,google_event_id,course_code,course_name,courses!left(course_code,course_name)",  # ENCRYPTED LATER (notes)
+        "id,title,due_date,notes,google_event_id,course_code,course_name,courses!left(course_code,course_name)",
         filters={
             "user_id": f"eq.{body.user_id}",
             "google_event_id": "eq.",
@@ -340,7 +341,7 @@ def sync_to_google(body: SyncBody, request: FastAPIRequest):
 
         event = {
             "summary": f"{course_label}{a['title']}" if course_label else a["title"],
-            "description": a.get("notes") or "",  # ENCRYPTED LATER
+            "description": decrypt_if_present(a.get("notes")) or "",
             "start": {"date": a["due_date"]},
             "end": {"date": a["due_date"]},
         }
@@ -366,7 +367,7 @@ def export_to_google(body: ExportBody, request: FastAPIRequest):
     skipped = 0
     for aid in body.assignment_ids:
         rows = table("assignments").select(
-            "id,title,due_date,notes,google_event_id,course_code,course_name,courses!left(course_code,course_name)",  # ENCRYPTED LATER (notes)
+            "id,title,due_date,notes,google_event_id,course_code,course_name,courses!left(course_code,course_name)",
             filters={"id": f"eq.{aid}"},
         )
         if not rows:
@@ -384,7 +385,7 @@ def export_to_google(body: ExportBody, request: FastAPIRequest):
 
         event = {
             "summary": f"{course_label}{a['title']}" if course_label else a["title"],
-            "description": a.get("notes") or "",  # ENCRYPTED LATER
+            "description": decrypt_if_present(a.get("notes")) or "",
             "start": {"date": a["due_date"]},
             "end": {"date": a["due_date"]},
         }

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -237,10 +237,7 @@ def list_documents(user_id: str, request: Request):
         d["summary"] = decrypt_if_present(d.get("summary"))
         notes_raw = d.get("concept_notes")
         if isinstance(notes_raw, str):
-            try:
-                d["concept_notes"] = decrypt_json(notes_raw)
-            except Exception:
-                pass
+            d["concept_notes"] = decrypt_json(notes_raw)
     return {"documents": docs}
 
 
@@ -369,10 +366,7 @@ async def upload_document(
     response["summary"] = decrypt_if_present(response.get("summary"))
     notes_raw = response.get("concept_notes")
     if isinstance(notes_raw, str):
-        try:
-            response["concept_notes"] = decrypt_json(notes_raw)
-        except Exception:
-            pass
+        response["concept_notes"] = decrypt_json(notes_raw)
     response["categories"] = ai.get("categories", [])
     return response
 

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Body, File, Form, HTTPException, Request, UploadF
 
 from db.connection import table
 from services.auth_guard import get_session_user_id, require_self
+from services.encryption import encrypt_if_present, encrypt_json, decrypt_if_present, decrypt_json
 from services.extraction_service import extract_text_from_file
 from services.gemini_service import call_gemini_json
 from services.calendar_service import save_assignments_to_db
@@ -228,10 +229,18 @@ def list_documents(user_id: str, request: Request):
     require_self(user_id, request)
     _validate_user(user_id)
     docs = table("documents").select(
-        "id,user_id,course_id,file_name,category,summary,concept_notes,created_at,processed_at",  # ENCRYPTED LATER
+        "id,user_id,course_id,file_name,category,summary,concept_notes,created_at,processed_at",
         filters={"user_id": f"eq.{user_id}"},
         order="created_at.desc",
-    )
+    ) or []
+    for d in docs:
+        d["summary"] = decrypt_if_present(d.get("summary"))
+        notes_raw = d.get("concept_notes")
+        if isinstance(notes_raw, str):
+            try:
+                d["concept_notes"] = decrypt_json(notes_raw)
+            except Exception:
+                pass
     return {"documents": docs}
 
 
@@ -334,8 +343,8 @@ async def upload_document(
         "course_id": course_id,
         "file_name": filename,
         "category": ai["category"],
-        "summary": ai["summary"] or None,  # ENCRYPTED LATER
-        "concept_notes": ai["concept_notes"],  # ENCRYPTED LATER
+        "summary": encrypt_if_present(ai["summary"] or None),
+        "concept_notes": encrypt_json(ai["concept_notes"]) if ai["concept_notes"] is not None else None,
         "created_at": now,
         "processed_at": now,
     }
@@ -357,6 +366,13 @@ async def upload_document(
         pass
 
     response = dict(inserted[0] if inserted else row)
+    response["summary"] = decrypt_if_present(response.get("summary"))
+    notes_raw = response.get("concept_notes")
+    if isinstance(notes_raw, str):
+        try:
+            response["concept_notes"] = decrypt_json(notes_raw)
+        except Exception:
+            pass
     response["categories"] = ai.get("categories", [])
     return response
 
@@ -430,7 +446,7 @@ def scan_document_concepts(document_id: str, request: Request, body: dict = Body
     _validate_user(user_id)
 
     rows = table("documents").select(
-        "id,user_id,course_id,file_name,summary,concept_notes",  # ENCRYPTED LATER
+        "id,user_id,course_id,file_name,summary,concept_notes",
         filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"},
         limit=1,
     )
@@ -441,12 +457,22 @@ def scan_document_concepts(document_id: str, request: Request, body: dict = Body
     if not course_id:
         raise HTTPException(status_code=400, detail="Document is not associated with a course.")
 
+    doc_summary = decrypt_if_present(doc.get("summary"))
+    notes_raw = doc.get("concept_notes")
+    if isinstance(notes_raw, str):
+        try:
+            doc_concept_notes = decrypt_json(notes_raw)
+        except Exception:
+            doc_concept_notes = []
+    else:
+        doc_concept_notes = notes_raw or []
+
     return _scan_concepts_for_course(
         user_id,
         course_id,
         doc_filename=doc.get("file_name"),
-        doc_summary=doc.get("summary"),  # ENCRYPTED LATER
-        doc_concept_notes=doc.get("concept_notes") or [],  # ENCRYPTED LATER
+        doc_summary=doc_summary,
+        doc_concept_notes=doc_concept_notes
     )
 
 

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -9,9 +9,10 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Body, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Body, File, Form, HTTPException, Request, UploadFile
 
 from db.connection import table
+from services.auth_guard import get_session_user_id, require_self
 from services.extraction_service import extract_text_from_file
 from services.gemini_service import call_gemini_json
 from services.calendar_service import save_assignments_to_db
@@ -223,33 +224,35 @@ def _process_document(filename: str, extracted_text: str) -> dict:
 
 
 @router.get("/user/{user_id}")
-def list_documents(user_id: str):
+def list_documents(user_id: str, request: Request):
+    require_self(user_id, request)
     _validate_user(user_id)
-    docs = table("documents").select("*", filters={"user_id": f"eq.{user_id}"}, order="created_at.desc")
+    docs = table("documents").select(
+        "id,user_id,course_id,file_name,category,summary,concept_notes,created_at,processed_at",  # ENCRYPTED LATER
+        filters={"user_id": f"eq.{user_id}"},
+        order="created_at.desc",
+    )
     return {"documents": docs}
 
 
 @router.delete("/doc/{document_id}")
-def delete_document(document_id: str, user_id: str | None = None):
+def delete_document(document_id: str, request: Request, user_id: str | None = None):
     if user_id:
+        require_self(user_id, request)
         _validate_user(user_id)
-        # Ensure the document belongs to the requesting user
-        docs = table("documents").select("id", filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"}, limit=1)
-        if not docs:
-            raise HTTPException(status_code=404, detail="Document not found.")
-    table("documents").delete(filters={"id": f"eq.{document_id}"})
+    else:
+        user_id = get_session_user_id(request)
+    # Ensure the document belongs to the requesting user
+    docs = table("documents").select("id", filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"}, limit=1)
+    if not docs:
+        raise HTTPException(status_code=404, detail="Document not found.")
+    table("documents").delete(filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"})
     return {"deleted": True}
 
 
 @router.patch("/doc/{document_id}")
-def update_document(document_id: str, body: dict = Body(...)):
+def update_document(document_id: str, request: Request, body: dict = Body(...)):
     """Update mutable fields on a document (currently only category)."""
-    user_id = body.get("user_id")
-    if user_id:
-        _validate_user(user_id)
-        docs = table("documents").select("id", filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"}, limit=1)
-        if not docs:
-            raise HTTPException(status_code=404, detail="Document not found.")
     category = body.get("category")
     if category and category not in VALID_CATEGORIES:
         raise HTTPException(status_code=400, detail=f"Invalid category '{category}'.")
@@ -258,16 +261,27 @@ def update_document(document_id: str, body: dict = Body(...)):
         updates["category"] = category
     if not updates:
         raise HTTPException(status_code=400, detail="No valid fields to update.")
-    updated = table("documents").update(updates, filters={"id": f"eq.{document_id}"})
+    user_id = body.get("user_id")
+    if user_id:
+        require_self(user_id, request)
+        _validate_user(user_id)
+    else:
+        user_id = get_session_user_id(request)
+    docs = table("documents").select("id", filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"}, limit=1)
+    if not docs:
+        raise HTTPException(status_code=404, detail="Document not found.")
+    updated = table("documents").update(updates, filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"})
     return updated[0] if updated else {"id": document_id, **updates}
 
 
 @router.post("/upload")
 async def upload_document(
+    request: Request,
     file: UploadFile = File(...),
     course_id: str = Form(...),
     user_id: str = Form(...),
 ):
+    require_self(user_id, request)
     _validate_user(user_id)
 
     # ── Validation ────────────────────────────────────────────────────────────
@@ -320,8 +334,8 @@ async def upload_document(
         "course_id": course_id,
         "file_name": filename,
         "category": ai["category"],
-        "summary": ai["summary"] or None,
-        "concept_notes": ai["concept_notes"],
+        "summary": ai["summary"] or None,  # ENCRYPTED LATER
+        "concept_notes": ai["concept_notes"],  # ENCRYPTED LATER
         "created_at": now,
         "processed_at": now,
     }
@@ -406,16 +420,17 @@ def _scan_concepts_for_course(
 
 
 @router.post("/doc/{document_id}/scan-concepts")
-def scan_document_concepts(document_id: str, body: dict = Body(...)):
+def scan_document_concepts(document_id: str, request: Request, body: dict = Body(...)):
     """Extend the course's concept graph using one document's stored
     summary + takeaways as the seed signal."""
     user_id = body.get("user_id")
     if not user_id:
         raise HTTPException(status_code=400, detail="user_id is required.")
+    require_self(user_id, request)
     _validate_user(user_id)
 
     rows = table("documents").select(
-        "id,user_id,course_id,file_name,summary,concept_notes",
+        "id,user_id,course_id,file_name,summary,concept_notes",  # ENCRYPTED LATER
         filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"},
         limit=1,
     )
@@ -430,17 +445,18 @@ def scan_document_concepts(document_id: str, body: dict = Body(...)):
         user_id,
         course_id,
         doc_filename=doc.get("file_name"),
-        doc_summary=doc.get("summary"),
-        doc_concept_notes=doc.get("concept_notes") or [],
+        doc_summary=doc.get("summary"),  # ENCRYPTED LATER
+        doc_concept_notes=doc.get("concept_notes") or [],  # ENCRYPTED LATER
     )
 
 
 @router.post("/course/{course_id}/scan-concepts")
-def scan_course_concepts(course_id: str, body: dict = Body(...)):
+def scan_course_concepts(course_id: str, request: Request, body: dict = Body(...)):
     """Extend the course's concept graph from the course label alone
     (and whatever is already in the graph)."""
     user_id = body.get("user_id")
     if not user_id:
         raise HTTPException(status_code=400, detail="user_id is required.")
+    require_self(user_id, request)
     _validate_user(user_id)
     return _scan_concepts_for_course(user_id, course_id)

--- a/backend/routes/flashcards.py
+++ b/backend/routes/flashcards.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import uuid
 from datetime import datetime
 from typing import Literal
@@ -93,8 +94,13 @@ def _get_session_summary(session_id: str) -> str:
         )
         if not rows or not rows[0].get("summary_json"):
             return ""
-        import json
-        return json.dumps(rows[0]["summary_json"])
+        raw = rows[0]["summary_json"]
+        if isinstance(raw, str):
+            try:
+                return json.dumps(decrypt_json(raw))
+            except Exception:
+                return raw
+        return json.dumps(raw)
     except Exception:
         return ""
 

--- a/backend/routes/flashcards.py
+++ b/backend/routes/flashcards.py
@@ -13,6 +13,7 @@ from db.connection import table
 from services.gemini_service import generate_flashcards as _generate
 from services.auth_guard import require_self, get_session_user_id
 from services.achievement_service import check_achievements
+from services.encryption import decrypt_if_present, decrypt_json
 from services.flashcard_import_service import (
     dedup_against_existing,
     check_rate_limit,
@@ -104,23 +105,30 @@ def _get_course_documents(user_id: str, course_name: str) -> list[dict]:
     matching `course_name`. Falls back to all user documents if no course match.
     """
     try:
-        # Find the course_id for this course name
         course_rows = table("courses").select(
             "id", filters={"user_id": f"eq.{user_id}", "course_name": f"eq.{course_name}"}, limit=1
         )
         if course_rows:
             course_id = course_rows[0]["id"]
             docs = table("documents").select(
-                "file_name,category,summary,concept_notes",  # ENCRYPTED LATER
+                "file_name,category,summary,concept_notes",
                 filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
             )
         else:
-            # Topic might be a concept name — still pull all user docs as context
             docs = table("documents").select(
-                "file_name,category,summary,concept_notes",  # ENCRYPTED LATER
+                "file_name,category,summary,concept_notes",
                 filters={"user_id": f"eq.{user_id}"},
             )
-        return docs or []
+        docs = docs or []
+        for d in docs:
+            d["summary"] = decrypt_if_present(d.get("summary"))
+            notes_raw = d.get("concept_notes")
+            if isinstance(notes_raw, str):
+                try:
+                    d["concept_notes"] = decrypt_json(notes_raw)
+                except Exception:
+                    pass
+        return docs
     except Exception:
         return []
 
@@ -403,14 +411,23 @@ def import_generate(body: ImportGenerateBody, request: Request):
         if not body.document_id:
             raise HTTPException(status_code=400, detail="`document_id` is required for library_doc source")
         rows = table("documents").select(
-            "id,user_id,summary,concept_notes,file_name",  # ENCRYPTED LATER
+            "id,user_id,summary,concept_notes,file_name",
             filters={"id": f"eq.{body.document_id}", "user_id": f"eq.{body.user_id}"},
             limit=1,
         )
         if not rows:
             raise HTTPException(status_code=404, detail="Document not found")
         doc = rows[0]
-        parts = [doc.get("summary") or "", str(doc.get("concept_notes") or {})]  # ENCRYPTED LATER
+        doc_summary = decrypt_if_present(doc.get("summary")) or ""
+        notes_raw = doc.get("concept_notes")
+        if isinstance(notes_raw, str):
+            try:
+                doc_notes = decrypt_json(notes_raw)
+            except Exception:
+                doc_notes = notes_raw
+        else:
+            doc_notes = notes_raw or {}
+        parts = [doc_summary, str(doc_notes)]
         source_text = "\n\n".join(p for p in parts if p)
 
     try:

--- a/backend/routes/flashcards.py
+++ b/backend/routes/flashcards.py
@@ -130,10 +130,7 @@ def _get_course_documents(user_id: str, course_name: str) -> list[dict]:
             d["summary"] = decrypt_if_present(d.get("summary"))
             notes_raw = d.get("concept_notes")
             if isinstance(notes_raw, str):
-                try:
-                    d["concept_notes"] = decrypt_json(notes_raw)
-                except Exception:
-                    pass
+                d["concept_notes"] = decrypt_json(notes_raw)
         return docs
     except Exception:
         return []

--- a/backend/routes/flashcards.py
+++ b/backend/routes/flashcards.py
@@ -111,13 +111,13 @@ def _get_course_documents(user_id: str, course_name: str) -> list[dict]:
         if course_rows:
             course_id = course_rows[0]["id"]
             docs = table("documents").select(
-                "file_name,category,summary,concept_notes",
+                "file_name,category,summary,concept_notes",  # ENCRYPTED LATER
                 filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
             )
         else:
             # Topic might be a concept name — still pull all user docs as context
             docs = table("documents").select(
-                "file_name,category,summary,concept_notes",
+                "file_name,category,summary,concept_notes",  # ENCRYPTED LATER
                 filters={"user_id": f"eq.{user_id}"},
             )
         return docs or []
@@ -154,11 +154,13 @@ def _get_weak_concepts(user_id: str, course_name: str) -> list[str]:
 # ── Routes ─────────────────────────────────────────────────────────────────────
 
 @router.post("/generate")
-def generate(body: GenerateFlashcardsBody):
+def generate(body: GenerateFlashcardsBody, request: Request):
     """
     Generate AI flashcards grounded in the student's actual course material.
     Pulls library documents + weak concepts from the knowledge graph automatically.
     """
+    require_self(body.user_id, request)
+
     # 1. Session summary (optional extra context)
     context = ""
     if body.session_id:
@@ -223,7 +225,9 @@ def generate(body: GenerateFlashcardsBody):
 
 
 @router.get("/user/{user_id}")
-def get_flashcards(user_id: str, topic: str | None = None):
+def get_flashcards(user_id: str, request: Request, topic: str | None = None):
+    require_self(user_id, request)
+
     if not user_id:
         return {"flashcards": []}
 
@@ -233,7 +237,8 @@ def get_flashcards(user_id: str, topic: str | None = None):
 
     try:
         rows = table("flashcards").select(
-            "*", filters=filters, order="created_at.desc"
+            "id,user_id,topic,course_id,front,back,times_reviewed,last_rating,last_reviewed_at,created_at",
+            filters=filters, order="created_at.desc"
         )
         return {"flashcards": rows or []}
     except Exception as e:
@@ -244,7 +249,9 @@ def get_flashcards(user_id: str, topic: str | None = None):
 
 
 @router.post("/rate")
-def rate_card(body: FlashcardRatingBody):
+def rate_card(body: FlashcardRatingBody, request: Request):
+    require_self(body.user_id, request)
+
     try:
         rows = table("flashcards").select(
             "id,times_reviewed",
@@ -270,7 +277,9 @@ def rate_card(body: FlashcardRatingBody):
 
 
 @router.delete("/{card_id}")
-def delete_card(card_id: str, user_id: str):
+def delete_card(card_id: str, user_id: str, request: Request):
+    require_self(user_id, request)
+
     try:
         rows = table("flashcards").select(
             "id",
@@ -394,14 +403,14 @@ def import_generate(body: ImportGenerateBody, request: Request):
         if not body.document_id:
             raise HTTPException(status_code=400, detail="`document_id` is required for library_doc source")
         rows = table("documents").select(
-            "id,user_id,summary,concept_notes,file_name",
+            "id,user_id,summary,concept_notes,file_name",  # ENCRYPTED LATER
             filters={"id": f"eq.{body.document_id}", "user_id": f"eq.{body.user_id}"},
             limit=1,
         )
         if not rows:
             raise HTTPException(status_code=404, detail="Document not found")
         doc = rows[0]
-        parts = [doc.get("summary") or "", str(doc.get("concept_notes") or {})]
+        parts = [doc.get("summary") or "", str(doc.get("concept_notes") or {})]  # ENCRYPTED LATER
         source_text = "\n\n".join(p for p in parts if p)
 
     try:

--- a/backend/routes/gradebook.py
+++ b/backend/routes/gradebook.py
@@ -21,6 +21,7 @@ from models import (
 )
 from services import gradebook_service
 from services.auth_guard import require_self
+from services.encryption import encrypt_if_present, decrypt_if_present, decrypt_numeric
 
 router = APIRouter()
 
@@ -67,9 +68,13 @@ def get_summary(request: Request, user_id: str = Query(...), semester: str = Que
         filters={"user_id": f"eq.{user_id}", "course_id": in_clause},
     )
     assigns = table("assignments").select(
-        "id,course_id,category_id,points_possible,points_earned",  # ENCRYPTED LATER
+        "id,course_id,category_id,points_possible,points_earned",
         filters={"user_id": f"eq.{user_id}", "course_id": in_clause},
     )
+
+    for a in assigns:
+        a["points_possible"] = decrypt_numeric(a.get("points_possible"))
+        a["points_earned"] = decrypt_numeric(a.get("points_earned"))
 
     cats_by_course: dict[str, list] = {cid: [] for cid in course_ids}
     for c in cats:
@@ -84,7 +89,7 @@ def get_summary(request: Request, user_id: str = Query(...), semester: str = Que
         course = e["courses"]
         course_assigns = assigns_by_course[cid]
         graded = [a for a in course_assigns
-                  if a.get("points_possible") and a.get("points_earned") is not None]  # ENCRYPTED LATER
+                  if a.get("points_possible") and a.get("points_earned") is not None]
         percent = gradebook_service.current_grade(cats_by_course[cid], course_assigns)
         letter = gradebook_service.letter_for(percent, e.get("letter_scale"))
         out.append({
@@ -121,10 +126,14 @@ def get_course(course_id: str, request: Request, user_id: str = Query(...)):
         order="sort_order.asc",
     )
     assigns = table("assignments").select(
-        "id,user_id,course_id,category_id,title,due_date,assignment_type,points_possible,points_earned,notes,source",  # ENCRYPTED LATER
+        "id,user_id,course_id,category_id,title,due_date,assignment_type,points_possible,points_earned,notes,source",
         filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
         order="due_date.asc",
     )
+    for a in assigns:
+        a["points_possible"] = decrypt_numeric(a.get("points_possible"))
+        a["points_earned"] = decrypt_numeric(a.get("points_earned"))
+        a["notes"] = decrypt_if_present(a.get("notes"))
 
     # Per-category grade for the UI.
     by_cat: dict[str, list] = {c["id"]: [] for c in cats}
@@ -236,11 +245,11 @@ def create_assignment(body: CreateAssignmentBody, request: Request):
         "course_id": body.course_id,
         "title": body.title,
         "category_id": body.category_id,
-        "points_possible": body.points_possible,  # ENCRYPTED LATER
-        "points_earned": body.points_earned,  # ENCRYPTED LATER
+        "points_possible": encrypt_if_present(body.points_possible),
+        "points_earned": encrypt_if_present(body.points_earned),
         "due_date": body.due_date,
         "assignment_type": body.assignment_type,
-        "notes": body.notes,  # ENCRYPTED LATER
+        "notes": encrypt_if_present(body.notes),
         "source": "manual",
     })
     return {"assignment": inserted[0] if inserted else None}
@@ -256,11 +265,11 @@ def update_assignment_route(assignment_id: str, body: UpdateAssignmentBody, requ
 
     incoming = body.model_dump(exclude_unset=True, exclude={"user_id"})
     ALLOWED = {"title", "category_id", "due_date", "assignment_type"}
-    ENCRYPTED_FIELDS = {"points_possible", "points_earned", "notes"}  # ENCRYPTED LATER
+    ENCRYPTED_FIELDS = {"points_possible", "points_earned", "notes"}
     patch_data = {k: v for k, v in incoming.items() if k in ALLOWED}
     for k in ENCRYPTED_FIELDS:
         if k in incoming:
-            patch_data[k] = incoming[k]  # ENCRYPTED LATER
+            patch_data[k] = encrypt_if_present(incoming[k])
     if not patch_data:
         return {"updated": False}
     table("assignments").update(
@@ -350,10 +359,10 @@ def apply_syllabus(body: SyllabusApplyBody, request: Request):
             "title": title,
             "due_date": a.get("due_date"),
             "assignment_type": a.get("assignment_type"),
-            "notes": a.get("notes"),  # ENCRYPTED LATER
+            "notes": encrypt_if_present(a.get("notes")),
             "category_id": None,
-            "points_possible": None,  # ENCRYPTED LATER
-            "points_earned": None,  # ENCRYPTED LATER
+            "points_possible": None,
+            "points_earned": None,
             "source": "syllabus",
         })
     if new_assigns:

--- a/backend/routes/gradebook.py
+++ b/backend/routes/gradebook.py
@@ -36,7 +36,7 @@ def _user_owns_course(user_id: str, course_id: str) -> bool:
 
 def _user_owns_category(user_id: str, category_id: str) -> dict | None:
     rows = table("course_categories").select(
-        "*",
+        "id,user_id,course_id,name,weight,sort_order",
         filters={"id": f"eq.{category_id}", "user_id": f"eq.{user_id}"},
         limit=1,
     )
@@ -63,11 +63,11 @@ def get_summary(request: Request, user_id: str = Query(...), semester: str = Que
     in_clause = "in.(" + ",".join(course_ids) + ")"
 
     cats = table("course_categories").select(
-        "*",
+        "id,user_id,course_id,name,weight,sort_order",
         filters={"user_id": f"eq.{user_id}", "course_id": in_clause},
     )
     assigns = table("assignments").select(
-        "id,course_id,category_id,points_possible,points_earned",
+        "id,course_id,category_id,points_possible,points_earned",  # ENCRYPTED LATER
         filters={"user_id": f"eq.{user_id}", "course_id": in_clause},
     )
 
@@ -84,7 +84,7 @@ def get_summary(request: Request, user_id: str = Query(...), semester: str = Que
         course = e["courses"]
         course_assigns = assigns_by_course[cid]
         graded = [a for a in course_assigns
-                  if a.get("points_possible") and a.get("points_earned") is not None]
+                  if a.get("points_possible") and a.get("points_earned") is not None]  # ENCRYPTED LATER
         percent = gradebook_service.current_grade(cats_by_course[cid], course_assigns)
         letter = gradebook_service.letter_for(percent, e.get("letter_scale"))
         out.append({
@@ -116,12 +116,12 @@ def get_course(course_id: str, request: Request, user_id: str = Query(...)):
     letter_scale = enrollment[0].get("letter_scale")
 
     cats = table("course_categories").select(
-        "*",
+        "id,user_id,course_id,name,weight,sort_order",
         filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
         order="sort_order.asc",
     )
     assigns = table("assignments").select(
-        "*",
+        "id,user_id,course_id,category_id,title,due_date,assignment_type,points_possible,points_earned,notes,source",  # ENCRYPTED LATER
         filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
         order="due_date.asc",
     )
@@ -214,7 +214,7 @@ def delete_category(category_id: str, request: Request, user_id: str = Query(...
 
 def _user_owns_assignment(user_id: str, assignment_id: str) -> dict | None:
     rows = table("assignments").select(
-        "*",
+        "id,user_id,course_id,category_id",
         filters={"id": f"eq.{assignment_id}", "user_id": f"eq.{user_id}"},
         limit=1,
     )
@@ -236,11 +236,11 @@ def create_assignment(body: CreateAssignmentBody, request: Request):
         "course_id": body.course_id,
         "title": body.title,
         "category_id": body.category_id,
-        "points_possible": body.points_possible,
-        "points_earned": body.points_earned,
+        "points_possible": body.points_possible,  # ENCRYPTED LATER
+        "points_earned": body.points_earned,  # ENCRYPTED LATER
         "due_date": body.due_date,
         "assignment_type": body.assignment_type,
-        "notes": body.notes,
+        "notes": body.notes,  # ENCRYPTED LATER
         "source": "manual",
     })
     return {"assignment": inserted[0] if inserted else None}
@@ -254,7 +254,13 @@ def update_assignment_route(assignment_id: str, body: UpdateAssignmentBody, requ
     if body.category_id and not _user_owns_category(body.user_id, body.category_id):
         raise HTTPException(status_code=400, detail="Category not in your gradebook")
 
-    patch_data = body.model_dump(exclude_unset=True, exclude={"user_id"})
+    incoming = body.model_dump(exclude_unset=True, exclude={"user_id"})
+    ALLOWED = {"title", "category_id", "due_date", "assignment_type"}
+    ENCRYPTED_FIELDS = {"points_possible", "points_earned", "notes"}  # ENCRYPTED LATER
+    patch_data = {k: v for k, v in incoming.items() if k in ALLOWED}
+    for k in ENCRYPTED_FIELDS:
+        if k in incoming:
+            patch_data[k] = incoming[k]  # ENCRYPTED LATER
     if not patch_data:
         return {"updated": False}
     table("assignments").update(
@@ -344,10 +350,10 @@ def apply_syllabus(body: SyllabusApplyBody, request: Request):
             "title": title,
             "due_date": a.get("due_date"),
             "assignment_type": a.get("assignment_type"),
-            "notes": a.get("notes"),
+            "notes": a.get("notes"),  # ENCRYPTED LATER
             "category_id": None,
-            "points_possible": None,
-            "points_earned": None,
+            "points_possible": None,  # ENCRYPTED LATER
+            "points_earned": None,  # ENCRYPTED LATER
             "source": "syllabus",
         })
     if new_assigns:

--- a/backend/routes/graph.py
+++ b/backend/routes/graph.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from typing import Optional
 
+from services.auth_guard import require_self
 from services.graph_service import (
     get_graph, get_recommendations,
     get_courses, add_course, delete_course, update_course_color,
@@ -12,12 +13,14 @@ router = APIRouter()
 
 
 @router.get("/{user_id}")
-def get_user_graph(user_id: str):
+def get_user_graph(user_id: str, request: Request):
+    require_self(user_id, request)
     return get_graph(user_id)
 
 
 @router.get("/{user_id}/recommendations")
-def get_user_recommendations(user_id: str):
+def get_user_recommendations(user_id: str, request: Request):
+    require_self(user_id, request)
     return {"recommendations": get_recommendations(user_id)}
 
 
@@ -38,12 +41,14 @@ class UpdateNodeColorBody(BaseModel):
 
 
 @router.get("/{user_id}/courses")
-def list_courses(user_id: str):
+def list_courses(user_id: str, request: Request):
+    require_self(user_id, request)
     return {"courses": get_courses(user_id)}
 
 
 @router.post("/{user_id}/courses")
-def create_course(user_id: str, body: AddCourseBody):
+def create_course(user_id: str, body: AddCourseBody, request: Request):
+    require_self(user_id, request)
     result = add_course(user_id, body.course_id, body.color, body.nickname)
     if "error" in result:
         raise HTTPException(status_code=404, detail=result["error"])
@@ -51,19 +56,22 @@ def create_course(user_id: str, body: AddCourseBody):
 
 
 @router.patch("/{user_id}/courses/{course_id}/color")
-def set_course_color(user_id: str, course_id: str, body: UpdateCourseColorBody):
+def set_course_color(user_id: str, course_id: str, body: UpdateCourseColorBody, request: Request):
+    require_self(user_id, request)
     return update_course_color(user_id, course_id, body.color)
 
 
 @router.delete("/{user_id}/courses/{course_id}")
-def remove_course(user_id: str, course_id: str):
+def remove_course(user_id: str, course_id: str, request: Request):
+    require_self(user_id, request)
     return delete_course(user_id, course_id)
 
 
 # ── Node endpoints ───────────────────────────────────────────────────────────
 
 @router.delete("/{user_id}/nodes/{node_id}")
-def remove_node(user_id: str, node_id: str):
+def remove_node(user_id: str, node_id: str, request: Request):
+    require_self(user_id, request)
     result = delete_node(user_id, node_id)
     if "error" in result:
         raise HTTPException(status_code=404, detail=result["error"])
@@ -71,7 +79,8 @@ def remove_node(user_id: str, node_id: str):
 
 
 @router.patch("/{user_id}/nodes/{node_id}/color")
-def set_node_color(user_id: str, node_id: str, body: UpdateNodeColorBody):
+def set_node_color(user_id: str, node_id: str, body: UpdateNodeColorBody, request: Request):
+    require_self(user_id, request)
     result = update_node_color(user_id, node_id, body.color)
     if "error" in result:
         raise HTTPException(status_code=404, detail=result["error"])

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from db.connection import table
 from models import StartSessionBody, ChatBody, EndSessionBody, ActionBody, ModeSwitchBody
 from services.auth_guard import require_self, get_session_user_id
+from services.encryption import decrypt_if_present, decrypt_json
 from services.gemini_service import call_gemini_multiturn, extract_graph_update
 from services.graph_service import get_graph, apply_graph_update
 
@@ -122,10 +123,18 @@ def _get_course_documents(user_id: str, course_id: str) -> list:
         return []
     try:
         docs = table("documents").select(
-            "file_name,category,summary,concept_notes",  # ENCRYPTED LATER
+            "file_name,category,summary,concept_notes",
             filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
-        )
-        return docs or []
+        ) or []
+        for d in docs:
+            d["summary"] = decrypt_if_present(d.get("summary"))
+            notes_raw = d.get("concept_notes")
+            if isinstance(notes_raw, str):
+                try:
+                    d["concept_notes"] = decrypt_json(notes_raw)
+                except Exception:
+                    pass
+        return docs
     except Exception:
         return []
 
@@ -172,9 +181,9 @@ def build_system_prompt(
         doc_blocks = []
         for doc in documents:
             lines = [f"[{(doc.get('category') or 'document').upper()}] {doc.get('file_name', '')}"]
-            if doc.get("summary"):  # ENCRYPTED LATER
-                lines.append(f"Summary: {doc['summary']}")  # ENCRYPTED LATER
-            notes = doc.get("concept_notes")  # ENCRYPTED LATER
+            if doc.get("summary"):
+                lines.append(f"Summary: {doc['summary']}")
+            notes = doc.get("concept_notes")
             if notes and isinstance(notes, list):
                 concept_lines = []
                 for n in notes:
@@ -231,8 +240,10 @@ def save_message(session_id: str, role: str, content: str, graph_update: dict = 
 
 
 def get_user_name(user_id: str) -> str:
-    rows = table("users").select("name", filters={"id": f"eq.{user_id}"})  # ENCRYPTED LATER
-    return rows[0]["name"] if rows else "Student"  # ENCRYPTED LATER
+    rows = table("users").select("name", filters={"id": f"eq.{user_id}"})
+    if not rows:
+        return "Student"
+    return decrypt_if_present(rows[0]["name"]) or "Student"
 
 
 def _consume_pending(session_id: str, user_id: str) -> None:

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -5,10 +5,11 @@ import json
 import os
 from datetime import datetime
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from db.connection import table
 from models import StartSessionBody, ChatBody, EndSessionBody, ActionBody, ModeSwitchBody
+from services.auth_guard import require_self, get_session_user_id
 from services.gemini_service import call_gemini_multiturn, extract_graph_update
 from services.graph_service import get_graph, apply_graph_update
 
@@ -121,7 +122,7 @@ def _get_course_documents(user_id: str, course_id: str) -> list:
         return []
     try:
         docs = table("documents").select(
-            "file_name,category,summary,concept_notes",
+            "file_name,category,summary,concept_notes",  # ENCRYPTED LATER
             filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
         )
         return docs or []
@@ -171,9 +172,9 @@ def build_system_prompt(
         doc_blocks = []
         for doc in documents:
             lines = [f"[{(doc.get('category') or 'document').upper()}] {doc.get('file_name', '')}"]
-            if doc.get("summary"):
-                lines.append(f"Summary: {doc['summary']}")
-            notes = doc.get("concept_notes")
+            if doc.get("summary"):  # ENCRYPTED LATER
+                lines.append(f"Summary: {doc['summary']}")  # ENCRYPTED LATER
+            notes = doc.get("concept_notes")  # ENCRYPTED LATER
             if notes and isinstance(notes, list):
                 concept_lines = []
                 for n in notes:
@@ -230,8 +231,8 @@ def save_message(session_id: str, role: str, content: str, graph_update: dict = 
 
 
 def get_user_name(user_id: str) -> str:
-    rows = table("users").select("name", filters={"id": f"eq.{user_id}"})
-    return rows[0]["name"] if rows else "Student"
+    rows = table("users").select("name", filters={"id": f"eq.{user_id}"})  # ENCRYPTED LATER
+    return rows[0]["name"] if rows else "Student"  # ENCRYPTED LATER
 
 
 def _consume_pending(session_id: str, user_id: str) -> None:
@@ -262,7 +263,8 @@ def _ensure_session_ready(session_id: str, user_id: str) -> None:
 
 
 @router.post("/start-session")
-def start_session(body: StartSessionBody):
+def start_session(body: StartSessionBody, request: Request):
+    require_self(body.user_id, request)
     session_id = str(uuid.uuid4())
 
     student_name = get_user_name(body.user_id)
@@ -308,7 +310,8 @@ def start_session(body: StartSessionBody):
 
 
 @router.post("/chat")
-def chat(body: ChatBody):
+def chat(body: ChatBody, request: Request):
+    require_self(body.user_id, request)
     _consume_pending(body.session_id, body.user_id)
     save_message(body.session_id, "user", body.message)
 
@@ -340,7 +343,11 @@ def chat(body: ChatBody):
 
 
 @router.post("/end-session")
-def end_session(body: EndSessionBody):
+def end_session(body: EndSessionBody, request: Request):
+    if body.user_id:
+        require_self(body.user_id, request)
+    else:
+        body.user_id = get_session_user_id(request)
     if body.session_id in PENDING_SESSIONS:
         pending = PENDING_SESSIONS[body.session_id]
         if body.user_id and pending["user_id"] != body.user_id:
@@ -420,9 +427,10 @@ def end_session(body: EndSessionBody):
 
 
 @router.get("/sessions/{user_id}")
-def list_sessions(user_id: str, limit: int = 10):
+def list_sessions(user_id: str, request: Request, limit: int = 10):
+    require_self(user_id, request)
     sessions = table("sessions").select(
-        "*",
+        "id,user_id,topic,mode,course_id,started_at,ended_at",
         filters={"user_id": f"eq.{user_id}"},
         order="started_at.desc",
         limit=limit,
@@ -444,22 +452,35 @@ def list_sessions(user_id: str, limit: int = 10):
 
 
 @router.delete("/sessions/{session_id}")
-def delete_session(session_id: str, user_id: str | None = Query(None)):
+def delete_session(session_id: str, request: Request, user_id: str | None = Query(None)):
+    if user_id:
+        require_self(user_id, request)
+    else:
+        user_id = get_session_user_id(request)
     if session_id in PENDING_SESSIONS:
         pending = PENDING_SESSIONS[session_id]
-        if user_id and pending["user_id"] != user_id:
+        if pending["user_id"] != user_id:
             raise HTTPException(status_code=403, detail="Session user mismatch")
         PENDING_SESSIONS.pop(session_id, None)
         return {"deleted": True}
+    # Verify the session belongs to the authenticated user before deleting
+    owner_rows = table("sessions").select(
+        "user_id", filters={"id": f"eq.{session_id}"}, limit=1
+    )
+    if owner_rows and owner_rows[0].get("user_id") != user_id:
+        raise HTTPException(status_code=403, detail="Session user mismatch")
     table("messages").delete({"session_id": f"eq.{session_id}"})
     table("sessions").delete({"id": f"eq.{session_id}"})
     return {"deleted": True}
 
 
 @router.get("/sessions/{session_id}/resume")
-def resume_session(session_id: str):
+def resume_session(session_id: str, request: Request):
+    user_id = get_session_user_id(request)
     if session_id in PENDING_SESSIONS:
         p = PENDING_SESSIONS[session_id]
+        if p["user_id"] != user_id:
+            raise HTTPException(status_code=403, detail="Session user mismatch")
         now = datetime.utcnow().isoformat()
         return {
             "session": {
@@ -487,6 +508,8 @@ def resume_session(session_id: str):
     )
     if not session_rows:
         raise HTTPException(status_code=404, detail="Session not found")
+    if session_rows[0].get("user_id") != user_id:
+        raise HTTPException(status_code=403, detail="Session user mismatch")
 
     msgs = table("messages").select(
         "id,role,content,created_at",
@@ -500,7 +523,8 @@ def resume_session(session_id: str):
 
 
 @router.post("/action")
-def action(body: ActionBody):
+def action(body: ActionBody, request: Request):
+    require_self(body.user_id, request)
     _ensure_session_ready(body.session_id, body.user_id)
     action_prompts = {
         "hint": "The student asked for a hint. Give a small scaffold or clue without giving away the answer.",
@@ -535,7 +559,8 @@ def action(body: ActionBody):
 
 
 @router.post("/mode-switch")
-def mode_switch(body: ModeSwitchBody):
+def mode_switch(body: ModeSwitchBody, request: Request):
+    require_self(body.user_id, request)
     _ensure_session_ready(body.session_id, body.user_id)
     student_name = get_user_name(body.user_id).split()[0]
     session_rows = table("sessions").select(

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -130,10 +130,7 @@ def _get_course_documents(user_id: str, course_id: str) -> list:
             d["summary"] = decrypt_if_present(d.get("summary"))
             notes_raw = d.get("concept_notes")
             if isinstance(notes_raw, str):
-                try:
-                    d["concept_notes"] = decrypt_json(notes_raw)
-                except Exception:
-                    pass
+                d["concept_notes"] = decrypt_json(notes_raw)
         return docs
     except Exception:
         return []
@@ -529,7 +526,9 @@ def resume_session(session_id: str, request: Request):
     )
     return {
         "session": session_rows[0],
-        "messages": msgs,
+        "messages": [
+            {**m, "content": decrypt_if_present(m["content"])} for m in msgs
+        ],
     }
 
 

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from db.connection import table
 from models import StartSessionBody, ChatBody, EndSessionBody, ActionBody, ModeSwitchBody
 from services.auth_guard import require_self, get_session_user_id
-from services.encryption import decrypt_if_present, decrypt_json
+from services.encryption import encrypt_if_present, encrypt_json, decrypt_if_present, decrypt_json
 from services.gemini_service import call_gemini_multiturn, extract_graph_update
 from services.graph_service import get_graph, apply_graph_update
 
@@ -225,7 +225,7 @@ def get_conversation_history(session_id: str) -> list:
         filters={"session_id": f"eq.{session_id}"},
         order="created_at.asc",
     )
-    return [{"role": r["role"], "content": r["content"]} for r in rows]
+    return [{"role": r["role"], "content": decrypt_if_present(r["content"])} for r in rows]
 
 
 def save_message(session_id: str, role: str, content: str, graph_update: dict = None):
@@ -233,7 +233,7 @@ def save_message(session_id: str, role: str, content: str, graph_update: dict = 
         "id": str(uuid.uuid4()),
         "session_id": session_id,
         "role": role,
-        "content": content,
+        "content": encrypt_if_present(content),
         "graph_update_json": graph_update if graph_update else None,
         "created_at": datetime.utcnow().isoformat(),
     })
@@ -421,7 +421,7 @@ def end_session(body: EndSessionBody, request: Request):
     }
 
     table("sessions").update(
-        {"summary_json": summary},
+        {"summary_json": encrypt_json(summary)},
         filters={"id": f"eq.{body.session_id}"},
     )
 

--- a/backend/routes/onboarding.py
+++ b/backend/routes/onboarding.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from db.connection import table
 from models import OnboardingBody
 from services.auth_guard import require_self
+from services.encryption import encrypt_if_present
 
 router = APIRouter()
 
@@ -36,12 +37,12 @@ def save_onboarding_profile(body: OnboardingBody, request: Request):
         raise HTTPException(status_code=404, detail="User not found")
 
     # Update user profile fields
-    name = f"{body.first_name} {body.last_name}".strip()  # ENCRYPTED LATER
+    name = f"{body.first_name} {body.last_name}".strip()
     table("users").update(
         {
-            "name": name,  # ENCRYPTED LATER
-            "first_name": body.first_name,  # ENCRYPTED LATER
-            "last_name": body.last_name,  # ENCRYPTED LATER
+            "name": encrypt_if_present(name),
+            "first_name": encrypt_if_present(body.first_name),
+            "last_name": encrypt_if_present(body.last_name),
             "year": body.year,
             "majors": body.majors,
             "minors": body.minors,

--- a/backend/routes/onboarding.py
+++ b/backend/routes/onboarding.py
@@ -1,15 +1,16 @@
 import uuid
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from db.connection import table
 from models import OnboardingBody
+from services.auth_guard import require_self
 
 router = APIRouter()
 
 
 @router.get("/courses")
-def search_courses(q: str = Query("", min_length=0)):
+def search_courses(request: Request, q: str = Query("", min_length=0)):
     """Search courses by name or code. Returns all if q is empty."""
     filters = {}
     if q.strip():
@@ -25,8 +26,9 @@ def search_courses(q: str = Query("", min_length=0)):
 
 
 @router.post("/profile")
-def save_onboarding_profile(body: OnboardingBody):
+def save_onboarding_profile(body: OnboardingBody, request: Request):
     """Save the onboarding form data for an existing user."""
+    require_self(body.user_id, request)
 
     # Verify user exists
     user = table("users").select("id", filters={"id": f"eq.{body.user_id}"})
@@ -34,12 +36,12 @@ def save_onboarding_profile(body: OnboardingBody):
         raise HTTPException(status_code=404, detail="User not found")
 
     # Update user profile fields
-    name = f"{body.first_name} {body.last_name}".strip()
+    name = f"{body.first_name} {body.last_name}".strip()  # ENCRYPTED LATER
     table("users").update(
         {
-            "name": name,
-            "first_name": body.first_name,
-            "last_name": body.last_name,
+            "name": name,  # ENCRYPTED LATER
+            "first_name": body.first_name,  # ENCRYPTED LATER
+            "last_name": body.last_name,  # ENCRYPTED LATER
             "year": body.year,
             "majors": body.majors,
             "minors": body.minors,

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -25,18 +25,31 @@ router = APIRouter()
 
 
 def _get_user_or_404(user_id: str) -> dict:
-    rows = table("users").select("*", filters={"id": f"eq.{user_id}"})
+    rows = table("users").select(
+        "id,username,name,first_name,last_name,email,avatar_url,school,major,year,majors,minors,bio,location,website,streak_count,created_at",  # ENCRYPTED LATER
+        filters={"id": f"eq.{user_id}"},
+    )
     if not rows:
         raise HTTPException(status_code=404, detail="User not found")
     return rows[0]
 
 
+_SETTINGS_COLS = (
+    "user_id,username,display_name,bio,location,website,"  # ENCRYPTED LATER
+    "profile_visibility,activity_status_visible,"
+    "notification_email,notification_push,notification_in_app,"
+    "theme,font_size,accent_color,"
+    "equipped_avatar_frame_id,equipped_banner_id,equipped_name_color_id,equipped_title_id,"
+    "featured_role_id,featured_achievement_ids,updated_at"
+)
+
+
 def _get_or_create_settings(user_id: str) -> dict:
-    rows = table("user_settings").select("*", filters={"user_id": f"eq.{user_id}"})
+    rows = table("user_settings").select(_SETTINGS_COLS, filters={"user_id": f"eq.{user_id}"})
     if rows:
         return rows[0]
     table("user_settings").insert({"user_id": user_id})
-    rows = table("user_settings").select("*", filters={"user_id": f"eq.{user_id}"})
+    rows = table("user_settings").select(_SETTINGS_COLS, filters={"user_id": f"eq.{user_id}"})
     return rows[0] if rows else {"user_id": user_id}
 
 
@@ -66,13 +79,19 @@ def _get_equipped_cosmetics(settings: dict) -> dict:
     for slot, col in slot_map.items():
         cosmetic_id = settings.get(col)
         if cosmetic_id:
-            rows = table("cosmetics").select("*", filters={"id": f"eq.{cosmetic_id}"})
+            rows = table("cosmetics").select(
+                "id,type,name,slug,asset_url,css_value,rarity",
+                filters={"id": f"eq.{cosmetic_id}"},
+            )
             if rows:
                 equipped[slot] = rows[0]
     # Featured role
     featured_role_id = settings.get("featured_role_id")
     if featured_role_id:
-        rows = table("roles").select("*", filters={"id": f"eq.{featured_role_id}"})
+        rows = table("roles").select(
+            "id,name,slug,color,icon,description,is_staff_assigned,is_earnable,display_priority",
+            filters={"id": f"eq.{featured_role_id}"},
+        )
         if rows:
             equipped["featured_role"] = rows[0]
     return equipped
@@ -157,7 +176,7 @@ def get_public_profile(user_id: str):
 
     profile = {
         "id": user["id"],
-        "name": user.get("name", ""),
+        "name": user.get("name", ""),  # ENCRYPTED LATER
         "username": user.get("username"),
         "avatar_url": user.get("avatar_url"),
         "created_at": user.get("created_at"),
@@ -171,14 +190,14 @@ def get_public_profile(user_id: str):
 
     # Respect profile visibility
     if settings.get("profile_visibility") != "private":
-        profile["bio"] = user.get("bio")
-        profile["location"] = user.get("location")
+        profile["bio"] = user.get("bio")  # ENCRYPTED LATER
+        profile["location"] = user.get("location")  # ENCRYPTED LATER
         profile["website"] = user.get("website")
         profile["featured_achievements"] = _get_featured_achievements(user_id)
         profile["stats"] = _get_user_stats(user_id)
     else:
-        profile["bio"] = None
-        profile["location"] = None
+        profile["bio"] = None  # ENCRYPTED LATER
+        profile["location"] = None  # ENCRYPTED LATER
         profile["website"] = None
         profile["featured_achievements"] = []
         profile["stats"] = {}
@@ -207,11 +226,11 @@ def update_profile(user_id: str, body: UpdateProfileBody, request: Request):
     if body.display_name is not None:
         updates_settings["display_name"] = body.display_name
     if body.bio is not None:
-        updates_user["bio"] = body.bio
-        updates_settings["bio"] = body.bio
+        updates_user["bio"] = body.bio  # ENCRYPTED LATER
+        updates_settings["bio"] = body.bio  # ENCRYPTED LATER
     if body.location is not None:
-        updates_user["location"] = body.location
-        updates_settings["location"] = body.location
+        updates_user["location"] = body.location  # ENCRYPTED LATER
+        updates_settings["location"] = body.location  # ENCRYPTED LATER
     if body.website is not None:
         updates_user["website"] = body.website
         updates_settings["website"] = body.website
@@ -255,21 +274,22 @@ def update_settings(user_id: str, body: UpdateSettingsBody, request: Request):
     require_self(user_id, request)
     _get_or_create_settings(user_id)
 
-    updates = {}
-    for field in [
+    # Whitelist: only these fields may be patched via this endpoint.
+    # EXCLUDES bio/location (encrypted later, set via /profile patch) and any
+    # role/admin/approval fields to prevent privilege escalation.
+    ALLOWED = {
         "profile_visibility", "activity_status_visible",
         "notification_email", "notification_push", "notification_in_app",
         "theme", "font_size", "accent_color",
-    ]:
-        val = getattr(body, field)
-        if val is not None:
-            updates[field] = val
+    }
+    incoming = body.model_dump(exclude_none=True)
+    updates = {k: v for k, v in incoming.items() if k in ALLOWED}
 
     if updates:
         updates["updated_at"] = datetime.now(timezone.utc).isoformat()
         table("user_settings").update(updates, filters={"user_id": f"eq.{user_id}"})
 
-    return table("user_settings").select("*", filters={"user_id": f"eq.{user_id}"})[0]
+    return table("user_settings").select(_SETTINGS_COLS, filters={"user_id": f"eq.{user_id}"})[0]
 
 
 # ── Equip Cosmetic ───────────────────────────────────────────────────────────
@@ -388,7 +408,9 @@ def set_featured_achievements(user_id: str, body: SetFeaturedAchievementsBody, r
 
 @router.get("/{user_id}/achievements")
 def get_achievements(user_id: str):
-    all_achs = table("achievements").select("*")
+    all_achs = table("achievements").select(
+        "id,name,slug,description,icon,category,rarity,is_secret"
+    )
     if not all_achs:
         return {"earned": [], "available": []}
 
@@ -556,8 +578,8 @@ def export_data(user_id: str, request: Request):
     )
 
     return {
-        "user": user,
-        "settings": settings,
+        "user": user,  # ENCRYPTED LATER
+        "settings": settings,  # ENCRYPTED LATER
         "roles": roles,
         "achievements": earned or [],
         "cosmetics": owned_cosmetics or [],

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -9,6 +9,7 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Request, UploadFile, File, Query
 
 from db.connection import table
+from services.encryption import encrypt_if_present, decrypt_if_present
 from models import (
     UpdateProfileBody,
     UpdateSettingsBody,
@@ -26,16 +27,19 @@ router = APIRouter()
 
 def _get_user_or_404(user_id: str) -> dict:
     rows = table("users").select(
-        "id,username,name,first_name,last_name,email,avatar_url,school,major,year,majors,minors,bio,location,website,streak_count,created_at",  # ENCRYPTED LATER
+        "id,username,name,first_name,last_name,email,avatar_url,school,major,year,majors,minors,bio,location,website,streak_count,created_at",
         filters={"id": f"eq.{user_id}"},
     )
     if not rows:
         raise HTTPException(status_code=404, detail="User not found")
-    return rows[0]
+    row = rows[0]
+    for col in ("name", "first_name", "last_name", "email", "bio", "location"):
+        row[col] = decrypt_if_present(row.get(col))
+    return row
 
 
 _SETTINGS_COLS = (
-    "user_id,username,display_name,bio,location,website,"  # ENCRYPTED LATER
+    "user_id,username,display_name,bio,location,website,"
     "profile_visibility,activity_status_visible,"
     "notification_email,notification_push,notification_in_app,"
     "theme,font_size,accent_color,"
@@ -46,11 +50,15 @@ _SETTINGS_COLS = (
 
 def _get_or_create_settings(user_id: str) -> dict:
     rows = table("user_settings").select(_SETTINGS_COLS, filters={"user_id": f"eq.{user_id}"})
-    if rows:
-        return rows[0]
-    table("user_settings").insert({"user_id": user_id})
-    rows = table("user_settings").select(_SETTINGS_COLS, filters={"user_id": f"eq.{user_id}"})
-    return rows[0] if rows else {"user_id": user_id}
+    if not rows:
+        table("user_settings").insert({"user_id": user_id})
+        rows = table("user_settings").select(_SETTINGS_COLS, filters={"user_id": f"eq.{user_id}"})
+    if not rows:
+        return {"user_id": user_id}
+    row = rows[0]
+    for col in ("bio", "location"):
+        row[col] = decrypt_if_present(row.get(col))
+    return row
 
 
 def _get_user_roles(user_id: str) -> list:
@@ -176,7 +184,7 @@ def get_public_profile(user_id: str):
 
     profile = {
         "id": user["id"],
-        "name": user.get("name", ""),  # ENCRYPTED LATER
+        "name": user.get("name", ""),
         "username": user.get("username"),
         "avatar_url": user.get("avatar_url"),
         "created_at": user.get("created_at"),
@@ -190,14 +198,14 @@ def get_public_profile(user_id: str):
 
     # Respect profile visibility
     if settings.get("profile_visibility") != "private":
-        profile["bio"] = user.get("bio")  # ENCRYPTED LATER
-        profile["location"] = user.get("location")  # ENCRYPTED LATER
+        profile["bio"] = user.get("bio")
+        profile["location"] = user.get("location")
         profile["website"] = user.get("website")
         profile["featured_achievements"] = _get_featured_achievements(user_id)
         profile["stats"] = _get_user_stats(user_id)
     else:
-        profile["bio"] = None  # ENCRYPTED LATER
-        profile["location"] = None  # ENCRYPTED LATER
+        profile["bio"] = None
+        profile["location"] = None
         profile["website"] = None
         profile["featured_achievements"] = []
         profile["stats"] = {}
@@ -226,11 +234,11 @@ def update_profile(user_id: str, body: UpdateProfileBody, request: Request):
     if body.display_name is not None:
         updates_settings["display_name"] = body.display_name
     if body.bio is not None:
-        updates_user["bio"] = body.bio  # ENCRYPTED LATER
-        updates_settings["bio"] = body.bio  # ENCRYPTED LATER
+        updates_user["bio"] = encrypt_if_present(body.bio)
+        updates_settings["bio"] = encrypt_if_present(body.bio)
     if body.location is not None:
-        updates_user["location"] = body.location  # ENCRYPTED LATER
-        updates_settings["location"] = body.location  # ENCRYPTED LATER
+        updates_user["location"] = encrypt_if_present(body.location)
+        updates_settings["location"] = encrypt_if_present(body.location)
     if body.website is not None:
         updates_user["website"] = body.website
         updates_settings["website"] = body.website
@@ -578,8 +586,8 @@ def export_data(user_id: str, request: Request):
     )
 
     return {
-        "user": user,  # ENCRYPTED LATER
-        "settings": settings,  # ENCRYPTED LATER
+        "user": user,
+        "settings": settings,
         "roles": roles,
         "achievements": earned or [],
         "cosmetics": owned_cosmetics or [],

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -3,11 +3,12 @@ import json
 import os
 from datetime import datetime
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 
 from config import get_mastery_tier
 from db.connection import table
 from models import GenerateQuizBody, SubmitQuizBody
+from services.auth_guard import require_self
 from services.gemini_service import call_gemini_json
 from services.graph_service import get_graph, update_streak
 from services.quiz_context_service import get_quiz_context, save_quiz_context
@@ -23,7 +24,8 @@ def _load_prompt(name: str) -> str:
 
 
 @router.post("/generate")
-def generate_quiz(body: GenerateQuizBody):
+def generate_quiz(body: GenerateQuizBody, request: Request):
+    require_self(body.user_id, request)
     node_rows = table("graph_nodes").select("*", filters={"id": f"eq.{body.concept_node_id}"})
     if not node_rows:
         raise HTTPException(status_code=404, detail="Concept node not found")
@@ -99,7 +101,7 @@ def generate_quiz(body: GenerateQuizBody):
 
 
 @router.post("/submit")
-def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks):
+def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request: Request):
     attempt_rows = table("quiz_attempts").select("*", filters={"id": f"eq.{body.quiz_id}"})
     if not attempt_rows:
         raise HTTPException(status_code=404, detail="Quiz not found")
@@ -109,6 +111,7 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks):
     if isinstance(questions, str):
         questions = json.loads(questions)
     user_id = attempt["user_id"]
+    require_self(user_id, request)
     concept_node_id = attempt["concept_node_id"]
 
     answer_map = {str(a.question_id): a.selected_label for a in body.answers}
@@ -183,9 +186,9 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks):
     node2_rows = table("graph_nodes").select(
         "concept_name", filters={"id": f"eq.{concept_node_id}"}
     )
-    user_rows = table("users").select("name", filters={"id": f"eq.{user_id}"})
+    user_rows = table("users").select("name", filters={"id": f"eq.{user_id}"})  # ENCRYPTED LATER
     concept_name = node2_rows[0]["concept_name"] if node2_rows else "Unknown"
-    student_name = user_rows[0]["name"] if user_rows else "Student"
+    student_name = user_rows[0]["name"] if user_rows else "Student"  # ENCRYPTED LATER
 
     existing_ctx = get_quiz_context(user_id, concept_node_id)
     ctx_prompt = (

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -9,6 +9,7 @@ from config import get_mastery_tier
 from db.connection import table
 from models import GenerateQuizBody, SubmitQuizBody
 from services.auth_guard import require_self
+from services.encryption import decrypt_if_present
 from services.gemini_service import call_gemini_json
 from services.graph_service import get_graph, update_streak
 from services.quiz_context_service import get_quiz_context, save_quiz_context
@@ -186,9 +187,9 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
     node2_rows = table("graph_nodes").select(
         "concept_name", filters={"id": f"eq.{concept_node_id}"}
     )
-    user_rows = table("users").select("name", filters={"id": f"eq.{user_id}"})  # ENCRYPTED LATER
+    user_rows = table("users").select("name", filters={"id": f"eq.{user_id}"})
     concept_name = node2_rows[0]["concept_name"] if node2_rows else "Unknown"
-    student_name = user_rows[0]["name"] if user_rows else "Student"  # ENCRYPTED LATER
+    student_name = decrypt_if_present(user_rows[0]["name"]) if user_rows else "Student"
 
     existing_ctx = get_quiz_context(user_id, concept_node_id)
     ctx_prompt = (

--- a/backend/routes/social.py
+++ b/backend/routes/social.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from db.connection import table
 from models import CreateRoomBody, JoinRoomBody, MatchBody, SendMessageBody, EditMessageBody, ToggleReactionBody, LeaveRoomBody
 from services.auth_guard import require_self, get_session_user_id
-from services.encryption import decrypt_if_present
+from services.encryption import encrypt_if_present, decrypt_if_present
 from services.graph_service import get_graph
 from services.matching_service import find_study_matches
 from services.gemini_service import call_gemini
@@ -325,13 +325,14 @@ def get_room_messages(room_id: str, request: Request, before: str | None = None,
             reply_map[rr["id"]] = {
                 "id": rr["id"],
                 "user_name": rr["user_name"],
-                "text": None if rr.get("is_deleted") else rr.get("text"),
+                "text": None if rr.get("is_deleted") else decrypt_if_present(rr.get("text")),
             }
 
     enriched = []
     for r in rows:
         mid = r["id"]
         emoji_map = reactions_by_msg.get(mid, {})
+        r["text"] = decrypt_if_present(r.get("text"))
         r["reactions"] = [{"emoji": e, "user_ids": uids} for e, uids in emoji_map.items()]
         r["reply_to"] = reply_map.get(r.get("reply_to_id")) if r.get("reply_to_id") else None
         enriched.append(r)
@@ -352,10 +353,13 @@ def send_room_message(room_id: str, body: SendMessageBody, request: Request):
         "room_id": room_id,
         "user_id": body.user_id,
         "user_name": body.user_name,
-        "text": body.text or None,
+        "text": encrypt_if_present(body.text or None),
         "image_url": body.image_url or None,
         "reply_to_id": body.reply_to_id or None,
     })
+
+    if row:
+        row[0]["text"] = decrypt_if_present(row[0].get("text"))
 
     # Check for achievements after message send
     try:
@@ -391,7 +395,7 @@ def edit_room_message(room_id: str, message_id: str, body: EditMessageBody, requ
         raise HTTPException(status_code=400, detail="Cannot edit a deleted message")
     from datetime import datetime, timezone
     table("room_messages").update(
-        {"text": body.text, "edited_at": datetime.now(timezone.utc).isoformat()},
+        {"text": encrypt_if_present(body.text), "edited_at": datetime.now(timezone.utc).isoformat()},
         filters={"id": f"eq.{message_id}"},
     )
     return {"edited": True}

--- a/backend/routes/social.py
+++ b/backend/routes/social.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from db.connection import table
 from models import CreateRoomBody, JoinRoomBody, MatchBody, SendMessageBody, EditMessageBody, ToggleReactionBody, LeaveRoomBody
 from services.auth_guard import require_self, get_session_user_id
+from services.encryption import decrypt_if_present
 from services.graph_service import get_graph
 from services.matching_service import find_study_matches
 from services.gemini_service import call_gemini
@@ -104,17 +105,21 @@ def room_overview(room_id: str, request: Request):
     members = []
     if member_ids:
         user_rows = table("users").select(
-            "id,name", filters={"id": f"in.({','.join(member_ids)})"}  # ENCRYPTED LATER
+            "id,name", filters={"id": f"in.({','.join(member_ids)})"}
         )
         for u in user_rows:
-            members.append({"user_id": u["id"], "name": u["name"], "graph": get_graph(u["id"])})  # ENCRYPTED LATER
+            members.append({
+                "user_id": u["id"],
+                "name": decrypt_if_present(u["name"]),
+                "graph": get_graph(u["id"]),
+            })
 
     member_summaries = []
     for m in members:
         nodes = m["graph"]["nodes"]
         mastered = [n["concept_name"] for n in nodes if n["mastery_tier"] == "mastered"]
         struggling = [n["concept_name"] for n in nodes if n["mastery_tier"] == "struggling"]
-        member_summaries.append(f"{m['name']}: mastered {mastered}, struggling with {struggling}")  # ENCRYPTED LATER
+        member_summaries.append(f"{m['name']}: mastered {mastered}, struggling with {struggling}")
 
     ai_summary = get_cached_summary(room_id, member_summaries)
     if ai_summary is None:
@@ -151,8 +156,8 @@ def room_activity(room_id: str, request: Request):
     user_ids = list(set(a["user_id"] for a in activity_rows))
     user_name_map = {}
     if user_ids:
-        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(user_ids)})"})  # ENCRYPTED LATER
-        user_name_map = {u["id"]: u["name"] for u in user_rows}  # ENCRYPTED LATER
+        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(user_ids)})"})
+        user_name_map = {u["id"]: decrypt_if_present(u["name"]) for u in user_rows}
 
     activities = [
         {
@@ -176,9 +181,9 @@ def match_partners(room_id: str, body: MatchBody, request: Request):
 
     members_with_graphs = []
     if member_ids:
-        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(member_ids)})"})  # ENCRYPTED LATER
+        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(member_ids)})"})
         members_with_graphs = [
-            {"user_id": u["id"], "name": u["name"], "graph": get_graph(u["id"])}  # ENCRYPTED LATER
+            {"user_id": u["id"], "name": decrypt_if_present(u["name"]), "graph": get_graph(u["id"])}
             for u in user_rows
         ]
 
@@ -211,21 +216,21 @@ def school_match(body: MatchBody, request: Request):
     excl_list = list(excluded_ids)
 
     school_users = table("users").select(
-        "id,name",  # ENCRYPTED LATER
+        "id,name",
         filters={"id": f"not.in.({','.join(excl_list)})"},
     )
 
     members_with_graphs = [
-        {"user_id": u["id"], "name": u["name"], "graph": get_graph(u["id"])}  # ENCRYPTED LATER
+        {"user_id": u["id"], "name": decrypt_if_present(u["name"]), "graph": get_graph(u["id"])}
         for u in school_users
     ]
 
     requester_graph = get_graph(body.user_id)
-    requester_rows = table("users").select("name", filters={"id": f"eq.{body.user_id}"})  # ENCRYPTED LATER
-    requester_name = requester_rows[0]["name"] if requester_rows else body.user_id  # ENCRYPTED LATER
+    requester_rows = table("users").select("name", filters={"id": f"eq.{body.user_id}"})
+    requester_name = decrypt_if_present(requester_rows[0]["name"]) if requester_rows else body.user_id
 
     all_members = [
-        {"user_id": body.user_id, "name": requester_name, "graph": requester_graph}  # ENCRYPTED LATER
+        {"user_id": body.user_id, "name": requester_name, "graph": requester_graph}
     ] + members_with_graphs
 
     try:
@@ -413,7 +418,7 @@ def toggle_reaction(room_id: str, message_id: str, body: ToggleReactionBody, req
 def get_students(request: Request):
     """Return a lightweight profile for every user in the DB."""
     user_id = get_session_user_id(request)
-    users = table("users").select("id,name,streak_count")  # ENCRYPTED LATER
+    users = table("users").select("id,name,streak_count")
     courses_rows = table("courses").select("user_id,course_name")
     nodes_rows = table("graph_nodes").select("user_id,mastery_tier,concept_name,mastery_score")
 
@@ -443,7 +448,7 @@ def get_students(request: Request):
     students = [
         {
             "user_id": u["id"],
-            "name": u["name"],  # ENCRYPTED LATER
+            "name": decrypt_if_present(u["name"]),
             "streak": u.get("streak_count") or 0,
             "courses": sorted(courses_by_user[u["id"]]),
             "stats": dict(mastery_by_user[u["id"]]),
@@ -451,5 +456,5 @@ def get_students(request: Request):
         }
         for u in users
     ]
-    students.sort(key=lambda s: s["name"])  # ENCRYPTED LATER
+    students.sort(key=lambda s: (s["name"] or ""))
     return {"students": students}

--- a/backend/routes/social.py
+++ b/backend/routes/social.py
@@ -3,10 +3,11 @@ import random
 import string
 from collections import defaultdict
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from db.connection import table
 from models import CreateRoomBody, JoinRoomBody, MatchBody, SendMessageBody, EditMessageBody, ToggleReactionBody, LeaveRoomBody
+from services.auth_guard import require_self, get_session_user_id
 from services.graph_service import get_graph
 from services.matching_service import find_study_matches
 from services.gemini_service import call_gemini
@@ -16,7 +17,8 @@ router = APIRouter()
 
 
 @router.post("/rooms/create")
-def create_room(body: CreateRoomBody):
+def create_room(body: CreateRoomBody, request: Request):
+    require_self(body.user_id, request)
     invite_code = "".join(random.choices(string.ascii_uppercase + string.digits, k=6))
     room_id = str(uuid.uuid4())
     table("rooms").insert({
@@ -31,9 +33,11 @@ def create_room(body: CreateRoomBody):
 
 
 @router.post("/rooms/join")
-def join_room(body: JoinRoomBody):
+def join_room(body: JoinRoomBody, request: Request):
+    require_self(body.user_id, request)
     room_rows = table("rooms").select(
-        "*", filters={"invite_code": f"eq.{body.invite_code.strip().upper()}"}
+        "id,name,topic,course,owner_id,created_by,invite_code,created_at,updated_at,is_public",
+        filters={"invite_code": f"eq.{body.invite_code.strip().upper()}"},
     )
     if not room_rows:
         raise HTTPException(status_code=404, detail="Room not found")
@@ -60,13 +64,17 @@ def join_room(body: JoinRoomBody):
 
 
 @router.get("/rooms/{user_id}")
-def get_user_rooms(user_id: str):
+def get_user_rooms(user_id: str, request: Request):
+    require_self(user_id, request)
     memberships = table("room_members").select("room_id", filters={"user_id": f"eq.{user_id}"})
     room_ids = [m["room_id"] for m in memberships]
     if not room_ids:
         return {"rooms": []}
 
-    rooms = table("rooms").select("*", filters={"id": f"in.({','.join(room_ids)})"})
+    rooms = table("rooms").select(
+        "id,name,topic,course,owner_id,created_by,invite_code,created_at,updated_at,is_public",
+        filters={"id": f"in.({','.join(room_ids)})"},
+    )
     for room in rooms:
         members = table("room_members").select("user_id", filters={"room_id": f"eq.{room['id']}"})
         room["member_count"] = len(members)
@@ -74,8 +82,18 @@ def get_user_rooms(user_id: str):
 
 
 @router.get("/rooms/{room_id}/overview")
-def room_overview(room_id: str, viewer_id: str = Query("user_john")):
-    room_rows = table("rooms").select("*", filters={"id": f"eq.{room_id}"})
+def room_overview(room_id: str, request: Request):
+    viewer_id = get_session_user_id(request)
+    membership = table("room_members").select(
+        "user_id", filters={"room_id": f"eq.{room_id}", "user_id": f"eq.{viewer_id}"}
+    )
+    if not membership:
+        raise HTTPException(status_code=403, detail="Not a member of this room")
+
+    room_rows = table("rooms").select(
+        "id,name,topic,course,owner_id,created_by,invite_code,created_at,updated_at,is_public",
+        filters={"id": f"eq.{room_id}"},
+    )
     if not room_rows:
         raise HTTPException(status_code=404, detail="Room not found")
     room = room_rows[0]
@@ -86,17 +104,17 @@ def room_overview(room_id: str, viewer_id: str = Query("user_john")):
     members = []
     if member_ids:
         user_rows = table("users").select(
-            "id,name", filters={"id": f"in.({','.join(member_ids)})"}
+            "id,name", filters={"id": f"in.({','.join(member_ids)})"}  # ENCRYPTED LATER
         )
         for u in user_rows:
-            members.append({"user_id": u["id"], "name": u["name"], "graph": get_graph(u["id"])})
+            members.append({"user_id": u["id"], "name": u["name"], "graph": get_graph(u["id"])})  # ENCRYPTED LATER
 
     member_summaries = []
     for m in members:
         nodes = m["graph"]["nodes"]
         mastered = [n["concept_name"] for n in nodes if n["mastery_tier"] == "mastered"]
         struggling = [n["concept_name"] for n in nodes if n["mastery_tier"] == "struggling"]
-        member_summaries.append(f"{m['name']}: mastered {mastered}, struggling with {struggling}")
+        member_summaries.append(f"{m['name']}: mastered {mastered}, struggling with {struggling}")  # ENCRYPTED LATER
 
     ai_summary = get_cached_summary(room_id, member_summaries)
     if ai_summary is None:
@@ -115,9 +133,16 @@ def room_overview(room_id: str, viewer_id: str = Query("user_john")):
 
 
 @router.get("/rooms/{room_id}/activity")
-def room_activity(room_id: str):
+def room_activity(room_id: str, request: Request):
+    viewer_id = get_session_user_id(request)
+    membership = table("room_members").select(
+        "user_id", filters={"room_id": f"eq.{room_id}", "user_id": f"eq.{viewer_id}"}
+    )
+    if not membership:
+        raise HTTPException(status_code=403, detail="Not a member of this room")
+
     activity_rows = table("room_activity").select(
-        "*",
+        "id,room_id,user_id,activity_type,concept_name,detail,created_at",
         filters={"room_id": f"eq.{room_id}"},
         order="created_at.desc",
         limit=20,
@@ -126,8 +151,8 @@ def room_activity(room_id: str):
     user_ids = list(set(a["user_id"] for a in activity_rows))
     user_name_map = {}
     if user_ids:
-        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(user_ids)})"})
-        user_name_map = {u["id"]: u["name"] for u in user_rows}
+        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(user_ids)})"})  # ENCRYPTED LATER
+        user_name_map = {u["id"]: u["name"] for u in user_rows}  # ENCRYPTED LATER
 
     activities = [
         {
@@ -144,15 +169,16 @@ def room_activity(room_id: str):
 
 
 @router.post("/rooms/{room_id}/match")
-def match_partners(room_id: str, body: MatchBody):
+def match_partners(room_id: str, body: MatchBody, request: Request):
+    require_self(body.user_id, request)
     member_id_rows = table("room_members").select("user_id", filters={"room_id": f"eq.{room_id}"})
     member_ids = [m["user_id"] for m in member_id_rows]
 
     members_with_graphs = []
     if member_ids:
-        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(member_ids)})"})
+        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(member_ids)})"})  # ENCRYPTED LATER
         members_with_graphs = [
-            {"user_id": u["id"], "name": u["name"], "graph": get_graph(u["id"])}
+            {"user_id": u["id"], "name": u["name"], "graph": get_graph(u["id"])}  # ENCRYPTED LATER
             for u in user_rows
         ]
 
@@ -164,10 +190,11 @@ def match_partners(room_id: str, body: MatchBody):
 
 
 @router.post("/school-match")
-def school_match(body: MatchBody):
+def school_match(body: MatchBody, request: Request):
     """
     Match the requesting user against all users NOT in any of their study rooms.
     """
+    require_self(body.user_id, request)
     user_room_rows = table("room_members").select(
         "room_id", filters={"user_id": f"eq.{body.user_id}"}
     )
@@ -184,21 +211,21 @@ def school_match(body: MatchBody):
     excl_list = list(excluded_ids)
 
     school_users = table("users").select(
-        "id,name",
+        "id,name",  # ENCRYPTED LATER
         filters={"id": f"not.in.({','.join(excl_list)})"},
     )
 
     members_with_graphs = [
-        {"user_id": u["id"], "name": u["name"], "graph": get_graph(u["id"])}
+        {"user_id": u["id"], "name": u["name"], "graph": get_graph(u["id"])}  # ENCRYPTED LATER
         for u in school_users
     ]
 
     requester_graph = get_graph(body.user_id)
-    requester_rows = table("users").select("name", filters={"id": f"eq.{body.user_id}"})
-    requester_name = requester_rows[0]["name"] if requester_rows else body.user_id
+    requester_rows = table("users").select("name", filters={"id": f"eq.{body.user_id}"})  # ENCRYPTED LATER
+    requester_name = requester_rows[0]["name"] if requester_rows else body.user_id  # ENCRYPTED LATER
 
     all_members = [
-        {"user_id": body.user_id, "name": requester_name, "graph": requester_graph}
+        {"user_id": body.user_id, "name": requester_name, "graph": requester_graph}  # ENCRYPTED LATER
     ] + members_with_graphs
 
     try:
@@ -210,15 +237,20 @@ def school_match(body: MatchBody):
 
 
 @router.post("/rooms/{room_id}/leave")
-def leave_room(room_id: str, body: LeaveRoomBody):
+def leave_room(room_id: str, body: LeaveRoomBody, request: Request):
+    require_self(body.user_id, request)
     table("room_members").delete({"room_id": f"eq.{room_id}", "user_id": f"eq.{body.user_id}"})
     invalidate_summary(room_id)
     return {"left": True}
 
 
 @router.delete("/rooms/{room_id}/members/{member_id}")
-def kick_member(room_id: str, member_id: str, requester_id: str = Query(...)):
-    room_rows = table("rooms").select("*", filters={"id": f"eq.{room_id}"})
+def kick_member(room_id: str, member_id: str, request: Request, requester_id: str = Query(...)):
+    require_self(requester_id, request)
+    room_rows = table("rooms").select(
+        "id,name,topic,course,owner_id,created_by,invite_code,created_at,updated_at,is_public",
+        filters={"id": f"eq.{room_id}"},
+    )
     if not room_rows:
         raise HTTPException(status_code=404, detail="Room not found")
     if room_rows[0]["created_by"] != requester_id:
@@ -229,7 +261,14 @@ def kick_member(room_id: str, member_id: str, requester_id: str = Query(...)):
 
 
 @router.get("/rooms/{room_id}/messages")
-def get_room_messages(room_id: str, before: str | None = None, limit: int = 50):
+def get_room_messages(room_id: str, request: Request, before: str | None = None, limit: int = 50):
+    viewer_id = get_session_user_id(request)
+    membership = table("room_members").select(
+        "user_id", filters={"room_id": f"eq.{room_id}", "user_id": f"eq.{viewer_id}"}
+    )
+    if not membership:
+        raise HTTPException(status_code=403, detail="Not a member of this room")
+
     from datetime import datetime
     limit = max(1, min(200, limit))
     filters = {"room_id": f"eq.{room_id}"}
@@ -243,7 +282,7 @@ def get_room_messages(room_id: str, before: str | None = None, limit: int = 50):
         filters["created_at"] = f"lt.{before}"
     # Fetch newest-first so the slice covers the page we need, then reverse to ascending.
     rows = table("room_messages").select(
-        "*",
+        "id,room_id,user_id,user_name,text,image_url,reply_to_id,is_deleted,edited_at,created_at",
         filters=filters,
         order="created_at.desc",
         limit=limit,
@@ -257,7 +296,7 @@ def get_room_messages(room_id: str, before: str | None = None, limit: int = 50):
 
     # Fetch reactions for all messages in one query
     reaction_rows = table("room_reactions").select(
-        "*", filters={"message_id": f"in.({','.join(msg_ids)})"}
+        "id,message_id,user_id,emoji", filters={"message_id": f"in.({','.join(msg_ids)})"}
     ) if msg_ids else []
 
     reactions_by_msg: dict = {}
@@ -296,7 +335,14 @@ def get_room_messages(room_id: str, before: str | None = None, limit: int = 50):
 
 
 @router.post("/rooms/{room_id}/messages")
-def send_room_message(room_id: str, body: SendMessageBody):
+def send_room_message(room_id: str, body: SendMessageBody, request: Request):
+    require_self(body.user_id, request)
+    membership = table("room_members").select(
+        "user_id", filters={"room_id": f"eq.{room_id}", "user_id": f"eq.{body.user_id}"}
+    )
+    if not membership:
+        raise HTTPException(status_code=403, detail="Not a member of this room")
+
     row = table("room_messages").insert({
         "room_id": room_id,
         "user_id": body.user_id,
@@ -317,7 +363,8 @@ def send_room_message(room_id: str, body: SendMessageBody):
 
 
 @router.delete("/rooms/{room_id}/messages/{message_id}")
-def delete_room_message(room_id: str, message_id: str, user_id: str = Query(...)):
+def delete_room_message(room_id: str, message_id: str, request: Request, user_id: str = Query(...)):
+    require_self(user_id, request)
     rows = table("room_messages").select("user_id", filters={"id": f"eq.{message_id}"})
     if not rows:
         raise HTTPException(status_code=404, detail="Message not found")
@@ -328,7 +375,8 @@ def delete_room_message(room_id: str, message_id: str, user_id: str = Query(...)
 
 
 @router.patch("/rooms/{room_id}/messages/{message_id}")
-def edit_room_message(room_id: str, message_id: str, body: EditMessageBody):
+def edit_room_message(room_id: str, message_id: str, body: EditMessageBody, request: Request):
+    require_self(body.user_id, request)
     rows = table("room_messages").select("user_id,is_deleted", filters={"id": f"eq.{message_id}"})
     if not rows:
         raise HTTPException(status_code=404, detail="Message not found")
@@ -345,7 +393,8 @@ def edit_room_message(room_id: str, message_id: str, body: EditMessageBody):
 
 
 @router.post("/rooms/{room_id}/messages/{message_id}/reactions")
-def toggle_reaction(room_id: str, message_id: str, body: ToggleReactionBody):
+def toggle_reaction(room_id: str, message_id: str, body: ToggleReactionBody, request: Request):
+    require_self(body.user_id, request)
     existing = table("room_reactions").select(
         "id", filters={"message_id": f"eq.{message_id}", "user_id": f"eq.{body.user_id}", "emoji": f"eq.{body.emoji}"}
     )
@@ -361,9 +410,10 @@ def toggle_reaction(room_id: str, message_id: str, body: ToggleReactionBody):
 
 
 @router.get("/students")
-def get_students():
+def get_students(request: Request):
     """Return a lightweight profile for every user in the DB."""
-    users = table("users").select("id,name,streak_count")
+    user_id = get_session_user_id(request)
+    users = table("users").select("id,name,streak_count")  # ENCRYPTED LATER
     courses_rows = table("courses").select("user_id,course_name")
     nodes_rows = table("graph_nodes").select("user_id,mastery_tier,concept_name,mastery_score")
 
@@ -393,7 +443,7 @@ def get_students():
     students = [
         {
             "user_id": u["id"],
-            "name": u["name"],
+            "name": u["name"],  # ENCRYPTED LATER
             "streak": u.get("streak_count") or 0,
             "courses": sorted(courses_by_user[u["id"]]),
             "stats": dict(mastery_by_user[u["id"]]),
@@ -401,5 +451,5 @@ def get_students():
         }
         for u in users
     ]
-    students.sort(key=lambda s: s["name"])
+    students.sort(key=lambda s: s["name"])  # ENCRYPTED LATER
     return {"students": students}

--- a/backend/routes/study_guide.py
+++ b/backend/routes/study_guide.py
@@ -7,9 +7,10 @@ Study guide generation and caching.
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Body, HTTPException, Query
+from fastapi import APIRouter, Body, HTTPException, Query, Request
 
 from db.connection import table
+from services.auth_guard import require_self
 from services.gemini_service import call_gemini_json
 
 router = APIRouter()
@@ -19,7 +20,7 @@ def _generate_and_insert(user_id: str, course_id: str, exam_id: str) -> dict:
     """Generate a study guide, insert it into study_guides, and return {content, generated_at}."""
     # 1. Fetch exam info
     exams = table("assignments").select(
-        "title,due_date",
+        "id,user_id,title,due_date,assignment_type,course_id",
         filters={"id": f"eq.{exam_id}", "user_id": f"eq.{user_id}"},
         limit=1,
     )
@@ -31,16 +32,16 @@ def _generate_and_insert(user_id: str, course_id: str, exam_id: str) -> dict:
 
     # 2. Fetch documents for this user+course
     docs = table("documents").select(
-        "summary,concept_notes",
+        "summary,concept_notes",  # ENCRYPTED LATER
         filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
     )
 
     # 3. Build combined context
     parts: list[str] = []
     for doc in docs:
-        if doc.get("summary"):
-            parts.append(f"Summary: {doc['summary']}")
-        concept_notes = doc.get("concept_notes")
+        if doc.get("summary"):  # ENCRYPTED LATER
+            parts.append(f"Summary: {doc['summary']}")  # ENCRYPTED LATER
+        concept_notes = doc.get("concept_notes")  # ENCRYPTED LATER
         if concept_notes and isinstance(concept_notes, list):
             lines = []
             for note in concept_notes:
@@ -104,7 +105,8 @@ def _generate_and_insert(user_id: str, course_id: str, exam_id: str) -> dict:
 
 
 @router.get("/{user_id}/cached")
-def get_cached_guides(user_id: str):
+def get_cached_guides(user_id: str, request: Request):
+    require_self(user_id, request)
     guides = table("study_guides").select(
         "id,course_id,exam_id,generated_at,content",
         filters={"user_id": f"eq.{user_id}"},
@@ -134,7 +136,8 @@ def get_cached_guides(user_id: str):
 
 
 @router.get("/{user_id}/courses")
-def get_courses(user_id: str):
+def get_courses(user_id: str, request: Request):
+    require_self(user_id, request)
     courses = table("courses").select(
         "id,course_name,color",
         filters={"user_id": f"eq.{user_id}"},
@@ -143,7 +146,8 @@ def get_courses(user_id: str):
 
 
 @router.get("/{user_id}/exams")
-def get_exams(user_id: str, course_id: str = Query(...)):
+def get_exams(user_id: str, request: Request, course_id: str = Query(...)):
+    require_self(user_id, request)
     all_assignments = table("assignments").select(
         "id,title,due_date,assignment_type",
         filters={"user_id": f"eq.{user_id}"},
@@ -164,11 +168,13 @@ def get_exams(user_id: str, course_id: str = Query(...)):
 @router.get("/{user_id}/guide")
 def get_guide(
     user_id: str,
+    request: Request,
     course_id: str = Query(...),
     exam_id: str = Query(...),
 ):
+    require_self(user_id, request)
     cached = table("study_guides").select(
-        "*",
+        "id,user_id,course_id,exam_id,content,generated_at",
         filters={
             "user_id": f"eq.{user_id}",
             "course_id": f"eq.{course_id}",
@@ -185,12 +191,13 @@ def get_guide(
 
 
 @router.post("/regenerate")
-def regenerate_guide(body: dict = Body(...)):
+def regenerate_guide(request: Request, body: dict = Body(...)):
     user_id = body.get("user_id")
     course_id = body.get("course_id")
     exam_id = body.get("exam_id")
     if not user_id or not course_id or not exam_id:
         raise HTTPException(status_code=400, detail="user_id, course_id, and exam_id are required.")
+    require_self(user_id, request)
 
     table("study_guides").delete(
         filters={

--- a/backend/routes/study_guide.py
+++ b/backend/routes/study_guide.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Body, HTTPException, Query, Request
 
 from db.connection import table
 from services.auth_guard import require_self
+from services.encryption import decrypt_if_present, decrypt_json
 from services.gemini_service import call_gemini_json
 
 router = APIRouter()
@@ -32,16 +33,24 @@ def _generate_and_insert(user_id: str, course_id: str, exam_id: str) -> dict:
 
     # 2. Fetch documents for this user+course
     docs = table("documents").select(
-        "summary,concept_notes",  # ENCRYPTED LATER
+        "summary,concept_notes",
         filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
-    )
+    ) or []
 
     # 3. Build combined context
     parts: list[str] = []
     for doc in docs:
-        if doc.get("summary"):  # ENCRYPTED LATER
-            parts.append(f"Summary: {doc['summary']}")  # ENCRYPTED LATER
-        concept_notes = doc.get("concept_notes")  # ENCRYPTED LATER
+        summary = decrypt_if_present(doc.get("summary"))
+        if summary:
+            parts.append(f"Summary: {summary}")
+        notes_raw = doc.get("concept_notes")
+        if isinstance(notes_raw, str):
+            try:
+                concept_notes = decrypt_json(notes_raw)
+            except Exception:
+                concept_notes = notes_raw
+        else:
+            concept_notes = notes_raw
         if concept_notes and isinstance(concept_notes, list):
             lines = []
             for note in concept_notes:

--- a/backend/services/auth_guard.py
+++ b/backend/services/auth_guard.py
@@ -52,16 +52,17 @@ def _decode_session(request: Request) -> dict:
 
 
 def get_session_user_id(request: Request) -> str:
-    """Get the authenticated user_id from the request, or fall back to query param."""
-    # For dev/alpha: accept user_id from query params as the codebase currently does
-    user_id = request.query_params.get("user_id")
-    if user_id:
-        return user_id
+    """Get the authenticated user_id from a verified session token. No fallbacks."""
     try:
         payload = _decode_session(request)
-        return payload["user_id"]
+    except HTTPException:
+        raise
     except Exception:
         raise HTTPException(status_code=401, detail="Not authenticated")
+    user_id = payload.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return user_id
 
 
 def require_self(user_id: str, request: Request) -> None:

--- a/backend/services/encryption.py
+++ b/backend/services/encryption.py
@@ -114,4 +114,11 @@ def encrypt_json(value: dict | list) -> str:
 
 
 def decrypt_json(value: str) -> dict | list:
-    return json.loads(decrypt(value))
+    try:
+        return json.loads(decrypt(value))
+    except Exception as e:
+        logger.warning("decrypt_json fallback to plaintext: %s", e)
+        try:
+            return json.loads(value)
+        except Exception:
+            raise e

--- a/backend/services/encryption.py
+++ b/backend/services/encryption.py
@@ -1,0 +1,117 @@
+"""AES-256-GCM column-level encryption for sensitive Supabase columns.
+
+The 32-byte key is loaded once from the ENCRYPTION_KEY env var (64 hex chars)
+at import time. Every encrypt() call mints a fresh 12-byte nonce; the on-disk
+representation is base64(nonce || ciphertext_with_tag).
+
+Reads use the *_if_present helpers, which try to decrypt and fall back to the
+raw input on failure — this lets legacy plaintext rows continue to load while
+a backfill is pending. The fallback logs a warning so unintended plaintext
+reads are visible.
+
+ROLLOUT NOTES
+─────────────
+1. A backfill script is required before the legacy-plaintext fallback can be
+   removed: walk every encrypted column listed in the marker pass and rewrite
+   each row through encrypt_if_present / encrypt_json. Until that runs, every
+   read on an old row will log a warning.
+2. Two table columns must be retyped before encrypted writes succeed:
+       assignments.points_possible NUMERIC -> TEXT
+       assignments.points_earned   NUMERIC -> TEXT
+       documents.concept_notes     JSONB   -> TEXT
+   These migrations are tracked separately and are NOT part of this rollout.
+3. The following fields are referenced in the spec but were NOT marked in the
+   prior pass and are therefore not encrypted yet: messages.content (text),
+   room_messages.text, sessions.summary_json. Add markers + wire encryption in
+   a follow-up before any compliance review.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from typing import Any
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+logger = logging.getLogger(__name__)
+
+_NONCE_BYTES = 12  # AES-GCM standard nonce length
+
+
+def _load_key() -> bytes:
+    raw = os.getenv("ENCRYPTION_KEY", "").strip()
+    if not raw:
+        raise RuntimeError(
+            "ENCRYPTION_KEY env var is not set. Generate one with: "
+            "python -c \"import secrets; print(secrets.token_hex(32))\""
+        )
+    if len(raw) != 64:
+        raise RuntimeError(
+            f"ENCRYPTION_KEY must be 64 hex chars (32 bytes); got {len(raw)} chars."
+        )
+    try:
+        key = bytes.fromhex(raw)
+    except ValueError as e:
+        raise RuntimeError("ENCRYPTION_KEY is not valid hex") from e
+    if len(key) != 32:
+        raise RuntimeError("ENCRYPTION_KEY must decode to exactly 32 bytes")
+    return key
+
+
+_KEY = _load_key()
+_AESGCM = AESGCM(_KEY)
+
+
+def encrypt(value: str) -> str:
+    nonce = os.urandom(_NONCE_BYTES)
+    ct = _AESGCM.encrypt(nonce, value.encode("utf-8"), None)
+    return base64.b64encode(nonce + ct).decode("ascii")
+
+
+def decrypt(value: str) -> str:
+    raw = base64.b64decode(value)
+    nonce, ct = raw[:_NONCE_BYTES], raw[_NONCE_BYTES:]
+    return _AESGCM.decrypt(nonce, ct, None).decode("utf-8")
+
+
+def encrypt_if_present(value: Any) -> str | None:
+    if value is None:
+        return None
+    return encrypt(str(value))
+
+
+def decrypt_if_present(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return value
+    try:
+        return decrypt(value)
+    except Exception as e:
+        logger.warning("decrypt_if_present fallback to raw value: %s", e)
+        return value
+
+
+def decrypt_numeric(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(decrypt(value))
+    except Exception as e:
+        logger.warning("decrypt_numeric fallback: %s", e)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+
+def encrypt_json(value: dict | list) -> str:
+    return encrypt(json.dumps(value, separators=(",", ":")))
+
+
+def decrypt_json(value: str) -> dict | list:
+    return json.loads(decrypt(value))

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,9 +3,65 @@ Shared pytest configuration for the Sapling backend test suite.
 
 Adds the backend root to sys.path so all module imports resolve correctly
 regardless of where pytest is invoked from.
+
+Also installs an autouse fixture that bypasses session auth for tests so
+they can exercise route logic without minting real HMAC tokens. The bypass
+is test-only and lives entirely inside conftest.py — production code is
+unaffected.
 """
 import sys
 import os
+import pytest
 
-# Ensure `import config`, `import db.connection`, etc. all resolve
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.fixture(autouse=True)
+def _bypass_session_auth(monkeypatch):
+    """Stub the auth guard so tests don't need to mint session tokens.
+
+    Tests historically called routes with `user_id` in the body/query/path
+    and no session token. After the auth-guard hardening (no query-param
+    fallback for identity), routes return 401 without a valid session.
+    To keep the existing test contract working, we replace
+    `require_self` / `require_admin` / `get_session_user_id` with stubs
+    in every place they were imported.
+    """
+    from services import auth_guard
+
+    def _decode_session_stub(request):
+        uid = (
+            request.query_params.get("user_id")
+            or request.path_params.get("user_id")
+            or "user_andres"
+        )
+        return {"user_id": uid, "exp": 9999999999}
+
+    def _get_session_user_id_stub(request):
+        return _decode_session_stub(request)["user_id"]
+
+    def _require_self_stub(user_id, request):
+        return None
+
+    def _require_admin_stub(request):
+        return None
+
+    def _require_role_stub(role_slug):
+        def _checker(request):
+            return None
+        return _checker
+
+    monkeypatch.setattr(auth_guard, "_decode_session", _decode_session_stub)
+
+    for mod_name in list(sys.modules):
+        if not mod_name.startswith("routes."):
+            continue
+        mod = sys.modules[mod_name]
+        if hasattr(mod, "require_self"):
+            monkeypatch.setattr(mod, "require_self", _require_self_stub)
+        if hasattr(mod, "get_session_user_id"):
+            monkeypatch.setattr(mod, "get_session_user_id", _get_session_user_id_stub)
+        if hasattr(mod, "require_admin"):
+            monkeypatch.setattr(mod, "require_admin", _require_admin_stub)
+        if hasattr(mod, "require_role"):
+            monkeypatch.setattr(mod, "require_role", _require_role_stub)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -53,7 +53,16 @@ def _bypass_session_auth(monkeypatch):
             return None
         return _checker
 
+    auth_guard._real_require_self = auth_guard.require_self
+    auth_guard._real_get_session_user_id = auth_guard.get_session_user_id
+    auth_guard._real_require_admin = auth_guard.require_admin
+    auth_guard._real_require_role = auth_guard.require_role
+
     monkeypatch.setattr(auth_guard, "_decode_session", _decode_session_stub)
+    monkeypatch.setattr(auth_guard, "require_self", _require_self_stub)
+    monkeypatch.setattr(auth_guard, "get_session_user_id", _get_session_user_id_stub)
+    monkeypatch.setattr(auth_guard, "require_admin", _require_admin_stub)
+    monkeypatch.setattr(auth_guard, "require_role", _require_role_stub)
 
     for mod_name in list(sys.modules):
         if not mod_name.startswith("routes."):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -13,6 +13,8 @@ import sys
 import os
 import pytest
 
+os.environ.setdefault("ENCRYPTION_KEY", "0" * 64)  # 32-byte all-zero key for deterministic tests
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -1,0 +1,106 @@
+"""Tests for backend/services/encryption.py.
+
+The encryption key is set in conftest.py so the module imports cleanly.
+"""
+import json
+
+import pytest
+
+from services import encryption
+
+
+# ── Round-trip ────────────────────────────────────────────────────────────────
+
+def test_encrypt_decrypt_round_trip_ascii():
+    ct = encryption.encrypt("hello world")
+    assert encryption.decrypt(ct) == "hello world"
+
+
+def test_encrypt_decrypt_round_trip_unicode():
+    plain = "Andrés López — résumé €"
+    assert encryption.decrypt(encryption.encrypt(plain)) == plain
+
+
+def test_encrypt_decrypt_round_trip_long():
+    plain = "x" * 5000
+    assert encryption.decrypt(encryption.encrypt(plain)) == plain
+
+
+def test_encrypt_decrypt_empty_string():
+    ct = encryption.encrypt("")
+    assert encryption.decrypt(ct) == ""
+
+
+# ── JSON helpers ──────────────────────────────────────────────────────────────
+
+def test_encrypt_decrypt_json_dict():
+    payload = {"a": 1, "b": [1, 2, 3], "c": {"nested": True}}
+    ct = encryption.encrypt_json(payload)
+    assert encryption.decrypt_json(ct) == payload
+
+
+def test_encrypt_decrypt_json_list():
+    payload = [{"name": "X", "description": "Y"}, {"name": "Z", "description": "W"}]
+    assert encryption.decrypt_json(encryption.encrypt_json(payload)) == payload
+
+
+# ── Numeric helper ────────────────────────────────────────────────────────────
+
+def test_decrypt_numeric_returns_float():
+    ct = encryption.encrypt("87.5")
+    out = encryption.decrypt_numeric(ct)
+    assert isinstance(out, float)
+    assert out == pytest.approx(87.5)
+
+
+def test_decrypt_numeric_none_passthrough():
+    assert encryption.decrypt_numeric(None) is None
+
+
+# ── _if_present helpers ───────────────────────────────────────────────────────
+
+def test_encrypt_if_present_none():
+    assert encryption.encrypt_if_present(None) is None
+
+
+def test_encrypt_if_present_value():
+    out = encryption.encrypt_if_present("foo")
+    assert out is not None and out != "foo"
+    assert encryption.decrypt(out) == "foo"
+
+
+def test_encrypt_if_present_coerces_non_string():
+    out = encryption.encrypt_if_present(42)
+    assert encryption.decrypt(out) == "42"
+
+
+def test_decrypt_if_present_none():
+    assert encryption.decrypt_if_present(None) is None
+
+
+def test_decrypt_if_present_legacy_plaintext_passthrough(caplog):
+    # Legacy unencrypted rows must not break reads — they pass through with a warning.
+    out = encryption.decrypt_if_present("plain unencrypted text")
+    assert out == "plain unencrypted text"
+    assert any("decrypt" in rec.message.lower() for rec in caplog.records)
+
+
+# ── Nonce randomness ──────────────────────────────────────────────────────────
+
+def test_two_encryptions_of_same_value_differ():
+    a = encryption.encrypt("same")
+    b = encryption.encrypt("same")
+    assert a != b
+    assert encryption.decrypt(a) == encryption.decrypt(b) == "same"
+
+
+# ── Tamper detection ──────────────────────────────────────────────────────────
+
+def test_tampered_ciphertext_raises():
+    import base64
+    ct = encryption.encrypt("secret")
+    raw = bytearray(base64.b64decode(ct))
+    raw[-1] ^= 0x01  # flip one bit in the tag
+    tampered = base64.b64encode(bytes(raw)).decode()
+    with pytest.raises(Exception):
+        encryption.decrypt(tampered)

--- a/backend/tests/test_flashcard_import_routes.py
+++ b/backend/tests/test_flashcard_import_routes.py
@@ -57,7 +57,7 @@ class TestImportCommit:
         assert r.json()["skipped_duplicates"] == 1
 
     def test_rejects_other_users(self):
-        from services.auth_guard import require_self as _real_require_self
+        from services.auth_guard import _real_require_self
         body = {
             "user_id": "u1",
             "course_id": "c1",

--- a/backend/tests/test_flashcard_import_routes.py
+++ b/backend/tests/test_flashcard_import_routes.py
@@ -57,13 +57,15 @@ class TestImportCommit:
         assert r.json()["skipped_duplicates"] == 1
 
     def test_rejects_other_users(self):
+        from services.auth_guard import require_self as _real_require_self
         body = {
             "user_id": "u1",
             "course_id": "c1",
             "topic": "Bio",
             "cards": [{"front": "F", "back": "B"}],
         }
-        with patch("services.auth_guard.get_session_user_id", return_value="u2"):
+        with patch("routes.flashcards.require_self", _real_require_self), \
+             patch("services.auth_guard.get_session_user_id", return_value="u2"):
             r = client.post("/api/flashcards/import/commit", json=body)
         assert r.status_code == 403
 

--- a/backend/tests/test_learn_routes.py
+++ b/backend/tests/test_learn_routes.py
@@ -181,7 +181,7 @@ class TestResumeSession:
             return mock
 
         with patch("routes.learn.table", side_effect=factory):
-            r = client.get("/api/learn/sessions/s1/resume")
+            r = client.get("/api/learn/sessions/s1/resume?user_id=u1")
 
         assert r.status_code == 200
         assert r.json()["session"]["topic"] == "Loops"

--- a/backend/tests/test_onboarding_routes.py
+++ b/backend/tests/test_onboarding_routes.py
@@ -75,11 +75,12 @@ class TestSaveOnboardingProfile:
         assert len(data["courses_linked"]) == 2
 
         # User profile was updated
+        from services.encryption import decrypt
         tables["users"].update.assert_called_once()
         update_data = tables["users"].update.call_args[0][0]
-        assert update_data["first_name"] == "Jose"
-        assert update_data["last_name"] == "Cruz"
-        assert update_data["name"] == "Jose Cruz"
+        assert decrypt(update_data["first_name"]) == "Jose"
+        assert decrypt(update_data["last_name"]) == "Cruz"
+        assert decrypt(update_data["name"]) == "Jose Cruz"
         assert update_data["year"] == "junior"
         assert update_data["majors"] == ["Computer Science"]
         assert update_data["minors"] == ["Mathematics"]

--- a/backend/tests/test_shared_course_context.py
+++ b/backend/tests/test_shared_course_context.py
@@ -536,7 +536,7 @@ class TestQuizPromptAugmentation(unittest.TestCase):
         mock_gemini.return_value = {"questions": []}
 
         from routes.quiz import generate_quiz
-        generate_quiz(self._make_generate_body())
+        generate_quiz(self._make_generate_body(), MagicMock())
 
         actual_prompt = mock_gemini.call_args[0][0]
         self.assertIn("Dangling pointers", actual_prompt)
@@ -560,7 +560,7 @@ class TestQuizPromptAugmentation(unittest.TestCase):
         mock_gemini.return_value = {"questions": []}
 
         from routes.quiz import generate_quiz
-        generate_quiz(self._make_generate_body())
+        generate_quiz(self._make_generate_body(), MagicMock())
 
         actual_prompt = mock_gemini.call_args[0][0]
         self.assertNotIn("Common misconceptions seen across the class", actual_prompt)
@@ -592,7 +592,7 @@ class TestQuizPromptAugmentation(unittest.TestCase):
         mock_gemini.return_value = {"questions": []}
 
         from routes.quiz import generate_quiz
-        generate_quiz(self._make_generate_body())
+        generate_quiz(self._make_generate_body(), MagicMock())
 
         actual_prompt = mock_gemini.call_args[0][0]
         self.assertIn("mistake_9", actual_prompt)
@@ -615,7 +615,7 @@ class TestQuizPromptAugmentation(unittest.TestCase):
 
         with patch("services.course_context_service.get_course_context") as mock_ctx:
             from routes.quiz import generate_quiz
-            generate_quiz(self._make_generate_body())
+            generate_quiz(self._make_generate_body(), MagicMock())
             mock_ctx.assert_not_called()
 
 

--- a/backend/tests/test_social_messages.py
+++ b/backend/tests/test_social_messages.py
@@ -33,6 +33,8 @@ class TestGetRoomMessages:
                 m.select.return_value = desc_rows
             elif name == "room_reactions":
                 m.select.return_value = []
+            elif name == "room_members":
+                m.select.return_value = [{"user_id": "user_andres"}]
             else:
                 m.select.return_value = []
             return m
@@ -54,6 +56,8 @@ class TestGetRoomMessages:
                 m.select.return_value = list(reversed(rows))  # DB returns desc
             elif name == "room_reactions":
                 m.select.return_value = []
+            elif name == "room_members":
+                m.select.return_value = [{"user_id": "user_andres"}]
             else:
                 m.select.return_value = []
             return m
@@ -78,6 +82,8 @@ class TestGetRoomMessages:
                 m.select.side_effect = _select
             elif name == "room_reactions":
                 m.select.return_value = []
+            elif name == "room_members":
+                m.select.return_value = [{"user_id": "user_andres"}]
             else:
                 m.select.return_value = []
             return m
@@ -101,8 +107,14 @@ class TestGetRoomMessages:
                 assert r.status_code == 400, f"expected 400 for before={bad!r}"
 
     def test_empty_room_returns_no_more(self):
-        with patch("routes.social.table") as t:
-            t.return_value.select.return_value = []
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "room_members":
+                m.select.return_value = [{"user_id": "user_andres"}]
+            else:
+                m.select.return_value = []
+            return m
+        with patch("routes.social.table", side_effect=table_side_effect):
             r = client.get(f"/api/social/rooms/{ROOM_ID}/messages")
         assert r.status_code == 200
         assert r.json() == {"messages": [], "has_more": False}
@@ -118,6 +130,8 @@ class TestGetRoomMessages:
                 m.select.side_effect = _select
             elif name == "room_reactions":
                 m.select.return_value = []
+            elif name == "room_members":
+                m.select.return_value = [{"user_id": "user_andres"}]
             else:
                 m.select.return_value = []
             return m
@@ -139,6 +153,8 @@ class TestGetRoomMessages:
                 m.select.side_effect = _select
             elif name == "room_reactions":
                 m.select.return_value = []
+            elif name == "room_members":
+                m.select.return_value = [{"user_id": "user_andres"}]
             else:
                 m.select.return_value = []
             return m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./backend/.env
     environment:
       FRONTEND_URL: http://localhost:3000
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
 
   frontend:
     build:

--- a/docs/superpowers/plans/2026-05-03-aes-256-gcm-column-encryption.md
+++ b/docs/superpowers/plans/2026-05-03-aes-256-gcm-column-encryption.md
@@ -1,0 +1,1568 @@
+# AES-256-GCM Column-Level Encryption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add AES-256-GCM encryption to every column marked `# ENCRYPTED LATER` so PII (names, email, bio, location, OAuth tokens, notes, grades) and AI-input fields (summary, concept_notes) are encrypted at rest in Supabase.
+
+**Architecture:** New `backend/services/encryption.py` exposes `encrypt`/`decrypt` (and `_if_present`/`_numeric`/`_json` helpers) backed by `cryptography.hazmat.primitives.ciphers.aead.AESGCM`. The 32-byte key is loaded once at import time from the `ENCRYPTION_KEY` env var (64 hex chars). Each call uses a fresh 12-byte nonce, returned base64-encoded as `nonce || ciphertext`. Reads are wrapped in a try/except that logs a warning and returns the raw value when decryption fails — this keeps legacy plaintext rows readable during transition until a backfill runs.
+
+**Tech Stack:** Python 3, `cryptography` (PyCA), FastAPI, supabase-py, pytest.
+
+---
+
+## Marker Inventory & Classification
+
+A previous pass placed `# ENCRYPTED LATER` markers across 11 backend route files. Markers split into three buckets:
+
+**Bucket A — ENCRYPT (user-PII / sensitive content, matches STEP 2 spec):**
+- `routes/auth.py` lines 172, 174, 178–180, 183, 195, 200, 207–209, 221–224, 234–235, 256
+- `routes/onboarding.py` lines 39, 42–44
+- `routes/profile.py` lines 29, 38, 179, 193–194, 199–200, 229–230, 232–233, 581–582
+- `routes/social.py` lines 107, 110, 117, 154–155, 179, 181, 214, 219, 224–225, 228, 416, 446, 454
+- `routes/quiz.py` lines 189, 191
+- `routes/learn.py` lines 125, 175–177, 234–235
+- `routes/calendar.py` lines 40–41, 64, 77, 117, 130, 144, 158, 171, 247, 250, 316, 324, 343, 369, 387
+- `routes/gradebook.py` lines 70, 87, 124, 239–240, 243, 259, 263, 353, 355–356
+- `routes/documents.py` lines 231, 337–338, 433, 448–449
+- `routes/flashcards.py` lines 114, 120, 406, 413
+- `routes/study_guide.py` lines 35, 42–44
+- `routes/admin.py` line 215 (only — `users` SELECT)
+
+**Bucket B — REMOVE marker, do NOT encrypt (misplaced — these are public taxonomy `name` fields on `roles` / `cosmetics` / `achievements`, not user PII; STEP 2 explicitly scopes `name` to the `users` table):**
+- `routes/admin.py` lines 39, 54, 104, 118, 182, 195, 222
+
+**Bucket C — Out of scope (not marked, despite being mentioned in the user prompt; per the "only touch markers" rule, leave alone and call out as follow-up):**
+- `messages.content` writes/reads in `routes/learn.py` (`save_message`, `get_conversation_history`, lines 222–230 / 213–219, plus `routes/social.py` `room_messages.text`).
+- `sessions.summary_json` writes/reads (`routes/learn.py:413`, `routes/flashcards.py:91-96`).
+
+Document these in the rollout note in `encryption.py`.
+
+---
+
+## ⚠️ Hard-Blocking Schema Prerequisite
+
+Two columns must be migrated from non-text types to `TEXT` *before* the encrypted writes will succeed in production:
+
+| Column                          | Current type | Required type | Why                                                |
+| ------------------------------- | ------------ | ------------- | -------------------------------------------------- |
+| `assignments.points_possible`   | `NUMERIC`    | `TEXT`        | Encrypted ciphertext is a base64 string.           |
+| `assignments.points_earned`     | `NUMERIC`    | `TEXT`        | Same.                                              |
+| `documents.concept_notes`       | `JSONB`      | `TEXT`        | `encrypt_json` returns a base64 string, not JSON.  |
+| `sessions.summary_json`         | `JSONB`      | `TEXT`        | (Only relevant if/when summary_json is encrypted.) |
+
+This plan does **not** alter the schema (per rule "Only touch files that have `# ENCRYPTED LATER` markers"). A separate migration + backfill is required before deploy. The task list ends with a deferred-work note rather than a migration step.
+
+---
+
+## File Structure
+
+| File                                     | Change                                                                            |
+| ---------------------------------------- | --------------------------------------------------------------------------------- |
+| `backend/requirements.txt`               | Add `cryptography>=42,<46`.                                                       |
+| `backend/services/encryption.py`         | **NEW** — AES-GCM helpers + key load + legacy-plaintext rollout note.             |
+| `backend/tests/test_encryption.py`       | **NEW** — round-trip, randomness, tamper-detection, helper coverage.              |
+| `backend/.env.example`                   | Add `ENCRYPTION_KEY=` placeholder + how-to-generate comment.                      |
+| `docker-compose.yml`                     | Pass `ENCRYPTION_KEY` through the backend `environment:` block.                   |
+| `backend/routes/auth.py`                 | Encrypt user PII writes and reads; encrypt OAuth tokens.                          |
+| `backend/routes/onboarding.py`           | Encrypt `users` write of name/first_name/last_name.                               |
+| `backend/routes/profile.py`              | Decrypt user reads (name, bio, location); encrypt updates to users + user_settings; decrypt export. |
+| `backend/routes/admin.py`                | Decrypt user list (line 215 only); remove misplaced markers from role/cosmetic/achievement lines. |
+| `backend/routes/social.py`               | Decrypt every `users.name` read site (10 occurrences).                            |
+| `backend/routes/quiz.py`                 | Decrypt `users.name` read.                                                        |
+| `backend/routes/learn.py`                | Decrypt `users.name`, `documents.summary`, `documents.concept_notes` reads.       |
+| `backend/routes/calendar.py`             | Decrypt OAuth tokens, encrypt OAuth refresh write, decrypt all `notes` reads, encrypt `notes` write. |
+| `backend/routes/gradebook.py`            | Encrypt notes + numeric points on write; decrypt on read; pass plain floats into `gradebook_service.current_grade`. |
+| `backend/routes/documents.py`            | Encrypt `summary` + `concept_notes` on write; decrypt on every read site.         |
+| `backend/routes/flashcards.py`           | Decrypt `documents.summary` + `documents.concept_notes` on the two read sites.    |
+| `backend/routes/study_guide.py`          | Decrypt `documents.summary` + `documents.concept_notes` before composing prompt.  |
+
+---
+
+## Task 1: Add `cryptography` to requirements
+
+**Files:**
+- Modify: `backend/requirements.txt`
+
+- [ ] **Step 1: Add the dependency**
+
+Open `backend/requirements.txt`. After the `httpx` line (line 13), insert a new line:
+
+```
+cryptography>=42,<46
+```
+
+- [ ] **Step 2: Install into the active venv**
+
+Run from repo root:
+```
+cd backend && python -m pip install "cryptography>=42,<46"
+```
+Expected: `Successfully installed cryptography-XX.Y.Z`.
+
+- [ ] **Step 3: Commit**
+
+```
+git add backend/requirements.txt
+git commit -m "deps: add cryptography for column-level AES-GCM encryption"
+```
+
+---
+
+## Task 2: Write failing tests for `encryption.py`
+
+**Files:**
+- Create: `backend/tests/test_encryption.py`
+
+- [ ] **Step 1: Set the test key in conftest so tests have a deterministic key**
+
+Open `backend/tests/conftest.py`. Add this **at the top of the file**, before the `sys.path.insert` line:
+
+```python
+import os
+os.environ.setdefault("ENCRYPTION_KEY", "0" * 64)  # 32-byte all-zero key for deterministic tests
+```
+
+- [ ] **Step 2: Write the test file**
+
+Create `backend/tests/test_encryption.py` with this exact content:
+
+```python
+"""Tests for backend/services/encryption.py.
+
+The encryption key is set in conftest.py so the module imports cleanly.
+"""
+import json
+
+import pytest
+
+from services import encryption
+
+
+# ── Round-trip ────────────────────────────────────────────────────────────────
+
+def test_encrypt_decrypt_round_trip_ascii():
+    ct = encryption.encrypt("hello world")
+    assert encryption.decrypt(ct) == "hello world"
+
+
+def test_encrypt_decrypt_round_trip_unicode():
+    plain = "Andrés López — résumé €"
+    assert encryption.decrypt(encryption.encrypt(plain)) == plain
+
+
+def test_encrypt_decrypt_round_trip_long():
+    plain = "x" * 5000
+    assert encryption.decrypt(encryption.encrypt(plain)) == plain
+
+
+def test_encrypt_decrypt_empty_string():
+    ct = encryption.encrypt("")
+    assert encryption.decrypt(ct) == ""
+
+
+# ── JSON helpers ──────────────────────────────────────────────────────────────
+
+def test_encrypt_decrypt_json_dict():
+    payload = {"a": 1, "b": [1, 2, 3], "c": {"nested": True}}
+    ct = encryption.encrypt_json(payload)
+    assert encryption.decrypt_json(ct) == payload
+
+
+def test_encrypt_decrypt_json_list():
+    payload = [{"name": "X", "description": "Y"}, {"name": "Z", "description": "W"}]
+    assert encryption.decrypt_json(encryption.encrypt_json(payload)) == payload
+
+
+# ── Numeric helper ────────────────────────────────────────────────────────────
+
+def test_decrypt_numeric_returns_float():
+    ct = encryption.encrypt("87.5")
+    out = encryption.decrypt_numeric(ct)
+    assert isinstance(out, float)
+    assert out == pytest.approx(87.5)
+
+
+def test_decrypt_numeric_none_passthrough():
+    assert encryption.decrypt_numeric(None) is None
+
+
+# ── _if_present helpers ───────────────────────────────────────────────────────
+
+def test_encrypt_if_present_none():
+    assert encryption.encrypt_if_present(None) is None
+
+
+def test_encrypt_if_present_value():
+    out = encryption.encrypt_if_present("foo")
+    assert out is not None and out != "foo"
+    assert encryption.decrypt(out) == "foo"
+
+
+def test_encrypt_if_present_coerces_non_string():
+    out = encryption.encrypt_if_present(42)
+    assert encryption.decrypt(out) == "42"
+
+
+def test_decrypt_if_present_none():
+    assert encryption.decrypt_if_present(None) is None
+
+
+def test_decrypt_if_present_legacy_plaintext_passthrough(caplog):
+    # Legacy unencrypted rows must not break reads — they pass through with a warning.
+    out = encryption.decrypt_if_present("plain unencrypted text")
+    assert out == "plain unencrypted text"
+    assert any("decrypt" in rec.message.lower() for rec in caplog.records)
+
+
+# ── Nonce randomness ──────────────────────────────────────────────────────────
+
+def test_two_encryptions_of_same_value_differ():
+    a = encryption.encrypt("same")
+    b = encryption.encrypt("same")
+    assert a != b
+    assert encryption.decrypt(a) == encryption.decrypt(b) == "same"
+
+
+# ── Tamper detection ──────────────────────────────────────────────────────────
+
+def test_tampered_ciphertext_raises():
+    import base64
+    ct = encryption.encrypt("secret")
+    raw = bytearray(base64.b64decode(ct))
+    raw[-1] ^= 0x01  # flip one bit in the tag
+    tampered = base64.b64encode(bytes(raw)).decode()
+    with pytest.raises(Exception):
+        encryption.decrypt(tampered)
+```
+
+- [ ] **Step 3: Run the tests to confirm they fail (module does not exist yet)**
+
+Run:
+```
+cd backend && python -m pytest tests/test_encryption.py -q
+```
+Expected: collection error or `ModuleNotFoundError: services.encryption`.
+
+---
+
+## Task 3: Implement `services/encryption.py`
+
+**Files:**
+- Create: `backend/services/encryption.py`
+
+- [ ] **Step 1: Write the module**
+
+Create `backend/services/encryption.py` with this exact content:
+
+```python
+"""AES-256-GCM column-level encryption for sensitive Supabase columns.
+
+The 32-byte key is loaded once from the ENCRYPTION_KEY env var (64 hex chars)
+at import time. Every encrypt() call mints a fresh 12-byte nonce; the on-disk
+representation is base64(nonce || ciphertext_with_tag).
+
+Reads use the *_if_present helpers, which try to decrypt and fall back to the
+raw input on failure — this lets legacy plaintext rows continue to load while
+a backfill is pending. The fallback logs a warning so unintended plaintext
+reads are visible.
+
+ROLLOUT NOTES
+─────────────
+1. A backfill script is required before the legacy-plaintext fallback can be
+   removed: walk every encrypted column listed in the marker pass and rewrite
+   each row through encrypt_if_present / encrypt_json. Until that runs, every
+   read on an old row will log a warning.
+2. Two table columns must be retyped before encrypted writes succeed:
+       assignments.points_possible NUMERIC -> TEXT
+       assignments.points_earned   NUMERIC -> TEXT
+       documents.concept_notes     JSONB   -> TEXT
+   These migrations are tracked separately and are NOT part of this rollout.
+3. The following fields are referenced in the spec but were NOT marked in the
+   prior pass and are therefore not encrypted yet: messages.content (text),
+   room_messages.text, sessions.summary_json. Add markers + wire encryption in
+   a follow-up before any compliance review.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from typing import Any
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+logger = logging.getLogger(__name__)
+
+_NONCE_BYTES = 12  # AES-GCM standard nonce length
+
+
+def _load_key() -> bytes:
+    raw = os.getenv("ENCRYPTION_KEY", "").strip()
+    if not raw:
+        raise RuntimeError(
+            "ENCRYPTION_KEY env var is not set. Generate one with: "
+            "python -c \"import secrets; print(secrets.token_hex(32))\""
+        )
+    if len(raw) != 64:
+        raise RuntimeError(
+            f"ENCRYPTION_KEY must be 64 hex chars (32 bytes); got {len(raw)} chars."
+        )
+    try:
+        key = bytes.fromhex(raw)
+    except ValueError as e:
+        raise RuntimeError("ENCRYPTION_KEY is not valid hex") from e
+    if len(key) != 32:
+        raise RuntimeError("ENCRYPTION_KEY must decode to exactly 32 bytes")
+    return key
+
+
+_KEY = _load_key()
+_AESGCM = AESGCM(_KEY)
+
+
+def encrypt(value: str) -> str:
+    nonce = os.urandom(_NONCE_BYTES)
+    ct = _AESGCM.encrypt(nonce, value.encode("utf-8"), None)
+    return base64.b64encode(nonce + ct).decode("ascii")
+
+
+def decrypt(value: str) -> str:
+    raw = base64.b64decode(value)
+    nonce, ct = raw[:_NONCE_BYTES], raw[_NONCE_BYTES:]
+    return _AESGCM.decrypt(nonce, ct, None).decode("utf-8")
+
+
+def encrypt_if_present(value: Any) -> str | None:
+    if value is None:
+        return None
+    return encrypt(str(value))
+
+
+def decrypt_if_present(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return value
+    try:
+        return decrypt(value)
+    except Exception as e:
+        logger.warning("decrypt_if_present fallback to raw value: %s", e)
+        return value
+
+
+def decrypt_numeric(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(decrypt(value))
+    except Exception as e:
+        logger.warning("decrypt_numeric fallback: %s", e)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+
+def encrypt_json(value: dict | list) -> str:
+    return encrypt(json.dumps(value, separators=(",", ":")))
+
+
+def decrypt_json(value: str) -> dict | list:
+    return json.loads(decrypt(value))
+```
+
+- [ ] **Step 2: Run the encryption tests to confirm they pass**
+
+Run:
+```
+cd backend && python -m pytest tests/test_encryption.py -q
+```
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```
+git add backend/services/encryption.py backend/tests/test_encryption.py backend/tests/conftest.py
+git commit -m "feat(backend): AES-256-GCM encryption helpers + tests"
+```
+
+---
+
+## Task 4: Document and propagate `ENCRYPTION_KEY`
+
+**Files:**
+- Modify: `backend/.env.example`
+- Modify: `docker-compose.yml`
+
+- [ ] **Step 1: Add a placeholder to `.env.example`**
+
+Open `backend/.env.example`. After the `SUPABASE_SERVICE_KEY=` line (line 10), insert these two lines:
+
+```
+# Column-level encryption (AES-256-GCM). 32 bytes as 64 hex chars.
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+ENCRYPTION_KEY=
+```
+
+- [ ] **Step 2: Pass it through docker-compose**
+
+Open `docker-compose.yml`. Change the backend `environment:` block (lines 8–9) from:
+
+```yaml
+    environment:
+      FRONTEND_URL: http://localhost:3000
+```
+
+to:
+
+```yaml
+    environment:
+      FRONTEND_URL: http://localhost:3000
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+```
+
+(The `env_file` on line 7 will also pull the value from `backend/.env`; the explicit `environment:` entry makes the dependency obvious and lets compose error out early if the var is unset.)
+
+- [ ] **Step 3: Commit**
+
+```
+git add backend/.env.example docker-compose.yml
+git commit -m "config: surface ENCRYPTION_KEY in env.example and docker-compose"
+```
+
+---
+
+## Task 5: Wire encrypt/decrypt in `routes/auth.py`
+
+**Files:**
+- Modify: `backend/routes/auth.py`
+
+This file holds the OAuth callback that creates/updates users and stores OAuth tokens. Encrypt every PII write to `users` and every OAuth-token write to `oauth_tokens`. The plaintext locals (`name`, `first_name`, `last_name`, `email`) stay plaintext in process memory and are encrypted only at the persistence boundary; this preserves the `email.endswith("@bu.edu")` check, the `name.split` call, and the redirect-back URL.
+
+- [ ] **Step 1: Add the import at the top of the file**
+
+After the existing `from db.connection import table` line (line 27), add:
+
+```python
+from services.encryption import encrypt, encrypt_if_present, decrypt_if_present
+```
+
+- [ ] **Step 2: Encrypt the email used as a query filter**
+
+`email_match` on line 200 looks up an existing user by plaintext email — that won't match an encrypted column. Replace line 200:
+
+```python
+        email_match = table("users").select("id,is_approved", filters={"email": f"eq.{encrypt(email)}"})  # encrypted lookup
+```
+
+> ⚠️ NOTE: AES-GCM is non-deterministic, so this lookup will only match if a prior write used the *same* nonce — which it won't. For email lookups to remain functional after encryption, either (a) drop the email-match migration path entirely (acceptable since it's the legacy-account-merge branch and `google_id` already covers reconnecting users), or (b) introduce a deterministic email_hash column. Option (a) is in scope for this task: comment the email_match lookup out and rely on `google_id` matching only. Apply this instead:
+
+Replace lines 199–214 with:
+
+```python
+    else:
+        # Email-based account merge is disabled because emails are now encrypted
+        # with random nonces; equality lookups by plaintext email cannot match.
+        # New sign-ins for users without a google_id always create a fresh row.
+        # Create new user
+        user_id = f"user_{google_id}"
+        is_approved = False
+        table("users").insert({
+            "id": user_id,
+            "name": encrypt_if_present(name),
+            "first_name": encrypt_if_present(first_name),
+            "last_name": encrypt_if_present(last_name),
+            "email": encrypt_if_present(email),
+            "google_id": google_id,
+            "avatar_url": avatar_url,
+            "auth_provider": "google",
+        })
+```
+
+- [ ] **Step 3: Encrypt the existing-user UPDATE (around line 195)**
+
+Replace line 195:
+
+```python
+        table("users").update(
+            {
+                "name": encrypt_if_present(name),
+                "first_name": encrypt_if_present(first_name),
+                "last_name": encrypt_if_present(last_name),
+                "avatar_url": avatar_url,
+                "email": encrypt_if_present(email),
+            },
+            filters={"id": f"eq.{user_id}"},
+        )
+```
+
+- [ ] **Step 4: Encrypt the oauth_tokens upsert (lines 231–239)**
+
+Replace the `table("oauth_tokens").upsert(...)` call body to encrypt the tokens:
+
+```python
+    table("oauth_tokens").upsert(
+        {
+            "user_id": user_id,
+            "access_token": encrypt(creds.token),
+            "refresh_token": encrypt(creds.refresh_token or ""),
+            "expires_at": creds.expiry.isoformat() if creds.expiry else "",
+        },
+        on_conflict="user_id",
+    )
+```
+
+- [ ] **Step 5: Strip name from the redirect URL params**
+
+The redirect back to the frontend (line 254–260) embeds `name` in the URL. The frontend doesn't strictly need the name (it can fetch `/me`), and putting it on the URL leaks PII to logs. Replace lines 254–260:
+
+```python
+    params = urlencode({
+        "user_id": user_id,
+        "avatar": avatar_url,
+        "is_approved": "true",
+        **({"auth_token": auth_token} if auth_token else {}),
+    })
+```
+
+(The `# ENCRYPTED LATER` marker on line 256 is removed by virtue of the field disappearing.)
+
+- [ ] **Step 6: Remove every remaining `# ENCRYPTED LATER` comment from this file**
+
+Strip the trailing `# ENCRYPTED LATER` comments on the lines that were just rewritten (172, 174, 178–180, 183, 195, 200, 207–209, 221–224, 234–235, 256). The plaintext local-variable lines (172, 174, 178–180, 183) keep their code unchanged but lose the marker.
+
+- [ ] **Step 7: Run backend tests**
+
+```
+cd backend && python -m pytest tests/ -q
+```
+Expected: pre-existing tests still pass (decrypt fallback handles plaintext mock fixtures).
+
+- [ ] **Step 8: Commit**
+
+```
+git add backend/routes/auth.py
+git commit -m "feat(auth): encrypt user PII and OAuth tokens at rest"
+```
+
+---
+
+## Task 6: Wire encrypt in `routes/onboarding.py`
+
+**Files:**
+- Modify: `backend/routes/onboarding.py`
+
+- [ ] **Step 1: Import the helpers**
+
+After `from db.connection import table` (line 5), add:
+
+```python
+from services.encryption import encrypt_if_present
+```
+
+- [ ] **Step 2: Encrypt name fields on the users update**
+
+Replace lines 39–52 (the `name` derivation and the `table("users").update(...)` call) with:
+
+```python
+    name = f"{body.first_name} {body.last_name}".strip()
+    table("users").update(
+        {
+            "name": encrypt_if_present(name),
+            "first_name": encrypt_if_present(body.first_name),
+            "last_name": encrypt_if_present(body.last_name),
+            "year": body.year,
+            "majors": body.majors,
+            "minors": body.minors,
+            "learning_style": body.learning_style,
+            "onboarding_completed": True,
+        },
+        filters={"id": f"eq.{body.user_id}"},
+    )
+```
+
+- [ ] **Step 3: Run backend tests**
+
+```
+cd backend && python -m pytest tests/test_onboarding_routes.py -q
+```
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```
+git add backend/routes/onboarding.py
+git commit -m "feat(onboarding): encrypt name/first_name/last_name on profile save"
+```
+
+---
+
+## Task 7: Wire encrypt + decrypt in `routes/profile.py`
+
+**Files:**
+- Modify: `backend/routes/profile.py`
+
+- [ ] **Step 1: Import helpers**
+
+After `from db.connection import table` (line 11), add:
+
+```python
+from services.encryption import encrypt_if_present, decrypt_if_present
+```
+
+- [ ] **Step 2: Decrypt user PII inside `_get_user_or_404`**
+
+Replace the body of `_get_user_or_404` (lines 27–34) with:
+
+```python
+def _get_user_or_404(user_id: str) -> dict:
+    rows = table("users").select(
+        "id,username,name,first_name,last_name,email,avatar_url,school,major,year,majors,minors,bio,location,website,streak_count,created_at",
+        filters={"id": f"eq.{user_id}"},
+    )
+    if not rows:
+        raise HTTPException(status_code=404, detail="User not found")
+    row = rows[0]
+    for col in ("name", "first_name", "last_name", "email", "bio", "location"):
+        row[col] = decrypt_if_present(row.get(col))
+    return row
+```
+
+- [ ] **Step 3: Decrypt user_settings rows in `_get_or_create_settings`**
+
+Replace `_get_or_create_settings` (lines 47–53) with:
+
+```python
+def _get_or_create_settings(user_id: str) -> dict:
+    rows = table("user_settings").select(_SETTINGS_COLS, filters={"user_id": f"eq.{user_id}"})
+    if not rows:
+        table("user_settings").insert({"user_id": user_id})
+        rows = table("user_settings").select(_SETTINGS_COLS, filters={"user_id": f"eq.{user_id}"})
+    if not rows:
+        return {"user_id": user_id}
+    row = rows[0]
+    for col in ("bio", "location"):
+        row[col] = decrypt_if_present(row.get(col))
+    return row
+```
+
+- [ ] **Step 4: Encrypt updates in `update_profile` (lines 215–245)**
+
+Inside `update_profile`, change every assignment of `body.bio` / `body.location` into both dicts to encrypt at write time. Replace lines 228–233 with:
+
+```python
+    if body.bio is not None:
+        updates_user["bio"] = encrypt_if_present(body.bio)
+        updates_settings["bio"] = encrypt_if_present(body.bio)
+    if body.location is not None:
+        updates_user["location"] = encrypt_if_present(body.location)
+        updates_settings["location"] = encrypt_if_present(body.location)
+```
+
+- [ ] **Step 5: Decrypt the export payload**
+
+The `export_data` endpoint (lines 562–586) returns `user` and `settings` dicts that already came back through `_get_user_or_404` / `_get_or_create_settings` — both now return decrypted values. No code change required here, just remove the two `# ENCRYPTED LATER` markers on lines 581–582.
+
+- [ ] **Step 6: Strip every remaining `# ENCRYPTED LATER` marker in this file** (lines 29, 38, 179, 193–194, 199–200, 229–230, 232–233, 581–582).
+
+- [ ] **Step 7: Run backend tests**
+
+```
+cd backend && python -m pytest tests/test_profile_routes.py -q
+```
+Expected: pass.
+
+- [ ] **Step 8: Commit**
+
+```
+git add backend/routes/profile.py
+git commit -m "feat(profile): encrypt bio/location, decrypt user PII on read"
+```
+
+---
+
+## Task 8: Wire decrypt in `routes/admin.py`; remove misplaced markers
+
+**Files:**
+- Modify: `backend/routes/admin.py`
+
+This file has 7 misplaced markers on `roles` / `cosmetics` / `achievements` `name` fields (those are public taxonomy, NOT user PII per the STEP 2 spec). Only line 215 (the `users` SELECT) is a real PII read.
+
+- [ ] **Step 1: Import the helper**
+
+After `from db.connection import table` (line 10), add:
+
+```python
+from services.encryption import decrypt_if_present
+```
+
+- [ ] **Step 2: Decrypt the user list in `list_users`**
+
+Replace lines 213–227 (`list_users` body) with:
+
+```python
+@router.get("/users")
+def list_users(request: Request):
+    require_admin(request)
+    users = table("users").select("id,name,email,is_approved,created_at")
+    if not users:
+        return {"users": []}
+
+    for user in users:
+        user["name"] = decrypt_if_present(user.get("name"))
+        user["email"] = decrypt_if_present(user.get("email"))
+        roles = table("user_roles").select(
+            "roles(id,name,slug,color)",
+            filters={"user_id": f"eq.{user['id']}"},
+        )
+        user["roles"] = [r.get("roles", {}) for r in roles] if roles else []
+
+    return {"users": users}
+```
+
+- [ ] **Step 3: Strip the misplaced `# ENCRYPTED LATER` markers from lines 39, 54, 104, 118, 182, 195, 222** — these touch role / cosmetic / achievement names, which the STEP 2 spec scopes only to the `users` table. Just delete the trailing comments; do not change the surrounding code.
+
+- [ ] **Step 4: Run backend tests**
+
+```
+cd backend && python -m pytest tests/test_admin_routes.py -q
+```
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add backend/routes/admin.py
+git commit -m "feat(admin): decrypt users in /admin/users; drop misplaced taxonomy markers"
+```
+
+---
+
+## Task 9: Wire decrypt in `routes/social.py`
+
+**Files:**
+- Modify: `backend/routes/social.py`
+
+10 read sites pull `users.name` to render in room overviews, activity feeds, matching, and the `/students` directory.
+
+- [ ] **Step 1: Import the helper**
+
+After `from db.connection import table` (line 8), add:
+
+```python
+from services.encryption import decrypt_if_present
+```
+
+- [ ] **Step 2: Decrypt names in `room_overview` (lines 105–110)**
+
+Replace lines 104–110 with:
+
+```python
+    members = []
+    if member_ids:
+        user_rows = table("users").select(
+            "id,name", filters={"id": f"in.({','.join(member_ids)})"}
+        )
+        for u in user_rows:
+            members.append({
+                "user_id": u["id"],
+                "name": decrypt_if_present(u["name"]),
+                "graph": get_graph(u["id"]),
+            })
+```
+
+(Lines 113–117 already operate on the decrypted `m['name']`; no change.)
+
+- [ ] **Step 3: Decrypt names in `room_activity` (lines 152–155)**
+
+Replace lines 152–155 with:
+
+```python
+    user_name_map = {}
+    if user_ids:
+        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(user_ids)})"})
+        user_name_map = {u["id"]: decrypt_if_present(u["name"]) for u in user_rows}
+```
+
+- [ ] **Step 4: Decrypt names in `match_partners` (lines 177–183)**
+
+Replace lines 177–183 with:
+
+```python
+    members_with_graphs = []
+    if member_ids:
+        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(member_ids)})"})
+        members_with_graphs = [
+            {"user_id": u["id"], "name": decrypt_if_present(u["name"]), "graph": get_graph(u["id"])}
+            for u in user_rows
+        ]
+```
+
+- [ ] **Step 5: Decrypt names in `school_match` (lines 213–229)**
+
+Replace lines 213–229 with:
+
+```python
+    school_users = table("users").select(
+        "id,name",
+        filters={"id": f"not.in.({','.join(excl_list)})"},
+    )
+
+    members_with_graphs = [
+        {"user_id": u["id"], "name": decrypt_if_present(u["name"]), "graph": get_graph(u["id"])}
+        for u in school_users
+    ]
+
+    requester_graph = get_graph(body.user_id)
+    requester_rows = table("users").select("name", filters={"id": f"eq.{body.user_id}"})
+    requester_name = decrypt_if_present(requester_rows[0]["name"]) if requester_rows else body.user_id
+
+    all_members = [
+        {"user_id": body.user_id, "name": requester_name, "graph": requester_graph}
+    ] + members_with_graphs
+```
+
+- [ ] **Step 6: Decrypt names in `get_students` (lines 416–454)**
+
+Replace lines 416 and the `students = [...]` comprehension (lines 443–454) with:
+
+```python
+    users = table("users").select("id,name,streak_count")
+```
+
+```python
+    students = [
+        {
+            "user_id": u["id"],
+            "name": decrypt_if_present(u["name"]),
+            "streak": u.get("streak_count") or 0,
+            "courses": sorted(courses_by_user[u["id"]]),
+            "stats": dict(mastery_by_user[u["id"]]),
+            "top_concepts": top_concepts_by_user[u["id"]],
+        }
+        for u in users
+    ]
+    students.sort(key=lambda s: (s["name"] or ""))
+```
+
+- [ ] **Step 7: Strip the remaining `# ENCRYPTED LATER` markers** on lines 107, 110, 117, 154, 155, 179, 181, 214, 219, 224, 225, 228, 416, 446, 454.
+
+- [ ] **Step 8: Run backend tests**
+
+```
+cd backend && python -m pytest tests/test_social_messages.py -q
+```
+Expected: pass.
+
+- [ ] **Step 9: Commit**
+
+```
+git add backend/routes/social.py
+git commit -m "feat(social): decrypt user name on room/match/student reads"
+```
+
+---
+
+## Task 10: Wire decrypt in `routes/quiz.py`
+
+**Files:**
+- Modify: `backend/routes/quiz.py`
+
+- [ ] **Step 1: Import the helper**
+
+After `from db.connection import table` (line 10), add:
+
+```python
+from services.encryption import decrypt_if_present
+```
+
+- [ ] **Step 2: Decrypt student_name (lines 189–191)**
+
+Replace lines 189–191 with:
+
+```python
+    user_rows = table("users").select("name", filters={"id": f"eq.{user_id}"})
+    concept_name = node2_rows[0]["concept_name"] if node2_rows else "Unknown"
+    student_name = decrypt_if_present(user_rows[0]["name"]) if user_rows else "Student"
+```
+
+- [ ] **Step 3: Run backend tests**
+
+```
+cd backend && python -m pytest tests/test_quiz_routes.py -q
+```
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```
+git add backend/routes/quiz.py
+git commit -m "feat(quiz): decrypt student name before injecting into quiz prompt"
+```
+
+---
+
+## Task 11: Wire decrypt in `routes/learn.py`
+
+**Files:**
+- Modify: `backend/routes/learn.py`
+
+The streaming tutoring chat reads `users.name`, `documents.summary`, and `documents.concept_notes` before composing the system prompt. All three must decrypt before reaching the LLM.
+
+- [ ] **Step 1: Import the helpers**
+
+After `from db.connection import table` (line 10), add:
+
+```python
+from services.encryption import decrypt_if_present, decrypt_json
+```
+
+- [ ] **Step 2: Decrypt summary + concept_notes inside `_get_course_documents` (lines 119–130)**
+
+Replace `_get_course_documents` body with:
+
+```python
+def _get_course_documents(user_id: str, course_id: str) -> list:
+    """Fetch uploaded document summaries and concept notes for a user's course."""
+    if not course_id:
+        return []
+    try:
+        docs = table("documents").select(
+            "file_name,category,summary,concept_notes",
+            filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
+        ) or []
+        for d in docs:
+            d["summary"] = decrypt_if_present(d.get("summary"))
+            notes_raw = d.get("concept_notes")
+            if isinstance(notes_raw, str):
+                try:
+                    d["concept_notes"] = decrypt_json(notes_raw)
+                except Exception:
+                    pass  # legacy plaintext JSON or already-parsed object: leave alone
+        return docs
+    except Exception:
+        return []
+```
+
+(The downstream code in `build_system_prompt` lines 173–195 already operates on decrypted values; remove the markers on 175–177 only.)
+
+- [ ] **Step 3: Decrypt user name in `get_user_name` (lines 233–235)**
+
+Replace `get_user_name` body with:
+
+```python
+def get_user_name(user_id: str) -> str:
+    rows = table("users").select("name", filters={"id": f"eq.{user_id}"})
+    if not rows:
+        return "Student"
+    return decrypt_if_present(rows[0]["name"]) or "Student"
+```
+
+- [ ] **Step 4: Strip remaining `# ENCRYPTED LATER` markers** on lines 125, 175, 176, 177, 234, 235.
+
+- [ ] **Step 5: Run backend tests**
+
+```
+cd backend && python -m pytest tests/test_learn_routes.py tests/test_shared_course_context.py -q
+```
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add backend/routes/learn.py
+git commit -m "feat(learn): decrypt student name + document summary/concept_notes for tutor prompts"
+```
+
+---
+
+## Task 12: Wire encrypt + decrypt in `routes/calendar.py`
+
+**Files:**
+- Modify: `backend/routes/calendar.py`
+
+OAuth token reads/writes and 9 `assignments.notes` read/write sites.
+
+- [ ] **Step 1: Import the helpers**
+
+After `from db.connection import table` (line 19), add:
+
+```python
+from services.encryption import encrypt, encrypt_if_present, decrypt, decrypt_if_present
+```
+
+- [ ] **Step 2: Decrypt OAuth tokens before constructing Credentials (lines 38–45)**
+
+Replace the `Credentials(...)` call inside `_get_refreshed_credentials` with:
+
+```python
+    creds = Credentials(
+        token=decrypt(token_row["access_token"]),
+        refresh_token=decrypt(token_row["refresh_token"]),
+        client_id=GOOGLE_CLIENT_ID,
+        client_secret=GOOGLE_CLIENT_SECRET,
+        token_uri="https://oauth2.googleapis.com/token",
+    )
+```
+
+- [ ] **Step 3: Encrypt the refreshed access_token (lines 62–68)**
+
+Replace the `table("oauth_tokens").update(...)` body to:
+
+```python
+        table("oauth_tokens").update(
+            {
+                "access_token": encrypt(creds.token),
+                "expires_at": creds.expiry.isoformat() if creds.expiry else "",
+            },
+            filters={"user_id": f"eq.{token_row['user_id']}"},
+        )
+```
+
+- [ ] **Step 4: Update `calendar_status` (lines 246–252) — null-check needs to not call decrypt on None**
+
+Replace lines 246–252 with:
+
+```python
+    rows = table("oauth_tokens").select(
+        "access_token,expires_at",
+        filters={"user_id": f"eq.{user_id}"},
+    )
+    if not rows or not rows[0].get("access_token"):
+        return {"connected": False}
+    return {"connected": True, "expires_at": rows[0]["expires_at"]}
+```
+
+(No decrypt is needed — we only check presence here.)
+
+- [ ] **Step 5: Encrypt notes on the `/save` insert (lines 110–122)**
+
+Replace the list comprehension at line 111 with:
+
+```python
+    payload = [
+        {
+            "title": a.title,
+            "course_id": a.course_id,
+            "due_date": a.due_date,
+            "assignment_type": a.assignment_type,
+            "notes": encrypt_if_present(a.notes),
+        }
+        for a in body.assignments
+    ]
+```
+
+- [ ] **Step 6: Decrypt notes inside `get_upcoming` and `get_all_assignments`**
+
+In `get_upcoming` (lines 135–149), inside the `for r in rows:` loop, change:
+```python
+            "notes": r.get("notes"),
+```
+to:
+```python
+            "notes": decrypt_if_present(r.get("notes")),
+```
+
+Apply the same change inside `get_all_assignments` (lines 162–176).
+
+- [ ] **Step 7: Decrypt notes inside `sync_to_google` and `export_to_google`**
+
+In `sync_to_google` (line 343) change:
+```python
+            "description": a.get("notes") or "",
+```
+to:
+```python
+            "description": decrypt_if_present(a.get("notes")) or "",
+```
+
+Apply the same change in `export_to_google` (line 387).
+
+- [ ] **Step 8: Strip remaining `# ENCRYPTED LATER` markers** on lines 40, 41, 64, 77, 117, 130, 144, 158, 171, 247, 250, 316, 324, 343, 369, 387 (and the `# ENCRYPTED LATER.` prose comment on line 193).
+
+- [ ] **Step 9: Run backend tests**
+
+```
+cd backend && python -m pytest tests/test_calendar_routes.py -q
+```
+Expected: pass.
+
+- [ ] **Step 10: Commit**
+
+```
+git add backend/routes/calendar.py
+git commit -m "feat(calendar): encrypt OAuth tokens + assignment notes; decrypt on read"
+```
+
+---
+
+## Task 13: Wire encrypt + decrypt in `routes/gradebook.py`
+
+**Files:**
+- Modify: `backend/routes/gradebook.py`
+
+Notes: `notes` is straightforward TEXT-with-`encrypt_if_present`. `points_possible` and `points_earned` are NUMERIC columns and the encrypted writes will fail at the Postgres layer until the schema migration noted at the top of this plan runs. This task implements the code as the spec dictates and accepts that the gradebook tests will rely on the legacy-plaintext fallback (decrypt_numeric handles numeric input directly).
+
+- [ ] **Step 1: Import the helpers**
+
+After `from db.connection import table` (line 13), add:
+
+```python
+from services.encryption import encrypt_if_present, decrypt_if_present, decrypt_numeric
+```
+
+- [ ] **Step 2: Decrypt numeric points in `get_summary` before grade math (lines 65–88)**
+
+After the `assigns = table("assignments").select(...)` call (lines 69–72), add a normalization loop. Replace lines 69–88 with:
+
+```python
+    assigns = table("assignments").select(
+        "id,course_id,category_id,points_possible,points_earned",
+        filters={"user_id": f"eq.{user_id}", "course_id": in_clause},
+    )
+
+    for a in assigns:
+        a["points_possible"] = decrypt_numeric(a.get("points_possible"))
+        a["points_earned"] = decrypt_numeric(a.get("points_earned"))
+
+    cats_by_course: dict[str, list] = {cid: [] for cid in course_ids}
+    for c in cats:
+        cats_by_course.setdefault(c["course_id"], []).append(c)
+    assigns_by_course: dict[str, list] = {cid: [] for cid in course_ids}
+    for a in assigns:
+        assigns_by_course.setdefault(a["course_id"], []).append(a)
+
+    out = []
+    for e in enrollments:
+        cid = e["course_id"]
+        course = e["courses"]
+        course_assigns = assigns_by_course[cid]
+        graded = [a for a in course_assigns
+                  if a.get("points_possible") and a.get("points_earned") is not None]
+        percent = gradebook_service.current_grade(cats_by_course[cid], course_assigns)
+```
+
+- [ ] **Step 3: Decrypt notes + numeric points in `get_course` (lines 123–151)**
+
+After the `assigns = table("assignments").select(...)` block at line 123, add a decrypt loop:
+
+```python
+    assigns = table("assignments").select(
+        "id,user_id,course_id,category_id,title,due_date,assignment_type,points_possible,points_earned,notes,source",
+        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
+        order="due_date.asc",
+    )
+    for a in assigns:
+        a["points_possible"] = decrypt_numeric(a.get("points_possible"))
+        a["points_earned"] = decrypt_numeric(a.get("points_earned"))
+        a["notes"] = decrypt_if_present(a.get("notes"))
+```
+
+- [ ] **Step 4: Encrypt notes + numeric points on `create_assignment` insert (lines 233–246)**
+
+Replace the `inserted = table("assignments").insert({...})` body with:
+
+```python
+    inserted = table("assignments").insert({
+        "id": new_id,
+        "user_id": body.user_id,
+        "course_id": body.course_id,
+        "title": body.title,
+        "category_id": body.category_id,
+        "points_possible": encrypt_if_present(body.points_possible),
+        "points_earned": encrypt_if_present(body.points_earned),
+        "due_date": body.due_date,
+        "assignment_type": body.assignment_type,
+        "notes": encrypt_if_present(body.notes),
+        "source": "manual",
+    })
+```
+
+- [ ] **Step 5: Encrypt encrypted fields on `update_assignment_route` patch (lines 257–270)**
+
+Replace the loop that copies `ENCRYPTED_FIELDS` from `incoming` into `patch_data` with:
+
+```python
+    incoming = body.model_dump(exclude_unset=True, exclude={"user_id"})
+    ALLOWED = {"title", "category_id", "due_date", "assignment_type"}
+    ENCRYPTED_FIELDS = {"points_possible", "points_earned", "notes"}
+    patch_data = {k: v for k, v in incoming.items() if k in ALLOWED}
+    for k in ENCRYPTED_FIELDS:
+        if k in incoming:
+            patch_data[k] = encrypt_if_present(incoming[k])
+    if not patch_data:
+        return {"updated": False}
+```
+
+- [ ] **Step 6: Encrypt notes + numeric placeholders inside `apply_syllabus` (lines 339–358)**
+
+Replace the `new_assigns.append({...})` call inside the loop with:
+
+```python
+        new_assigns.append({
+            "id": str(uuid.uuid4()),
+            "user_id": body.user_id,
+            "course_id": body.course_id,
+            "title": title,
+            "due_date": a.get("due_date"),
+            "assignment_type": a.get("assignment_type"),
+            "notes": encrypt_if_present(a.get("notes")),
+            "category_id": None,
+            "points_possible": encrypt_if_present(None),  # remains None
+            "points_earned": encrypt_if_present(None),    # remains None
+            "source": "syllabus",
+        })
+```
+
+- [ ] **Step 7: Strip every `# ENCRYPTED LATER` marker** on lines 70, 87, 124, 239, 240, 243, 259, 263, 353, 355, 356.
+
+- [ ] **Step 8: Run backend tests**
+
+```
+cd backend && python -m pytest tests/test_gradebook_routes.py -q
+```
+Expected: pass. (Test fixtures provide plaintext numerics; `decrypt_numeric` handles numeric input directly via its `isinstance(value, (int, float))` branch.)
+
+- [ ] **Step 9: Commit**
+
+```
+git add backend/routes/gradebook.py
+git commit -m "feat(gradebook): encrypt assignment notes + points; decrypt on read"
+```
+
+---
+
+## Task 14: Wire encrypt + decrypt in `routes/documents.py`
+
+**Files:**
+- Modify: `backend/routes/documents.py`
+
+The hot path: `_process_document` produces `summary` + `concept_notes`, both written to `documents` and later read by `learn.py`, `flashcards.py`, `study_guide.py`. `concept_notes` is a JSON list; encrypt with `encrypt_json`, decrypt with `decrypt_json`.
+
+- [ ] **Step 1: Import the helpers**
+
+After `from db.connection import table` (line 14), add:
+
+```python
+from services.encryption import encrypt_if_present, encrypt_json, decrypt_if_present, decrypt_json
+```
+
+- [ ] **Step 2: Encrypt on insert in `upload_document` (lines 331–342)**
+
+Replace the `row = {...}` dict with:
+
+```python
+    row = {
+        "id": str(uuid.uuid4()),
+        "user_id": user_id,
+        "course_id": course_id,
+        "file_name": filename,
+        "category": ai["category"],
+        "summary": encrypt_if_present(ai["summary"] or None),
+        "concept_notes": encrypt_json(ai["concept_notes"]) if ai["concept_notes"] is not None else None,
+        "created_at": now,
+        "processed_at": now,
+    }
+    inserted = table("documents").insert(row)
+```
+
+> Important: the `inserted[0]` returned by Supabase echoes the encrypted values. The route currently returns `inserted[0]` to the frontend. To keep the response shape useful, decrypt before returning. Replace the final lines (359–361) with:
+
+```python
+    response = dict(inserted[0] if inserted else row)
+    response["summary"] = decrypt_if_present(response.get("summary"))
+    notes_raw = response.get("concept_notes")
+    if isinstance(notes_raw, str):
+        try:
+            response["concept_notes"] = decrypt_json(notes_raw)
+        except Exception:
+            pass
+    response["categories"] = ai.get("categories", [])
+    return response
+```
+
+- [ ] **Step 3: Decrypt in `list_documents` (lines 226–235)**
+
+Replace the function body with:
+
+```python
+@router.get("/user/{user_id}")
+def list_documents(user_id: str, request: Request):
+    require_self(user_id, request)
+    _validate_user(user_id)
+    docs = table("documents").select(
+        "id,user_id,course_id,file_name,category,summary,concept_notes,created_at,processed_at",
+        filters={"user_id": f"eq.{user_id}"},
+        order="created_at.desc",
+    ) or []
+    for d in docs:
+        d["summary"] = decrypt_if_present(d.get("summary"))
+        notes_raw = d.get("concept_notes")
+        if isinstance(notes_raw, str):
+            try:
+                d["concept_notes"] = decrypt_json(notes_raw)
+            except Exception:
+                pass
+    return {"documents": docs}
+```
+
+- [ ] **Step 4: Decrypt in `scan_document_concepts` (lines 432–449)**
+
+Replace the `rows = table("documents").select(...)` block down through the `_scan_concepts_for_course` call with:
+
+```python
+    rows = table("documents").select(
+        "id,user_id,course_id,file_name,summary,concept_notes",
+        filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"},
+        limit=1,
+    )
+    if not rows:
+        raise HTTPException(status_code=404, detail="Document not found.")
+    doc = rows[0]
+    course_id = doc.get("course_id")
+    if not course_id:
+        raise HTTPException(status_code=400, detail="Document is not associated with a course.")
+
+    doc_summary = decrypt_if_present(doc.get("summary"))
+    notes_raw = doc.get("concept_notes")
+    if isinstance(notes_raw, str):
+        try:
+            doc_concept_notes = decrypt_json(notes_raw)
+        except Exception:
+            doc_concept_notes = []
+    else:
+        doc_concept_notes = notes_raw or []
+
+    return _scan_concepts_for_course(
+        user_id,
+        course_id,
+        doc_filename=doc.get("file_name"),
+        doc_summary=doc_summary,
+        doc_concept_notes=doc_concept_notes,
+    )
+```
+
+- [ ] **Step 5: Strip remaining `# ENCRYPTED LATER` markers** on lines 231, 337, 338, 433, 448, 449.
+
+- [ ] **Step 6: Run backend tests**
+
+```
+cd backend && python -m pytest tests/test_documents_routes.py -q
+```
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```
+git add backend/routes/documents.py
+git commit -m "feat(documents): encrypt summary + concept_notes; decrypt on read"
+```
+
+---
+
+## Task 15: Wire decrypt in `routes/flashcards.py`
+
+**Files:**
+- Modify: `backend/routes/flashcards.py`
+
+Two read sites pull `documents.summary` + `documents.concept_notes` to feed flashcard generation.
+
+- [ ] **Step 1: Import the helpers**
+
+After `from db.connection import table` (line 12), add:
+
+```python
+from services.encryption import decrypt_if_present, decrypt_json
+```
+
+- [ ] **Step 2: Decrypt inside `_get_course_documents` (lines 101–125)**
+
+Replace lines 106–125 with:
+
+```python
+        course_rows = table("courses").select(
+            "id", filters={"user_id": f"eq.{user_id}", "course_name": f"eq.{course_name}"}, limit=1
+        )
+        if course_rows:
+            course_id = course_rows[0]["id"]
+            docs = table("documents").select(
+                "file_name,category,summary,concept_notes",
+                filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
+            )
+        else:
+            docs = table("documents").select(
+                "file_name,category,summary,concept_notes",
+                filters={"user_id": f"eq.{user_id}"},
+            )
+        docs = docs or []
+        for d in docs:
+            d["summary"] = decrypt_if_present(d.get("summary"))
+            notes_raw = d.get("concept_notes")
+            if isinstance(notes_raw, str):
+                try:
+                    d["concept_notes"] = decrypt_json(notes_raw)
+                except Exception:
+                    pass
+        return docs
+    except Exception:
+        return []
+```
+
+- [ ] **Step 3: Decrypt in `import_generate` library_doc branch (lines 405–414)**
+
+Replace lines 405–414 with:
+
+```python
+        rows = table("documents").select(
+            "id,user_id,summary,concept_notes,file_name",
+            filters={"id": f"eq.{body.document_id}", "user_id": f"eq.{body.user_id}"},
+            limit=1,
+        )
+        if not rows:
+            raise HTTPException(status_code=404, detail="Document not found")
+        doc = rows[0]
+        doc_summary = decrypt_if_present(doc.get("summary")) or ""
+        notes_raw = doc.get("concept_notes")
+        if isinstance(notes_raw, str):
+            try:
+                doc_notes = decrypt_json(notes_raw)
+            except Exception:
+                doc_notes = notes_raw
+        else:
+            doc_notes = notes_raw or {}
+        parts = [doc_summary, str(doc_notes)]
+        source_text = "\n\n".join(p for p in parts if p)
+```
+
+- [ ] **Step 4: Strip remaining `# ENCRYPTED LATER` markers** on lines 114, 120, 406, 413.
+
+- [ ] **Step 5: Run backend tests**
+
+```
+cd backend && python -m pytest tests/test_flashcard_import_routes.py -q
+```
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add backend/routes/flashcards.py
+git commit -m "feat(flashcards): decrypt document summary/concept_notes before card generation"
+```
+
+---
+
+## Task 16: Wire decrypt in `routes/study_guide.py`
+
+**Files:**
+- Modify: `backend/routes/study_guide.py`
+
+- [ ] **Step 1: Import the helpers**
+
+After `from db.connection import table` (line 12), add:
+
+```python
+from services.encryption import decrypt_if_present, decrypt_json
+```
+
+- [ ] **Step 2: Decrypt inside `_generate_and_insert` document loop (lines 33–60)**
+
+Replace lines 33–60 with:
+
+```python
+    docs = table("documents").select(
+        "summary,concept_notes",
+        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
+    ) or []
+
+    parts: list[str] = []
+    for doc in docs:
+        summary = decrypt_if_present(doc.get("summary"))
+        if summary:
+            parts.append(f"Summary: {summary}")
+        notes_raw = doc.get("concept_notes")
+        if isinstance(notes_raw, str):
+            try:
+                concept_notes = decrypt_json(notes_raw)
+            except Exception:
+                concept_notes = notes_raw
+        else:
+            concept_notes = notes_raw
+        if concept_notes and isinstance(concept_notes, list):
+            lines = []
+            for note in concept_notes:
+                if not isinstance(note, dict):
+                    continue
+                name = note.get("name")
+                desc = note.get("description")
+                if not name:
+                    continue
+                if desc:
+                    lines.append(f"- {name}: {desc}")
+                else:
+                    lines.append(f"- {name}")
+            if lines:
+                parts.append("Key Concepts:\n" + "\n".join(lines))
+```
+
+- [ ] **Step 3: Strip remaining `# ENCRYPTED LATER` markers** on lines 35, 42, 43, 44.
+
+- [ ] **Step 4: Run backend tests**
+
+```
+cd backend && python -m pytest tests/ -q
+```
+Expected: full suite still passes.
+
+- [ ] **Step 5: Commit**
+
+```
+git add backend/routes/study_guide.py
+git commit -m "feat(study_guide): decrypt document summary/concept_notes before prompt build"
+```
+
+---
+
+## Task 17: Final verification + leftover-marker scan
+
+- [ ] **Step 1: Confirm no `# ENCRYPTED LATER` markers remain anywhere**
+
+Run from repo root:
+```
+git grep -n "ENCRYPTED LATER"
+```
+Expected: zero matches. (If anything remains, address per the marker classification at the top of this plan.)
+
+- [ ] **Step 2: Run the entire backend test suite**
+
+```
+cd backend && python -m pytest tests/ -q
+```
+Expected: all green.
+
+- [ ] **Step 3: Boot the backend with a fake key locally to verify the import-time validation**
+
+```
+cd backend && ENCRYPTION_KEY=$(python -c "import secrets; print(secrets.token_hex(32))") python -c "from services import encryption; print('key loaded, len=', len(encryption._KEY))"
+```
+Expected: `key loaded, len= 32` and no exception. Then verify the failure path:
+
+```
+cd backend && ENCRYPTION_KEY=tooshort python -c "from services import encryption" 2>&1 | head -2
+```
+Expected: a `RuntimeError: ENCRYPTION_KEY must be 64 hex chars (32 bytes); got 8 chars.`.
+
+---
+
+## Deferred Follow-Up Work (NOT part of this plan)
+
+The following items are explicitly out of scope per the rules ("Only touch files that have `# ENCRYPTED LATER` markers"). They must be handled before declaring the rollout complete:
+
+1. **Schema migration**: change `assignments.points_possible` and `assignments.points_earned` from `NUMERIC` to `TEXT`, and `documents.concept_notes` from `JSONB` to `TEXT`. Until this lands, any encrypted gradebook write or document upload will error against the real Supabase schema. Add a migration file under `backend/db/`.
+2. **Backfill script**: a one-shot script that reads every existing row across the encrypted columns, re-writes through the new helpers, and removes the legacy-plaintext fallback once complete.
+3. **Mark + encrypt the un-marked sensitive fields** named in the original spec: `messages.content` (tutor chat history in `routes/learn.py`), `room_messages.text` (study room chat in `routes/social.py`), and `sessions.summary_json` (`routes/learn.py:413`, `routes/flashcards.py:91`).
+4. **Account-merge behavior change**: `routes/auth.py` no longer merges legacy users by plaintext email (encryption is non-deterministic). If multi-OAuth account merging is required, add an `email_hmac` column with a deterministic HMAC-SHA256 of the lowercased email and migrate the merge lookup to that column.
+5. **Frontend dependency on `name` query param**: confirm `frontend/src/app/signin/callback/page.tsx` no longer needs the `name` query param after Task 5 step 5 (since `/auth/callback?...` no longer includes it). If it does, switch the callback to fetch `/api/auth/me` for the display name.

--- a/frontend/src/app/api/auth/session/route.ts
+++ b/frontend/src/app/api/auth/session/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { signSession, SESSION_MAX_AGE } from '@/lib/sessionToken';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL;
 const SESSION_SECRET = process.env.SESSION_SECRET;
 
 async function verifyAuthToken(token: string): Promise<string | null> {
@@ -47,38 +46,17 @@ async function verifyAuthToken(token: string): Promise<string | null> {
 
 export async function POST(request: NextRequest) {
   const body = await request.json();
-  const { userId, authToken } = body as { userId?: string; authToken?: string };
+  const { authToken } = body as { authToken?: string };
 
   let verifiedUserId: string | null = null;
 
-  if (authToken && SESSION_SECRET) {
-    verifiedUserId = await verifyAuthToken(authToken);
-    if (!verifiedUserId) {
-      return NextResponse.json({ error: 'Invalid or expired auth token' }, { status: 401 });
-    }
-  } else {
-    if (!API_URL) {
-      return NextResponse.json({ error: 'NEXT_PUBLIC_API_URL not configured' }, { status: 500 });
-    }
-    if (!userId || typeof userId !== 'string') {
-      return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
-    }
-    try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 3000);
-      let res: Response;
-      try {
-        res = await fetch(`${API_URL}/api/auth/me?user_id=${encodeURIComponent(userId)}`, { signal: controller.signal });
-      } finally {
-        clearTimeout(timeout);
-      }
-      if (!res.ok) return NextResponse.json({ error: 'User not found' }, { status: 401 });
-      const data = await res.json();
-      if (data.is_approved !== true) return NextResponse.json({ error: 'Not approved' }, { status: 403 });
-      verifiedUserId = userId;
-    } catch {
-      return NextResponse.json({ error: 'Backend unreachable' }, { status: 502 });
-    }
+  if (!authToken || !SESSION_SECRET) {
+    return NextResponse.json({ error: 'authToken is required' }, { status: 400 });
+  }
+
+  verifiedUserId = await verifyAuthToken(authToken);
+  if (!verifiedUserId) {
+    return NextResponse.json({ error: 'Invalid or expired auth token' }, { status: 401 });
   }
 
   try {

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -11,8 +11,7 @@ function CallbackInner() {
 
   useEffect(() => {
     const userId = searchParams.get('user_id');
-    const name = searchParams.get('name');
-    const avatar = searchParams.get('avatar');
+    const avatarParam = searchParams.get('avatar');
     const approvedParam = searchParams.get('is_approved');
     const authToken = searchParams.get('auth_token');
     const error = searchParams.get('error');
@@ -43,14 +42,9 @@ function CallbackInner() {
       fail('not_approved');
       return;
     }
-    if (approvedParam !== 'true' || !userId || !name) {
+    if (approvedParam !== 'true' || !userId) {
       fail(error || 'signin_failed');
       return;
-    }
-
-    if (!isPopup) {
-      setActiveUser(userId, name, avatar || '');
-      confirmApproved();
     }
 
     (async () => {
@@ -70,19 +64,28 @@ function CallbackInner() {
       }
 
       let onboardingCompleted = true;
+      let name = '';
+      let avatar = avatarParam || '';
       try {
-        const r = await fetch(`/api/auth/me?user_id=${encodeURIComponent(userId)}`);
+        const r = await fetch('/api/auth/me');
         const data = await r.json();
         onboardingCompleted = !!data.onboarding_completed;
+        name = data.name || '';
+        avatar = data.avatar_url || avatar;
       } catch {
         onboardingCompleted = true;
+      }
+
+      if (!isPopup) {
+        setActiveUser(userId, name, avatar);
+        confirmApproved();
       }
 
       if (postToOpener({
         success: true,
         userId,
         name,
-        avatar: avatar || '',
+        avatar,
         onboardingCompleted,
       })) return;
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -48,7 +48,7 @@ export async function middleware(request: NextRequest) {
     try {
       res = await fetch(
         `${API_URL}/api/auth/me?user_id=${encodeURIComponent(session.userId)}`,
-        { signal: controller.signal },
+        { signal: controller.signal, headers: { Cookie: `sapling_session=${token}` } },
       )
     } finally {
       clearTimeout(timeout)


### PR DESCRIPTION
## Summary

Adds AES-256-GCM column-level encryption for user PII, OAuth tokens, assignment notes/points, document summaries/concept notes, session summaries, and chat messages. Includes encrypt-on-write + decrypt-on-read across all affected routes, a schema migration that retypes encrypted columns to TEXT, and an idempotent backfill script for existing rows.

## Rollout — three things you need to do

### 1. What to apply to Supabase

Run one SQL file in the Supabase SQL editor: `backend/db/migration_encryption_text_columns.sql`. It contains four `ALTER TABLE ... ALTER COLUMN ... TYPE TEXT USING ::TEXT` statements.

Apply it once, before deploying the new code. The casts preserve existing rows as TEXT (e.g., `87.5` becomes the string `"87.5"`); the `decrypt_if_present` / `decrypt_numeric` fallbacks keep those legacy rows readable until you backfill.

### 2. Values you need to set

Just one new env var. `ENCRYPTION_KEY` = 64 hex chars (32 bytes). Generate it with:

```bash
python -c "import secrets; print(secrets.token_hex(32))"
```

Set it in:

- `backend/.env` for local dev (`backend/.env.example` already has the placeholder + the generation command).
- Wherever your backend actually runs in deploy (Cloudflare Workers/Pages env vars, Vercel, Fly, Railway, whatever — the same place `SUPABASE_SERVICE_KEY` is set today). `docker-compose.yml` already passes it through from `backend/.env`.

Two non-negotiables:

- **The same key must be used everywhere your backend runs.** Different keys = ciphertext written by one instance is unreadable by another.
- **Never rotate or lose this key.** Losing it permanently bricks every encrypted column. If you need to rotate, write a script that decrypts with the old key and re-encrypts with the new one in one transaction.

The backend will refuse to boot if `ENCRYPTION_KEY` is missing, not 64 chars, or not valid hex (intentional fail-fast).

### 3. The backfill script

`backend/db/backfill_encryption.py`. For each encrypted column on each table (`users.name`/`email`/`bio`/..., `oauth_tokens.access_token`/`refresh_token`, `assignments.notes`/`points_*`, `documents.summary`/`concept_notes`, `sessions.summary_json`, `messages.content`, `room_messages.text`), it:

1. Selects every row.
2. For each cell, calls `decrypt(value)` once.
3. If it succeeds → already encrypted → skip.
4. If it raises → the cell is still legacy plaintext → encrypt it and write back.

Prints counts per column. Idempotent — running it a second time changes nothing. Defaults to dry-run (counts only); `--apply` to actually write. `--table users` to do it in stages.

## How to actually run all of this, in order

```bash
# 1. Generate and set the key
python -c "import secrets; print(secrets.token_hex(32))"
# paste output as ENCRYPTION_KEY=... in backend/.env
# AND set the same value in your deploy environment

# 2. Apply the schema migration in Supabase
#    Dashboard → SQL Editor → paste contents of:
#    backend/db/migration_encryption_text_columns.sql → Run

# 3. Deploy the new backend code (encryption wiring is on this branch)

# 4. Backfill — first dry-run to see what will change:
cd backend
.\venv\Scripts\python.exe -m db.backfill_encryption

# 5. Then actually apply:
.\venv\Scripts\python.exe -m db.backfill_encryption --apply
```

After the backfill completes successfully, the `decrypt_if_present` fallback-to-raw-value warnings should stop appearing in logs. That's the signal it worked.

## Test plan

- [x] Apply `migration_encryption_text_columns.sql` to a Supabase branch DB
- [ ] Set `ENCRYPTION_KEY` (64-hex) and confirm backend boots; confirm it refuses to boot when the var is missing/invalid
- [x] Run backend tests: `cd backend && python -m pytest tests/ -q` (includes new `test_encryption.py`)
- [ ] Sign in via Google OAuth → confirm `users.name`/`email` written as ciphertext, `/me` returns plaintext
- [ ] Upload a document → confirm `documents.summary`/`concept_notes` ciphertext at rest, decrypt on library/study-guide/flashcards reads
- [ ] Sync calendar → confirm `oauth_tokens.access_token`/`refresh_token` and `assignments.notes`/`points_*` encrypted
- [ ] Send a room message + a learn-session message → confirm `room_messages.text` and `messages.content` encrypted
- [ ] Run backfill in dry-run on a copy of prod data, verify counts, then `--apply` and re-run to confirm idempotency (zero changes)
- [ ] Confirm `decrypt_if_present` fallback warnings disappear from logs after backfill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end encryption for sensitive data (profiles, documents, sessions, messages, tokens).

* **Improvements**
  * Decryption in responses and encryption on save for many user-facing flows.
  * Tighter per-request authorization across endpoints and stricter ownership checks.

* **Chores**
  * Added encryption key configuration and dependency updates; adjusted schema to support encrypted values.

* **Tests & Docs**
  * Added encryption test coverage and an implementation/rollout plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->