### PR TITLE
fix(db): type encryption columns as TEXT in canonical schema

### DIFF
--- a/backend/db/supabase_schema.sql
+++ b/backend/db/supabase_schema.sql
@@ -111,7 +111,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     course_id    TEXT REFERENCES courses(id),
     started_at   TIMESTAMPTZ DEFAULT now(),
     ended_at     TIMESTAMPTZ,
-    summary_json JSONB,
+    summary_json TEXT, -- encrypted base64 text (AES-256-GCM via services/encryption.py)
     name         TEXT
 );
 
@@ -159,8 +159,8 @@ CREATE TABLE IF NOT EXISTS assignments (
     notes           TEXT,
     google_event_id TEXT,
     category_id     TEXT REFERENCES course_categories(id) ON DELETE SET NULL,
-    points_possible NUMERIC,
-    points_earned   NUMERIC,
+    points_possible TEXT, -- encrypted base64 text (AES-256-GCM via services/encryption.py)
+    points_earned   TEXT, -- encrypted base64 text (AES-256-GCM via services/encryption.py)
     source          TEXT DEFAULT 'manual',
     created_at      TIMESTAMPTZ DEFAULT now()
 );
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS documents (
     category     TEXT NOT NULL,
     summary      TEXT,
     flashcards   JSONB,
-    concept_notes JSONB,
+    concept_notes TEXT, -- encrypted base64 text (AES-256-GCM via services/encryption.py)
     created_at   TIMESTAMPTZ DEFAULT now(),
     processed_at TIMESTAMPTZ
 );

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -104,3 +104,39 @@ def test_tampered_ciphertext_raises():
     tampered = base64.b64encode(bytes(raw)).decode()
     with pytest.raises(Exception):
         encryption.decrypt(tampered)
+
+
+# ── #200: columns retyped NUMERIC/JSONB -> TEXT in the canonical schema ─────────
+# These hold encrypted base64 *text*, so the value each column stores must survive
+# the exact write->read helpers the routes use. The route-level coverage for
+# documents.concept_notes lives in the test_documents_routes module quarantined
+# under #210, so assert the round-trip here (non-quarantined) before that change
+# lands. summary_json/concept_notes -> encrypt_json/decrypt_json; points ->
+# encrypt_if_present/decrypt_numeric (see routes/learn.py, routes/documents.py,
+# routes/gradebook.py).
+
+def test_summary_json_text_column_round_trip():
+    # sessions.summary_json — a JSON object (learn.py writes encrypt_json(summary))
+    summary = {"concepts": ["limits", "derivatives"], "score": 0.82, "notes": "ünïcode"}
+    assert encryption.decrypt_json(encryption.encrypt_json(summary)) == summary
+
+
+def test_concept_notes_text_column_round_trip():
+    # documents.concept_notes — a JSON array of {name, description}
+    # (documents.py writes encrypt_json(concept_notes))
+    concept_notes = [
+        {"name": "Eigenvalue", "description": "Scalar λ with Av = λv."},
+        {"name": "Span", "description": "All linear combinations of a set."},
+    ]
+    assert encryption.decrypt_json(encryption.encrypt_json(concept_notes)) == concept_notes
+
+
+def test_points_text_column_round_trip():
+    # assignments.points_possible / points_earned — numbers written via
+    # encrypt_if_present and read back via decrypt_numeric.
+    for value in (100, 95.5, 0):
+        ct = encryption.encrypt_if_present(value)
+        assert isinstance(ct, str)  # stored as TEXT, not NUMERIC
+        assert encryption.decrypt_numeric(ct) == float(value)
+    assert encryption.encrypt_if_present(None) is None
+    assert encryption.decrypt_numeric(None) is None


### PR DESCRIPTION
## What

Retype four encryption columns in the canonical `backend/db/supabase_schema.sql` from NUMERIC/JSONB to TEXT, so the canonical schema matches `backend/db/migration_encryption_text_columns.sql`:

- `assignments.points_possible` NUMERIC -> TEXT
- `assignments.points_earned` NUMERIC -> TEXT
- `documents.concept_notes` JSONB -> TEXT
- `sessions.summary_json` JSONB -> TEXT

Each line now carries an inline comment noting it holds encrypted base64 text.

## Why

The encryption helpers in `services/encryption.py` emit base64 **text** (`nonce || ciphertext_with_tag`), written via `encrypt_if_present` in `routes/gradebook.py` and `services/calendar_service.py`. NUMERIC/JSONB columns cannot store those strings, so a DB built from the canonical schema rejects every encrypted gradebook/document write. The migration already retypes these to TEXT; the canonical schema disagreed, so correctness depended on which file an environment applied. This makes the canonical schema the correct source of truth for new environments.

**Caveat:** the live/prod DB already applied `migration_encryption_text_columns.sql`, so **prod is unaffected**. This change only fixes the canonical schema for NEW environments (e.g. the staging env in #100). The migration file's intent is unchanged — this just makes the canonical schema agree with it.

## How verified

Pure DDL (no runtime test). Verified by re-reading and grepping that both files now agree on the column types:

```
$ grep -nE "points_possible|points_earned|concept_notes|summary_json" backend/db/supabase_schema.sql
114:    summary_json TEXT, -- encrypted base64 text (AES-256-GCM via services/encryption.py)
162:    points_possible TEXT, -- encrypted base64 text (AES-256-GCM via services/encryption.py)
163:    points_earned   TEXT, -- encrypted base64 text (AES-256-GCM via services/encryption.py)
179:    concept_notes TEXT, -- encrypted base64 text (AES-256-GCM via services/encryption.py)
```

All four match the migration's TEXT targets (`migration_encryption_text_columns.sql:18-27`).

Closes #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Applied encryption to sensitive data fields for enhanced protection. Session summaries, assignment scoring details including both possible and earned points, and document concept notes are now encrypted at the application level. This change strengthens data protection measures and improves overall confidentiality and security of sensitive information stored in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->