### PR TITLE
fix(a11y): single-source rarity tokens, 3:1 legendary, neutral rarity text

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -104,17 +104,6 @@
   --bg-mesh:         #f0f4f2;
   --font-inter: var(--font-sans);
 
-  --rarity-common: #8a8372;
-  --rarity-uncommon: #4e873c;
-  --rarity-rare: #3e6f8a;
-  --rarity-epic: #7b4b99;
-  --rarity-legendary: #b4862c;
-  --rarity-common-bg:    color-mix(in oklab, #8a8372 14%, transparent);
-  --rarity-uncommon-bg:  color-mix(in oklab, #4e873c 14%, transparent);
-  --rarity-rare-bg:      color-mix(in oklab, #3e6f8a 14%, transparent);
-  --rarity-epic-bg:      color-mix(in oklab, #7b4b99 14%, transparent);
-  --rarity-legendary-bg: color-mix(in oklab, #b4862c 14%, transparent);
-
   --c-sage: #4e873c;
   --c-sky: #3e6f8a;
   --c-rose: #a8456b;
@@ -556,8 +545,8 @@ input[type="reset"]:disabled {
   --rarity-rare-bg:      rgba(43, 140, 150, 0.08);
   --rarity-epic:         #8b5cf6;
   --rarity-epic-bg:      rgba(139, 92, 246, 0.08);
-  --rarity-legendary:    var(--brand-progress);
-  --rarity-legendary-bg: rgba(232, 163, 58, 0.08);
+  --rarity-legendary:    #b4862c; /* not --brand-progress: #e8a33a is 2.10:1 on --bg-panel, under the 3:1 non-text bar */
+  --rarity-legendary-bg: rgba(232, 163, 58, 0.08); /* stays on the lighter gold: a #b4862c-based tint puts the TitleFlair border vs its own interior under 3:1 */
 }
 
 /* ══════════════════════════════════════════════════════════════════

--- a/frontend/src/components/ProfileView.tsx
+++ b/frontend/src/components/ProfileView.tsx
@@ -7,13 +7,8 @@ import { RoleBadge } from "./RoleBadge";
 import { Icon } from "./Icon";
 import type { UserProfile } from "@/lib/types";
 
-const rarityColor: Record<string, string> = {
-  common: "#8a8372",
-  uncommon: "#4e873c",
-  rare: "#3e6f8a",
-  epic: "#7b4b99",
-  legendary: "#b4862c",
-};
+// Rarity colors come only from the canonical --rarity-* tokens (globals.css).
+const rarityVar = (r: string) => `var(--rarity-${r}, var(--text-muted))`;
 
 export function ProfileView({ profile, embedded = false }: { profile: UserProfile; embedded?: boolean }) {
   const eq = profile.equipped_cosmetics || {};
@@ -145,15 +140,15 @@ export function ProfileView({ profile, embedded = false }: { profile: UserProfil
           <div className="label-micro" style={{ marginBottom: 10 }}>Featured achievements</div>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))", gap: 10 }}>
             {profile.featured_achievements!.map(ua => {
-              const c = rarityColor[ua.achievement.rarity] || "var(--text-muted)";
+              const c = rarityVar(ua.achievement.rarity);
               return (
                 <div
                   key={ua.achievement.id}
                   style={{
                     padding: 12,
                     textAlign: "center",
-                    border: `1px solid ${c}33`,
-                    background: `${c}0f`,
+                    border: `1px solid color-mix(in srgb, ${c} 20%, transparent)`,
+                    background: `color-mix(in srgb, ${c} 6%, transparent)`,
                     borderRadius: "var(--r-md)",
                     borderTop: `3px solid ${c}`,
                   }}

--- a/frontend/src/components/TitleFlair.tsx
+++ b/frontend/src/components/TitleFlair.tsx
@@ -12,6 +12,8 @@ interface TitleFlairProps {
 export function TitleFlair({ cosmetic, className, style }: TitleFlairProps) {
   if (!cosmetic) return null;
   const rarity = cosmetic.rarity ?? "common";
+  // Rarity is never conveyed by colored text (fails 4.5:1 on several tiers);
+  // the border carries the color and the literal tier name carries the cue.
   return (
     <span
       className={className}
@@ -25,12 +27,12 @@ export function TitleFlair({ cosmetic, className, style }: TitleFlairProps) {
         textTransform: "uppercase",
         borderRadius: "var(--r-full)",
         border: `1px solid var(--rarity-${rarity})`,
-        color: `var(--rarity-${rarity})`,
+        color: "var(--text)",
         background: `var(--rarity-${rarity}-bg)`,
         ...style,
       }}
     >
-      {cosmetic.name}
+      {cosmetic.name} · {rarity}
     </span>
   );
 }

--- a/frontend/src/components/screens/Achievements.tsx
+++ b/frontend/src/components/screens/Achievements.tsx
@@ -9,13 +9,9 @@ import { useUser } from "@/context/UserContext";
 import { fetchAchievements, setFeaturedAchievements } from "@/lib/api";
 import type { Achievement as AchType, UserAchievement, RarityTier, AchievementCategory } from "@/lib/types";
 
-const rarityBg: Record<RarityTier, string> = {
-  common: "#8a8372",
-  uncommon: "#4e873c",
-  rare: "#3e6f8a",
-  epic: "#7b4b99",
-  legendary: "#b4862c",
-};
+// Rarity colors come only from the canonical --rarity-* tokens (globals.css);
+// rarity text itself stays neutral (colored text fails 4.5:1 on several tiers).
+const rarityVar = (r: RarityTier) => `var(--rarity-${r}, var(--border))`;
 
 type CatFilter = "all" | AchievementCategory;
 
@@ -39,7 +35,7 @@ function Card({
   onToggleFeature?: () => void;
   canFeature?: boolean;
 }) {
-  const c = rarityBg[a.rarity];
+  const c = rarityVar(a.rarity);
   const secret = a.is_secret && !isEarned;
   const pct = progress ? Math.min(100, Math.round((progress.current / Math.max(1, progress.target)) * 100)) : null;
   return (
@@ -50,14 +46,14 @@ function Card({
         position: "relative",
         borderTop: `3px solid ${c}`,
         opacity: isEarned ? 1 : 0.85,
-        boxShadow: isEarned ? `0 2px 12px ${c}22, var(--shadow-sm)` : "var(--shadow-sm)",
+        boxShadow: isEarned ? `0 2px 12px color-mix(in srgb, ${c} 13%, transparent), var(--shadow-sm)` : "var(--shadow-sm)",
       }}
     >
       <div style={{ display: "flex", gap: 14 }}>
         <div
           style={{
             width: 52, height: 52, borderRadius: "var(--r-md)",
-            background: isEarned ? `${c}22` : "var(--bg-soft)",
+            background: isEarned ? `color-mix(in srgb, ${c} 13%, transparent)` : "var(--bg-soft)",
             color: c, display: "flex", alignItems: "center", justifyContent: "center",
             fontSize: 26, flexShrink: 0,
             filter: isEarned ? "none" : "grayscale(1) opacity(0.5)",
@@ -68,7 +64,7 @@ function Card({
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 6 }}>
             <div style={{ fontWeight: 600, fontSize: 14 }}>{secret ? "Secret Achievement" : a.name}</div>
-            <span className="chip" style={{ color: c, borderColor: `${c}44`, background: `${c}11` }}>
+            <span className="chip" style={{ color: "var(--text)", borderColor: `color-mix(in srgb, ${c} 27%, transparent)`, background: `color-mix(in srgb, ${c} 7%, transparent)` }}>
               {a.rarity}
             </span>
           </div>
@@ -227,7 +223,7 @@ export function Achievements() {
           {featuredIds.map((id) => {
             const ua = earnedById.get(id);
             if (!ua) return null;
-            const c = rarityBg[ua.achievement.rarity];
+            const c = rarityVar(ua.achievement.rarity);
             return (
               <div
                 key={id}
@@ -260,6 +256,9 @@ export function Achievements() {
                 </button>
                 <div style={{ fontSize: 26, marginBottom: 4 }}>{ua.achievement.icon || "★"}</div>
                 <div style={{ fontSize: 11, fontWeight: 600 }}>{ua.achievement.name}</div>
+                <div style={{ fontSize: 10, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.08em", marginTop: 2 }}>
+                  {ua.achievement.rarity}
+                </div>
               </div>
             );
           })}


### PR DESCRIPTION
Resolves the PROGRAM.md backlog item: duplicate --rarity-* definitions in globals.css.

- Deletes the dead revamp `:root` rarity block; the legacy block (canonical per decision) now defines each of the ten tokens exactly once.
- `--rarity-legendary` pinned to #b4862c (was `var(--brand-progress)` #e8a33a at 2.10:1 — under the 3:1 non-text bar). All five tiers now clear 3:1 on every required non-text surface (legendary worst case 3.02).
- Hard-coded copies of the rarity palette in ProfileView.tsx and Achievements.tsx replaced with the canonical tokens (hex-alpha suffixes → color-mix; ProfileView featured legendary is pixel-identical, confirming the conversion).
- Rarity is never conveyed by colored text: TitleFlair and the Achievements rarity chip render neutral `var(--text)`; TitleFlair appends the literal tier name; the Achievements showcase strip gains a rarity text line (was border-color-only, a 1.4.1 gap).
- `--rarity-legendary-bg` intentionally stays on the lighter gold base (comment added): a #b4862c-based tint would put the TitleFlair border vs its own interior under 3:1.

Verified by fresh-context measurement: all rarity-adjacent text ≥4.87:1; all required non-text ≥3.02:1; two legendary items (Achievements icon-tile glyph 2.82, progress fill 2.64) rely on the documented decorative/redundant carve-out. Toast and Settings render pixel-identical for the four unchanged tiers (headless-Chrome harness diff).

**Do not merge yet — awaiting visual sign-off on the changed surfaces.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized rarity tier styling across achievement cards and profile features using design tokens.
  * Reorganized CSS for consistent color application across components.
  * Updated featured achievement cards with improved rarity tier visibility.

* **Bug Fixes**
  * Enhanced accessibility: rarity tiers now indicated via border color and explicit tier label instead of text color alone, improving contrast and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->