### PR TITLE
fix(graph): remove the Re-run forces button on the knowledge graph

### DIFF
--- a/frontend/src/components/KnowledgeGraph2D.tsx
+++ b/frontend/src/components/KnowledgeGraph2D.tsx
@@ -356,7 +356,6 @@ function KnowledgeGraph2DImpl({
   };
 
   const resetView = () => setView({ tx: 0, ty: 0, scale: 1 });
-  const reheat = () => simRef.current?.alpha(0.8).restart();
 
   const hoveredMastery = hovered
     ? hovered.is_subject_root
@@ -562,14 +561,6 @@ function KnowledgeGraph2DImpl({
           title="Reset view"
         >
           ⟲
-        </button>
-        <button
-          className="btn btn--ghost btn--sm"
-          style={{ padding: "2px 8px", fontSize: 10 }}
-          onClick={reheat}
-          title="Re-run forces"
-        >
-          ✦
         </button>
       </div>
 


### PR DESCRIPTION
## What

Removes the **Re-run forces** button (the ✦ control) from the 2D knowledge graph toolbar in `frontend/src/components/KnowledgeGraph2D.tsx`, along with its now-unused `reheat` click handler.

## Why

The force-simulation restart control is an internal/debug-style affordance with no clear user value, cluttering the graph toolbar. Tracked in #101.

## How verified

- `npx tsc --noEmit` — clean
- `npx vitest run` — 5 files, 37 tests passing
- Confirmed `simRef` is still used by the live simulation lifecycle; only `reheat` and the button were removed. No other references to `reheat` / "Re-run forces" remain.

Closes #101