### PR TITLE
fix(storage): surface real Supabase error on avatar upload failure

### DIFF
--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -77,7 +77,20 @@ def upload_cosmetic_asset(cosmetic_id: str, file_bytes: bytes, content_type: str
         headers={**_headers, "Content-Type": content_type, "x-upsert": "true"},
     )
     if resp.status_code not in (200, 201):
-        raise HTTPException(status_code=502, detail="Failed to upload cosmetic asset")
+        # Same shape as upload_avatar's error path — surface the real
+        # Supabase response so admin-side cosmetic uploads aren't a
+        # black box either. URL + headers stay out of the message
+        # (the latter contains the service-role key).
+        body_text = (resp.text or "").strip()[:500]
+        logger.warning(
+            "upload_cosmetic_asset: Supabase storage rejected upload "
+            "cosmetic=%s status=%d body=%s",
+            cosmetic_id, resp.status_code, body_text,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=f"Cosmetic asset upload failed (Supabase {resp.status_code}): {body_text or 'no body'}",
+        )
     public_url = f"{SUPABASE_URL}/storage/v1/object/public/{STORAGE_BUCKET}/{path}"
     return public_url
 

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -2,9 +2,13 @@
 Storage service for avatar and cosmetic asset uploads via Supabase Storage.
 """
 
+import logging
+
 from fastapi import HTTPException
 from config import SUPABASE_URL, SUPABASE_SERVICE_KEY, STORAGE_BUCKET, MAX_AVATAR_SIZE
 import httpx
+
+logger = logging.getLogger(__name__)
 
 ALLOWED_CONTENT_TYPES = {"image/jpeg", "image/png", "image/webp", "image/gif"}
 
@@ -40,7 +44,24 @@ def upload_avatar(user_id: str, file_bytes: bytes, content_type: str) -> str:
         headers={**_headers, "Content-Type": content_type, "x-upsert": "true"},
     )
     if resp.status_code not in (200, 201):
-        raise HTTPException(status_code=502, detail="Failed to upload avatar")
+        # Surface the real Supabase response so the failure is debuggable
+        # without server access. Common shapes:
+        #   {"statusCode":"404","error":"Bucket not found"}    — bucket missing
+        #   {"statusCode":"403","error":"new row violates ..."} — RLS/policy denied
+        #   {"statusCode":"413","error":"Payload too large"}   — bucket size limit
+        body_text = (resp.text or "").strip()[:500]
+        logger.warning(
+            "upload_avatar: Supabase storage rejected upload "
+            "user=%s status=%d body=%s",
+            user_id, resp.status_code, body_text,
+        )
+        # Pass through the upstream message so the caller's toast is
+        # actionable. We only show body_text — never the URL or headers
+        # (the latter contains the service-role key).
+        raise HTTPException(
+            status_code=502,
+            detail=f"Avatar upload failed (Supabase {resp.status_code}): {body_text or 'no body'}",
+        )
     public_url = f"{SUPABASE_URL}/storage/v1/object/public/{STORAGE_BUCKET}/{path}"
     return public_url
 

--- a/backend/tests/test_storage_service.py
+++ b/backend/tests/test_storage_service.py
@@ -52,12 +52,47 @@ class TestUploadAvatar:
     def test_raises_on_failure(self):
         mock_resp = MagicMock()
         mock_resp.status_code = 500
+        mock_resp.text = ""
 
         with patch("services.storage_service.httpx.put", return_value=mock_resp):
             from services.storage_service import upload_avatar
             with pytest.raises(HTTPException) as exc:
                 upload_avatar("u1", b"pixels", "image/png")
             assert exc.value.status_code == 502
+
+    def test_surfaces_supabase_body_on_failure(self):
+        """The HTTPException detail must include the upstream Supabase
+        status + body so frontend toasts and Logfire spans become
+        actionable instead of black-box. PR #86 contract."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_resp.text = '{"statusCode":"404","error":"Bucket not found"}'
+
+        with patch("services.storage_service.httpx.put", return_value=mock_resp):
+            from services.storage_service import upload_avatar
+            with pytest.raises(HTTPException) as exc:
+                upload_avatar("u1", b"pixels", "image/png")
+
+        detail = exc.value.detail
+        assert "Supabase 404" in detail
+        assert "Bucket not found" in detail
+        # Service-role key must NEVER leak into the response body.
+        assert "Bearer" not in detail
+        assert "apikey" not in detail
+
+    def test_failure_with_empty_body_falls_back_gracefully(self):
+        """When Supabase returns no body (rare but possible on 5xx), the
+        detail must still be a complete sentence — not 'Supabase 502: '."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 502
+        mock_resp.text = ""
+
+        with patch("services.storage_service.httpx.put", return_value=mock_resp):
+            from services.storage_service import upload_avatar
+            with pytest.raises(HTTPException) as exc:
+                upload_avatar("u1", b"pixels", "image/png")
+
+        assert "no body" in exc.value.detail
 
     def test_jpeg_extension(self):
         mock_resp = MagicMock()
@@ -80,6 +115,26 @@ class TestUploadCosmeticAsset:
             url = upload_cosmetic_asset("cos_1", b"pixels", "image/webp")
 
         assert "cosmetics/cos_1.webp" in url
+
+    def test_surfaces_supabase_body_on_failure(self):
+        """Parity with upload_avatar — admin-side cosmetic uploads must
+        also surface the upstream Supabase error so failures aren't a
+        black box. PR #86 contract."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        mock_resp.text = '{"statusCode":"403","error":"new row violates row-level security"}'
+
+        with patch("services.storage_service.httpx.put", return_value=mock_resp):
+            from services.storage_service import upload_cosmetic_asset
+            with pytest.raises(HTTPException) as exc:
+                upload_cosmetic_asset("cos_1", b"pixels", "image/png")
+
+        detail = exc.value.detail
+        assert "Supabase 403" in detail
+        assert "row-level security" in detail
+        # Service-role key must NEVER leak into the response body.
+        assert "Bearer" not in detail
+        assert "apikey" not in detail
 
 
 class TestDeleteAsset:


### PR DESCRIPTION
## Summary

The "Change avatar" button has been failing in production with a useless toast: \"Upload failed: HTTP 502\". The route currently swallows the upstream Supabase response and replaces it with a generic \"Failed to upload avatar\" message — making the actual cause invisible without server access.

This PR surfaces the real Supabase response on the failure path so we can diagnose the underlying issue (likely a bucket-misconfig, RLS policy, or size-limit problem on the \`avatars\` bucket).

## What changed

\`backend/services/storage_service.py::upload_avatar\` now:

- **Logs the full Supabase response** via \`logger.warning\` with user_id correlation. Visible in Logfire / Railway logs.
- **Includes the upstream status + truncated body** (max 500 chars) in the HTTPException detail so the frontend toast becomes actionable: \`\"Avatar upload failed (Supabase 404): {Bucket not found}\"\` is self-explanatory.

## What's NOT in this PR

The actual underlying fix — that depends on what Supabase reports. Most likely causes:
- **Bucket missing**: 404 — fix is to create the \`avatars\` bucket in the Supabase dashboard.
- **RLS denied**: 403 — fix is a storage policy update (or service-role bypass check).
- **Size limit**: 413 — fix is to bump the bucket's per-file size limit.

Once we see the actual error in the next user attempt, a follow-up PR closes the root cause.

## Security

Body is surfaced; URL and headers are NOT. The service-role key lives in headers and must not leak — verified by reading the diff. Body is truncated to 500 chars to bound response size.

## Test plan

- [x] \`pytest -k 'avatar or storage or profile'\` → 39 passed, no regressions.
- [ ] Click \"Change avatar\" in production → confirm toast now shows the real upstream error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)