### PR TITLE
fix(theme): remove orphaned dark-mode stylesheet + Settings toggle

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -597,59 +597,6 @@ input[type="reset"]:disabled {
 }
 
 /* ══════════════════════════════════════════════════════════════════
-   DARK MODE
-   ══════════════════════════════════════════════════════════════════ */
-
-html.dark {
-  --bg:             #0f1110;
-  --bg-mesh:        #0f1110;
-  --bg-panel:       #1a1d1b;
-  --bg-sidebar:     #151816;
-  --bg-topbar:      #151816;
-  --bg-input:       #1a1d1b;
-  --bg-subtle:      #1f2421;
-  --bg-space:       #0f1110;
-  --bg-glass:       rgba(0, 0, 0, 0.35);
-
-  --accent:         #8a9a5b;
-  --accent-hover:   #9aab6c;
-  --accent-dim:     rgba(138, 154, 91, 0.12);
-  --accent-border:  rgba(138, 154, 91, 0.35);
-  --accent-active:  rgba(138, 154, 91, 0.7);
-  --accent-glow:    rgba(138, 154, 91, 0.15);
-
-  --text:             #e5e7eb;
-  --text-primary:     #e5e7eb;
-  --text-secondary:   #d1d5db;
-  --text-muted:       #9ca3af;
-  --text-dim:         #6b7280;
-  --text-placeholder: #4b5563;
-
-  --border:         rgba(148, 163, 184, 0.15);
-  --border-light:   rgba(148, 163, 184, 0.08);
-  --border-mid:     rgba(148, 163, 184, 0.22);
-  --border-glass:   rgba(148, 163, 184, 0.12);
-
-  --shadow-sm:  0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
-  --shadow-md:  0 4px 12px rgba(0, 0, 0, 0.35), 0 2px 4px rgba(0, 0, 0, 0.2);
-  --shadow-lg:  0 12px 32px rgba(0, 0, 0, 0.4), 0 4px 8px rgba(0, 0, 0, 0.25);
-
-  --rarity-common-bg:    rgba(107, 114, 128, 0.15);
-  --rarity-uncommon-bg:  rgba(46, 125, 82, 0.15);
-  --rarity-rare-bg:      rgba(43, 140, 150, 0.15);
-  --rarity-epic-bg:      rgba(139, 92, 246, 0.15);
-  --rarity-legendary-bg: rgba(232, 163, 58, 0.15);
-
-  color-scheme: dark;
-}
-
-html.dark input,
-html.dark select,
-html.dark textarea {
-  color-scheme: dark;
-}
-
-/* ══════════════════════════════════════════════════════════════════
    ACHIEVEMENT / TOAST ANIMATIONS
    ══════════════════════════════════════════════════════════════════ */
 

--- a/frontend/src/components/screens/Settings.tsx
+++ b/frontend/src/components/screens/Settings.tsx
@@ -402,7 +402,7 @@ export function Settings() {
               </div>
               {(
                 [
-                  ["Theme", "theme", ["light", "dark"]],
+                  ["Theme", "theme", ["light"]],
                   ["Font size", "font_size", ["small", "medium", "large"]],
                   ["Profile visibility", "profile_visibility", ["public", "school", "private"]],
                 ] as const


### PR DESCRIPTION
## What
Removes dead dark-mode code from the light-mode-only app:
- Deletes the `html.dark { … }` token block (and `html.dark input/select/textarea` `color-scheme` rules) from `frontend/src/app/globals.css`.
- Removes the `"dark"` option from the Theme selector in `frontend/src/components/screens/Settings.tsx` (Theme now offers only `"light"`).

## Why
The project is light-mode only, and `globals.css` itself notes that dark mode "gets its own branch — not squatting in the same stylesheet." Nothing ever applied the `.dark` class (Settings only sets `--accent` inline), so the token block was dead CSS and the `"dark"` Theme option was a latent regression that could one wire away activate an off-spec theme with glowing chrome.

## How verified
- `npx tsc --noEmit` — clean (exit 0).
- `npx vitest run` — 37 passed (5 files), exit 0.
- Grep confirms no remaining references to `html.dark` / `.dark` / `color-scheme: dark` / `prefers-color-scheme` in `frontend/src`. The `settings.theme` field is retained (still valid, now light-only) and is never used to toggle a dark class. `--accent-glow` remains only in the in-spec `.landing-page` block, untouched.

Closes #105