### PR TITLE
perf(profile): optimistic avatar update — show picked image instantly

### DIFF
--- a/frontend/src/components/screens/Settings.tsx
+++ b/frontend/src/components/screens/Settings.tsx
@@ -62,7 +62,7 @@ type UsernameState = { status: "idle" | "checking" | "available" | "taken" | "in
 
 export function Settings() {
   const toast = useToast();
-  const { userId, userName, avatarUrl, userReady, signOut, refreshProfile } = useUser();
+  const { userId, userName, avatarUrl, userReady, signOut, refreshProfile, setAvatarUrl } = useUser();
   const [tab, setTab] = React.useState<Tab>("profile");
   const [settings, setSettings] = React.useState<UserSettings | null>(null);
   const [layoutPref, setLayoutPref] = useLayoutPref();
@@ -115,14 +115,40 @@ export function Settings() {
       if (avatarFileRef.current) avatarFileRef.current.value = "";
       return;
     }
+
+    // Optimistic UI: paint the picked image immediately via a local
+    // blob URL so the user sees their face in the avatar circle the
+    // instant they pick the file. The actual upload + Supabase
+    // round-trip can take 1–3s on slow connections; without this,
+    // there's a visible delay between "Avatar updated" toast and
+    // the image appearing.
+    //
+    // We capture the previous URL up front so we can revert on
+    // failure, and revoke the blob URL once we either swap to the
+    // real Supabase URL or roll back, to free its memory.
+    const previousAvatar = avatarUrl;
+    const blobUrl = URL.createObjectURL(file);
+    setAvatarUrl(blobUrl);
     setUploadingAvatar(true);
     try {
-      await uploadAvatar(userId, file);
-      await refreshProfile();
+      const result = await uploadAvatar(userId, file);
+      // Swap to the canonical Supabase URL with a cache-bust so
+      // re-uploads on the same deterministic path actually refresh.
+      // No need to call refreshProfile() — we already have the URL,
+      // and skipping the extra /api/auth/me round-trip removes ~50–
+      // 200ms of latency from the perceived flow.
+      const sep = result.avatar_url.includes("?") ? "&" : "?";
+      setAvatarUrl(`${result.avatar_url}${sep}v=${Date.now()}`);
       toast.success("Avatar updated");
     } catch (err) {
+      // Revert to whatever the user had before so the optimistic
+      // paint doesn't leave a ghost of a file that never landed.
+      setAvatarUrl(previousAvatar);
       toast.error(`Upload failed: ${String(err)}`);
     } finally {
+      // Always free the blob URL — whether we swapped to the
+      // server URL or reverted, the blob is no longer referenced.
+      URL.revokeObjectURL(blobUrl);
       setUploadingAvatar(false);
       if (avatarFileRef.current) avatarFileRef.current.value = "";
     }

--- a/frontend/src/context/UserContext.tsx
+++ b/frontend/src/context/UserContext.tsx
@@ -27,6 +27,11 @@ interface UserContextValue {
   confirmApproved: () => void;
   signOut: () => Promise<void>;
   refreshProfile: () => Promise<void>;
+  // Direct setter exposed so callers can do an optimistic UI update
+  // (e.g. show a local blob URL for an avatar the user just picked
+  // before the upload finishes). The next refreshProfile() will
+  // overwrite this with the canonical Supabase URL + cache-bust.
+  setAvatarUrl: (url: string) => void;
 }
 
 export const UserContext = createContext<UserContextValue>({
@@ -46,6 +51,7 @@ export const UserContext = createContext<UserContextValue>({
   confirmApproved: () => {},
   signOut: () => Promise.resolve(),
   refreshProfile: () => Promise.resolve(),
+  setAvatarUrl: () => {},
 });
 
 export function UserProvider({ children }: { children: React.ReactNode }) {
@@ -181,7 +187,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     () => ({
       userId, userName, avatarUrl, users, userReady, isAuthenticated, isApproved,
       username, roles, equippedCosmetics, featuredRole, isAdmin,
-      setActiveUser, confirmApproved, signOut, refreshProfile,
+      setActiveUser, confirmApproved, signOut, refreshProfile, setAvatarUrl,
     }),
     [userId, userName, avatarUrl, users, userReady, isAuthenticated, isApproved,
      username, roles, equippedCosmetics, featuredRole, isAdmin, refreshProfile]


### PR DESCRIPTION
## TL;DR

The avatar upload feature is fully working after PRs #84-#89, but **felt slow** because the UI waited for the full server round-trip before showing the new image. This PR makes the avatar appear **the instant the user picks the file**, with the actual upload happening in the background.

## What you'll feel

| Before | After |
|---|---|
| Pick file → "Uploading…" button + old initial-letter fallback for 1–3 seconds → toast → image appears | Pick file → image appears IMMEDIATELY → "Uploading…" button briefly → toast confirms |

## Mechanism

This is a textbook **optimistic UI** pattern:

1. **Capture** the current `avatarUrl` (for revert-on-failure).
2. **`URL.createObjectURL(file)`** → a local blob URL the browser renders without a single network call.
3. **`setAvatarUrl(blobUrl)`** → `<Avatar>` re-renders with the local file.
4. **`uploadAvatar(...)` runs in background** (still awaited so we know if it failed).
5. On **success**, swap the blob for the canonical Supabase URL with `?v=<timestamp>` cache-bust. **Skipped `refreshProfile()`** since we already have the URL — saves another ~50–200 ms round-trip.
6. On **failure**, revert `setAvatarUrl(previousAvatar)` so the optimistic paint doesn't leave a ghost of a file that never landed. Toast surfaces the error.
7. **`URL.revokeObjectURL(blobUrl)`** in `finally` frees the local blob's memory whether we swapped or reverted.

## What changed

- **`frontend/src/context/UserContext.tsx`**: exposed `setAvatarUrl` on the context value (with a docstring explaining the optimistic-paint use case). The `useState` setter was already there; this just makes it accessible to consumers.
- **`frontend/src/components/screens/Settings.tsx::handleAvatarFile`**: the new flow above. Same validation logic (MIME starts-with image, size ≤ 5 MB), same toast messages, same upload helper. Just paints the optimistic blob first and skips the now-redundant `refreshProfile()` call.

## Why skipping `refreshProfile()` is safe

`refreshProfile()` was being called after `uploadAvatar()` returned the new URL — its only purpose in this flow was to update `avatarUrl` in context. We now do that directly with the upload response. Other context fields (username, roles, equipped cosmetics, etc.) don't change as a side effect of an avatar upload, so they don't need refreshing here.

## Test plan

- [x] `npx tsc --noEmit` → clean.
- [x] `npx vitest run` → 29 passed (no regressions).
- [ ] **Manual smoke**:
  - Click "Change avatar" → pick a PNG → image appears INSTANTLY in both the Settings card and the TopNav corner.
  - Toast says "Avatar updated" within 1–3s.
  - Hard refresh → avatar persists (proves the server-side write actually happened).
- [ ] **Failure path**: temporarily kill the network → pick a file → the image still paints optimistically, then the toast says "Upload failed: …" and the avatar reverts to the prior state.

## Out of scope

- The actual upload latency itself (base64 encode + POST + Supabase write + DB update). That's bound by network + Supabase API. This PR only fixes the *perceived* latency.
- No backend changes.
- The cache-bust timestamp pattern from PR #89 is preserved for the swap-to-real-URL step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)