### PR TITLE
fix(security): gate /profile/[userId] in the middleware matcher (#189)

### DIFF
--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { middleware, config } from './middleware';
+
+const ORIGIN = 'https://app.saplinglearn.com';
+
+function req(path: string): NextRequest {
+  // No session cookie → unauthenticated visitor.
+  return new NextRequest(`${ORIGIN}${path}`);
+}
+
+describe('middleware — /profile gating (#189)', () => {
+  beforeEach(() => {
+    // Ensure the local-mode short-circuit is off so gating actually runs.
+    vi.stubEnv('NEXT_PUBLIC_LOCAL_MODE', 'false');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('redirects an unauthenticated /profile/:id request (no longer passes through)', async () => {
+    const res = await middleware(req('/profile/some-user-id'));
+    // Pre-fix: /profile wasn't protected → NextResponse.next() (status 200, no
+    // Location). Post-fix: redirected to sign-in.
+    expect(res.headers.get('location')).toBeTruthy();
+    expect(res.status).toBe(307);
+  });
+
+  it('still lets a genuinely public path pass through (no over-broadening)', async () => {
+    const res = await middleware(req('/about'));
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  it('lists /profile in config.matcher so middleware actually runs there', () => {
+    expect(config.matcher).toContain('/profile/:path*');
+  });
+});

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,11 +2,15 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { verifySession } from '@/lib/sessionToken'
 
+// Every route in the (shell) group is gated here. #189: /profile/[userId]
+// was the one shell route missing from both this list and config.matcher, so
+// the middleware never ran there and an unauthenticated visitor could
+// enumerate /profile/<any-id>. Gate it consistently with its siblings.
 const PROTECTED = [
   '/dashboard', '/learn', '/quiz', '/study', '/tree',
   '/library', '/calendar', '/social',
   '/settings', '/achievements', '/admin',
-  '/gradebook', '/course-planner', '/notetaker'
+  '/gradebook', '/course-planner', '/notetaker', '/profile'
 ]
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL
@@ -70,6 +74,7 @@ export const config = {
     '/calendar/:path*', '/social/:path*',
     '/settings/:path*', '/achievements/:path*',
     '/admin/:path*',
-    '/gradebook/:path*', '/course-planner/:path*', '/notetaker/:path*'
+    '/gradebook/:path*', '/course-planner/:path*', '/notetaker/:path*',
+    '/profile/:path*'
   ]
 }


### PR DESCRIPTION
Closes #189.

## Problem
`/profile/[userId]` lives in the `(shell)` route group alongside `dashboard`, `settings`, `achievements`, `gradebook`, etc. — **every** one of which the middleware gates via `PROTECTED` + `config.matcher`. `/profile` was the **only** shell route missing from both, so the middleware never ran there and an unauthenticated visitor could enumerate `/profile/<any-id>`. The page (`fetchPublicProfile`) had no auth guard of its own — gating was incidental, not intentional.

## Fix
Add `/profile` to `PROTECTED` and `/profile/:path*` to `config.matcher`, making gating consistent with its sibling shell routes. (The backend over-exposure of profile data is the distinct issue #134; this PR is only the frontend routing gap.)

## Tests — `middleware.test.ts`
- Unauthenticated `/profile/:id` → **redirect to sign-in** (pre-fix: `NextResponse.next()`, status 200, passed through).
- `config.matcher` **includes** `/profile/:path*` (pre-fix: absent — so middleware wouldn't even run there in prod).
- Control: a genuinely public path still passes through (no over-broadening).

Both negative assertions **fail on pre-fix code**.

## Scope / decision
Chose **protect** over document-public because all sibling `(shell)` routes are gated and the issue frames the gap as incidental. File-disjoint from #190 (this touches `middleware.ts`; #190 touches `api/auth/session/route.ts`) — no conflict.

⚠️ Per Wave-1 convention: **do not merge** — opened for review.