### PR TITLE
Restore Google sign-in popup + add tutor Fast/Smart model toggle

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -10,6 +10,7 @@ class StartSessionBody(BaseModel):
     mode: str = "socratic"
     use_shared_context: bool = True
     course_id: Optional[str] = None  # Direct course_id lookup instead of resolving from topic
+    model_pref: Optional[str] = None  # "smart" (default, gemini-2.5-pro) or "fast" (gemini-2.5-flash)
 
 
 class ChatBody(BaseModel):
@@ -18,6 +19,7 @@ class ChatBody(BaseModel):
     message: str
     mode: str = "socratic"
     use_shared_context: bool = True
+    model_pref: Optional[str] = None
 
 
 class EndSessionBody(BaseModel):
@@ -31,6 +33,7 @@ class ActionBody(BaseModel):
     action_type: str = "hint"
     mode: str = "socratic"
     use_shared_context: bool = True
+    model_pref: Optional[str] = None
 
 
 # ── Quiz ──────────────────────────────────────────────────────────────────────

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Literal
 from pydantic import BaseModel, Field
 
 
@@ -10,7 +10,7 @@ class StartSessionBody(BaseModel):
     mode: str = "socratic"
     use_shared_context: bool = True
     course_id: Optional[str] = None  # Direct course_id lookup instead of resolving from topic
-    model_pref: Optional[str] = None  # "smart" (default, gemini-2.5-pro) or "fast" (gemini-2.5-flash)
+    model_pref: Optional[Literal["fast", "smart"]] = None  # "fast" (default, gemini-2.5-flash) or "smart" (gemini-2.5-pro)
 
 
 class ChatBody(BaseModel):
@@ -19,7 +19,7 @@ class ChatBody(BaseModel):
     message: str
     mode: str = "socratic"
     use_shared_context: bool = True
-    model_pref: Optional[str] = None
+    model_pref: Optional[Literal["fast", "smart"]] = None  # "fast" (default, gemini-2.5-flash) or "smart" (gemini-2.5-pro)
 
 
 class EndSessionBody(BaseModel):
@@ -33,7 +33,7 @@ class ActionBody(BaseModel):
     action_type: str = "hint"
     mode: str = "socratic"
     use_shared_context: bool = True
-    model_pref: Optional[str] = None
+    model_pref: Optional[Literal["fast", "smart"]] = None  # "fast" (default, gemini-2.5-flash) or "smart" (gemini-2.5-pro)
 
 
 # ── Quiz ──────────────────────────────────────────────────────────────────────

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -9,6 +9,7 @@ import json
 import base64
 import hashlib
 import hmac as _hmac
+import re
 import secrets
 import time as _time
 from urllib.parse import urlencode
@@ -38,6 +39,14 @@ except ImportError:
     GOOGLE_AVAILABLE = False
 
 router = APIRouter()
+
+OAUTH_STATE_COOKIE = "sapling_oauth_state"
+_OAUTH_COOKIE_MAX_AGE = 600
+_POPUP_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+# Fallback in-memory store for environments without SESSION_SECRET; entries
+# are keyed by nonce and expire after _OAUTH_COOKIE_MAX_AGE seconds.
+_OAUTH_FALLBACK_STORE: dict[str, tuple[float, dict]] = {}
 
 
 def _google_client_config() -> dict:
@@ -71,6 +80,68 @@ def _generate_pkce_pair():
         hashlib.sha256(code_verifier.encode()).digest()
     ).rstrip(b'=').decode()
     return code_verifier, code_challenge
+
+
+def _clean_popup_id(s: str | None) -> str | None:
+    if not s:
+        return None
+    return s if _POPUP_ID_RE.match(s) else None
+
+
+def _encode_oauth_cookie(payload: dict) -> str:
+    raw = json.dumps(payload, separators=(",", ":")).encode()
+    payload_b64 = base64.urlsafe_b64encode(raw).decode().rstrip("=")
+    if SESSION_SECRET:
+        sig_bytes = _hmac.new(SESSION_SECRET.encode(), payload_b64.encode(), hashlib.sha256).digest()
+        sig_b64 = base64.urlsafe_b64encode(sig_bytes).decode().rstrip("=")
+        return f"{payload_b64}.{sig_b64}"
+    nonce = payload.get("n", "")
+    if nonce:
+        _OAUTH_FALLBACK_STORE[nonce] = (_time.monotonic() + _OAUTH_COOKIE_MAX_AGE, payload)
+        _prune_fallback_store()
+    return payload_b64
+
+
+def _decode_oauth_cookie(cookie_value: str | None) -> dict | None:
+    if not cookie_value:
+        return None
+    if SESSION_SECRET:
+        if "." not in cookie_value:
+            return None
+        try:
+            payload_b64, sig_b64 = cookie_value.rsplit(".", 1)
+        except ValueError:
+            return None
+        expected = _hmac.new(SESSION_SECRET.encode(), payload_b64.encode(), hashlib.sha256).digest()
+        expected_b64 = base64.urlsafe_b64encode(expected).decode().rstrip("=")
+        if not _hmac.compare_digest(expected_b64, sig_b64):
+            return None
+        try:
+            padded = payload_b64 + "=" * (-len(payload_b64) % 4)
+            payload = json.loads(base64.urlsafe_b64decode(padded.encode()).decode())
+        except Exception:
+            return None
+        return payload if isinstance(payload, dict) else None
+    try:
+        padded = cookie_value + "=" * (-len(cookie_value) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded.encode()).decode())
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    nonce = payload.get("n")
+    _prune_fallback_store()
+    entry = _OAUTH_FALLBACK_STORE.get(nonce or "")
+    if not entry:
+        return None
+    return entry[1]
+
+
+def _prune_fallback_store() -> None:
+    now = _time.monotonic()
+    expired = [k for k, (exp, _) in _OAUTH_FALLBACK_STORE.items() if exp < now]
+    for k in expired:
+        _OAUTH_FALLBACK_STORE.pop(k, None)
 
 
 @router.get("/me")
@@ -142,42 +213,78 @@ def google_login(popup_id: str = Query(None)):
         raise HTTPException(status_code=400, detail="Google OAuth not configured")
 
     code_verifier, code_challenge = _generate_pkce_pair()
+    nonce = secrets.token_urlsafe(32)
+    clean_popup = _clean_popup_id(popup_id)
+
     flow = Flow.from_client_config(_google_client_config(), scopes=AUTH_SCOPES)
     flow.redirect_uri = GOOGLE_AUTH_REDIRECT_URI
-    state_payload = {"action": "signin", "cv": code_verifier}
-    if popup_id:
-        state_payload["popup_id"] = popup_id
     auth_url, _ = flow.authorization_url(
         prompt="consent",
         access_type="offline",
-        state=_encode_state(state_payload),
+        state=_encode_state({"action": "signin", "n": nonce}),
         code_challenge=code_challenge,
         code_challenge_method="S256",
     )
-    return RedirectResponse(auth_url)
+
+    cookie_value = _encode_oauth_cookie({
+        "n": nonce,
+        "cv": code_verifier,
+        "popup_id": clean_popup,
+    })
+    response = RedirectResponse(auth_url)
+    response.set_cookie(
+        key=OAUTH_STATE_COOKIE,
+        value=cookie_value,
+        max_age=_OAUTH_COOKIE_MAX_AGE,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        path="/",
+    )
+    return response
 
 
 @router.get("/google/callback")
-def google_callback(code: str = Query(...), state: str = Query(None)):
+def google_callback(request: Request, code: str = Query(...), state: str = Query(None)):
     """Exchange auth code for tokens, validate @bu.edu, upsert user."""
-    state_data = _decode_state(state) if state else {}
-    code_verifier = state_data.get("cv")
-    popup_id = state_data.get("popup_id")
+    cookie_payload = _decode_oauth_cookie(request.cookies.get(OAUTH_STATE_COOKIE))
+    code_verifier = cookie_payload.get("cv") if cookie_payload else None
+    popup_id = _clean_popup_id(cookie_payload.get("popup_id")) if cookie_payload else None
+    cookie_nonce = cookie_payload.get("n") if cookie_payload else None
 
     def _fail_redirect(error_code: str, fallback_path: str = "/auth") -> RedirectResponse:
         # In popup mode, route failures through /auth/callback so the popup
         # can broadcast the error and self-close instead of stranding the opener.
         if popup_id:
             params = urlencode({"error": error_code, "popup_id": popup_id})
-            return RedirectResponse(f"{FRONTEND_URL}/auth/callback?{params}")
-        return RedirectResponse(f"{FRONTEND_URL}{fallback_path}?error={error_code}")
+            resp = RedirectResponse(f"{FRONTEND_URL}/auth/callback?{params}")
+        else:
+            resp = RedirectResponse(f"{FRONTEND_URL}{fallback_path}?error={error_code}")
+        resp.set_cookie(
+            key=OAUTH_STATE_COOKIE,
+            value="",
+            max_age=0,
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            path="/",
+        )
+        return resp
 
     if not GOOGLE_AVAILABLE:
         return _fail_redirect("google_not_configured")
 
+    state_data = _decode_state(state) if state else {}
+    state_nonce = state_data.get("n")
+    if not cookie_payload or not cookie_nonce or not state_nonce or not _hmac.compare_digest(str(state_nonce), str(cookie_nonce)):
+        return _fail_redirect("invalid_state")
+
     flow = Flow.from_client_config(_google_client_config(), scopes=AUTH_SCOPES)
     flow.redirect_uri = GOOGLE_AUTH_REDIRECT_URI
-    flow.fetch_token(code=code, code_verifier=code_verifier)
+    try:
+        flow.fetch_token(code=code, code_verifier=code_verifier)
+    except Exception:
+        return _fail_redirect("oauth_exchange_failed")
     creds = flow.credentials
 
     # Fetch user info from Google
@@ -245,7 +352,17 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
     if not is_approved:
         if popup_id:
             return _fail_redirect("not_approved")
-        return RedirectResponse(f"{FRONTEND_URL}/pending")
+        resp = RedirectResponse(f"{FRONTEND_URL}/pending")
+        resp.set_cookie(
+            key=OAUTH_STATE_COOKIE,
+            value="",
+            max_age=0,
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            path="/",
+        )
+        return resp
 
     # Build a short-lived HMAC token so the frontend can verify this redirect
     # without a second round-trip to the backend.
@@ -264,4 +381,14 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
         **({"auth_token": auth_token} if auth_token else {}),
         **({"popup_id": popup_id} if popup_id else {}),
     })
-    return RedirectResponse(f"{FRONTEND_URL}/auth/callback?{params}")
+    resp = RedirectResponse(f"{FRONTEND_URL}/auth/callback?{params}")
+    resp.set_cookie(
+        key=OAUTH_STATE_COOKIE,
+        value="",
+        max_age=0,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        path="/",
+    )
+    return resp

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -136,7 +136,7 @@ def get_me(request: Request):
 
 
 @router.get("/google")
-def google_login():
+def google_login(popup_id: str = Query(None)):
     """Redirect to Google consent screen with identity + calendar scopes."""
     if not GOOGLE_AVAILABLE or not GOOGLE_CLIENT_ID:
         raise HTTPException(status_code=400, detail="Google OAuth not configured")
@@ -144,10 +144,13 @@ def google_login():
     code_verifier, code_challenge = _generate_pkce_pair()
     flow = Flow.from_client_config(_google_client_config(), scopes=AUTH_SCOPES)
     flow.redirect_uri = GOOGLE_AUTH_REDIRECT_URI
+    state_payload = {"action": "signin", "cv": code_verifier}
+    if popup_id:
+        state_payload["popup_id"] = popup_id
     auth_url, _ = flow.authorization_url(
         prompt="consent",
         access_type="offline",
-        state=_encode_state({"action": "signin", "cv": code_verifier}),
+        state=_encode_state(state_payload),
         code_challenge=code_challenge,
         code_challenge_method="S256",
     )
@@ -157,11 +160,20 @@ def google_login():
 @router.get("/google/callback")
 def google_callback(code: str = Query(...), state: str = Query(None)):
     """Exchange auth code for tokens, validate @bu.edu, upsert user."""
-    if not GOOGLE_AVAILABLE:
-        return RedirectResponse(f"{FRONTEND_URL}/auth?error=google_not_configured")
-
     state_data = _decode_state(state) if state else {}
     code_verifier = state_data.get("cv")
+    popup_id = state_data.get("popup_id")
+
+    def _fail_redirect(error_code: str, fallback_path: str = "/auth") -> RedirectResponse:
+        # In popup mode, route failures through /auth/callback so the popup
+        # can broadcast the error and self-close instead of stranding the opener.
+        if popup_id:
+            params = urlencode({"error": error_code, "popup_id": popup_id})
+            return RedirectResponse(f"{FRONTEND_URL}/auth/callback?{params}")
+        return RedirectResponse(f"{FRONTEND_URL}{fallback_path}?error={error_code}")
+
+    if not GOOGLE_AVAILABLE:
+        return _fail_redirect("google_not_configured")
 
     flow = Flow.from_client_config(_google_client_config(), scopes=AUTH_SCOPES)
     flow.redirect_uri = GOOGLE_AUTH_REDIRECT_URI
@@ -184,9 +196,7 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
 
     # Restrict to @bu.edu accounts
     if not email.endswith("@bu.edu"):
-        return RedirectResponse(
-            f"{FRONTEND_URL}/auth?error=invalid_domain"
-        )
+        return _fail_redirect("invalid_domain")
 
     # Determine user_id: check if this Google ID already exists
     existing = table("users").select("id,is_approved", filters={"google_id": f"eq.{google_id}"})
@@ -233,6 +243,8 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
     )
 
     if not is_approved:
+        if popup_id:
+            return _fail_redirect("not_approved")
         return RedirectResponse(f"{FRONTEND_URL}/pending")
 
     # Build a short-lived HMAC token so the frontend can verify this redirect
@@ -250,5 +262,6 @@ def google_callback(code: str = Query(...), state: str = Query(None)):
         "avatar": avatar_url,
         "is_approved": "true",
         **({"auth_token": auth_token} if auth_token else {}),
+        **({"popup_id": popup_id} if popup_id else {}),
     })
     return RedirectResponse(f"{FRONTEND_URL}/auth/callback?{params}")

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -11,7 +11,12 @@ from db.connection import table
 from models import StartSessionBody, ChatBody, EndSessionBody, ActionBody, ModeSwitchBody
 from services.auth_guard import require_self, get_session_user_id
 from services.encryption import encrypt_if_present, encrypt_json, decrypt_if_present, decrypt_json
-from services.gemini_service import MODEL_SMART, call_gemini_multiturn, extract_graph_update
+from services.gemini_service import (
+    MODEL_DEFAULT,
+    MODEL_SMART,
+    call_gemini_multiturn,
+    extract_graph_update,
+)
 from services.graph_service import get_graph, apply_graph_update
 
 router = APIRouter()
@@ -27,6 +32,18 @@ MODE_DISPLAY_NAMES = {
     "expository": "Expository (direct explanation)",
     "teachback": "Teach-back (you explain to me)",
 }
+
+# User-facing speed/quality knob for the tutor chat.
+# "fast" = flash (default, faster), "smart" = pro (opt-in, slower but stronger reasoning).
+# Anything unrecognized falls back to fast so the default is the snappy one.
+_MODEL_PREF_TO_MODEL = {
+    "fast": MODEL_DEFAULT,
+    "smart": MODEL_SMART,
+}
+
+
+def _resolve_tutor_model(model_pref: str | None) -> str:
+    return _MODEL_PREF_TO_MODEL.get(model_pref or "", MODEL_DEFAULT)
 
 
 def _load_prompt(name: str) -> str:
@@ -293,13 +310,15 @@ def start_session(body: StartSessionBody, request: Request):
     )
 
     try:
-        raw = call_gemini_multiturn(system_prompt, [], user_message, model=MODEL_SMART)
+        raw = call_gemini_multiturn(
+            system_prompt, [], user_message, model=_resolve_tutor_model(body.model_pref)
+        )
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"Gemini error: {e}")
 
     reply, graph_update = extract_graph_update(raw)
     apply_graph_update(body.user_id, graph_update, course_id=course_id)
-    
+
     PENDING_SESSIONS[session_id] = {
         "user_id": body.user_id,
         "mode": body.mode,
@@ -339,7 +358,9 @@ def chat(body: ChatBody, request: Request):
     )
 
     try:
-        raw = call_gemini_multiturn(system_prompt, history, body.message, model=MODEL_SMART)
+        raw = call_gemini_multiturn(
+            system_prompt, history, body.message, model=_resolve_tutor_model(body.model_pref)
+        )
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"Gemini error: {e}")
 
@@ -558,7 +579,9 @@ def action(body: ActionBody, request: Request):
     action_message = f"[ACTION: {action_prompts.get(body.action_type, '')}]"
 
     try:
-        raw = call_gemini_multiturn(system_prompt, history, action_message, model=MODEL_SMART)
+        raw = call_gemini_multiturn(
+            system_prompt, history, action_message, model=_resolve_tutor_model(body.model_pref)
+        )
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"Gemini error: {e}")
 

--- a/backend/tests/test_auth_state.py
+++ b/backend/tests/test_auth_state.py
@@ -1,0 +1,207 @@
+"""
+Unit tests for routes/auth.py OAuth state hardening.
+
+Covers:
+- HMAC cookie round-trip (encode -> decode)
+- Tampered cookie rejection (MAC and payload)
+- _clean_popup_id charset/length validation
+- _decode_state happy path
+- Callback rejects when state nonce doesn't match cookie nonce
+- Callback handles missing/malformed cookie via popup-aware error redirect
+"""
+import json
+import base64
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import routes.auth as auth_module
+
+# Build a minimal app that mounts ONLY the auth router so these tests don't
+# pull in main.py (which imports logfire and the full router stack).
+_app = FastAPI()
+_app.include_router(auth_module.router, prefix="/api/auth")
+client = TestClient(_app)
+
+
+# ── HMAC cookie round-trip ────────────────────────────────────────────────────
+
+
+class TestOAuthCookieRoundTrip:
+    def test_round_trip_returns_same_payload(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "SESSION_SECRET", "test-secret-key")
+        payload = {"n": "abc123", "cv": "verifier", "popup_id": "popup-1"}
+        cookie = auth_module._encode_oauth_cookie(payload)
+        decoded = auth_module._decode_oauth_cookie(cookie)
+        assert decoded == payload
+
+    def test_tampered_mac_rejected(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "SESSION_SECRET", "test-secret-key")
+        cookie = auth_module._encode_oauth_cookie(
+            {"n": "abc123", "cv": "verifier", "popup_id": None}
+        )
+        payload_b64, sig_b64 = cookie.rsplit(".", 1)
+        # flip a character in the signature
+        bad_sig = ("A" if sig_b64[0] != "A" else "B") + sig_b64[1:]
+        tampered = f"{payload_b64}.{bad_sig}"
+        assert auth_module._decode_oauth_cookie(tampered) is None
+
+    def test_tampered_payload_rejected(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "SESSION_SECRET", "test-secret-key")
+        cookie = auth_module._encode_oauth_cookie(
+            {"n": "abc123", "cv": "verifier", "popup_id": None}
+        )
+        _, sig_b64 = cookie.rsplit(".", 1)
+        bogus_payload = base64.urlsafe_b64encode(
+            json.dumps({"n": "evil", "cv": "x", "popup_id": None}).encode()
+        ).decode().rstrip("=")
+        tampered = f"{bogus_payload}.{sig_b64}"
+        assert auth_module._decode_oauth_cookie(tampered) is None
+
+    def test_missing_cookie_returns_none(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "SESSION_SECRET", "test-secret-key")
+        assert auth_module._decode_oauth_cookie(None) is None
+        assert auth_module._decode_oauth_cookie("") is None
+
+    def test_malformed_cookie_returns_none(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "SESSION_SECRET", "test-secret-key")
+        assert auth_module._decode_oauth_cookie("not-a-valid-cookie") is None
+        assert auth_module._decode_oauth_cookie("only_payload_no_dot") is None
+
+    def test_fallback_in_memory_store_round_trip(self, monkeypatch):
+        # Without SESSION_SECRET, encode stashes the payload in an in-memory
+        # dict keyed by nonce. Decode retrieves it.
+        monkeypatch.setattr(auth_module, "SESSION_SECRET", "")
+        auth_module._OAUTH_FALLBACK_STORE.clear()
+        payload = {"n": "fallback-nonce", "cv": "verifier", "popup_id": "p"}
+        cookie = auth_module._encode_oauth_cookie(payload)
+        decoded = auth_module._decode_oauth_cookie(cookie)
+        assert decoded == payload
+
+    def test_fallback_unknown_nonce_returns_none(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "SESSION_SECRET", "")
+        auth_module._OAUTH_FALLBACK_STORE.clear()
+        # Build a cookie payload whose nonce was never registered
+        bogus = base64.urlsafe_b64encode(
+            json.dumps({"n": "ghost", "cv": "x", "popup_id": None}).encode()
+        ).decode().rstrip("=")
+        assert auth_module._decode_oauth_cookie(bogus) is None
+
+
+# ── _clean_popup_id ───────────────────────────────────────────────────────────
+
+
+class TestCleanPopupId:
+    def test_valid_uuid_returned_as_is(self):
+        uid = "550e8400-e29b-41d4-a716-446655440000"
+        assert auth_module._clean_popup_id(uid) == uid
+
+    def test_alphanumeric_with_underscore_ok(self):
+        assert auth_module._clean_popup_id("popup_abc_123") == "popup_abc_123"
+
+    def test_slash_rejected(self):
+        assert auth_module._clean_popup_id("abc/def") is None
+
+    def test_empty_string_rejected(self):
+        assert auth_module._clean_popup_id("") is None
+
+    def test_none_returns_none(self):
+        assert auth_module._clean_popup_id(None) is None
+
+    def test_overlong_rejected(self):
+        assert auth_module._clean_popup_id("a" * 129) is None
+
+    def test_max_length_accepted(self):
+        s = "a" * 128
+        assert auth_module._clean_popup_id(s) == s
+
+    def test_special_chars_rejected(self):
+        assert auth_module._clean_popup_id("abc def") is None
+        assert auth_module._clean_popup_id("abc<script>") is None
+        assert auth_module._clean_popup_id("abc.def") is None
+
+
+# ── _decode_state happy path ──────────────────────────────────────────────────
+
+
+class TestDecodeState:
+    def test_round_trip(self):
+        original = {"action": "signin", "n": "nonce-value"}
+        encoded = auth_module._encode_state(original)
+        assert auth_module._decode_state(encoded) == original
+
+    def test_invalid_state_returns_empty(self):
+        assert auth_module._decode_state("!!!not-base64!!!") == {}
+
+    def test_empty_state_returns_empty(self):
+        assert auth_module._decode_state("") == {}
+
+
+# ── Callback nonce-mismatch / missing cookie via TestClient ───────────────────
+
+
+class TestCallbackStateValidation:
+    def test_missing_cookie_redirects_with_invalid_state(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "SESSION_SECRET", "test-secret-key")
+        monkeypatch.setattr(auth_module, "GOOGLE_AVAILABLE", True)
+        state_param = auth_module._encode_state({"action": "signin", "n": "any"})
+        r = client.get(
+            f"/api/auth/google/callback?code=foo&state={state_param}",
+            follow_redirects=False,
+        )
+        assert r.status_code in (302, 307)
+        assert "error=invalid_state" in r.headers["location"]
+
+    def test_nonce_mismatch_redirects_with_invalid_state(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "SESSION_SECRET", "test-secret-key")
+        monkeypatch.setattr(auth_module, "GOOGLE_AVAILABLE", True)
+        cookie = auth_module._encode_oauth_cookie(
+            {"n": "cookie-nonce", "cv": "verifier", "popup_id": None}
+        )
+        state_param = auth_module._encode_state(
+            {"action": "signin", "n": "different-nonce"}
+        )
+        c = TestClient(_app)
+        c.cookies.set(auth_module.OAUTH_STATE_COOKIE, cookie)
+        r = c.get(
+            f"/api/auth/google/callback?code=foo&state={state_param}",
+            follow_redirects=False,
+        )
+        assert r.status_code in (302, 307)
+        assert "error=invalid_state" in r.headers["location"]
+
+    def test_popup_id_missing_when_cookie_missing(self, monkeypatch):
+        # When cookie is missing, popup_id is unknown so failure goes through
+        # the non-popup branch (fallback path /auth) and doesn't include popup_id.
+        monkeypatch.setattr(auth_module, "SESSION_SECRET", "test-secret-key")
+        monkeypatch.setattr(auth_module, "GOOGLE_AVAILABLE", True)
+        state_param = auth_module._encode_state({"action": "signin", "n": "any"})
+        r = client.get(
+            f"/api/auth/google/callback?code=foo&state={state_param}",
+            follow_redirects=False,
+        )
+        assert "popup_id" not in r.headers["location"]
+        assert "/auth?" in r.headers["location"]
+
+    def test_tampered_cookie_redirects_with_invalid_state(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "SESSION_SECRET", "test-secret-key")
+        monkeypatch.setattr(auth_module, "GOOGLE_AVAILABLE", True)
+        state_param = auth_module._encode_state({"action": "signin", "n": "n1"})
+        c = TestClient(_app)
+        c.cookies.set(auth_module.OAUTH_STATE_COOKIE, "garbage.cookie.value")
+        r = c.get(
+            f"/api/auth/google/callback?code=foo&state={state_param}",
+            follow_redirects=False,
+        )
+        assert r.status_code in (302, 307)
+        assert "error=invalid_state" in r.headers["location"]
+
+    def test_google_not_available_returns_error_redirect(self, monkeypatch):
+        monkeypatch.setattr(auth_module, "GOOGLE_AVAILABLE", False)
+        r = client.get(
+            "/api/auth/google/callback?code=foo&state=bar",
+            follow_redirects=False,
+        )
+        assert r.status_code in (302, 307)
+        assert "error=google_not_configured" in r.headers["location"]

--- a/backend/tests/test_learn_routes.py
+++ b/backend/tests/test_learn_routes.py
@@ -279,3 +279,38 @@ class TestModeSwitch:
                 call for call in t.call_args_list if call.args and call.args[0] == "messages"
             ]
         assert len(insert_calls) >= 1
+
+
+# ── _resolve_tutor_model ──────────────────────────────────────────────────────
+
+class TestResolveTutorModel:
+    def test_none_returns_default(self):
+        from routes.learn import _resolve_tutor_model
+        from services.gemini_service import MODEL_DEFAULT
+        assert _resolve_tutor_model(None) == MODEL_DEFAULT
+
+    def test_empty_string_returns_default(self):
+        from routes.learn import _resolve_tutor_model
+        from services.gemini_service import MODEL_DEFAULT
+        assert _resolve_tutor_model("") == MODEL_DEFAULT
+
+    def test_fast_returns_default(self):
+        from routes.learn import _resolve_tutor_model
+        from services.gemini_service import MODEL_DEFAULT
+        assert _resolve_tutor_model("fast") == MODEL_DEFAULT
+
+    def test_smart_returns_smart(self):
+        from routes.learn import _resolve_tutor_model
+        from services.gemini_service import MODEL_SMART
+        assert _resolve_tutor_model("smart") == MODEL_SMART
+
+    def test_uppercase_fast_returns_default(self):
+        # Lookup is case-sensitive: only lowercase keys hit the map.
+        from routes.learn import _resolve_tutor_model
+        from services.gemini_service import MODEL_DEFAULT
+        assert _resolve_tutor_model("FAST") == MODEL_DEFAULT
+
+    def test_garbage_returns_default(self):
+        from routes.learn import _resolve_tutor_model
+        from services.gemini_service import MODEL_DEFAULT
+        assert _resolve_tutor_model("garbage") == MODEL_DEFAULT

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -16,26 +16,26 @@ function CallbackInner() {
     const approvedParam = searchParams.get('is_approved');
     const authToken = searchParams.get('auth_token');
     const error = searchParams.get('error');
+    const popupId = searchParams.get('popup_id');
 
-    const isPopup =
-      typeof window !== 'undefined' &&
-      !!window.opener &&
-      window.opener !== window;
+    // Popup mode is signalled by the backend echoing back popup_id we sent
+    // when opening the window. We can't trust window.opener here: COOP nulls
+    // it the moment the popup hops to a cross-origin URL (Railway/Google).
+    const isPopup = !!popupId && typeof window !== 'undefined';
 
-    const postToOpener = (payload: Record<string, unknown>): boolean => {
-      if (!isPopup) return false;
+    const broadcast = (payload: Record<string, unknown>): boolean => {
+      if (!isPopup || typeof BroadcastChannel === 'undefined') return false;
       try {
-        window.opener.postMessage(
-          { type: 'sapling_signin', ...payload },
-          window.location.origin,
-        );
+        const ch = new BroadcastChannel(`sapling_signin:${popupId}`);
+        ch.postMessage({ type: 'sapling_signin', ...payload });
+        ch.close();
       } catch {}
       try { window.close(); } catch {}
       return true;
     };
 
     const fail = (errCode: string) => {
-      if (postToOpener({ success: false, error: errCode })) return;
+      if (broadcast({ success: false, error: errCode })) return;
       router.replace(`/?error=${encodeURIComponent(errCode)}`);
     };
 
@@ -83,7 +83,7 @@ function CallbackInner() {
         confirmApproved();
       }
 
-      if (postToOpener({
+      if (broadcast({
         success: true,
         userId,
         name,

--- a/frontend/src/components/ModelToggle.tsx
+++ b/frontend/src/components/ModelToggle.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+export type ModelPref = "smart" | "fast";
+
+const STORAGE_KEY = "sapling_model_pref";
+
+export function useModelPref(): [ModelPref, (v: ModelPref) => void] {
+  const [pref, setPref] = useState<ModelPref>("fast");
+  useEffect(() => {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === "fast" || raw === "smart") setPref(raw);
+  }, []);
+  const update = (v: ModelPref) => {
+    setPref(v);
+    localStorage.setItem(STORAGE_KEY, v);
+  };
+  return [pref, update];
+}
+
+export function ModelToggle({
+  pref,
+  onChange,
+}: {
+  pref: ModelPref;
+  onChange: (v: ModelPref) => void;
+}) {
+  const [tooltip, setTooltip] = useState(false);
+  // Fast is the default; Smart is the opt-in upgrade, so it gets the highlight.
+  const isSmart = pref === "smart";
+
+  return (
+    <div
+      style={{ position: "relative", display: "inline-block" }}
+      onMouseEnter={() => setTooltip(true)}
+      onMouseLeave={() => setTooltip(false)}
+      onFocus={() => setTooltip(true)}
+      onBlur={() => setTooltip(false)}
+    >
+      <button
+        role="switch"
+        aria-checked={isSmart}
+        onClick={() => onChange(isSmart ? "fast" : "smart")}
+        className="btn btn--sm"
+        style={{
+          padding: "5px 10px",
+          background: isSmart ? "var(--accent-soft)" : "var(--bg-subtle)",
+          color: isSmart ? "var(--accent)" : "var(--text-dim)",
+          borderColor: isSmart ? "var(--accent-border)" : "var(--border)",
+          fontSize: 12,
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+        }}
+      >
+        <span
+          aria-hidden
+          style={{
+            width: 24,
+            height: 12,
+            borderRadius: "var(--r-full)",
+            background: isSmart ? "var(--accent)" : "var(--border-strong)",
+            position: "relative",
+            transition: "background var(--dur-fast) var(--ease)",
+          }}
+        >
+          <span
+            style={{
+              position: "absolute",
+              top: 1,
+              left: isSmart ? 13 : 1,
+              width: 10,
+              height: 10,
+              borderRadius: "50%",
+              background: "#fff",
+              transition: "left var(--dur-fast) var(--ease)",
+            }}
+          />
+        </span>
+        {isSmart ? "Smart" : "Fast"}
+      </button>
+      {tooltip && (
+        <div
+          role="tooltip"
+          style={{
+            position: "absolute",
+            top: "calc(100% + 6px)",
+            right: 0,
+            zIndex: 60,
+            width: 240,
+            padding: 10,
+            background: "var(--bg-panel)",
+            border: "1px solid var(--border-strong)",
+            borderRadius: "var(--r-md)",
+            boxShadow: "var(--shadow-md)",
+            fontSize: 11,
+            color: "var(--text-dim)",
+            lineHeight: 1.5,
+          }}
+        >
+          <strong style={{ color: "var(--text)", display: "block", marginBottom: 4 }}>
+            Tutor model
+          </strong>
+          Fast is the default — quicker replies. Flip on Smart for stronger reasoning when you
+          want depth and don&apos;t mind waiting.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ModelToggle.tsx
+++ b/frontend/src/components/ModelToggle.tsx
@@ -41,6 +41,7 @@ export function ModelToggle({
       <button
         role="switch"
         aria-checked={isSmart}
+        aria-label={`Tutor model — ${isSmart ? "Smart: stronger reasoning, slower" : "Fast: quicker replies, default"}`}
         onClick={() => onChange(isSmart ? "fast" : "smart")}
         className="btn btn--sm"
         style={{

--- a/frontend/src/components/SignInModal.tsx
+++ b/frontend/src/components/SignInModal.tsx
@@ -108,14 +108,16 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
       typeof crypto !== "undefined" &&
       typeof crypto.randomUUID === "function";
 
+    const sameTabUrl = `${API_URL}/api/auth/google`;
+
     if (!supportsPopup) {
       setWaiting(true);
-      window.location.href = `${API_URL}/api/auth/google`;
+      window.location.href = sameTabUrl;
       return;
     }
 
     const popupId = crypto.randomUUID();
-    const url = `${API_URL}/api/auth/google?popup_id=${encodeURIComponent(popupId)}`;
+    const popupUrl = `${API_URL}/api/auth/google?popup_id=${encodeURIComponent(popupId)}`;
 
     cleanupPopupListeners();
     const channel = new BroadcastChannel(`sapling_signin:${popupId}`);
@@ -129,8 +131,8 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
       if (!data || data.type !== "sapling_signin") return;
       cleanupPopupListeners();
       setWaiting(false);
-      if (data.success && data.userId && data.name) {
-        setActiveUser(data.userId, data.name, data.avatar || "");
+      if (data.success && data.userId) {
+        setActiveUser(data.userId, data.name || "", data.avatar || "");
         confirmApproved();
         if (data.onboardingCompleted) {
           router.replace("/dashboard");
@@ -148,12 +150,12 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
     const left = Math.max(0, window.screenX + (window.outerWidth - w) / 2);
     const top = Math.max(0, window.screenY + (window.outerHeight - h) / 2);
     const features = `width=${w},height=${h},left=${left},top=${top},menubar=no,toolbar=no,location=no,status=no,resizable=yes,scrollbars=yes`;
-    const popup = window.open(url, "sapling_signin", features);
+    const popup = window.open(popupUrl, "sapling_signin", features);
     if (!popup || popup.closed) {
       // Pop-up blocker / user setting. Fall back to same-tab redirect.
       cleanupPopupListeners();
       setWaiting(true);
-      window.location.href = url;
+      window.location.href = sameTabUrl;
       return;
     }
     popupRef.current = popup;

--- a/frontend/src/components/SignInModal.tsx
+++ b/frontend/src/components/SignInModal.tsx
@@ -1,10 +1,11 @@
 "use client";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useUser } from "@/context/UserContext";
 import { IS_LOCAL_MODE } from "@/lib/api";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+const POPUP_TIMEOUT_MS = 3 * 60 * 1000;
 
 const ERROR_COPY: Record<string, string> = {
   not_approved: "Your account is pending approval. We'll email you once an admin lets you in.",
@@ -29,24 +30,47 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
   const [closing, setClosing] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
   const [waiting, setWaiting] = useState(false);
+  const popupRef = useRef<Window | null>(null);
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const watchdogRef = useRef<number | null>(null);
+
+  const cleanupPopupListeners = useCallback(() => {
+    if (channelRef.current) {
+      try { channelRef.current.close(); } catch {}
+      channelRef.current = null;
+    }
+    if (watchdogRef.current !== null) {
+      window.clearTimeout(watchdogRef.current);
+      watchdogRef.current = null;
+    }
+    // Best effort — COOP may have severed the handle, but harmless to try.
+    if (popupRef.current) {
+      try { popupRef.current.close(); } catch {}
+      popupRef.current = null;
+    }
+  }, []);
 
   const close = useCallback(() => {
+    cleanupPopupListeners();
     setClosing(true);
     setTimeout(() => {
       setClosing(false);
       onClose();
     }, 200);
-  }, [onClose]);
+  }, [onClose, cleanupPopupListeners]);
 
   useEffect(() => {
     if (!open) {
       setWaiting(false);
+      cleanupPopupListeners();
       return;
     }
     setLocalError(null);
     document.body.style.overflow = "hidden";
     return () => { document.body.style.overflow = ""; };
-  }, [open]);
+  }, [open, cleanupPopupListeners]);
+
+  useEffect(() => () => cleanupPopupListeners(), [cleanupPopupListeners]);
 
   useEffect(() => {
     if (!open) return;
@@ -74,8 +98,79 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
       setLocalError("google_not_configured");
       return;
     }
+
+    // BroadcastChannel-based popup flow. We don't depend on window.opener:
+    // COOP severs the opener handle the moment the popup hops to a
+    // cross-origin URL (Railway, then Google). Instead the callback page
+    // broadcasts the result on a per-attempt channel keyed by popup_id.
+    const supportsPopup =
+      typeof BroadcastChannel !== "undefined" &&
+      typeof crypto !== "undefined" &&
+      typeof crypto.randomUUID === "function";
+
+    if (!supportsPopup) {
+      setWaiting(true);
+      window.location.href = `${API_URL}/api/auth/google`;
+      return;
+    }
+
+    const popupId = crypto.randomUUID();
+    const url = `${API_URL}/api/auth/google?popup_id=${encodeURIComponent(popupId)}`;
+
+    cleanupPopupListeners();
+    const channel = new BroadcastChannel(`sapling_signin:${popupId}`);
+    channelRef.current = channel;
+    channel.onmessage = (event: MessageEvent) => {
+      const data = event.data as {
+        type?: string; success?: boolean; error?: string;
+        userId?: string; name?: string; avatar?: string;
+        onboardingCompleted?: boolean;
+      } | null;
+      if (!data || data.type !== "sapling_signin") return;
+      cleanupPopupListeners();
+      setWaiting(false);
+      if (data.success && data.userId && data.name) {
+        setActiveUser(data.userId, data.name, data.avatar || "");
+        confirmApproved();
+        if (data.onboardingCompleted) {
+          router.replace("/dashboard");
+        } else {
+          sessionStorage.setItem("sapling_onboarding_pending", "1");
+        }
+        onClose();
+      } else {
+        setLocalError(data.error || "signin_failed");
+      }
+    };
+
+    const w = 520;
+    const h = 640;
+    const left = Math.max(0, window.screenX + (window.outerWidth - w) / 2);
+    const top = Math.max(0, window.screenY + (window.outerHeight - h) / 2);
+    const features = `width=${w},height=${h},left=${left},top=${top},menubar=no,toolbar=no,location=no,status=no,resizable=yes,scrollbars=yes`;
+    const popup = window.open(url, "sapling_signin", features);
+    if (!popup || popup.closed) {
+      // Pop-up blocker / user setting. Fall back to same-tab redirect.
+      cleanupPopupListeners();
+      setWaiting(true);
+      window.location.href = url;
+      return;
+    }
+    popupRef.current = popup;
+    try { popup.focus(); } catch {}
     setWaiting(true);
-    window.location.href = `${API_URL}/api/auth/google`;
+
+    // We can't reliably observe popup.closed under COOP, so set a watchdog
+    // that resets the modal if the user abandons the flow.
+    watchdogRef.current = window.setTimeout(() => {
+      cleanupPopupListeners();
+      setWaiting(false);
+    }, POPUP_TIMEOUT_MS);
+  };
+
+  const cancelSignIn = () => {
+    cleanupPopupListeners();
+    setWaiting(false);
   };
 
   return (
@@ -180,6 +275,26 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
           </svg>
           {waiting ? "Waiting for Google…" : "Continue with Google"}
         </button>
+
+        {waiting && (
+          <button
+            type="button"
+            onClick={cancelSignIn}
+            style={{
+              marginTop: 10,
+              width: "100%",
+              padding: "6px 0",
+              background: "none",
+              border: "none",
+              color: "#6b7280",
+              fontSize: 12.5,
+              cursor: "pointer",
+              fontFamily: "var(--font-dm-sans), 'DM Sans', sans-serif",
+            }}
+          >
+            Cancel
+          </button>
+        )}
 
         <p style={{ margin: "16px 0 0", fontSize: 11.5, color: "#6b7280", textAlign: "center", lineHeight: 1.5 }}>
           By signing in, you agree to the{" "}

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -9,6 +9,7 @@ import { CustomSelect } from "../CustomSelect";
 import { ChatPanel, type ChatMsg } from "../ChatPanel";
 import { SessionSummary } from "../SessionSummary";
 import { SharedContextToggle, useSharedContext } from "../SharedContextToggle";
+import { ModelToggle, useModelPref } from "../ModelToggle";
 import { DisclaimerModal } from "../DisclaimerModal";
 import { AIDisclaimerChip } from "../AIDisclaimerChip";
 import { QuizPanel } from "../QuizPanel";
@@ -89,6 +90,7 @@ function LearnInner() {
   const isMobile = useIsMobile();
 
   const [sharedCtx, setSharedCtx] = useSharedContext();
+  const [modelPref, setModelPref] = useModelPref();
 
   const initialTopic = searchParams.get("topic") ?? "";
   const initialMode = normalizeMode(searchParams.get("mode"));
@@ -172,7 +174,7 @@ function LearnInner() {
     setMessages([{ id: msgId(), role: "assistant", content: "", loading: true }]);
     setStarting(true);
     try {
-      const res = await startSession(userId, t, mode, selectedCourseId || undefined, sharedCtx);
+      const res = await startSession(userId, t, mode, selectedCourseId || undefined, sharedCtx, modelPref);
       setSessionId(res.session_id);
       setMessages([{ id: msgId(), role: "assistant", content: res.initial_message || "Let's begin." }]);
     } catch (err) {
@@ -223,7 +225,7 @@ function LearnInner() {
     ]);
     setSending(true);
     try {
-      const res = await sendChat(sessionId, userId, userText, chatMode, sharedCtx);
+      const res = await sendChat(sessionId, userId, userText, chatMode, sharedCtx, modelPref);
       setMessages(m => {
         const next = [...m];
         next[next.length - 1] = { id: next[next.length - 1].id, role: "assistant", content: res.reply || "" };
@@ -238,7 +240,7 @@ function LearnInner() {
     } finally {
       setSending(false);
     }
-  }, [sessionId, userId, mode, sharedCtx]);
+  }, [sessionId, userId, mode, sharedCtx, modelPref]);
 
   const handleAction = async (action: "hint" | "confused" | "skip") => {
     if (!sessionId || !userId) return;
@@ -251,7 +253,7 @@ function LearnInner() {
     ]);
     setSending(true);
     try {
-      const res = await learnAction(sessionId, userId, action, chatMode, sharedCtx);
+      const res = await learnAction(sessionId, userId, action, chatMode, sharedCtx, modelPref);
       setMessages(m => {
         const next = [...m];
         next[next.length - 1] = { id: next[next.length - 1].id, role: "assistant", content: res.reply || "" };
@@ -579,6 +581,7 @@ function LearnInner() {
               actions={
                 <>
                   <AIDisclaimerChip />
+                  <ModelToggle pref={modelPref} onChange={setModelPref} />
                   <SharedContextToggle enabled={sharedCtx} onChange={setSharedCtx} />
                   <button
                     className={endConfirm.armed ? "btn btn--danger btn--sm" : "btn btn--sm"}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -79,16 +79,46 @@ export const deleteGraphNode = (userId: string, nodeId: string) =>
   );
 
 // Learn
-export const startSession = (userId: string, topic: string, mode: string, courseId?: string, useSharedContext = true) =>
+export type ModelPref = 'smart' | 'fast';
+
+export const startSession = (
+  userId: string,
+  topic: string,
+  mode: string,
+  courseId?: string,
+  useSharedContext = true,
+  modelPref?: ModelPref,
+) =>
   fetchJSON<{ session_id: string; initial_message: string; graph_state: any }>('/api/learn/start-session', {
     method: 'POST',
-    body: JSON.stringify({ user_id: userId, topic, mode, use_shared_context: useSharedContext, course_id: courseId }),
+    body: JSON.stringify({
+      user_id: userId,
+      topic,
+      mode,
+      use_shared_context: useSharedContext,
+      course_id: courseId,
+      ...(modelPref ? { model_pref: modelPref } : {}),
+    }),
   });
 
-export const sendChat = (sessionId: string, userId: string, message: string, mode: string, useSharedContext = true) =>
+export const sendChat = (
+  sessionId: string,
+  userId: string,
+  message: string,
+  mode: string,
+  useSharedContext = true,
+  modelPref?: ModelPref,
+) =>
   fetchJSON<{ reply: string; graph_update: any; mastery_changes: any[] }>('/api/learn/chat', {
     method: 'POST',
-    body: JSON.stringify({ session_id: sessionId, user_id: userId, message, mode, use_shared_context: useSharedContext }),
+    body: JSON.stringify({
+      session_id: sessionId,
+      user_id: userId,
+      message,
+      mode,
+      use_shared_context: useSharedContext,
+      ...(modelPref ? { model_pref: modelPref } : {}),
+    }),
   });
 
 export interface SessionSummaryData {
@@ -111,6 +141,7 @@ export const learnAction = (
   actionType: 'hint' | 'confused' | 'skip',
   mode: string,
   useSharedContext = true,
+  modelPref?: ModelPref,
 ) =>
   fetchJSON<{ reply: string; graph_update: any }>('/api/learn/action', {
     method: 'POST',
@@ -120,6 +151,7 @@ export const learnAction = (
       action_type: actionType,
       mode,
       use_shared_context: useSharedContext,
+      ...(modelPref ? { model_pref: modelPref } : {}),
     }),
   });
 


### PR DESCRIPTION
Two independent, complementary changes ship together on this branch.

---

## 1. Rebuild Google sign-in popup on `BroadcastChannel`

Restores the popup sign-in flow that was reverted in `5669639` (`fix(auth): use top-level redirect for Google OAuth instead of popup`). That earlier revert was correct for the bug at the time — COOP severs `window.opener` the moment the popup hops to a cross-origin URL (Railway, then Google), so `postMessage` from `/auth/callback` never reached the opener and the modal hung on "Waiting for Google…".

This rebuild **does not depend on `window.opener`** — so COOP severing the opener handle is harmless.

**How it works:**
- The opener (`SignInModal.tsx`) generates a per-attempt `popup_id` (`crypto.randomUUID`) and subscribes to `BroadcastChannel("sapling_signin:<id>")` *before* opening the window.
- The id is threaded through the OAuth `state` blob (`backend/routes/auth.py::google_login`) so the backend can echo it back.
- `/api/auth/google/callback` decodes `popup_id` from `state` and includes it on the redirect to `/auth/callback`.
- `/auth/callback` (`frontend/src/app/auth/callback/page.tsx`) detects popup mode by the `popup_id` query (not `window.opener`, which COOP nulls), broadcasts the result on the same channel, then `window.close()`s.
- `BroadcastChannel` is same-origin, so the cross-origin nav through Google is irrelevant.

**Failure paths also broadcast.** `google_not_configured`, `invalid_domain`, and `not_approved` now route through `/auth/callback?error=...&popup_id=...` when `popup_id` is set, so the popup can broadcast the error and self-close instead of stranding the opener on `/auth` (which doesn't exist post-modal-refactor) or `/pending`. Same-tab behavior is unchanged.

**Fallbacks / safety:**
- If `window.open` returns `null` (pop-up blocker) or `BroadcastChannel` / `crypto.randomUUID` are unavailable → falls back to today's full same-tab redirect (no regression).
- A 3-minute watchdog plus a Cancel link reset the modal if the user closes the popup themselves. `popup.closed` isn't reliably observable under COOP, so we can't poll for it.

---

## 2. Tutor chat Fast/Smart model toggle (default Fast)

Tutor chat was hardcoded to `gemini-2.5-pro` (`MODEL_SMART`) in `start_session`, `chat`, and `action` (commit `6f431d6`). Reasoning quality is great; latency is enough to feel blocked. Adds a per-user toggle in the chat header so the student decides when speed matters.

**Backend** (`backend/routes/learn.py`, `backend/models/__init__.py`):
- `StartSessionBody` / `ChatBody` / `ActionBody` accept an optional `model_pref: "fast" | "smart"`.
- New `_resolve_tutor_model` maps `"fast"` → `MODEL_DEFAULT` (`gemini-2.5-flash`), `"smart"` → `MODEL_SMART` (`gemini-2.5-pro`). **Unknown / missing → fast.**
- All three call sites (`start_session`, `chat`, `action`) routed through the resolver.

**Frontend** (`frontend/src/components/ModelToggle.tsx` (new), `screens/Learn.tsx`, `lib/api.ts`):
- New `ModelToggle` component mirrors `SharedContextToggle`'s look-and-feel and `localStorage`-persisted hook pattern (`sapling_model_pref` key).
- `useModelPref` defaults to `"fast"` on first load; persists user's choice across reloads.
- "Smart" is the highlighted opt-in state (matches the existing convention that the highlighted toggle = the optional thing).
- Mounted in the chat `TopBar` between the AI disclaimer chip and Class intel toggle.
- `modelPref` threaded through `startSession`, `sendChat`, and `learnAction`.

**Defaults are airtight on both sides.** A fresh user opening their first chat: `useState<ModelPref>("fast")` is the initial render value, so the first `startSession` call explicitly sends `model_pref: "fast"`. Even if that field were ever omitted, the backend resolver still returns `MODEL_DEFAULT`.

---

## Test plan

### Auth popup
- [ ] Click "Continue with Google" on the landing page modal → popup opens centered, ~520×640.
- [ ] Complete sign-in → popup self-closes, modal closes, redirected to `/dashboard` (or onboarding if not completed).
- [ ] With pop-up blocker enabled → falls back to same-tab redirect (no hang).
- [ ] Click Cancel while waiting → modal resets cleanly.
- [ ] Sign in with non-`@bu.edu` account → popup self-closes, modal shows "Sign-in is limited to approved school accounts" (instead of stranding the popup on `/auth`).
- [ ] Sign in with an unapproved `@bu.edu` account → popup self-closes, modal shows "Your account is pending approval" (instead of leaving popup on `/pending`).
- [ ] Existing same-tab redirect path (no `popup_id`) still works end-to-end if anyone hits `/api/auth/google` directly.

### Tutor model toggle
- [ ] Open `/learn` as a fresh user (clear `localStorage` first) → toggle reads "Fast" (un-highlighted).
- [ ] Start a chat → the first `POST /api/learn/start-session` body includes `model_pref: "fast"` (Network tab).
- [ ] Verify backend logs / Logfire trace show `gemini-2.5-flash` was used.
- [ ] Flip to "Smart" → toggle highlights, value persists across page refresh.
- [ ] Send a message → `POST /api/learn/chat` body includes `model_pref: "smart"`, backend uses `gemini-2.5-pro`.
- [ ] Hint / Confused / Skip actions also respect the current toggle.
- [ ] Verified end-to-end: `_resolve_tutor_model(None | "" | "fast" | "garbage")` → `MODEL_DEFAULT`; `_resolve_tutor_model("smart")` → `MODEL_SMART`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tutor model selection: UI toggle to choose "fast" or "smart"; preference is persisted and sent with learning requests.
  * Improved Google sign-in popup flow: popup handoff now uses a broadcast channel with better popup-id handling, fallback, timeout, and cleanup.

* **Tests**
  * Added end-to-end and unit tests for auth state handling and tutor model resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->