### PR TITLE
docs: sync ROADMAP + README/CLAUDE to current tracked work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,18 +13,21 @@ A FastAPI + Supabase backend that ingests student documents, calls Gemini to cla
 
 ## Repo map
 
-- backend/main.py:24 — FastAPI app, CORS, and every router mount.
-- backend/routes/documents.py:149 — `_process_document` single-call classify/summarize/extract (refactor target #1).
-- backend/routes/documents.py:265 — `upload_document` POST `/api/documents/upload` pipeline.
-- backend/routes/learn.py:152 — `build_system_prompt` for the streaming tutor (SSE).
+- backend/main.py:84 — FastAPI app, CORS, and every router mount (mounts at :139).
+- backend/routes/documents.py:181 — `_process_document` single-call classify/summarize/extract (refactor target #1).
+- backend/routes/documents.py:577 — `upload_document` POST `/api/documents/upload` pipeline.
+- backend/routes/learn.py:239 — `build_system_prompt` for the streaming tutor (SSE).
 - backend/routes/quiz.py:1 — quiz session create/answer/score endpoints.
+- backend/routes/notes.py:31 — `/api/notes` notetaker CRUD, concept link/unlink, and agent actions (`summarize`/`extract-concepts`/`chat`/`send-to-tutor`/`generate-quiz`).
 - backend/routes/auth.py:1 — Google OAuth + HMAC session token issuance.
-- backend/services/gemini_service.py:62 — `call_gemini` plain-text call (LLM seam being deprecated).
-- backend/services/gemini_service.py:129 — `call_gemini_json` JSON-mode helper used by document/quiz prompts.
+- backend/services/gemini_service.py:64 — `call_gemini` plain-text call (LLM seam being deprecated).
+- backend/services/gemini_service.py:135 — `call_gemini_json` JSON-mode helper used by document/quiz prompts.
+- backend/services/notes_service.py:45 — notes CRUD with column encryption (`create_note`/`update_note`/`save_summary`/`link_concept`).
 - backend/services/graph_service.py:375 — `apply_graph_update` (becomes a Pydantic AI tool).
 - backend/services/extraction_service.py:1 — OCR engine router (Docling / GOT-OCR / Tesseract).
 - backend/services/auth_guard.py:1 — `require_self` / `require_admin` FastAPI dependencies.
-- backend/db/connection.py:71 — `table()` factory; the only sanctioned Supabase entry point.
+- backend/agents/note_summary.py, note_concepts.py, note_chat.py — Pydantic AI agents backing the `/api/notes` agent actions (model slots in `agents/_providers.py`).
+- backend/db/connection.py:102 — `table()` factory; the only sanctioned Supabase entry point.
 
 ## Commands
 
@@ -60,4 +63,4 @@ Lint: # TODO: no lint command defined (no ruff/flake8/black config in repo).
 
 ## Gotchas
 
-- Column-level encryption is on for sensitive columns (`users.name`/`first_name`/`last_name`/`bio`/`location`, Google OAuth tokens, `messages.content`, `room_messages.text`, `sessions.summary_json`, `documents.summary` + `concept_notes`, gradebook + calendar assignment notes/points). Helpers live in `backend/services/encryption.py`; use `encrypt_if_present` at write boundaries and `decrypt_if_present` / `decrypt_numeric` at read boundaries (including before injecting into AI prompts). `ENCRYPTION_KEY` must be set (32 bytes as 64 hex chars; generate via `python -c "import secrets; print(secrets.token_hex(32))"`).
+- Column-level encryption is on for sensitive columns (`users.name`/`first_name`/`last_name`/`bio`/`location`, Google OAuth tokens, `messages.content`, `room_messages.text`, `sessions.summary_json`, `documents.summary` + `concept_notes`, `notes.title`/`body`/`last_summary`, gradebook + calendar assignment notes/points). Helpers live in `backend/services/encryption.py`; use `encrypt_if_present` at write boundaries and `decrypt_if_present` / `decrypt_numeric` at read boundaries (including before injecting into AI prompts). `ENCRYPTION_KEY` must be set (32 bytes as 64 hex chars; generate via `python -c "import secrets; print(secrets.token_hex(32))"`).

--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ Sapling is a study tool that adapts to how you learn. Chat with an AI tutor acro
 
 ## Features
 
-* **Live Knowledge Graph** — Your understanding is visualized as a growing node graph. Mastery scores update dynamically after every session and quiz, with per-course color shading and mastery-based opacity.
+* **Live Knowledge Graph** — Your understanding is visualized as a growing node graph, with a 2D (D3/SVG, default) or 3D (WebGL) view toggle. Mastery scores update dynamically after every session and quiz, with per-course color shading and mastery-based opacity.
 * **Three Teaching Modes** — Socratic (guided reasoning), Expository (direct explanation), and TeachBack (you explain, Sapling corrects). Chat supports inline math (KaTeX), Mermaid diagrams, function plots, and theorem callouts.
-* **Adaptive Quizzes** — AI-generated quizzes targeting your weakest concepts, with difficulty scaling based on your performance.
+* **Adaptive Quizzes** — AI-generated quizzes targeting your weakest concepts, with difficulty scaling based on your performance and spaced-repetition scheduling that resurfaces concepts you've missed before.
 * **Flashcards** — Generate AI flashcards per course, or import them from paste, file (CSV/Markdown/Anki), URL, AI prompt, or photo. Study by topic with spaced-repetition ratings (Easy / Hard / Forgot).
 * **Gradebook** — Track your real-world grade per course. Categories + weights, per-assignment scores, per-course letter-scale overrides, and current grade calculation. Upload a syllabus and Sapling extracts categories and assignments automatically.
 * **Study Guide** — Generate a Gemini-powered exam study guide from your uploaded course materials. Guides are cached per exam and can be regenerated at any time.
 * **Class Intelligence** — Aggregates anonymized class-wide patterns to surface common misconceptions and weak areas, personalizing your sessions.
 * **Calendar & Syllabus Tracking** — Paste your syllabus and Sapling extracts assignments, deadlines, and topics automatically.
 * **Document Library** — Upload PDFs and notes (up to 100 MB each); Sapling extracts summaries, key concept notes, and flashcard topics to enrich your knowledge graph and study guides. Uploads use a streaming SSE pipeline so the UI shows live per-phase progress (*"Classifying..." → "Extracting summary, concepts, and syllabus..." → "Saved."*). Concept notes can be re-scanned manually per doc or per course.
+* **Notetaker** — Write typed notes per course with debounced autosave and tags. Per note, Sapling can AI-summarize, extract concepts (merged into your knowledge graph and linked back to the note), answer questions in a note-grounded AI chat, send the note to the tutor, or generate a quiz targeting the note's weakest linked concept.
 * **Study Rooms** — Invite classmates, compare knowledge graphs, and track relative mastery across your group.
 * **Room Chat** — Real-time text chat with avatars inside each study room.
 * **User Profiles** — Public profiles with academic info, bio, featured achievements, and equipped cosmetics.
@@ -38,9 +39,9 @@ Sapling is a study tool that adapts to how you learn. Chat with an AI tutor acro
 
 ## Tech Stack
 
-* **Frontend** — Next.js 16 (TypeScript, App Router) with D3.js for interactive graph visualization. Vitest with jsdom + React Testing Library for unit + component tests.
-* **Backend** — FastAPI (Python) serving a REST API. Document ingestion runs through a Pydantic AI agentic pipeline (4 typed worker agents fanned out in parallel via `asyncio.gather`); other LLM-driven routes still use the structured-prompt helper in `services/gemini_service.py` until they're migrated.
-* **AI** — Google Gemini, with per-task model routing configurable via env vars. Defaults: `gemini-2.5-flash-lite` for classifier + summary; `gemini-2.5-flash` for concept extraction + syllabus parsing; `gemini-2.5-flash-lite` for quiz generation and concept suggestions. Override per task via `SAPLING_MODEL_<TASK>`.
+* **Frontend** — Next.js 16 (TypeScript, App Router). The knowledge graph renders in 2D via D3.js (default) or 3D via `react-force-graph-3d` (three.js/WebGL), lazy-loaded so the 3D stack only enters the bundle when toggled on. Vitest with jsdom + React Testing Library for unit + component tests.
+* **Backend** — FastAPI (Python) serving a REST API. Document ingestion runs through a Pydantic AI agentic pipeline (4 typed worker agents fanned out in parallel via `asyncio.gather`). Quiz generation, the chat tutor, syllabus extraction, and the notetaker (summary / concepts / chat) are also Pydantic AI agents; the remaining LLM-driven routes still use the structured-prompt helper in `services/gemini_service.py` until they're migrated.
+* **AI** — Google Gemini, with per-task model routing configurable via env vars. Defaults: `gemini-2.5-flash-lite` for classifier, summary, quiz generation, and note summary/concepts; `gemini-2.5-flash` for concept extraction, syllabus parsing, and note chat; `gemini-2.5-pro` for the chat tutor. Override per task via `SAPLING_MODEL_<TASK>`.
 * **Streaming** — `sse-starlette` Server-Sent Events on `POST /api/documents/upload` for live per-phase progress. The frontend SSE consumer (`frontend/src/lib/sse.ts`) parses the wire format from a fetch ReadableStream so it works with multipart POSTs (which `EventSource` can't do).
 * **Observability** — [Logfire](https://logfire.pydantic.dev) auto-instruments Pydantic AI agent runs, tool calls, and FastAPI requests. A custom span scrubber (`backend/services/logfire_scrubber.py`) truncates and SHA-256-fingerprints risky attribute paths (prompt text, model output, message content) before egress so user-uploaded document text never ships verbatim. `genai-prices` provides per-call cost telemetry. Per-request structured logging includes a correlation ID, status, and duration.
 * **OCR** — Docling (layout-aware PDF → Markdown) with GOT-OCR 2.0 fallback for math/handwriting; Tesseract retained as a legacy fallback.
@@ -129,6 +130,21 @@ npm run dev                # → http://localhost:3000
 - `POST` `/api/documents/doc/{doc_id}/scan-concepts` — Re-extract concepts from a stored document into the course graph
 - `POST` `/api/documents/course/{course_id}/scan-concepts` — Extend a course's concept graph from its label alone
 
+**Notes**
+- `GET`    `/api/notes/user/{user_id}` — List a user's notes (filter by `course_id`)
+- `POST`   `/api/notes` — Create a note
+- `GET`    `/api/notes/{note_id}` — Fetch a single note
+- `PATCH`  `/api/notes/{note_id}` — Update a note (title, body, tags, course)
+- `DELETE` `/api/notes/{note_id}` — Delete a note
+- `GET`    `/api/notes/{note_id}/concepts` — List concepts linked to a note
+- `POST`   `/api/notes/{note_id}/concepts` — Link a graph concept to a note
+- `DELETE` `/api/notes/{note_id}/concepts/{concept_node_id}` — Unlink a concept
+- `POST`   `/api/notes/{note_id}/summarize` — AI-summarize the note (agent-backed)
+- `POST`   `/api/notes/{note_id}/extract-concepts` — Extract concepts, merge into the graph, link back to the note
+- `POST`   `/api/notes/{note_id}/chat` — Ask a question grounded in the note (agent-backed)
+- `POST`   `/api/notes/{note_id}/send-to-tutor` — Build a tutor handoff (topic + preface) from the note
+- `POST`   `/api/notes/{note_id}/generate-quiz` — Pick the note's weakest linked concept to quiz on
+
 **Social**
 - `POST` `/api/social/rooms/create` — Create a study room
 - `POST` `/api/social/rooms/join` — Join a study room by invite code
@@ -163,14 +179,22 @@ npm run dev                # → http://localhost:3000
 - `DELETE` `/api/profile/{user_id}` — Delete account
 
 **Admin**
-- `POST` `/api/admin/roles` — Create a role
-- `POST` `/api/admin/roles/assign` — Assign a role to a user
-- `POST` `/api/admin/roles/revoke` — Revoke a role from a user
-- `POST` `/api/admin/achievements` — Create an achievement
-- `POST` `/api/admin/achievements/triggers` — Create an achievement trigger
+- `GET`/`POST` `/api/admin/roles` — List / create roles
+- `PATCH`/`DELETE` `/api/admin/roles/{role_id}` — Update / delete a role
+- `POST`/`DELETE` `/api/admin/roles/assign` · `/api/admin/roles/revoke` — Assign / revoke a role
+- `GET`/`POST`/`DELETE` `/api/admin/roles/cosmetics` (+ `/api/admin/roles/{role_id}/cosmetics`) — Link cosmetics to roles
+- `GET`/`POST` `/api/admin/achievements` — List / create achievements
+- `PATCH`/`DELETE` `/api/admin/achievements/{achievement_id}` — Update / delete an achievement
 - `POST` `/api/admin/achievements/grant` — Manually grant an achievement
-- `POST` `/api/admin/cosmetics` — Create a cosmetic item
-- `POST` `/api/admin/approve/{user_id}` — Approve a pending user
+- `GET`/`POST`/`PATCH`/`DELETE` achievement triggers (`/api/admin/achievements/{achievement_id}/triggers`, `/api/admin/achievements/triggers`, `/api/admin/achievements/triggers/{trigger_id}`)
+- `GET`/`POST`/`DELETE` `/api/admin/achievements/cosmetics` (+ `/api/admin/achievements/{achievement_id}/cosmetics`) — Link cosmetics to achievements
+- `GET`/`POST` `/api/admin/cosmetics` — List / create cosmetic items
+- `PATCH`/`DELETE` `/api/admin/cosmetics/{cosmetic_id}` — Update / delete a cosmetic
+- `GET` `/api/admin/users` — Paginated, searchable user list
+- `PATCH` `/api/admin/users/{user_id}/approve` · `/unapprove` — Approve / unapprove a user
+- `POST` `/api/admin/allowlist/approve` · `/api/admin/allowlist/revoke` — Manage the email allowlist
+- `GET` `/api/admin/audit` — Paginated admin audit log (filter by action / target)
+- `GET` `/api/admin/analytics/overview` — Totals, 30-day series, and role counts
 
 **Feedback**
 - `POST` `/api/feedback/feedback` — Submit session or general feedback
@@ -199,6 +223,11 @@ npm run dev                # → http://localhost:3000
 | `SAPLING_MODEL_SUMMARY` | — | Override summary-agent model (default `gemini-2.5-flash-lite`) |
 | `SAPLING_MODEL_CONCEPTS` | — | Override concept-extraction-agent model (default `gemini-2.5-flash`) |
 | `SAPLING_MODEL_SYLLABUS` | — | Override syllabus-extraction-agent model (default `gemini-2.5-flash`) |
+| `SAPLING_MODEL_QUIZ` | — | Override quiz-generation-agent model (default `gemini-2.5-flash-lite`) |
+| `SAPLING_MODEL_CHAT_TUTOR` | — | Override chat-tutor-agent model (default `gemini-2.5-pro`) |
+| `SAPLING_MODEL_NOTE_SUMMARY` | — | Override note-summary-agent model (default `gemini-2.5-flash-lite`) |
+| `SAPLING_MODEL_NOTE_CONCEPTS` | — | Override note-concepts-agent model (default `gemini-2.5-flash-lite`) |
+| `SAPLING_MODEL_NOTE_CHAT` | — | Override note-chat-agent model (default `gemini-2.5-flash`) |
 | `OCR_ASYNC_ENABLED` | — | When `true`, the streaming `/upload` route runs OCR off the request critical path with a `progress:extracting_text` SSE event. Default `false`. |
 | `DBOS_ENABLED` | — | When `true` AND `dbos` is installed AND `DBOS_DATABASE_URL` is set, `process_document` runs as a checkpointed DBOS workflow with per-step resume on crash. Default `false` (decorators are no-op passthroughs). See `docs/decisions/0011-durable-execution-dbos.md`. |
 | `DBOS_DATABASE_URL` | — | Postgres connection string for DBOS metadata (separate from Supabase). Required only when `DBOS_ENABLED=true`. |
@@ -212,13 +241,13 @@ npm run dev                # → http://localhost:3000
 
 ## Tests
 
-**Backend** — pytest, mocked Gemini + Supabase. ~430 tests, ~40s.
+**Backend** — pytest, mocked Gemini + Supabase. ~660 tests.
 ```bash
 cd backend
 python -m pytest tests/ -q --ignore=tests/evals
 ```
 
-**Frontend** — Vitest. Pure-logic tests (`sse.ts`, `api.ts`) run in node; component tests (`DocumentUploadModal.test.tsx`) use jsdom + React Testing Library + `@testing-library/jest-dom`. Per-file `// @vitest-environment jsdom` directive keeps the lib tests fast.
+**Frontend** — Vitest. Pure-logic tests (`sse.ts`, `api.ts`) run in node; component tests (e.g. `DocumentUploadModal`, `TopNav`, `KnowledgeGraph3D`) use jsdom + React Testing Library + `@testing-library/jest-dom`. Per-file `// @vitest-environment jsdom` directive keeps the lib tests fast.
 ```bash
 cd frontend
 npm install
@@ -227,7 +256,7 @@ npm test            # vitest run
 npm run test:watch  # vitest watch
 ```
 
-**Evals** (live Gemini, on demand) — 70 cases across the 4 worker agents (`document_classification`, `document_summary`, `concept_extraction`, `syllabus_extraction`). Three modes via `SAPLING_EVAL_MODE`:
+**Evals** (live Gemini, on demand) — 95 cases across 6 agents: the 4 worker agents (`document_classification`, `document_summary`, `concept_extraction`, `syllabus_extraction`) plus the chat tutor (`chat_tutor`) and quiz generator (`quiz_generation`). Three modes via `SAPLING_EVAL_MODE`:
 ```bash
 cd backend
 # Replay (default; no network, requires recorded cassettes):
@@ -237,13 +266,13 @@ SAPLING_EVAL_MODE=record python tests/evals/document_classification.py
 # Live (hits live Gemini, no recording):
 SAPLING_EVAL_MODE=live   python tests/evals/document_classification.py
 ```
-The `.github/workflows/evals.yml` workflow runs replay-mode in CI; it's currently `workflow_dispatch`-only until cassette coverage is complete (4 / 70 recorded today).
+The `.github/workflows/evals.yml` workflow runs replay-mode in CI; it's currently `workflow_dispatch`-only until cassette coverage is complete (4 / 95 recorded today).
 
 ## Architecture & Dev Context
 
 **Live architecture overview** — `docs/architecture.md`.
 
-**Architectural Decision Records** — `docs/decisions/` (append-only, MADR-minimal format). Twelve ADRs as of merge:
+**Architectural Decision Records** — `docs/decisions/` (append-only, MADR-minimal format). Seventeen ADRs as of merge:
 - `0001` — Adopt Pydantic AI as the agent framework
 - `0002` — Markdown-based dev-context vault structure
 - `0003` — Per-call `usage_limits=` and inline system prompts
@@ -256,6 +285,11 @@ The `.github/workflows/evals.yml` workflow runs replay-mode in CI; it's currentl
 - `0010` — OCR async / two-phase upload (partial — feature flag shipped, full design deferred)
 - `0011` — Durable execution via DBOS (partial — optional shim shipped, real DBOS opt-in)
 - `0012` — Concept-by-concept streaming (deferred — needs eval data on Gemini's emission ordering first)
+- `0013` — Refactor #2 (quiz generation) shipped as `quiz_agent`
+- `0014` — Adaptive quiz iteration (spaced repetition + history + difficulty)
+- `0015` — Refactor #3 (chat tutor) shipped as `chat_tutor_agent`
+- `0016` — Refactor #4 (syllabus extraction) unified onto the agent
+- `0017` — Notetaker dynamic implementation (CRUD + four agent-backed actions)
 
 **Things that didn't work** — `docs/attempts/` (each entry has a mandatory "What I'd try next" section).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,80 +74,88 @@ the roles in the table above.
 
 ### Active epics
 
+All work below is filed as GitHub issues and assigned. Counts as of 2026-06-08:
+**Jose 20 · Jack 16 · Luke 14 · Andres 13.**
+
 - **#113** — Frontend UI audit (10/20) — owner **Jose** — `docs/frontend-ui-audit.md`
-- **#136** — Backend & contract bug audit (31 findings) — owner **Luke**, with the `agents`
-  items (#125, #127) to **Jack** — `docs/backend-contract-bug-audit.md`
-- **Observability** cohort #115–#122 — owner **Luke**; dashboard UI to **Jose** —
-  `docs/observability-logging-tracking.md` _(no `[EPIC]` issue yet — consider opening one for parity)_
+- **#136** — Backend & contract bug audit (31 findings) — owner **Luke**, `agents` items
+  (#125, #127) to **Jack** — `docs/backend-contract-bug-audit.md`
+- **#142** — Semesters (view grades & classes by term) — backbone (#137/#138) to **Andres**,
+  UI (#139/#140) to **Jose**
+- **#152** — Agent migration (retire `gemini_service` as the LLM seam) — owner **Jack**
+  (#143–#151 + hardening #153/#154)
+- **Observability** cohort #115–#122 — **Luke** (data) · **Jack** (#118/#119) · **Jose** (#121/#122)
+  · **Andres** (#117/#120) — `docs/observability-logging-tracking.md` _(no `[EPIC]` issue yet)_
 
 > **P0s take precedence over the sprint plan below.** The backend audit surfaced two P0
-> data-exposure bugs — #123 (calendar export IDOR) and #124 (realtime chat ciphertext) —
-> that should be fixed before continuing feature work.
+> data-exposure bugs — #123 (calendar export IDOR, Luke) and #124 (realtime chat ciphertext,
+> Andres) — that should be fixed before continuing feature work.
 
 ---
 
 ## Now → Next 2 Weeks (through ~2026-06-21)
 
-Goal: stabilize the document pipeline and lay the groundwork for the agent migration.
+Goal: ship the two P0 data-exposure fixes, then the first tranche of audit + feature work.
+(The agents are already wired — the migration is now about retiring the remaining
+`gemini_service` call sites, tracked under epic #152, not spiking new agents.)
 
-- **Jack** — Build on the existing notetaker agents (`note_summary`,
-  `note_concepts`, `note_chat` in `backend/agents/`). Extend the same
-  Pydantic AI pattern to the document pipeline: spike a classify agent behind
-  the existing `gemini_service` seam so it can be swapped without route changes.
-  Keep model slots centralized in `agents/_providers.py`.
-- **Luke** — Refactor `routes/documents.py::_process_document` (the single-call
-  classify/summarize/extract) into discrete, testable steps. Backfill tests in
-  `backend/tests/`.
-- **Jose** — Polish the tutoring chat (SSE streaming) and the notetaker UI;
-  surface document processing status to the user. Tighten loading/error states.
-- **Andres** — Set up a lint/format baseline (the `# TODO` in CLAUDE.md — pick
-  ruff + black), wire CI, and review the agent-seam and refactor PRs.
+- **Andres** — P0 #124 (realtime chat ciphertext, fullstack); start streaming chat #70 +
+  SSE deltas #74; semesters DB migration #137. Plus the lint/format + CI baseline
+  (the `# TODO` in CLAUDE.md — ruff + black) and reviewing the audit/migration PRs.
+- **Luke** — P0 #123 (calendar IDOR) + encryption boundaries #126; refactor
+  `routes/documents.py::_process_document` into discrete, testable steps (coordinate with
+  #132 + Jack's #143); backend audit P1s #130/#134.
+- **Jose** — frontend audit P0s #102/#103/#104; fix the Social page #131 (pairs with
+  Andres's #124); notetaker data-loss #133.
+- **Jack** — agent-migration kickoff: #143 (document classify agent) + #153 (output-retry
+  hardening); fix #125 (cross-user doc leak) and #127 (tutor mastery tool + usage limits).
 
 ## Weeks 3–4 (~2026-06-22 → 2026-07-05)
 
-Goal: first real agent in production path; pipeline hardening.
+Goal: feature surfaces off the Gemini seam; semesters shipped; pipeline hardening.
 
-- **Jack** — Migrate the classify step fully to a Pydantic AI agent; begin the
-  summarize agent. Make `apply_graph_update` callable as an agent tool.
-- **Luke** — Harden `upload_document` upload pipeline; review OCR engine routing
-  in `extraction_service.py` (Docling / GOT-OCR / Tesseract) and pick sane
-  defaults. Verify encryption boundaries on all sensitive columns.
-- **Jose** — Knowledge-graph visualization improvements; reflect extracted
-  assignments and concepts in the UI.
-- **Andres** — Integration testing across the new agent + frontend; keep the
-  Gemini fallback path working during migration.
+- **Jack** — Migration surfaces #144 (calendar extraction) / #145 (quiz + course-context)
+  / #146 (flashcards) / #147 (remaining one-shots); extraction-accuracy eval harness #148.
+- **Luke** — Perf/caching #97–#99 and staging env #100; calendar sync #61, Class-Intel
+  write-gating #72; review OCR routing in `extraction_service.py` defaults (ties to #132).
+- **Jose** — frontend audit P1s #105–#110; semesters UI #139 (gradebook switcher +
+  transcript) / #140 (dashboard grouping + Archive).
+- **Andres** — semesters API + GPA #138; document-pipeline robustness #132; integration
+  testing across the migrated agents + frontend.
 
 ---
 
 ## July — Agent Migration
 
-Goal: retire `gemini_service.py` as the primary LLM seam.
+Goal: retire `gemini_service.py` as the primary LLM seam (epic #152).
 
-- **Jack** — Summarize + extract agents live; consolidate prompts; add eval
-  harness for extraction accuracy. Deprecate `call_gemini*` helpers.
-- **Luke** — Quiz endpoints (`routes/quiz.py`) move onto the agent layer;
-  session/scoring cleanup. Data migrations as needed.
-- **Jose** — Quiz-taking UI and results; graph-driven study suggestions.
-- **Andres** — Decision records in `docs/decisions/` for the migration;
-  performance pass; release coordination.
+- **Jack** — Final cutover #151 (remove `call_gemini*` + `gemini_service.py`, retire the
+  ADR-0001 legacy chat fallback last); platform hardening #153/#154 (output retries +
+  DBOS durability / crash-safe streaming).
+- **Luke** — Quiz scoring & idempotency #129; session/scoring cleanup; data migrations as
+  needed; remaining backend audit P2/P3 (#135).
+- **Jose** — Quiz-taking UI and results; graph-driven study suggestions; frontend audit P2s
+  #111/#112.
+- **Andres** — Decision record in `docs/decisions/` for the migration cutover; performance
+  pass; release coordination.
 
 ## August — Tutoring & Knowledge Graph Depth
 
 Goal: make the tutor genuinely graph-aware.
 
-- **Jack** — Graph-grounded retrieval for the tutor system prompt
-  (`build_system_prompt`); tool-use loop for on-the-fly graph updates.
+- **Jack** — Graph-grounded tutor retrieval + tool-use loop #149 (depends on #127);
+  graph/study-tools archive toggle #141.
 - **Luke** — Scale the graph data model; query performance on
-  `graph_nodes`/`graph_edges`; rate limiting and cost controls on LLM calls.
+  `graph_nodes`/`graph_edges` (with #128); rate limiting and cost controls on LLM calls.
 - **Jose** — Interactive graph navigation; per-concept mastery views.
-- **Andres** — End-to-end QA, telemetry/observability, beta feedback loop.
+- **Andres** — End-to-end QA; observability wrap-up #117/#120; beta feedback loop.
 
 ## September — Polish & Beta
 
 Goal: a stable beta for real students.
 
-- **Jack** — Quality tuning from real usage; guardrails and prompt-injection
-  hardening on student-supplied content.
+- **Jack** — Quality tuning from real usage; prompt-injection hardening on
+  student-supplied content #150.
 - **Luke** — Production readiness: backups, monitoring, auth/security review,
   load testing.
 - **Jose** — Accessibility, mobile/responsive pass, onboarding flow.
@@ -168,12 +176,12 @@ Goal: a stable beta for real students.
 
 ## Milestones
 
-| Target          | Milestone                                              |
-| --------------- | ------------------------------------------------------ |
-| End of June     | Document pipeline refactored; first agent in path      |
-| End of July     | `gemini_service` retired as primary LLM seam           |
-| End of August   | Graph-aware tutor end to end                           |
-| End of September| Stable beta with real students                         |
+| Target          | Milestone                                                        |
+| --------------- | ---------------------------------------------------------------- |
+| End of June     | P0 data-exposure fixes shipped (#123/#124); doc pipeline refactored; semesters live (#142) |
+| End of July     | `gemini_service` retired as primary LLM seam (#152 cutover #151) |
+| End of August   | Graph-aware tutor end to end (#149); observability live          |
+| End of September| Stable beta with real students                                  |
 
 > Dates are targets, not commitments. Revisit this file at the start of each
 > sprint and adjust scope before adjusting dates.


### PR DESCRIPTION
Follow-up to #114 (already merged). These two commits landed on the branch *after* #114 merged, so they aren't on `main` yet.

## What's here
- **ROADMAP.md** — synced to the now-tracked work: adds the Semesters (#142) and Agent-migration (#152) epics, fixes the stale "spike a classify agent" framing (agents are already wired — the work is retiring the remaining `gemini_service` call sites), and anchors every phase + milestone to real issue numbers and assignees.
- **README.md / CLAUDE.md** — doc sync from a prior `/update-mds` run: notetaker + `/api/notes` endpoints, the 2D/3D knowledge-graph toggle, current Pydantic AI agent coverage vs remaining `gemini_service` surfaces, and observability.

Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Notetaker capabilities documentation, including AI summarization, concept extraction, tutoring chat, and quiz generation
  * Clarified Live Knowledge Graph feature descriptions and frontend rendering details
  * Expanded API documentation for note operations and administrative functions
  * Updated tech stack and architecture documentation with implementation refinements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->