### PR TITLE
fix(security): decrypt gradebook-create + profile-settings responses (#126 #18, #19)

### DIFF
--- a/backend/routes/gradebook.py
+++ b/backend/routes/gradebook.py
@@ -252,7 +252,15 @@ def create_assignment(body: CreateAssignmentBody, request: Request):
         "notes": encrypt_if_present(body.notes),
         "source": "manual",
     })
-    return {"assignment": inserted[0] if inserted else None}
+    # #126 (#18): the insert representation returns the stored ciphertext for
+    # points/notes. Decrypt before returning so the client never receives
+    # ciphertext, matching the read path in get_course.
+    row = inserted[0] if inserted else None
+    if row:
+        row["points_possible"] = decrypt_numeric(row.get("points_possible"))
+        row["points_earned"] = decrypt_numeric(row.get("points_earned"))
+        row["notes"] = decrypt_if_present(row.get("notes"))
+    return {"assignment": row}
 
 
 @router.patch("/assignments/{assignment_id}")

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -346,7 +346,9 @@ def update_settings(user_id: str, body: UpdateSettingsBody, request: Request):
         updates["updated_at"] = datetime.now(timezone.utc).isoformat()
         table("user_settings").update(updates, filters={"user_id": f"eq.{user_id}"})
 
-    return table("user_settings").select(_SETTINGS_COLS, filters={"user_id": f"eq.{user_id}"})[0]
+    # #126 (#19): return through the decrypting helper (like GET) so the
+    # response carries plaintext bio/location, not the stored ciphertext.
+    return _get_or_create_settings(user_id)
 
 
 # ── Equip Cosmetic ───────────────────────────────────────────────────────────

--- a/backend/tests/test_response_decrypt_boundary.py
+++ b/backend/tests/test_response_decrypt_boundary.py
@@ -1,0 +1,88 @@
+"""
+Regression tests for #126 findings #18 and #19: two response-boundary leaks
+where an encrypted column was returned to the (authenticated, owning) client as
+ciphertext instead of plaintext.
+
+These are encryption-boundary correctness tests (owner-only, NOT cross-user):
+they assert the response carries decrypted plaintext, and would fail pre-fix
+(which returned the stored ciphertext).
+"""
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+from services.encryption import encrypt_if_present
+
+client = TestClient(app)
+
+
+class TestGradebookCreateAssignmentResponse:
+    """#18: create_assignment returned inserted[0] — the stored ciphertext for
+    points_possible/points_earned/notes — with no decrypt."""
+
+    def test_response_is_decrypted_not_ciphertext(self):
+        stored = {
+            "id": "a1",
+            "user_id": "user_andres",
+            "course_id": "c1",
+            "category_id": None,
+            "title": "HW1",
+            "due_date": "2026-03-01",
+            "assignment_type": "homework",
+            "points_possible": encrypt_if_present(100),
+            "points_earned": encrypt_if_present(95),
+            "notes": encrypt_if_present("Study chapters 1-3"),
+            "source": "manual",
+        }
+        with patch("routes.gradebook._user_owns_course", return_value=True), \
+             patch("routes.gradebook.table") as t:
+            t.return_value.insert.return_value = [dict(stored)]
+            r = client.post(
+                "/api/gradebook/assignments",
+                json={
+                    "user_id": "user_andres",
+                    "course_id": "c1",
+                    "title": "HW1",
+                    "points_possible": 100,
+                    "points_earned": 95,
+                    "notes": "Study chapters 1-3",
+                },
+            )
+
+        assert r.status_code == 200
+        a = r.json()["assignment"]
+        # Pre-fix these were the stored ciphertext strings.
+        assert a["points_possible"] == 100.0
+        assert a["points_earned"] == 95.0
+        assert a["notes"] == "Study chapters 1-3"
+        assert a["notes"] != stored["notes"]
+
+
+class TestProfileSettingsPatchResponse:
+    """#19: PATCH /settings returned a raw select of _SETTINGS_COLS with no
+    decrypt, unlike GET — so bio/location came back as ciphertext."""
+
+    def test_response_is_decrypted_not_ciphertext(self):
+        stored = {
+            "user_id": "user_andres",
+            "bio": encrypt_if_present("my secret bio"),
+            "location": encrypt_if_present("Boston, MA"),
+            "theme": "dark",
+            "profile_visibility": "public",
+        }
+
+        with patch("routes.profile.table") as t:
+            # Fresh copy per call so _get_or_create_settings' in-place decrypt
+            # doesn't bleed across the two selects it performs.
+            t.return_value.select.side_effect = lambda *a, **k: [dict(stored)]
+            r = client.patch(
+                "/api/profile/user_andres/settings",
+                json={"theme": "light"},
+            )
+
+        assert r.status_code == 200
+        body = r.json()
+        # Pre-fix bio/location came back as ciphertext.
+        assert body["bio"] == "my secret bio"
+        assert body["location"] == "Boston, MA"


### PR DESCRIPTION
Part of #126 (findings #18 & #19, both **LOW**). Second of the two #126 PRs (the HIGH plaintext-write is #226).

## Two response-boundary leaks (owner-only, not cross-user)
- **#18** — `gradebook.create_assignment` returned `inserted[0]`, i.e. the stored **ciphertext** for `points_possible`/`points_earned`/`notes`, with no decrypt. (Masked today only because `Course.tsx` reloads and discards the response.)
- **#19** — `profile` PATCH `/settings` returned a raw `_SETTINGS_COLS` select with no decrypt, unlike GET — so `bio`/`location` came back as ciphertext.

## Fixes
- gradebook: decrypt the inserted row's points/notes before returning, mirroring `get_course`'s read path (`decrypt_numeric`/`decrypt_if_present`, already imported).
- profile: return through the decrypting `_get_or_create_settings(user_id)` helper instead of a raw select.

## Tests
`tests/test_response_decrypt_boundary.py`: both assert the response carries **plaintext**, not the stored ciphertext. Both **fail on pre-fix code** (ciphertext returned). Full gradebook + profile route suites pass (51 tests).

⚠️ Encryption-boundary change — **do not merge**, opened for your review.