### PR TITLE
fix(security): validate COOKIE_DOMAIN + same-origin CSRF check on session route (#190)

### DIFF
--- a/frontend/src/app/api/auth/session/route.test.ts
+++ b/frontend/src/app/api/auth/session/route.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const URL = 'https://app.saplinglearn.com/api/auth/session';
+const SECRET = 'x'.repeat(32);
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+async function loadRoute(env: Record<string, string>) {
+  vi.resetModules();
+  for (const [k, v] of Object.entries(env)) vi.stubEnv(k, v);
+  return import('./route');
+}
+
+describe('session route — COOKIE_DOMAIN validation (#190)', () => {
+  it('does not scope the cleared cookie to an overly-broad COOKIE_DOMAIN', async () => {
+    // Pre-fix: COOKIE_DOMAIN='.com' was applied verbatim → cookie.domain='.com'.
+    const { DELETE } = await loadRoute({ SESSION_SECRET: SECRET, COOKIE_DOMAIN: '.com' });
+    const res = await DELETE(new NextRequest(URL, { method: 'DELETE' }));
+    expect(res.cookies.get('sapling_session')?.domain).toBeUndefined();
+  });
+
+  it('keeps a well-formed COOKIE_DOMAIN', async () => {
+    const { DELETE } = await loadRoute({
+      SESSION_SECRET: SECRET,
+      COOKIE_DOMAIN: '.saplinglearn.com',
+    });
+    const res = await DELETE(new NextRequest(URL, { method: 'DELETE' }));
+    expect(res.cookies.get('sapling_session')?.domain).toBe('.saplinglearn.com');
+  });
+});
+
+describe('session route — CSRF / same-origin enforcement (#190)', () => {
+  it('rejects a cross-origin POST with 403', async () => {
+    // Pre-fix: no origin check → reaches auth → 401 for the bad token (not 403).
+    const { POST } = await loadRoute({ SESSION_SECRET: SECRET });
+    const req = new NextRequest(URL, {
+      method: 'POST',
+      headers: { origin: 'https://evil.example.org', 'content-type': 'application/json' },
+      body: JSON.stringify({ authToken: 'forged' }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+
+  it('lets a same-origin POST through the CSRF check', async () => {
+    const { POST } = await loadRoute({ SESSION_SECRET: SECRET });
+    const req = new NextRequest(URL, {
+      method: 'POST',
+      headers: { origin: 'https://app.saplinglearn.com', 'content-type': 'application/json' },
+      body: JSON.stringify({ authToken: 'invalid' }),
+    });
+    const res = await POST(req);
+    // Not blocked as cross-origin; falls through to auth, which rejects the
+    // bad token with 401. The point: same-origin requests aren't 403'd.
+    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(401);
+  });
+});

--- a/frontend/src/app/api/auth/session/route.ts
+++ b/frontend/src/app/api/auth/session/route.ts
@@ -1,8 +1,30 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { signSession, SESSION_MAX_AGE } from '@/lib/sessionToken';
+import { sanitizeCookieDomain } from '@/lib/cookieDomain';
 
 const SESSION_SECRET = process.env.SESSION_SECRET;
-const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN || undefined;
+// #190: validate COOKIE_DOMAIN instead of trusting env verbatim — an
+// overly-broad value would scope the session cookie across unrelated
+// subdomains. An invalid value degrades to a host-only cookie.
+const COOKIE_DOMAIN = sanitizeCookieDomain(process.env.COOKIE_DOMAIN);
+
+/**
+ * CSRF defense beyond SameSite=Lax (#190): reject cross-origin requests to the
+ * session endpoint. When a browser sends an Origin header (always, for these
+ * fetch POST/DELETE calls), its host must match this route's host. A missing
+ * Origin (non-browser client) is allowed — CSRF is a browser-driven attack and
+ * browsers always send Origin here. This is the documented anti-CSRF strategy
+ * for the state-changing session endpoint, layered on top of SameSite=Lax.
+ */
+function isCrossOrigin(request: NextRequest): boolean {
+  const origin = request.headers.get('origin');
+  if (!origin) return false;
+  try {
+    return new URL(origin).host !== request.nextUrl.host;
+  } catch {
+    return true;
+  }
+}
 
 async function verifyAuthToken(token: string): Promise<string | null> {
   if (!SESSION_SECRET) return null;
@@ -46,6 +68,10 @@ async function verifyAuthToken(token: string): Promise<string | null> {
 }
 
 export async function POST(request: NextRequest) {
+  if (isCrossOrigin(request)) {
+    return NextResponse.json({ error: 'Cross-origin request rejected' }, { status: 403 });
+  }
+
   const body = await request.json();
   const { authToken } = body as { authToken?: string };
 
@@ -84,7 +110,11 @@ export async function POST(request: NextRequest) {
   }
 }
 
-export async function DELETE() {
+export async function DELETE(request: NextRequest) {
+  if (isCrossOrigin(request)) {
+    return NextResponse.json({ error: 'Cross-origin request rejected' }, { status: 403 });
+  }
+
   const response = NextResponse.json({ ok: true });
   response.cookies.set('sapling_session', '', {
     httpOnly: true,

--- a/frontend/src/lib/cookieDomain.test.ts
+++ b/frontend/src/lib/cookieDomain.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeCookieDomain } from './cookieDomain';
+
+describe('sanitizeCookieDomain', () => {
+  it('accepts well-formed domains (with or without a leading dot)', () => {
+    expect(sanitizeCookieDomain('.saplinglearn.com')).toBe('.saplinglearn.com');
+    expect(sanitizeCookieDomain('saplinglearn.com')).toBe('saplinglearn.com');
+    expect(sanitizeCookieDomain('app.example.com')).toBe('app.example.com');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(sanitizeCookieDomain('  saplinglearn.com  ')).toBe('saplinglearn.com');
+  });
+
+  it('rejects overly-broad bare suffixes', () => {
+    expect(sanitizeCookieDomain('.com')).toBeUndefined();
+    expect(sanitizeCookieDomain('com')).toBeUndefined();
+  });
+
+  it('rejects single-label hosts', () => {
+    expect(sanitizeCookieDomain('localhost')).toBeUndefined();
+  });
+
+  it('rejects values carrying a scheme, port, path, or whitespace', () => {
+    expect(sanitizeCookieDomain('https://saplinglearn.com')).toBeUndefined();
+    expect(sanitizeCookieDomain('saplinglearn.com:443')).toBeUndefined();
+    expect(sanitizeCookieDomain('saplinglearn.com/path')).toBeUndefined();
+    expect(sanitizeCookieDomain('sapling learn.com')).toBeUndefined();
+  });
+
+  it('rejects empty / nullish input', () => {
+    expect(sanitizeCookieDomain('')).toBeUndefined();
+    expect(sanitizeCookieDomain('   ')).toBeUndefined();
+    expect(sanitizeCookieDomain(undefined)).toBeUndefined();
+    expect(sanitizeCookieDomain(null)).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/cookieDomain.ts
+++ b/frontend/src/lib/cookieDomain.ts
@@ -1,0 +1,33 @@
+/**
+ * Validate the COOKIE_DOMAIN env value before it scopes the session cookie.
+ *
+ * #190: COOKIE_DOMAIN was applied verbatim from env, so a misconfigured or
+ * overly-broad value (e.g. ".com") would scope the session cookie across
+ * unrelated subdomains. A value that fails validation is dropped (returns
+ * undefined → host-only cookie) rather than silently widening cookie scope.
+ *
+ * Note: this is a conservative shape/breadth check, not a full public-suffix
+ * lookup — it rejects bare suffixes like ".com" but cannot detect every
+ * multi-label public suffix (e.g. ".co.uk"). Pair with a sane deploy config.
+ */
+
+// Lowercase DNS name, optional single leading dot, ≥2 labels, each label
+// 1-63 chars of [a-z0-9-] not starting/ending with a hyphen. No scheme, port,
+// path, whitespace, or uppercase.
+const DOMAIN_RE =
+  /^\.?(?=.{1,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/;
+
+export function sanitizeCookieDomain(
+  raw: string | undefined | null,
+): string | undefined {
+  if (!raw) return undefined;
+  const value = raw.trim();
+  if (!value || !DOMAIN_RE.test(value)) return undefined;
+
+  // Require ≥2 labels in the registrable portion so a bare suffix like ".com"
+  // or "com" — which would scope the cookie far too widely — is rejected.
+  const labels = value.replace(/^\./, '').split('.');
+  if (labels.length < 2) return undefined;
+
+  return value;
+}


### PR DESCRIPTION
Closes #190.

## Problems (two residual hardening gaps on `/api/auth/session`)
1. **`COOKIE_DOMAIN` was trusted verbatim** from env — a misconfigured/overly-broad value (e.g. `.com`) would scope the session cookie across unrelated subdomains.
2. **CSRF defense relied solely on `SameSite=Lax`** — no second line for the state-changing session endpoint.

## Fixes
- **`sanitizeCookieDomain()`** (`lib/cookieDomain.ts`): conservative shape + breadth validation (lowercase DNS name, ≥2 labels, no scheme/port/path/whitespace). Bare suffixes like `.com` and single-label hosts are rejected; an invalid value degrades to a **host-only** cookie instead of widening scope. Used for both the `set` and the `delete` cookie.
- **Same-origin check** on `POST`/`DELETE`: a browser-sent `Origin` must match the route host, else **403**. A missing Origin (non-browser client) is allowed — CSRF is browser-driven and browsers always send Origin for these fetch calls. This is the documented anti-CSRF strategy layered on top of SameSite. Verified the real callers (`auth/callback` POST, `UserContext` logout DELETE) are same-origin and unaffected.

## Tests (vuln-closing)
- `route.test.ts`: cross-origin POST → **403** (pre-fix: 401); overly-broad `COOKIE_DOMAIN` not applied to the cookie (pre-fix: `domain='.com'`). Plus a same-origin pass-through control and a well-formed-domain control.
- `cookieDomain.test.ts`: unit coverage of accept/reject cases.

Both negative assertions **fail on pre-fix code**.

## Scope / notes
File-disjoint from #189 (that touches `middleware.ts`; this touches `api/auth/session/route.ts` + a new `lib/cookieDomain.ts`) — they don't conflict. The validator is a shape/breadth check, **not** a full public-suffix lookup (rejects `.com` but not every multi-label suffix like `.co.uk`); noted in-code.

⚠️ Per Wave-1 convention: **do not merge** — opened for review.