### PR TITLE
fix(graph): resolve color fallback so SVG nodes don't render black

### DIFF
--- a/frontend/src/components/KnowledgeGraph.tsx
+++ b/frontend/src/components/KnowledgeGraph.tsx
@@ -219,10 +219,12 @@ function KnowledgeGraphImpl({
   // ── Helpers ──────────────────────────────────────────────────────────────
   const masteryOpacity = (tier: GraphNode["mastery_tier"]) =>
     ({ mastered: 1, learning: 0.78, struggling: 0.55, unexplored: 0.28 })[tier] || 0.6;
-  const nodeRadius = (n: GraphNode) => (n.is_subject_root ? 22 : 8 + (n.mastery_score || 0) * 12);
+  const nodeRadius = (n: GraphNode) => (n.is_subject_root ? 28 : 8 + (n.mastery_score || 0) * 12);
+  // SVG `fill=` doesn't resolve CSS custom properties, so `var(--c-sage)`
+  // would render black. Use the resolved hex.
   const courseColor = (n?: GraphNode) => {
-    if (!n) return "var(--c-sage)";
-    const base = n.color || "var(--c-sage)";
+    if (!n) return "#8a9a5b";
+    const base = n.color || "#8a9a5b";
     if (n.is_subject_root) return base;
     return shadeFor(base, n.id);
   };

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -21,7 +21,7 @@ import {
   type Assignment,
 } from "@/lib/api";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
-import type { GraphNode, GraphEdge } from "@/lib/data";
+import { paletteFor, type GraphNode, type GraphEdge } from "@/lib/data";
 
 const QUOTES = [
   "Learning is the only thing the mind never exhausts, never fears, and never regrets. — da Vinci",
@@ -38,7 +38,10 @@ function apiToGraphNode(n: ApiNode, courses: EnrolledCourse[]): GraphNode {
     id: n.id,
     name: n.concept_name,
     subject: n.subject,
-    color: n.course_color || course?.color || "var(--c-sage)",
+    color:
+      n.course_color ||
+      course?.color ||
+      paletteFor(n.course_id || course?.course_id || n.subject),
     is_subject_root: n.is_subject_root,
     mastery_tier: n.mastery_tier === "subject_root" ? "mastered" : n.mastery_tier,
     mastery_score: n.mastery_score,

--- a/frontend/src/components/screens/Tree.tsx
+++ b/frontend/src/components/screens/Tree.tsx
@@ -12,7 +12,7 @@ import { getGraph, getCourses, getSessions, deleteGraphNode, type EnrolledCourse
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
-import type { GraphNode, GraphEdge } from "@/lib/data";
+import { paletteFor, type GraphNode, type GraphEdge } from "@/lib/data";
 
 type Tier = "all" | "mastered" | "learning" | "struggling" | "unexplored";
 
@@ -29,7 +29,10 @@ function apiToGraphNode(n: ApiNode, courses: EnrolledCourse[]): GraphNode {
     id: n.id,
     name: n.concept_name,
     subject: n.subject,
-    color: n.course_color || course?.color || "var(--c-sage)",
+    color:
+      n.course_color ||
+      course?.color ||
+      paletteFor(n.course_id || course?.course_id || n.subject),
     is_subject_root: n.is_subject_root,
     mastery_tier: n.mastery_tier === "subject_root" ? "mastered" : n.mastery_tier,
     mastery_score: n.mastery_score,

--- a/frontend/src/lib/data.ts
+++ b/frontend/src/lib/data.ts
@@ -5,6 +5,21 @@ export type Course = {
   color: string;
 };
 
+// Deterministic course palette used as a fallback when the backend doesn't
+// supply a per-course color. SVG `fill=` doesn't resolve `var(--…)`, so a
+// missing color previously rendered black; this maps a stable seed to a hue.
+const COURSE_PALETTE = [
+  "#8a9a5b", "#3e6f8a", "#7b4b99", "#b4562c",
+  "#3f8a7c", "#c89c4a", "#a06b8e", "#6b8a3e",
+];
+
+export function paletteFor(seed: string | null | undefined): string {
+  if (!seed) return COURSE_PALETTE[0];
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = ((h << 5) - h + seed.charCodeAt(i)) | 0;
+  return COURSE_PALETTE[Math.abs(h) % COURSE_PALETTE.length];
+}
+
 export type GraphNode = {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- SVG presentation attributes (`fill=`) don't resolve CSS custom properties — when the backend doesn't supply a per-course color, the `var(--c-sage)` fallback was rendering black.
- Adds a deterministic hex palette + `paletteFor(seed)` helper in `lib/data.ts` and wires it into the Dashboard, Tree, and KnowledgeGraph fallback paths.
- Bumps subject-root node radius from 22 → 28 so course family centers read distinctly from concept nodes.

## Test plan
- [x] `npx tsc --noEmit` in `frontend/` — clean
- [ ] Manual: load Dashboard / Tree with a course that has no `course_color` and confirm nodes render with a stable hue (not black)
- [ ] Manual: confirm subject-root nodes look noticeably larger than concept nodes
- [ ] Manual: same course id always maps to the same palette entry across screens

## Note
A sibling fallback exists in `screens/Learn.tsx#apiToGraphNode`. It's intentionally left untouched here because PR #93 is in flight on that file. Once both land, a one-liner can switch Learn's fallback to `paletteFor(...)` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)