### PR TITLE
fix(profile): refresh avatar in UserContext after upload (final #75 symptom)

### DIFF
--- a/frontend/src/context/UserContext.tsx
+++ b/frontend/src/context/UserContext.tsx
@@ -113,6 +113,28 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       setRoles(data.roles ?? []);
       setEquippedCosmetics(data.equipped_cosmetics ?? {});
       setIsAdmin(data.is_admin ?? false);
+      // Avatar URL has to be refreshed here too — Settings.tsx calls
+      // refreshProfile() after a successful avatar upload to pick up
+      // the new image, and without this line the avatar stayed on
+      // whatever value setActiveUser put in at login (often empty,
+      // showing the initial-letter fallback in <Avatar>).
+      //
+      // Cache-bust with `?v=<timestamp>` because the storage URL is
+      // deterministic — every upload writes to
+      // `avatars/{user_id}/avatar.{ext}`, so a re-upload produces an
+      // identical URL and browsers serve the cached old image. The
+      // timestamp changes on every refresh, which forces a re-fetch
+      // from Supabase Storage's CDN once per refreshProfile() call.
+      // Avatars are small (<5 MB cap, usually <100 KB after
+      // browser-side compression), so the extra fetch per refresh is
+      // not a meaningful bandwidth concern.
+      const rawAvatar = (data.avatar_url ?? '').trim();
+      if (rawAvatar) {
+        const sep = rawAvatar.includes('?') ? '&' : '?';
+        setAvatarUrl(`${rawAvatar}${sep}v=${Date.now()}`);
+      } else {
+        setAvatarUrl('');
+      }
       const fr = data.equipped_cosmetics?.featured_role ?? null;
       setFeaturedRole(fr);
     } catch {}


### PR DESCRIPTION
## TL;DR

Avatar uploads now succeed end-to-end (the chain of fixes from PRs #84 → #86 → #87 → #88 is on main and the file lands in Supabase Storage), but **the user's avatar in the TopNav and Settings page still shows the initial-letter fallback** until a hard refresh. Two reasons:

1. **`UserContext::fetchProfileData` was missing a `setAvatarUrl` call.** It refreshed `username`, `roles`, `equippedCosmetics`, `isAdmin`, `featuredRole` after upload — but not the avatar. So even though `/api/auth/me` returns the new `avatar_url`, React state never picked it up. `Settings.tsx::handleAvatarFile` calls `refreshProfile()` after a successful upload expecting the avatar to refresh; it wasn't.
2. **The Supabase Storage URL is deterministic** — `avatars/{user_id}/avatar.{ext}` — so every upload writes to the same path and produces the same public URL. After the first upload + state update, subsequent re-uploads would still show the cached old image because the browser sees the same `<img src>`.

## What changed

`frontend/src/context/UserContext.tsx::fetchProfileData` now:
- Reads `data.avatar_url` from `/api/auth/me` and calls `setAvatarUrl(...)`.
- Appends `?v=<Date.now()>` to bust the browser cache so re-uploaded avatars actually re-fetch from Supabase Storage's CDN. Re-fetches once per `refreshProfile()` call — acceptable since avatars are small (<5 MB cap, usually <100 KB after browser-side compression).

Falls back to empty string when the user has no avatar yet.

## Test plan

- [x] `npx tsc --noEmit` → clean.
- [x] `npx vitest run` → 29 passed.
- [ ] **Manual smoke** (after deploy):
  - Existing avatar that was uploaded earlier today should now appear immediately (no hard refresh required after this lands).
  - Click "Change avatar" → pick a different PNG → toast → new image immediately replaces the old one in TopNav and Settings.

## Why this couldn't have been caught earlier

`fetchProfileData` is unit-test-light because it mostly just feeds React state from a single API response. The bug is "didn't update one of N fields" — easy to miss in code review since the existing fields it does update look correct, and there's no schema-level enforcement that requires every API field be plumbed into state.

A follow-up could:
- Add a unit test for `fetchProfileData` that asserts every API field surfaces in context.
- Or define the context-state shape from the API response type, so missing fields fail at compile time.

Both are out of scope here — the fix is one block in one function.

## Cumulative effect

After this merges, all five PRs together close issue #75 end-to-end:
- **PR #84** — route schema (`school`/`major` removed from SELECT)
- **PR #86** — diagnostic logging on storage failures
- **PR #87** — JSON+base64 transport (worked around browser multipart issue)
- **PR #88** — auto-create the `avatars` bucket on app startup
- **PR #89 (this one)** — refresh avatar URL in React state after upload + cache-bust

🤖 Generated with [Claude Code](https://claude.com/claude-code)