### PR TITLE
test(tutor): cross-link thinking budgets + parametrize + drop param shadowing

### DIFF
--- a/backend/tests/test_gemini_service.py
+++ b/backend/tests/test_gemini_service.py
@@ -206,8 +206,11 @@ def _capture_multiturn_thinking_budget(model: str) -> int:
     """
     captured: dict = {}
 
-    def fake_chats_create(*, model, config, history):
-        captured["thinking_budget"] = config.thinking_config.thinking_budget
+    def fake_chats_create(**kwargs):
+        # Accept all kwargs the real _client.chats.create receives
+        # (model, config, history) without rebinding the outer `model`
+        # parameter. Only `config` is inspected here.
+        captured["thinking_budget"] = kwargs["config"].thinking_config.thinking_budget
         chat = MagicMock()
         resp = MagicMock()
         resp.text = "ok"
@@ -236,8 +239,17 @@ class TestCallGeminiMultiturnThinking:
         (dynamic). Pin the literal value, not just "any positive int"."""
         assert _capture_multiturn_thinking_budget("gemini-2.5-pro") == 2048
 
-    def test_flash_disables_thinking(self):
+    def test_legacy_pro_matches_agent_constant(self):
+        """Legacy-path Pro budget must match the agent-path constant —
+        they're the same setting on different code paths. A future bump
+        of `_PRO_THINKING_BUDGET` in routes/learn.py without updating the
+        legacy literal in gemini_service.py would silently desynchronize
+        the two paths; this test catches that."""
+        from routes.learn import _PRO_THINKING_BUDGET
+        assert _capture_multiturn_thinking_budget("gemini-2.5-pro") == _PRO_THINKING_BUDGET
+
+    @pytest.mark.parametrize("model", ["gemini-2.5-flash", "gemini-2.5-flash-lite"])
+    def test_non_pro_disables_thinking(self, model: str):
         """Non-pro models (Flash, Flash-Lite) get thinking_budget=0 —
         Pro is the only model that actually thinks on this path."""
-        assert _capture_multiturn_thinking_budget("gemini-2.5-flash") == 0
-        assert _capture_multiturn_thinking_budget("gemini-2.5-flash-lite") == 0
+        assert _capture_multiturn_thinking_budget(model) == 0


### PR DESCRIPTION
## Summary

Three small polish follow-ups from PR #80's third review pass. Test-only changes; no behavior change.

- **`test_legacy_pro_matches_agent_constant`** — cross-links the legacy-path thinking budget assertion (\`services/gemini_service.py:111\`) to \`routes.learn._PRO_THINKING_BUDGET\`. Previously both pinned the literal \`2048\` independently; a future bump of the constant on the agent path would silently desynchronize from the legacy literal until someone noticed. This test catches that.
- **\`test_non_pro_disables_thinking\`** — parametrized over \`gemini-2.5-flash\` and \`gemini-2.5-flash-lite\`. Replaces the prior single test that stacked two assertions into one body, so per-input failures are now isolated.
- **\`fake_chats_create(**kwargs)\`** — drops the inner \`model\` param that shadowed the outer \`_capture_multiturn_thinking_budget\` parameter. The real \`_client.chats.create\` dispatches by kwarg name, so the inner has to accept the kwargs; \`**kwargs\` is the cleanest way to satisfy the dispatch without rebinding the outer name.

## Why a separate PR
Caught in the third review pass of PR #80 after CI was already green and the PR was ready to merge. Splitting into a small follow-up keeps the original PR focused and easy to revert if needed.

## Test plan
- [x] \`python -m pytest tests/test_gemini_service.py -q\` — 28 pass (was 27 + 1 new cross-link test)
- [x] Diff is test-only; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)