### PR TITLE
fix(quiz): scope graph_nodes by user_id in generate/submit (IDOR)

### DIFF
--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -215,7 +215,8 @@ async def _legacy_generate_quiz(body: GenerateQuizBody, request: Request) -> lis
     persisting it and shaping the HTTP response.
     """
     node_rows = table("graph_nodes").select(
-        "*", filters={"id": f"eq.{body.concept_node_id}"}
+        "*",
+        filters={"id": f"eq.{body.concept_node_id}", "user_id": f"eq.{body.user_id}"},
     )
     if not node_rows:
         raise HTTPException(status_code=404, detail="Concept node not found")
@@ -297,7 +298,8 @@ async def _legacy_generate_quiz(body: GenerateQuizBody, request: Request) -> lis
 async def generate_quiz(body: GenerateQuizBody, request: Request):
     require_self(body.user_id, request)
     node_rows = table("graph_nodes").select(
-        "*", filters={"id": f"eq.{body.concept_node_id}"}
+        "*",
+        filters={"id": f"eq.{body.concept_node_id}", "user_id": f"eq.{body.user_id}"},
     )
     if not node_rows:
         raise HTTPException(status_code=404, detail="Concept node not found")
@@ -389,12 +391,18 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
 
     node_rows = table("graph_nodes").select(
         "mastery_score,times_studied,mastery_events",
-        filters={"id": f"eq.{concept_node_id}"},
+        filters={"id": f"eq.{concept_node_id}", "user_id": f"eq.{user_id}"},
     )
-    mastery_before = node_rows[0]["mastery_score"] if node_rows else 0.0
+    if not node_rows:
+        # The attempt's concept node must belong to the attempt's owner.
+        # A missing/foreign node means we'd otherwise write mastery to
+        # someone else's row (IDOR) — refuse before any write.
+        raise HTTPException(status_code=404, detail="Concept node not found")
+    node = node_rows[0]
+    mastery_before = node["mastery_score"]
     mastery_after = max(0.0, min(1.0, mastery_before + (score * 0.03) - ((total - score) * 0.02)))
     new_tier = get_mastery_tier(mastery_after)
-    times_studied = (node_rows[0]["times_studied"] if node_rows else 0) + 1
+    times_studied = node["times_studied"] + 1
 
     score_ratio = score / total if total > 0 else 0.0
     if score_ratio >= 0.7:
@@ -404,7 +412,7 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
     else:
         event_type = "confusion"
 
-    existing_events = (node_rows[0].get("mastery_events") or []) if node_rows else []
+    existing_events = node.get("mastery_events") or []
     quiz_event = {
         "ts": datetime.utcnow().isoformat(),
         "delta": round(mastery_after - mastery_before, 4),
@@ -421,7 +429,7 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
             "last_studied_at": datetime.utcnow().isoformat(),
             "mastery_events": updated_events,
         },
-        filters={"id": f"eq.{concept_node_id}"},
+        filters={"id": f"eq.{concept_node_id}", "user_id": f"eq.{user_id}"},
     )
     table("quiz_attempts").update(
         {
@@ -436,7 +444,8 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
     update_streak(user_id)
 
     node2_rows = table("graph_nodes").select(
-        "concept_name", filters={"id": f"eq.{concept_node_id}"}
+        "concept_name",
+        filters={"id": f"eq.{concept_node_id}", "user_id": f"eq.{user_id}"},
     )
     user_rows = table("users").select("name", filters={"id": f"eq.{user_id}"})
     concept_name = node2_rows[0]["concept_name"] if node2_rows else "Unknown"

--- a/backend/tests/test_quiz_routes.py
+++ b/backend/tests/test_quiz_routes.py
@@ -240,6 +240,131 @@ class TestSubmitQuiz:
         assert r.json()["score"] == 2
 
 
+# ── Cross-user node ownership (IDOR regression, issue #157) ─────────────────
+
+
+class TestQuizNodeOwnership:
+    """User A must not be able to generate or submit a quiz against a
+    concept node owned by user B. Both paths must 404 (not 200) so an
+    attacker can't read a victim's concept content nor corrupt the
+    victim's mastery fields.
+
+    The graph_nodes table is owner-scoped: a SELECT scoped to a user_id
+    that doesn't own the node returns no rows. The factory below models
+    real DB behaviour — an *unscoped* read (the bug) still leaks B's node,
+    so these tests fail on unscoped code and pass only once the route
+    filters every node read by the caller's user_id.
+    """
+
+    NODE_OWNER = "user_beatriz"   # victim B owns the node
+    ATTACKER = "user_andres"      # attacker A
+
+    def _node_row(self) -> dict:
+        return {
+            "id": "node_b",
+            "user_id": self.NODE_OWNER,
+            "course_id": "course1",
+            "concept_name": "Beatriz Secret Concept",
+            "mastery_score": 0.5,
+            "times_studied": 3,
+            "mastery_events": [],
+        }
+
+    def _ownership_aware_graph_select(self, columns="*", filters=None, **_):
+        """Faithfully model DB row-filtering for the victim's node.
+
+        The row comes back when the query matches by id and EITHER no
+        user_id scope is applied (the *buggy* unscoped read, which leaks
+        B's node to anyone) OR the scope names the owner. A scope naming
+        a non-owner (the attacker) returns nothing — so unscoped code
+        leaks/writes (test fails) and only owner-scoped reads 404 for A.
+        """
+        filters = filters or {}
+        if filters.get("id") != "eq.node_b":
+            return []
+        user_filter = filters.get("user_id")
+        if user_filter is None or user_filter == f"eq.{self.NODE_OWNER}":
+            return [self._node_row()]
+        return []
+
+    def test_generate_against_foreign_node_returns_404(self):
+        """A POSTs /generate with B's concept_node_id but A's user_id.
+        The owner-scoped node read misses → 404, before any quiz_attempts
+        row is created and before the agent ever runs."""
+        def factory(name):
+            mock = MagicMock()
+            if name == "graph_nodes":
+                mock.select.side_effect = self._ownership_aware_graph_select
+            else:
+                mock.select.return_value = []
+                mock.insert.return_value = []
+            return mock
+
+        agent_run = AsyncMock()
+        with (
+            patch("routes.quiz.table", side_effect=factory),
+            patch("routes.quiz.quiz_agent.run", new=agent_run),
+        ):
+            r = client.post("/api/quiz/generate", json={
+                "user_id": self.ATTACKER,
+                "concept_node_id": "node_b",
+                "num_questions": 1,
+                "difficulty": "easy",
+                "use_shared_context": False,
+            })
+
+        assert r.status_code == 404
+        # The agent must never run for a foreign node — no content leak.
+        agent_run.assert_not_called()
+
+    def test_submit_against_foreign_node_returns_404_and_writes_nothing(self):
+        """A owns the quiz_attempts row (so require_self passes), but the
+        attempt's concept_node_id points at B's node. The owner-scoped
+        node read (using the attempt's user_id == A) misses → 404, and no
+        graph_nodes.update fires, so B's mastery stays intact."""
+        update_calls: list = []
+
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                mock.select.return_value = [{
+                    "id": "quiz_a",
+                    "user_id": self.ATTACKER,        # attempt belongs to A
+                    "concept_node_id": "node_b",     # but targets B's node
+                    "difficulty": "medium",
+                    "questions_json": SAMPLE_QUESTIONS,
+                }]
+                mock.update.return_value = []
+            elif name == "graph_nodes":
+                mock.select.side_effect = self._ownership_aware_graph_select
+                mock.update.side_effect = lambda *a, **k: update_calls.append((a, k)) or []
+            else:
+                mock.select.return_value = []
+                mock.update.return_value = []
+            return mock
+
+        with (
+            patch("routes.quiz.table", side_effect=factory),
+            patch("routes.quiz.update_streak"),
+            patch("routes.quiz.get_quiz_context", return_value={}),
+            patch("routes.quiz.call_gemini_json", return_value={}),
+        ):
+            r = client.post("/api/quiz/submit", json={
+                "quiz_id": "quiz_a",
+                "answers": [
+                    {"question_id": 1, "selected_label": "A"},
+                    {"question_id": 2, "selected_label": "D"},
+                ],
+            })
+
+        assert r.status_code == 404
+        # No mastery write to the victim's node (or any node) occurred.
+        assert update_calls == [], (
+            "submit_quiz wrote to graph_nodes for a foreign concept node — "
+            "IDOR regression (issue #157)."
+        )
+
+
 # ── POST /api/quiz/generate ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What
Scope every `graph_nodes` access in the quiz flow by the owning user so a caller can only generate/submit quizzes against their **own** concept nodes. Foreign or missing nodes now return **404** instead of leaking content or corrupting another user's mastery.

- `generate_quiz` and `_legacy_generate_quiz`: node read filtered by `{id, user_id: body.user_id}`.
- `submit_quiz`: the mastery read/write and the `concept_name` read are filtered by `{id, user_id: attempt["user_id"]}`; a missing/foreign node now raises 404 **before** any mastery write (previously it silently defaulted `mastery_before=0.0` and wrote to `graph_nodes WHERE id=<victim node>`).

## Why
`require_self(body.user_id)` only checks that the request body's `user_id` equals the session user — it never verifies the targeted node belongs to that user. Every `graph_nodes` read/write in the quiz flow filtered by `id` alone (unlike `services/graph_service.py`, which scopes by `user_id`). An authenticated attacker could:

1. `POST /api/quiz/generate` with their own `user_id` + a victim's `concept_node_id` → 200 + a `quiz_attempts` row they own (and the victim's concept content leaks into the generated quiz).
2. `POST /api/quiz/submit` for that attempt → `require_self(attempt["user_id"])` passes, and the handler overwrites the **victim's** `mastery_score`, `mastery_tier`, `times_studied`, `last_studied_at`, and `mastery_events`.

High-severity IDOR / cross-user data-integrity bug.

## How verified
- `cd backend && PYTHONPATH=. python -m pytest tests/test_quiz_routes.py -q` → **32 passed** (30 pre-existing + 2 new).
- New `TestQuizNodeOwnership` proves user A cannot generate **or** submit against user B's node (both 404) and that submit writes nothing to `graph_nodes`. The mock models real DB row-filtering, so both tests **fail on the unscoped code** and pass only with the fix (verified by stashing the route change).

Closes #157