### PR TITLE
test(ci): make document-upload tests hermetic, remove #210 quarantine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,19 +45,17 @@ jobs:
           SUPABASE_URL: https://dummy.supabase.co
           SUPABASE_SERVICE_KEY: dummy-service-key
           SESSION_SECRET: dummy-session-secret
-        # test_documents_routes (whole module) + test_graph_service::test_skips_self_edges
-        # are PRE-EXISTING failures: they make unmocked network calls / have a mock-dict
-        # bug, never caught because there was no CI. Quarantined so the gate is green for
-        # the other ~580 tests; tracked in #210 to be made hermetic + un-quarantined.
+        # Only the OCR integration tests are excluded (heavy deps, run via the
+        # manual evals workflow). The earlier #210 quarantine of
+        # test_documents_routes + the graph self-edges test is gone — they're
+        # hermetic now (shared db-client mock in conftest) and gate normally.
         run: |
           python -m pytest tests/ -q \
             --ignore=tests/evals \
             --ignore=tests/test_docling_integration.py \
             --ignore=tests/test_ocr_pipeline.py \
             --ignore=tests/test_extraction_backends.py \
-            --ignore=tests/test_extraction_service.py \
-            --ignore=tests/test_documents_routes.py \
-            --deselect "tests/test_graph_service.py::TestApplyGraphUpdate::test_skips_self_edges"
+            --ignore=tests/test_extraction_service.py
 
   frontend:
     name: Frontend (lint + tsc + vitest)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,11 +11,41 @@ unaffected.
 """
 import sys
 import os
+from unittest.mock import MagicMock
+
 import pytest
 
 os.environ.setdefault("ENCRYPTION_KEY", "0" * 64)  # 32-byte all-zero key for deterministic tests
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_supabase_client(monkeypatch):
+    """Hermetic safety net (#210): no test may make a real Supabase call.
+
+    Every db access ultimately flows through `db.connection._client` (the single
+    persistent httpx.Client behind SupabaseTable). Routes/services that call
+    `db.connection.table()` directly — e.g. `apply_graph_update` inside the
+    document-upload legacy pipeline — would otherwise escape a test's per-route
+    `table` mock and hit the network (the whole `test_documents_routes` module
+    was failing/quarantined for exactly this reason). Replace that client with a
+    stub returning benign empty responses. Tests that need specific db data still
+    patch their own `table`/service reference; this only catches what escapes.
+    """
+    import db.connection as dbconn
+
+    def _empty_response(*_args, **_kwargs):
+        resp = MagicMock(name="supabase_response")
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = []
+        resp.headers = {}
+        return resp
+
+    fake_client = MagicMock(name="hermetic_supabase_client")
+    for verb in ("get", "post", "patch", "delete"):
+        getattr(fake_client, verb).side_effect = _empty_response
+    monkeypatch.setattr(dbconn, "_client", fake_client)
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_graph_service.py
+++ b/backend/tests/test_graph_service.py
@@ -504,7 +504,13 @@ class TestApplyGraphUpdate:
         with patch("services.graph_service.table", side_effect=factory):
             apply_graph_update("u1", graph_update, course_id="c1")
 
-        mocks["graph_edges"].insert.assert_not_called()
+        # The only edge (A -> a) is a self-edge after case-folding, so it must be
+        # skipped. The factory populates `mocks` lazily, so when the self-edge is
+        # dropped before any graph_edges access the table is never in `mocks` —
+        # which still proves no insert happened. Guard the lookup so that path
+        # doesn't KeyError and mask the real assertion.
+        if "graph_edges" in mocks:
+            mocks["graph_edges"].insert.assert_not_called()
 
 
 # ── get_recommendations ───────────────────────────────────────────────────────


### PR DESCRIPTION
## What
Restores real CI coverage for the document-upload pipeline by making its tests hermetic, then removes the #210 quarantine from `ci.yml`.

## Why
Standing up CI (#162) revealed the entire `test_documents_routes` module (22 tests) + `test_graph_service::test_skips_self_edges` were failing on a clean toolchain — never caught because there was no CI. Root cause: the upload legacy pipeline calls `apply_graph_update` → `db.connection.table()` → the single shared `httpx.Client`, escaping each test's per-route `table` mock and hitting the network.

## How
- **conftest.py:** new autouse `_hermetic_supabase_client` fixture replaces `db.connection._client` with a stub returning benign empty responses — a shared safety net so *no* test can make a real Supabase call, regardless of which service bypasses per-test mocks. (Not per-test stubs.)
- **test_graph_service.py:** guard the `mocks["graph_edges"]` lookup in `test_skips_self_edges` — the factory creates table mocks lazily, so when the self-edge is correctly skipped `graph_edges` is never accessed and the bare lookup raised `KeyError`, masking the real `assert_not_called`.
- **ci.yml:** removed `--ignore=tests/test_documents_routes.py` and the `--deselect` for the graph test. Only the heavy OCR integration tests remain excluded (manual evals workflow).

## Verified
Full gated suite with the quarantine removed: **614 passed** (was 555 with 23 quarantined). All 22 document tests + the graph test genuinely run and PASS — not skipped, not xfail. No regression in the db-wrapper/storage tests (the new autouse mock is overridden by their own per-test mocks).

Closes #210