### PR TITLE
fix(security): encrypt syllabus-extracted assignment notes at write boundary (#126 #4)

### DIFF
--- a/backend/services/calendar_service.py
+++ b/backend/services/calendar_service.py
@@ -12,6 +12,7 @@ from agents.tools.syllabus_adapter import syllabus_to_wire_dict
 from services.extraction_service import extract_text_from_file
 from services.gemini_service import call_gemini_json
 from services.assignment_dedupe import assignment_dedupe_key
+from services.encryption import encrypt_if_present
 from db.connection import table
 
 logger = logging.getLogger(__name__)
@@ -52,7 +53,12 @@ def insert_new_assignments(user_id: str, assignments: list[dict]) -> int:
             "course_id": a.get("course_id") or None,
             "due_date": key[1],
             "assignment_type": a.get("assignment_type") or "other",
-            "notes": a.get("notes"),
+            # #126: encrypt at the write boundary. assignments.notes is an
+            # encrypted column; every other writer (calendar.py, gradebook.py)
+            # encrypts. Syllabus-extracted notes were being persisted as
+            # plaintext, defeating column encryption and spamming decrypt
+            # fallback warnings on read.
+            "notes": encrypt_if_present(a.get("notes")),
         })
     if rows:
         table("assignments").insert(rows)

--- a/backend/tests/test_assignment_notes_encryption.py
+++ b/backend/tests/test_assignment_notes_encryption.py
@@ -1,0 +1,53 @@
+"""
+Regression test for #126 finding #4: syllabus-extracted assignment notes were
+written to assignments.notes as PLAINTEXT (no encrypt_if_present), defeating
+column-level encryption at rest.
+
+This is an encryption-boundary correctness test (not a cross-user-access test):
+it asserts the value handed to the DB insert is ciphertext, and that it
+round-trips back to the original plaintext via decrypt.
+"""
+from unittest.mock import MagicMock, patch
+
+from services.calendar_service import insert_new_assignments
+from services.encryption import decrypt
+
+PLAINTEXT_NOTES = "Bring a calculator; covers chapters 3-5 (private)."
+
+
+class TestAssignmentNotesEncryptedAtRest:
+    def test_notes_are_encrypted_before_insert(self):
+        captured = {}
+
+        def _insert(rows):
+            captured["rows"] = rows
+            return rows
+
+        with patch("services.calendar_service.table") as t:
+            # No existing rows → nothing deduped; capture what gets inserted.
+            t.return_value.select.return_value = []
+            t.return_value.insert.side_effect = _insert
+
+            n = insert_new_assignments(
+                "user_andres",
+                [{"title": "Midterm", "due_date": "2026-03-01", "notes": PLAINTEXT_NOTES}],
+            )
+
+        assert n == 1
+        written = captured["rows"][0]["notes"]
+        # Pre-fix: written == PLAINTEXT_NOTES (stored in the clear). Post-fix the
+        # column holds ciphertext that is NOT the plaintext...
+        assert written != PLAINTEXT_NOTES
+        # ...and decrypts back to the original.
+        assert decrypt(written) == PLAINTEXT_NOTES
+
+    def test_none_notes_stay_none(self):
+        captured = {}
+        with patch("services.calendar_service.table") as t:
+            t.return_value.select.return_value = []
+            t.return_value.insert.side_effect = lambda rows: captured.setdefault("rows", rows)
+            insert_new_assignments(
+                "user_andres",
+                [{"title": "Reading", "due_date": "2026-03-02", "notes": None}],
+            )
+        assert captured["rows"][0]["notes"] is None


### PR DESCRIPTION
Part of #126 (finding #4, **HIGH**). Split per request: this is the HIGH plaintext-write fix; the two LOW response-decrypt findings (#18/#19) follow in a separate PR.

## Vulnerability
`insert_new_assignments` (`services/calendar_service.py`) wrote `"notes": a.get("notes")` with **no `encrypt_if_present`**. `assignments.notes` is an encrypted column; every other writer (`calendar.py:128`, `gradebook.py:252`) encrypts. Uploading a syllabus persisted assignment notes as **plaintext at rest**, defeating column encryption and spamming `decrypt_if_present fallback` warnings on read. This single function is the write site behind **both** callers — the calendar save flow and the documents upload pipeline (via `save_assignments_to_db` → `insert_new_assignments`).

## Fix
Wrap the write in `encrypt_if_present` (one line + import). Test asserts the value handed to the insert is ciphertext that `decrypt()`s back to the original plaintext; `None` stays `None`. Fails on pre-fix code (stored plaintext).

## ⚠️ Existing-data gap (NOT closed by this PR — needs your decision)
This stops **new** plaintext writes. **Rows already written in plaintext remain exposed at rest.** Evidence they exist: `services/encryption.py` ROLLOUT NOTES explicitly state the decrypt fallback exists so "legacy plaintext rows continue to load while a backfill is pending," and "a backfill script is required" — and none has run.

I could **not** get a live count: the only Supabase project reachable via MCP is `lajrjnjyvbpaaspzgpvh`, which is the unrelated **GTM-Builds** production DB (not Sapling), and the read was correctly denied as an unapproved prod query. Re-encrypting existing rows is a **data migration** (read each `assignments.notes`, attempt `decrypt`, re-`encrypt` on failure, write back) — exactly why the #197 migration framework matters. **Surfacing for a separate decision; not silently re-encrypting here.** See my message for the detection query + migration shape.

⚠️ Auth/encryption-boundary change — **do not merge**, opened for your review.