### PR TITLE
fix(storage): auto-create avatars bucket on app startup (closes #75 root cause)

### DIFF
--- a/backend/db/migration_avatars_bucket.sql
+++ b/backend/db/migration_avatars_bucket.sql
@@ -1,0 +1,36 @@
+-- Create the `avatars` storage bucket used by:
+--   • backend/services/storage_service.py::upload_avatar
+--     (path: avatars/{user_id}/avatar.{ext})
+--   • backend/services/storage_service.py::upload_cosmetic_asset
+--     (path: cosmetics/{cosmetic_id}.{ext})
+--
+-- NOTE: as of the lifespan handler in backend/main.py, the backend
+-- itself calls `ensure_bucket_exists` on startup against this bucket
+-- with the same settings, so new environments self-bootstrap. This
+-- file is kept as the canonical SQL doc + manual fallback for
+-- environments where running the backend isn't an option (e.g.,
+-- inspecting bucket settings via the SQL editor, or restoring a
+-- bucket that was deliberately deleted).
+--
+-- Settings derived from the validators in storage_service.py:
+--   • public = true so the public-URL read path
+--     (/storage/v1/object/public/avatars/...) works for <img src>
+--     without auth — required because browsers can't send the
+--     service-role key.
+--   • file_size_limit = 5 MB to match MAX_AVATAR_SIZE in
+--     backend/config.py:35.
+--   • allowed_mime_types matches ALLOWED_CONTENT_TYPES in
+--     backend/services/storage_service.py:9.
+--
+-- Idempotent — ON CONFLICT (id) DO NOTHING means re-running this on
+-- an already-bootstrapped environment is a no-op.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+    'avatars',
+    'avatars',
+    true,
+    5242880,  -- 5 MB
+    ARRAY['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+)
+ON CONFLICT (id) DO NOTHING;

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import logfire
@@ -10,7 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from config import FRONTEND_URL, PORT
+from config import FRONTEND_URL, MAX_AVATAR_SIZE, PORT, STORAGE_BUCKET
 
 # App-wide log format. Per-request log lines (with request_id, duration,
 # status) are emitted from RequestIDMiddleware; this just sets the
@@ -58,7 +59,33 @@ logfire.configure(
 )
 logfire.instrument_pydantic_ai()
 
-app = FastAPI(title="Sapling API", version="1.0.0")
+# ── App lifespan: self-bootstrap external resources ─────────────────────────
+#
+# The avatars + cosmetics storage bucket is required by
+# routes/profile.py::upload_user_avatar (and the cosmetic admin path).
+# Issue #75 / PRs #84-#87 chased the symptom (uploads fail) before the
+# real cause (the bucket never existed) surfaced in a Supabase audit.
+# Creating it on startup makes new environments self-bootstrap and
+# protects against the same class of "code expects a Supabase resource
+# that no migration ever made" bugs.
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    from services.storage_service import (
+        ALLOWED_CONTENT_TYPES,
+        ensure_bucket_exists,
+    )
+
+    ensure_bucket_exists(
+        STORAGE_BUCKET,
+        public=True,  # required for unauthenticated <img src> reads
+        file_size_limit=MAX_AVATAR_SIZE,
+        allowed_mime_types=sorted(ALLOWED_CONTENT_TYPES),
+    )
+    yield
+    # No shutdown hooks today.
+
+
+app = FastAPI(title="Sapling API", version="1.0.0", lifespan=_lifespan)
 logfire.instrument_fastapi(app)
 
 if recost_api_key and RecostMiddleware is not None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,7 @@ from routes.admin import router as admin_router
 from routes.newsletter import router as newsletter_router
 from services.logfire_scrubber import EXTRA_PATTERNS, scrub_value
 from services.request_context import RequestIDMiddleware, current_request_id
+from services.storage_service import ALLOWED_CONTENT_TYPES, ensure_bucket_exists
 
 try:
     from recost.frameworks.fastapi import RecostMiddleware
@@ -70,12 +71,7 @@ logfire.instrument_pydantic_ai()
 # that no migration ever made" bugs.
 @asynccontextmanager
 async def _lifespan(_app: FastAPI):
-    from services.storage_service import (
-        ALLOWED_CONTENT_TYPES,
-        ensure_bucket_exists,
-    )
-
-    ensure_bucket_exists(
+    await ensure_bucket_exists(
         STORAGE_BUCKET,
         public=True,  # required for unauthenticated <img src> reads
         file_size_limit=MAX_AVATAR_SIZE,

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -26,7 +26,7 @@ _headers = {
 }
 
 
-def ensure_bucket_exists(
+async def ensure_bucket_exists(
     bucket_id: str,
     *,
     public: bool,
@@ -34,8 +34,8 @@ def ensure_bucket_exists(
     allowed_mime_types: list[str],
 ) -> None:
     """Idempotently ensure a Supabase Storage bucket exists with the
-    given settings. Called on app startup so new environments
-    self-bootstrap.
+    given settings. Called from FastAPI's `lifespan` on app startup
+    so new environments self-bootstrap.
 
     The Supabase Storage API returns:
       • 200 — bucket created.
@@ -51,6 +51,9 @@ def ensure_bucket_exists(
 
     Service-role uploads bypass Storage RLS, so no policy needs to be
     attached after creation.
+
+    Async because it runs inside FastAPI's async lifespan; using
+    httpx.AsyncClient avoids blocking the event loop during startup.
     """
     if not SUPABASE_URL or not SUPABASE_SERVICE_KEY:
         logger.warning(
@@ -70,7 +73,8 @@ def ensure_bucket_exists(
         "allowed_mime_types": allowed_mime_types,
     }
     try:
-        resp = httpx.post(url, json=body, headers=_headers, timeout=10.0)
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(url, json=body, headers=_headers)
     except Exception:
         logger.exception(
             "ensure_bucket_exists(%s): Supabase Storage API call raised — "

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -26,6 +26,74 @@ _headers = {
 }
 
 
+def ensure_bucket_exists(
+    bucket_id: str,
+    *,
+    public: bool,
+    file_size_limit: int,
+    allowed_mime_types: list[str],
+) -> None:
+    """Idempotently ensure a Supabase Storage bucket exists with the
+    given settings. Called on app startup so new environments
+    self-bootstrap.
+
+    The Supabase Storage API returns:
+      • 200 — bucket created.
+      • 409 — bucket already exists. Treated as success; we DO NOT
+              overwrite settings, in case an admin has intentionally
+              tuned them in the dashboard.
+      • 4xx/5xx — logged as a warning and we move on. Startup is not
+              gated on storage-bucket availability — a transient
+              Supabase outage shouldn't block the deploy. If the
+              bucket genuinely doesn't exist after this, the next
+              upload returns 502 with the upstream error visible
+              (per upload_avatar's diagnostic logging from PR #86).
+
+    Service-role uploads bypass Storage RLS, so no policy needs to be
+    attached after creation.
+    """
+    if not SUPABASE_URL or not SUPABASE_SERVICE_KEY:
+        logger.warning(
+            "ensure_bucket_exists(%s): SUPABASE_URL or SUPABASE_SERVICE_KEY "
+            "missing — skipping bucket bootstrap. Storage operations will "
+            "fail at runtime if the bucket doesn't exist.",
+            bucket_id,
+        )
+        return
+
+    url = f"{SUPABASE_URL}/storage/v1/bucket"
+    body = {
+        "id": bucket_id,
+        "name": bucket_id,
+        "public": public,
+        "file_size_limit": file_size_limit,
+        "allowed_mime_types": allowed_mime_types,
+    }
+    try:
+        resp = httpx.post(url, json=body, headers=_headers, timeout=10.0)
+    except Exception:
+        logger.exception(
+            "ensure_bucket_exists(%s): Supabase Storage API call raised — "
+            "bucket existence is unknown.",
+            bucket_id,
+        )
+        return
+
+    if resp.status_code in (200, 201):
+        logger.info("Storage bucket %s created.", bucket_id)
+    elif resp.status_code == 409:
+        # "Bucket already exists" — expected on every restart after the
+        # first. Don't log at warning level; this is the steady-state path.
+        logger.debug("Storage bucket %s already exists.", bucket_id)
+    else:
+        logger.warning(
+            "ensure_bucket_exists(%s): Supabase returned %d body=%s",
+            bucket_id,
+            resp.status_code,
+            (resp.text or "").strip()[:300],
+        )
+
+
 def _validate_upload(file_bytes: bytes, content_type: str):
     if content_type not in ALLOWED_CONTENT_TYPES:
         raise HTTPException(status_code=415, detail="Unsupported image type. Allowed: jpeg, png, webp, gif")

--- a/backend/tests/test_storage_service.py
+++ b/backend/tests/test_storage_service.py
@@ -137,6 +137,74 @@ class TestUploadCosmeticAsset:
         assert "apikey" not in detail
 
 
+class TestEnsureBucketExists:
+    """Pin the startup bootstrap behavior. Backend lifespan calls this
+    on app boot so new Supabase environments self-create the avatars
+    bucket — fixes the underlying cause of issue #75 (bucket missing,
+    every avatar upload returned 502 'Bucket not found')."""
+
+    KW = dict(public=True, file_size_limit=5_242_880, allowed_mime_types=["image/png"])
+
+    def _resp(self, status_code, text=""):
+        m = MagicMock()
+        m.status_code = status_code
+        m.text = text
+        return m
+
+    def test_creates_bucket_when_missing(self):
+        post = self._resp(200)
+        with patch("services.storage_service.httpx.post", return_value=post) as p:
+            from services.storage_service import ensure_bucket_exists
+            ensure_bucket_exists("avatars", **self.KW)
+        # Verify the API contract: POST to .../storage/v1/bucket with
+        # the expected body shape.
+        assert p.called
+        call_args = p.call_args
+        assert call_args.args[0].endswith("/storage/v1/bucket")
+        body = call_args.kwargs["json"]
+        assert body["id"] == "avatars"
+        assert body["name"] == "avatars"
+        assert body["public"] is True
+        assert body["file_size_limit"] == 5_242_880
+        assert body["allowed_mime_types"] == ["image/png"]
+
+    def test_idempotent_on_409_already_exists(self):
+        """Re-running on an already-created bucket must not raise."""
+        post = self._resp(409, '{"statusCode":"409","error":"Duplicate"}')
+        with patch("services.storage_service.httpx.post", return_value=post):
+            from services.storage_service import ensure_bucket_exists
+            # Should not raise.
+            ensure_bucket_exists("avatars", **self.KW)
+
+    def test_logs_warning_on_unexpected_status(self):
+        """Other 4xx/5xx are non-fatal — startup should not block on
+        Supabase availability."""
+        post = self._resp(500, "Internal Server Error")
+        with patch("services.storage_service.httpx.post", return_value=post):
+            from services.storage_service import ensure_bucket_exists
+            ensure_bucket_exists("avatars", **self.KW)
+
+    def test_swallows_network_exception(self):
+        """A transient network error (DNS, connection refused) must
+        not crash startup."""
+        with patch(
+            "services.storage_service.httpx.post",
+            side_effect=Exception("connection refused"),
+        ):
+            from services.storage_service import ensure_bucket_exists
+            ensure_bucket_exists("avatars", **self.KW)
+
+    def test_skips_when_credentials_missing(self):
+        """If SUPABASE_URL or service key is unset, log + skip without
+        crashing or making a network call. Lets the backend still
+        start in tests / partial-config environments."""
+        with patch("services.storage_service.SUPABASE_URL", ""), \
+             patch("services.storage_service.httpx.post") as p:
+            from services.storage_service import ensure_bucket_exists
+            ensure_bucket_exists("avatars", **self.KW)
+        p.assert_not_called()
+
+
 class TestDeleteAsset:
     def test_calls_httpx_delete(self):
         with patch("services.storage_service.httpx.delete") as mock_del:

--- a/backend/tests/test_storage_service.py
+++ b/backend/tests/test_storage_service.py
@@ -8,8 +8,10 @@ Tests cover:
   - upload_cosmetic_asset constructs correct path
   - delete_asset calls correct endpoint
 """
+import asyncio
+
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 from fastapi import HTTPException
 
 
@@ -137,6 +139,34 @@ class TestUploadCosmeticAsset:
         assert "apikey" not in detail
 
 
+def _patch_async_client(*, status_code=200, body_text="", raises=None):
+    """Patch `httpx.AsyncClient` to return a stubbed response (or
+    raise) without doing a real network call. Returns the patcher so
+    tests can inspect the recorded `post(...)` call args.
+
+    `httpx.AsyncClient` is used inside an `async with` block, so the
+    mock has to behave as an async context manager. The `post` method
+    is itself awaitable. AsyncMock handles both shapes when set on
+    the right attributes.
+    """
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = body_text
+
+    client_instance = MagicMock()
+    client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+    client_instance.__aexit__ = AsyncMock(return_value=None)
+    if raises is not None:
+        client_instance.post = AsyncMock(side_effect=raises)
+    else:
+        client_instance.post = AsyncMock(return_value=resp)
+
+    # AsyncClient(timeout=...) -> client_instance. The constructor is
+    # called synchronously, so a MagicMock side effect is correct.
+    cls_mock = MagicMock(return_value=client_instance)
+    return patch("services.storage_service.httpx.AsyncClient", cls_mock), client_instance
+
+
 class TestEnsureBucketExists:
     """Pin the startup bootstrap behavior. Backend lifespan calls this
     on app boot so new Supabase environments self-create the avatars
@@ -145,21 +175,16 @@ class TestEnsureBucketExists:
 
     KW = dict(public=True, file_size_limit=5_242_880, allowed_mime_types=["image/png"])
 
-    def _resp(self, status_code, text=""):
-        m = MagicMock()
-        m.status_code = status_code
-        m.text = text
-        return m
-
     def test_creates_bucket_when_missing(self):
-        post = self._resp(200)
-        with patch("services.storage_service.httpx.post", return_value=post) as p:
+        patcher, client = _patch_async_client(status_code=200)
+        with patcher:
             from services.storage_service import ensure_bucket_exists
-            ensure_bucket_exists("avatars", **self.KW)
+            asyncio.run(ensure_bucket_exists("avatars", **self.KW))
+
         # Verify the API contract: POST to .../storage/v1/bucket with
         # the expected body shape.
-        assert p.called
-        call_args = p.call_args
+        assert client.post.called
+        call_args = client.post.call_args
         assert call_args.args[0].endswith("/storage/v1/bucket")
         body = call_args.kwargs["json"]
         assert body["id"] == "avatars"
@@ -170,39 +195,72 @@ class TestEnsureBucketExists:
 
     def test_idempotent_on_409_already_exists(self):
         """Re-running on an already-created bucket must not raise."""
-        post = self._resp(409, '{"statusCode":"409","error":"Duplicate"}')
-        with patch("services.storage_service.httpx.post", return_value=post):
+        patcher, _ = _patch_async_client(
+            status_code=409, body_text='{"statusCode":"409","error":"Duplicate"}',
+        )
+        with patcher:
             from services.storage_service import ensure_bucket_exists
-            # Should not raise.
-            ensure_bucket_exists("avatars", **self.KW)
+            asyncio.run(ensure_bucket_exists("avatars", **self.KW))
 
     def test_logs_warning_on_unexpected_status(self):
         """Other 4xx/5xx are non-fatal — startup should not block on
         Supabase availability."""
-        post = self._resp(500, "Internal Server Error")
-        with patch("services.storage_service.httpx.post", return_value=post):
+        patcher, _ = _patch_async_client(status_code=500, body_text="Internal Server Error")
+        with patcher:
             from services.storage_service import ensure_bucket_exists
-            ensure_bucket_exists("avatars", **self.KW)
+            asyncio.run(ensure_bucket_exists("avatars", **self.KW))
 
     def test_swallows_network_exception(self):
         """A transient network error (DNS, connection refused) must
         not crash startup."""
-        with patch(
-            "services.storage_service.httpx.post",
-            side_effect=Exception("connection refused"),
-        ):
+        patcher, _ = _patch_async_client(raises=Exception("connection refused"))
+        with patcher:
             from services.storage_service import ensure_bucket_exists
-            ensure_bucket_exists("avatars", **self.KW)
+            asyncio.run(ensure_bucket_exists("avatars", **self.KW))
 
     def test_skips_when_credentials_missing(self):
         """If SUPABASE_URL or service key is unset, log + skip without
         crashing or making a network call. Lets the backend still
         start in tests / partial-config environments."""
         with patch("services.storage_service.SUPABASE_URL", ""), \
-             patch("services.storage_service.httpx.post") as p:
+             patch("services.storage_service.httpx.AsyncClient") as ac:
             from services.storage_service import ensure_bucket_exists
-            ensure_bucket_exists("avatars", **self.KW)
-        p.assert_not_called()
+            asyncio.run(ensure_bucket_exists("avatars", **self.KW))
+        ac.assert_not_called()
+
+
+class TestLifespanWiresEnsureBucketExists:
+    """Pin that the FastAPI lifespan actually calls
+    ensure_bucket_exists on app boot. Without this, a future refactor
+    that drops the call from `_lifespan` wouldn't fail any test —
+    we'd silently regress to the original "bucket-doesn't-exist"
+    bug from issue #75."""
+
+    def test_lifespan_invokes_ensure_bucket_exists_with_avatars_settings(self):
+        from unittest.mock import AsyncMock
+
+        # Patch in main.py's namespace because the import is hoisted
+        # to module-level there. AsyncMock so `await` inside the
+        # lifespan resolves cleanly.
+        with patch("main.ensure_bucket_exists", new=AsyncMock()) as m:
+            from fastapi.testclient import TestClient
+            from main import app
+            with TestClient(app):
+                # Entering the context triggers the lifespan startup.
+                pass
+
+        m.assert_called_once()
+        # Verify the lifespan passes the avatars-specific settings the
+        # bucket actually needs: public for unauthenticated <img src>
+        # reads, MAX_AVATAR_SIZE for the size cap, and the same MIME
+        # types the route's _validate_upload allows.
+        from config import MAX_AVATAR_SIZE, STORAGE_BUCKET
+        from services.storage_service import ALLOWED_CONTENT_TYPES
+        args = m.call_args
+        assert args.args[0] == STORAGE_BUCKET
+        assert args.kwargs["public"] is True
+        assert args.kwargs["file_size_limit"] == MAX_AVATAR_SIZE
+        assert set(args.kwargs["allowed_mime_types"]) == ALLOWED_CONTENT_TYPES
 
 
 class TestDeleteAsset:


### PR DESCRIPTION
## TL;DR

Issue #75's avatar bug had a buried root cause that didn't surface until a Supabase audit: **the `avatars` storage bucket the backend code references was never created in the production project**. Every prior fix (PR #84 schema, #86 diagnostics, #87 JSON+base64) addressed real but secondary symptoms — the bucket itself just didn't exist.

This PR makes the backend **self-heal on startup**: the FastAPI lifespan calls `ensure_bucket_exists` against Supabase Storage's API, creating the bucket if missing. **Production gets fixed on the next deploy with no manual dashboard step**, and any future environment (staging, CI, a fresh Supabase project) self-bootstraps the same way.

## What changed

| File | Change |
|---|---|
| `backend/services/storage_service.py` | New `ensure_bucket_exists(bucket_id, *, public, file_size_limit, allowed_mime_types)`. POSTs to `/storage/v1/bucket` via the service-role key. 200/201 → created; 409 → already exists (treated as success, no overwrite); other → warning + continue; network exception → swallowed. Startup must NOT block on Supabase availability. |
| `backend/main.py` | New `_lifespan` async context manager calls `ensure_bucket_exists` once on app boot with the avatars bucket's exact settings — `public=true`, 5 MB size limit, four allowed image MIME types — derived from the existing constants in `config.py` and `storage_service.py`. |
| `backend/tests/test_storage_service.py` | **5 new tests** pinning the behavior: creation request shape, 409 idempotency, non-fatal warning on unexpected status, network-exception resilience, missing-credentials skip path. |
| `backend/db/migration_avatars_bucket.sql` | Canonical SQL fallback / audit doc — kept for manual environments where running the backend isn't an option. |

## Why settings drift is intentionally NOT corrected

If the bucket exists with different settings (an admin tuned the size limit up to 10 MB, say), the 409 response treats it as success and we leave the settings alone. Reverting admin-tuned dashboards on every backend restart would be hostile. The `ensure_bucket_exists` contract is "make sure it exists," not "force these exact settings every boot."

## Why this is the right "once and for all" fix

| Approach | Problem |
|---|---|
| ❌ Manual dashboard click | Production fixed; staging/CI/new envs not. Repeats the bug in a year. |
| ❌ Migration SQL only | Same problem — has to be remembered and applied per-environment. |
| ✅ Backend self-heal on startup | Every environment that runs the backend gets the bucket. New envs don't need a runbook. Service-role key is already there. |

## Test plan

- [x] `pytest tests/test_storage_service.py -q` → 17 passed (was 12 + 5 new).
- [x] `pytest tests/ -q --ignore=tests/evals` → 619 passed, same 3 pre-existing live-Supabase failures (`test_skips_self_edges`, `test_save_to_db`, `test_full_pipeline`) unchanged.
- [x] `python -c "from main import app"` — backend boots clean under the new lifespan.
- [ ] **Production**: after merge + deploy, check Logfire for the `Storage bucket avatars created.` log line on first boot, then `Storage bucket avatars already exists` on subsequent restarts.
- [ ] **Manual smoke**: click "Change avatar" → pick a PNG → expect green "Avatar updated" toast and the new image renders. (PR #87's JSON path + this PR's bucket creation = end-to-end working.)

## Out of scope

- The other minor avatar improvements from PR #87's review remain in place (size-check before encode, route-level 413, diagnostic logging).
- Cosmetic asset uploads also use the same bucket and benefit automatically.
- No frontend change.
- No breaking API contract change.

## Rollback

Single revert. The bucket creation is idempotent + best-effort — reverting just removes the `_lifespan` handler; the bucket stays where it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avatar storage bucket is now automatically provisioned at application startup with configured size limits and file type restrictions.

* **Tests**
  * Added comprehensive test coverage for storage bucket initialization and application startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->