### PR TITLE
fix(api): require auth on GET /api/users roster

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -162,13 +162,18 @@ def health():
 
 
 @app.get("/api/users")
-def list_users():
+def list_users(request: Request):
     """List users with decrypted display names.
 
     The `users.name` column is encrypted at rest (see
     services.encryption); decrypt before returning so clients render the
     human-readable name, not ciphertext. Sort by the decrypted value.
+
+    Requires an authenticated session: this returns decrypted legal names,
+    so an unauthenticated caller must never reach the roster (401).
     """
+    from services.auth_guard import get_session_user_id
+    get_session_user_id(request)  # 401 if unauthenticated
     from db.connection import table
     from services.encryption import decrypt_if_present
     rows = table("users").select("id,name,room_id")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -53,6 +53,7 @@ def _bypass_session_auth(monkeypatch):
             return None
         return _checker
 
+    auth_guard._real_decode_session = auth_guard._decode_session
     auth_guard._real_require_self = auth_guard.require_self
     auth_guard._real_get_session_user_id = auth_guard.get_session_user_id
     auth_guard._real_require_admin = auth_guard.require_admin

--- a/backend/tests/test_users_roster_auth.py
+++ b/backend/tests/test_users_roster_auth.py
@@ -1,0 +1,55 @@
+"""
+Regression tests for GET /api/users (main.list_users) auth.
+
+The roster endpoint returns each user's decrypted legal name, so it must
+require an authenticated session. See issue #156: it previously had no
+auth dependency and leaked the full roster to anonymous callers.
+
+The autouse `_bypass_session_auth` fixture in conftest.py stubs the auth
+guard so authenticated-path tests don't need real tokens; the
+unauthenticated test restores the real guard to assert the 401.
+"""
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+class TestListUsersAuth:
+    def test_unauthenticated_returns_401(self):
+        # Restore the real guard (and its session decoder) so a request with no
+        # cookie/token => 401, undoing the autouse bypass from conftest.
+        from services import auth_guard
+
+        with patch.object(
+            auth_guard, "get_session_user_id", auth_guard._real_get_session_user_id
+        ), patch.object(
+            auth_guard, "_decode_session", auth_guard._real_decode_session
+        ):
+            # No cookie, no auth_token: _decode_session raises 401 before any
+            # DB access, so we never touch the (unmocked) users table.
+            r = client.get("/api/users")
+
+        assert r.status_code == 401
+
+    def test_authenticated_returns_200_with_decrypted_names(self):
+        rows = [
+            {"id": "u1", "name": "ENC_BOB", "room_id": "r1"},
+            {"id": "u2", "name": "ENC_ALICE", "room_id": "r2"},
+        ]
+        decrypt_map = {"ENC_BOB": "Bob", "ENC_ALICE": "Alice"}
+
+        with patch("db.connection.table") as t, patch(
+            "services.encryption.decrypt_if_present",
+            side_effect=lambda v: decrypt_map.get(v, v),
+        ):
+            t.return_value.select.return_value = rows
+            r = client.get("/api/users")
+
+        assert r.status_code == 200
+        names = [u["name"] for u in r.json()["users"]]
+        # Sorted by decrypted name, lowercased.
+        assert names == ["Alice", "Bob"]


### PR DESCRIPTION
## What
Add an authenticated-session requirement to `GET /api/users` (`list_users` in `backend/main.py`). The handler now takes `request: Request` and calls `get_session_user_id(request)` before any DB access, so unauthenticated callers receive 401.

## Why
`list_users` had no `Request` parameter and no auth dependency. It selected `id,name,room_id` for **all** users and returned `decrypt_if_present(name)`. Because `users.name` is encrypted at rest, any anonymous caller (e.g. `curl https://api.saplinglearn.com/api/users`) received a full roster of decrypted legal names — defeating the column-encryption control for the most sensitive field.

The frontend already calls this endpoint with `credentials:'include'` from authenticated shell routes, so requiring a session is non-breaking.

## How verified
From the worktree's `backend/` directory:

```
PYTHONPATH=. python -m pytest tests/test_users_roster_auth.py -q
```
Result: `2 passed in 1.02s`

New tests in `tests/test_users_roster_auth.py`:
- `test_unauthenticated_returns_401` — restores the real auth guard (undoing the autouse test bypass) and asserts `GET /api/users` with no cookie/token returns 401, before any DB access.
- `test_authenticated_returns_200_with_decrypted_names` — asserts an authenticated call returns 200 with names decrypted and sorted.

Broader regression run (admin/users/auth/profile/quiz suites), deselecting one pre-existing date-flaky analytics test unrelated to this change:

```
PYTHONPATH=. python -m pytest tests/test_users_roster_auth.py tests/test_admin_routes.py tests/test_users_search.py tests/test_auth_state.py tests/test_profile_routes.py tests/test_quiz_routes.py -q --deselect tests/test_admin_routes.py::TestAnalyticsOverview::test_returns_totals_and_series
```
Result: `136 passed, 1 deselected`

A one-line test-infra addition in `tests/conftest.py` saves the real `_decode_session` (`_real_decode_session`) so the 401 test can restore it alongside the already-saved `_real_get_session_user_id`.

Closes #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `/api/users` endpoint now requires user authentication. Unauthenticated requests return HTTP 401. Authenticated users receive a list of users with decrypted display names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->