### PR TITLE
fix(notetaker): flush debounced autosave + carry course context to tutor

### DIFF
--- a/frontend/src/app/(shell)/notetaker/page.tsx
+++ b/frontend/src/app/(shell)/notetaker/page.tsx
@@ -207,32 +207,95 @@ export default function NotetakerPage() {
     });
   }, [notes, query, courseFilter, courseFor]);
 
-  // Debounced autosave for title/body/tags.
-  const saveTimersRef = React.useRef<Map<string, number>>(new Map());
-  const queueSave = React.useCallback(
-    (noteId: string, patch: Partial<Pick<ApiNote, "title" | "body" | "tags">>) => {
+  // Debounced autosave for title/body/tags. We keep the latest pending patch
+  // per note next to its timer so it can be flushed immediately on unmount,
+  // navigation, or when switching notes — instead of being silently dropped.
+  type PendingSave = {
+    handle: number;
+    patch: Partial<Pick<ApiNote, "title" | "body" | "tags">>;
+  };
+  const pendingSavesRef = React.useRef<Map<string, PendingSave>>(new Map());
+  // Drives the editor footer so it never claims "Saved" while a write is still
+  // queued or in flight.
+  const [saveStatus, setSaveStatus] = React.useState<"saved" | "unsaved" | "saving">(
+    "saved",
+  );
+
+  const runSave = React.useCallback(
+    (
+      noteId: string,
+      patch: Partial<Pick<ApiNote, "title" | "body" | "tags">>,
+      keepalive = false,
+    ) => {
       if (!userId) return;
-      const timers = saveTimersRef.current;
-      const existing = timers.get(noteId);
-      if (existing) window.clearTimeout(existing);
-      const handle = window.setTimeout(() => {
-        timers.delete(noteId);
-        patchNote(noteId, userId, patch).catch((e) =>
-          console.error("Autosave failed", e),
-        );
-      }, 800);
-      timers.set(noteId, handle);
+      setSaveStatus("saving");
+      patchNote(noteId, userId, patch, { keepalive })
+        .then(() => {
+          if (pendingSavesRef.current.size === 0) setSaveStatus("saved");
+        })
+        .catch((e) => console.error("Autosave failed", e));
     },
     [userId],
   );
 
+  const flushSave = React.useCallback(
+    (noteId: string, keepalive = false) => {
+      if (!userId) return;
+      const pending = pendingSavesRef.current.get(noteId);
+      if (!pending) return;
+      window.clearTimeout(pending.handle);
+      pendingSavesRef.current.delete(noteId);
+      runSave(noteId, pending.patch, keepalive);
+    },
+    [userId, runSave],
+  );
+
+  const flushAllSaves = React.useCallback(
+    (keepalive = false) => {
+      for (const noteId of Array.from(pendingSavesRef.current.keys())) {
+        flushSave(noteId, keepalive);
+      }
+    },
+    [flushSave],
+  );
+
+  const queueSave = React.useCallback(
+    (noteId: string, patch: Partial<Pick<ApiNote, "title" | "body" | "tags">>) => {
+      if (!userId) return;
+      const pending = pendingSavesRef.current;
+      const existing = pending.get(noteId);
+      const merged = { ...(existing?.patch ?? {}), ...patch };
+      if (existing) window.clearTimeout(existing.handle);
+      setSaveStatus("unsaved");
+      const handle = window.setTimeout(() => {
+        pending.delete(noteId);
+        runSave(noteId, merged);
+      }, 800);
+      pending.set(noteId, { handle, patch: merged });
+    },
+    [userId, runSave],
+  );
+
+  // Flush pending edits before the active note changes, so switching notes
+  // never drops a queued save.
+  const prevActiveIdRef = React.useRef<string | null>(activeId);
   React.useEffect(() => {
-    const timers = saveTimersRef.current;
+    const prev = prevActiveIdRef.current;
+    if (prev && prev !== activeId) flushSave(prev);
+    prevActiveIdRef.current = activeId;
+  }, [activeId, flushSave]);
+
+  // Flush on unmount and on tab close / hard navigation. The pagehide flush
+  // uses keepalive so the request survives the unload; the unmount flush is a
+  // normal request that completes against the still-live page.
+  React.useEffect(() => {
+    const onPageHide = () => flushAllSaves(true);
+    window.addEventListener("pagehide", onPageHide);
     return () => {
-      timers.forEach((handle) => window.clearTimeout(handle));
-      timers.clear();
+      window.removeEventListener("pagehide", onPageHide);
+      flushAllSaves();
     };
-  }, []);
+  }, [flushAllSaves]);
 
   const updateActive = (patch: Partial<Note>) => {
     if (!active) return;
@@ -330,6 +393,7 @@ export default function NotetakerPage() {
 
   const onGenerateQuiz = async () => {
     if (!active || !userId) return;
+    flushSave(active.id);
     setBusy("quiz");
     try {
       const { concept_node_id } = await generateQuizFromNote(active.id, userId);
@@ -342,6 +406,7 @@ export default function NotetakerPage() {
 
   const onSendToTutor = async () => {
     if (!active || !userId) return;
+    flushSave(active.id);
     setBusy("tutor");
     try {
       const { topic, course_id } = await sendNoteToTutor(active.id, userId);
@@ -549,6 +614,7 @@ export default function NotetakerPage() {
             <NoteEditor
               note={active}
               onChange={updateActive}
+              saveStatus={saveStatus}
               fullscreen={fullscreen}
               onToggleFullscreen={() => setFullscreen((f) => !f)}
             />
@@ -864,11 +930,13 @@ function CourseFilterChip({
 function NoteEditor({
   note,
   onChange,
+  saveStatus,
   fullscreen,
   onToggleFullscreen,
 }: {
   note: Note;
   onChange: (patch: Partial<Note>) => void;
+  saveStatus: "saved" | "unsaved" | "saving";
   fullscreen: boolean;
   onToggleFullscreen: () => void;
 }) {
@@ -984,8 +1052,12 @@ function NoteEditor({
         }}
       >
         <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
-          <Icon name="check" size={11} />
-          Saved · {relTime(note.updatedAt)}
+          <Icon name={saveStatus === "saved" ? "check" : "pencil"} size={11} />
+          {saveStatus === "saving"
+            ? "Saving…"
+            : saveStatus === "unsaved"
+              ? "Unsaved changes"
+              : `Saved · ${relTime(note.updatedAt)}`}
         </span>
         <span style={{ display: "inline-flex", alignItems: "center", gap: 12 }}>
           <span>{note.body.split(/\s+/).filter(Boolean).length} words</span>

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -95,11 +95,12 @@ function LearnInner() {
 
   const initialTopic = searchParams.get("topic") ?? "";
   const initialMode = normalizeMode(searchParams.get("mode"));
+  const initialCourseId = searchParams.get("course") ?? "";
 
   const [mode, setMode] = useState<Mode>(initialMode);
   const [topic, setTopic] = useState<string>(initialTopic);
   const [topicDraft, setTopicDraft] = useState<string>(initialTopic);
-  const [selectedCourseId, setSelectedCourseId] = useState<string | "">("");
+  const [selectedCourseId, setSelectedCourseId] = useState<string | "">(initialCourseId);
 
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [messages, setMessages] = useState<ChatMsg[]>([]);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1125,10 +1125,14 @@ export const patchNote = (
   noteId: string,
   userId: string,
   patch: Partial<Pick<Note, 'title' | 'body' | 'tags' | 'course_id'>>,
+  // `keepalive` lets a final autosave survive a page unload (tab close /
+  // navigation) instead of being cancelled mid-flight.
+  opts?: { keepalive?: boolean },
 ) =>
   fetchJSON<Note>(`/api/notes/${noteId}`, {
     method: 'PATCH',
     body: JSON.stringify({ user_id: userId, ...patch }),
+    keepalive: opts?.keepalive,
   });
 
 export const deleteNote = (noteId: string, userId: string) =>


### PR DESCRIPTION
## What
Fixes two notetaker data-loss bugs from #133:

1. **Dropped debounced autosave.** The 800ms-debounced `patchNote` cleared its pending timer on unmount / note-switch **without flushing**, so edits typed within the debounce window were silently lost while the footer still read "Saved" — including when clicking *Send to tutor* / *Generate quiz*, which `router.push` and unmount the page.
2. **Lost course context on send-to-tutor.** `onSendToTutor` pushes `/learn?topic=…&course=<id>`, but `LearnInner` only read `topic`/`mode`/`suggest`. `selectedCourseId` stayed `""` and the session started with no `courseId`.

## Why
Users lost recent edits when navigating away from a note, and tutor sessions launched from a note silently dropped the note's course, weakening the learning context. Both are correctness/data-integrity issues (P2).

## How verified
- Track the latest pending patch per note alongside its timer; flush it on note-change, on unmount, on `pagehide` (tab close), and before send-to-tutor / generate-quiz navigation. Pending patches are merged so partial title/body/tags edits aren't lost. The `pagehide` flush uses a `keepalive` request so it survives the unload.
- Footer is now driven by save state (`Saved` / `Unsaved changes` / `Saving…`) so it no longer falsely claims "Saved".
- `LearnInner` seeds `selectedCourseId` from `searchParams.get("course")`, so the carried-over course flows into `startSession` and the course selector.
- `cd frontend && npx tsc --noEmit` → clean (exit 0).
- `cd frontend && npx vitest run` → 5 files, 37 tests passing.

Closes #133
