### PR TITLE
fix(security): gate /api/gemini-test behind require_admin (#198)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -190,8 +190,17 @@ def list_users(request: Request):
 
 
 @app.get("/api/gemini-test")
-def gemini_test():
-    """Test Gemini connectivity. Shows clear error if API key is missing/wrong."""
+def gemini_test(request: Request):
+    """Admin-only Gemini connectivity check. Shows a clear error if the API
+    key is missing/wrong.
+
+    Gated behind `require_admin` (#198): every hit makes a real, billable
+    `call_gemini` round-trip, so an unauthenticated caller could burn Gemini
+    quota at will and use the `{"ok": ...}` response as an oracle for whether
+    the API key is configured. Only admins may trigger LLM spend here.
+    """
+    from services.auth_guard import require_admin
+    require_admin(request)  # 403 unless the session belongs to an admin; 401 if unauthenticated
     from services.gemini_service import call_gemini
     try:
         reply = call_gemini('Reply with exactly the text: Gemini OK', retries=0)

--- a/backend/tests/test_gemini_test_auth.py
+++ b/backend/tests/test_gemini_test_auth.py
@@ -1,0 +1,50 @@
+"""
+Regression tests for GET /api/gemini-test (main.gemini_test) auth.
+
+Issue #198: the endpoint had no auth and made a real, billable `call_gemini`
+round-trip on every hit, so anonymous callers could burn Gemini quota and use
+the `{"ok": ...}` response as an oracle for whether the API key is valid. It is
+now gated behind `require_admin`.
+
+The autouse `_bypass_session_auth` fixture in conftest.py stubs the auth guard
+so the admin-path test reaches the handler without minting tokens; the
+unauthenticated test restores the real guard to assert the 401.
+"""
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+class TestGeminiTestAuth:
+    def test_unauthenticated_returns_401_and_makes_no_llm_call(self):
+        # Restore the real guard so a request with no cookie/token => 401,
+        # undoing the autouse bypass from conftest. require_admin calls
+        # get_session_user_id first, which raises 401 before any role lookup.
+        from services import auth_guard
+
+        with patch.object(
+            auth_guard, "require_admin", auth_guard._real_require_admin
+        ), patch.object(
+            auth_guard, "get_session_user_id", auth_guard._real_get_session_user_id
+        ), patch.object(
+            auth_guard, "_decode_session", auth_guard._real_decode_session
+        ), patch("services.gemini_service.call_gemini") as call_gemini:
+            r = client.get("/api/gemini-test")
+
+        # Pre-fix this returned 200 with {"ok": ...}; the fix makes it 401 and,
+        # critically, the LLM is never called for an anonymous request.
+        assert r.status_code == 401
+        call_gemini.assert_not_called()
+
+    def test_admin_reaches_handler(self):
+        # Autouse bypass stubs require_admin to a no-op, so an admin-equivalent
+        # request reaches the handler. Mock the LLM so the test is hermetic.
+        with patch("services.gemini_service.call_gemini", return_value="Gemini OK"):
+            r = client.get("/api/gemini-test")
+
+        assert r.status_code == 200
+        assert r.json() == {"ok": True, "reply": "Gemini OK"}


### PR DESCRIPTION
Closes #198.

## Problem
`GET /api/gemini-test` had no auth and made a real, billable `call_gemini(...)` round-trip on every hit. Anonymous callers could burn Gemini quota at will and use the `{"ok": ...}` response as an oracle for whether the API key is configured/valid — a debug endpoint left wired into the production app.

## Fix
Gate the endpoint behind `require_admin` (the existing guard in `services/auth_guard.py`). Anonymous → 401, non-admin → 403, admin → reaches the connectivity check. Kept (rather than removed) so operators retain a deliberate, auth-gated Gemini probe; `/api/health` remains the unauthenticated liveness check.

## Test (vuln-closing)
`tests/test_gemini_test_auth.py`:
- `test_unauthenticated_returns_401_and_makes_no_llm_call` — restores the real auth guard (undoing conftest's autouse bypass) and asserts an anonymous GET returns **401** and `call_gemini` is **never** called. **Fails on pre-fix code** (returned 200 + a live LLM call); passes post-fix.
- `test_admin_reaches_handler` — admin-equivalent request reaches the handler (LLM mocked).

## Scope
One file + one test. No behavior change for authenticated admins.

⚠️ Per Wave-1 convention: **do not merge** — opened for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secured admin endpoint with authentication enforcement to prevent unauthorized access and unintended API quota usage.

* **Tests**
  * Added tests to validate authentication requirements for the admin endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->