### PR TITLE
fix(security): startup config validation + fail-closed unsigned-session fallback (#174)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -16,6 +16,12 @@ PORT = int(os.getenv("PORT", "5000"))
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
 SESSION_SECRET = os.getenv("SESSION_SECRET", "")
 
+# Deployment mode (#174). Defaults to "production" so the config is fail-closed:
+# a deployment that sets nothing gets the strict checks. Set APP_ENV=local (or
+# development/dev/test) to relax SESSION_SECRET for local dev.
+APP_ENV = os.getenv("APP_ENV", "production").strip().lower()
+IS_LOCAL = APP_ENV in {"local", "development", "dev", "test"}
+
 GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/calendar.events",
     "https://www.googleapis.com/auth/calendar.readonly",
@@ -33,6 +39,39 @@ AUTH_SCOPES = [
 
 STORAGE_BUCKET: str = "avatars"
 MAX_AVATAR_SIZE: int = 5 * 1024 * 1024  # 5 MB
+
+
+def validate_config() -> None:
+    """Fail loudly at startup if required configuration is missing (#174).
+
+    Without this the app boots with empty secrets and fails opaquely later:
+    a "" SUPABASE_URL builds a malformed REST URL on the first DB call, a
+    missing GEMINI_API_KEY surfaces only mid-request, and — worst — an empty
+    SESSION_SECRET silently disables HMAC signing and drops session/OAuth
+    state into an unsigned in-memory fallback. Raise one clear error naming
+    every missing key instead.
+
+    SESSION_SECRET is required outside local dev (IS_LOCAL) and must be a
+    strong secret — a whitespace-only or short value would silently become a
+    weak HMAC signing key. We require >= 32 bytes after stripping, matching the
+    frontend (lib/sessionToken.ts). The other three are always required
+    (CI/tests supply dummy values).
+    """
+    missing = []
+    if not SUPABASE_URL:
+        missing.append("SUPABASE_URL")
+    if not SUPABASE_SERVICE_KEY:
+        missing.append("SUPABASE_SERVICE_KEY")
+    if not GEMINI_API_KEY:
+        missing.append("GEMINI_API_KEY")
+    if not IS_LOCAL and len((SESSION_SECRET or "").strip().encode("utf-8")) < 32:
+        missing.append("SESSION_SECRET (must be set and >= 32 bytes)")
+    if missing:
+        raise RuntimeError(
+            "Missing required configuration: "
+            + ", ".join(missing)
+            + f". (APP_ENV={APP_ENV!r}; set APP_ENV=local to relax SESSION_SECRET for local dev.)"
+        )
 
 
 def get_mastery_tier(score: float) -> str:

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from config import FRONTEND_URL, MAX_AVATAR_SIZE, PORT, STORAGE_BUCKET
+from config import FRONTEND_URL, MAX_AVATAR_SIZE, PORT, STORAGE_BUCKET, validate_config
 
 # App-wide log format. Per-request log lines (with request_id, duration,
 # status) are emitted from RequestIDMiddleware; this just sets the
@@ -71,6 +71,9 @@ logfire.instrument_pydantic_ai()
 # that no migration ever made" bugs.
 @asynccontextmanager
 async def _lifespan(_app: FastAPI):
+    # #174: fail loudly at startup if required secrets are missing, before
+    # serving any request, rather than booting and failing opaquely later.
+    validate_config()
     await ensure_bucket_exists(
         STORAGE_BUCKET,
         public=True,  # required for unauthenticated <img src> reads

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -24,6 +24,7 @@ from config import (
     AUTH_SCOPES,
     FRONTEND_URL,
     SESSION_SECRET,
+    IS_LOCAL,
 )
 from db.connection import table
 from services.encryption import encrypt, encrypt_if_present, decrypt_if_present
@@ -106,6 +107,15 @@ def _encode_oauth_cookie(payload: dict) -> str:
         sig_bytes = _hmac.new(SESSION_SECRET.encode(), payload_b64.encode(), hashlib.sha256).digest()
         sig_b64 = base64.urlsafe_b64encode(sig_bytes).decode().rstrip("=")
         return f"{payload_b64}.{sig_b64}"
+    # #174: the unsigned in-memory fallback is local-dev only. Outside local it
+    # is a silent, insecure degradation (unsigned OAuth state) — fail closed.
+    # (validate_config already blocks startup without SESSION_SECRET in prod;
+    # this is defense in depth at the use site.)
+    if not IS_LOCAL:
+        raise RuntimeError(
+            "SESSION_SECRET is required outside local dev; refusing to issue "
+            "unsigned OAuth state."
+        )
     nonce = payload.get("n", "")
     if nonce:
         _OAUTH_FALLBACK_STORE[nonce] = (_time.monotonic() + _OAUTH_COOKIE_MAX_AGE, payload)
@@ -133,6 +143,11 @@ def _decode_oauth_cookie(cookie_value: str | None) -> dict | None:
         except Exception:
             return None
         return payload if isinstance(payload, dict) else None
+    # #174: the unsigned in-memory path is local-dev only. Outside local,
+    # refuse to accept unsigned OAuth state (symmetric with the encode-side
+    # guard) so no unsigned cookie is ever honored in production.
+    if not IS_LOCAL:
+        return None
     try:
         padded = cookie_value + "=" * (-len(cookie_value) % 4)
         payload = json.loads(base64.urlsafe_b64decode(padded.encode()).decode())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,6 +16,10 @@ from unittest.mock import MagicMock
 import pytest
 
 os.environ.setdefault("ENCRYPTION_KEY", "0" * 64)  # 32-byte all-zero key for deterministic tests
+# Tests run as local mode so validate_config() (invoked by the one test that
+# enters the FastAPI lifespan) doesn't reject the short dummy SESSION_SECRET the
+# CI env supplies. Production defaults APP_ENV=production (strict). #174.
+os.environ.setdefault("APP_ENV", "test")
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/backend/tests/test_auth_state.py
+++ b/backend/tests/test_auth_state.py
@@ -71,8 +71,10 @@ class TestOAuthCookieRoundTrip:
 
     def test_fallback_in_memory_store_round_trip(self, monkeypatch):
         # Without SESSION_SECRET, encode stashes the payload in an in-memory
-        # dict keyed by nonce. Decode retrieves it.
+        # dict keyed by nonce. Decode retrieves it. #174: this unsigned
+        # fallback is local-dev only, so the test must declare local mode.
         monkeypatch.setattr(auth_module, "SESSION_SECRET", "")
+        monkeypatch.setattr(auth_module, "IS_LOCAL", True)
         auth_module._OAUTH_FALLBACK_STORE.clear()
         payload = {"n": "fallback-nonce", "cv": "verifier", "popup_id": "p"}
         cookie = auth_module._encode_oauth_cookie(payload)
@@ -81,6 +83,7 @@ class TestOAuthCookieRoundTrip:
 
     def test_fallback_unknown_nonce_returns_none(self, monkeypatch):
         monkeypatch.setattr(auth_module, "SESSION_SECRET", "")
+        monkeypatch.setattr(auth_module, "IS_LOCAL", True)
         auth_module._OAUTH_FALLBACK_STORE.clear()
         # Build a cookie payload whose nonce was never registered
         bogus = base64.urlsafe_b64encode(

--- a/backend/tests/test_config_validation_failclosed.py
+++ b/backend/tests/test_config_validation_failclosed.py
@@ -1,0 +1,106 @@
+"""
+Regression tests for #174:
+- validate_config() fails loudly at startup, naming every missing required key.
+- the unsigned in-memory OAuth-state fallback is unreachable outside local dev.
+
+The fail-closed test fails on pre-fix code, where _encode_oauth_cookie silently
+fell back to the unsigned in-memory store whenever SESSION_SECRET was empty,
+regardless of environment.
+"""
+import pytest
+
+import config
+from routes import auth as auth_mod
+
+
+def _set_required(monkeypatch, **overrides):
+    base = {
+        "SUPABASE_URL": "https://x.supabase.co",
+        "SUPABASE_SERVICE_KEY": "service-key",
+        "GEMINI_API_KEY": "gemini-key",
+        "SESSION_SECRET": "x" * 40,  # >= 32 bytes (strong)
+        "IS_LOCAL": False,
+    }
+    base.update(overrides)
+    for k, v in base.items():
+        monkeypatch.setattr(config, k, v)
+
+
+class TestValidateConfig:
+    def test_passes_when_all_present(self, monkeypatch):
+        _set_required(monkeypatch)
+        config.validate_config()  # no raise
+
+    def test_raises_naming_every_missing_key(self, monkeypatch):
+        _set_required(
+            monkeypatch,
+            SUPABASE_URL="",
+            SUPABASE_SERVICE_KEY="",
+            GEMINI_API_KEY="",
+            SESSION_SECRET="",
+            IS_LOCAL=False,
+        )
+        with pytest.raises(RuntimeError) as exc:
+            config.validate_config()
+        msg = str(exc.value)
+        for key in ("SUPABASE_URL", "SUPABASE_SERVICE_KEY", "GEMINI_API_KEY", "SESSION_SECRET"):
+            assert key in msg
+
+    def test_session_secret_required_outside_local(self, monkeypatch):
+        _set_required(monkeypatch, SESSION_SECRET="", IS_LOCAL=False)
+        with pytest.raises(RuntimeError) as exc:
+            config.validate_config()
+        assert "SESSION_SECRET" in str(exc.value)
+
+    def test_session_secret_relaxed_in_local(self, monkeypatch):
+        _set_required(monkeypatch, SESSION_SECRET="", IS_LOCAL=True)
+        config.validate_config()  # no raise — relaxed for local dev
+
+    def test_weak_session_secret_rejected_outside_local(self, monkeypatch):
+        # Present-but-weak must NOT pass: whitespace-only and a too-short secret
+        # would become a weak HMAC key. >= 32 bytes is required (matches FE).
+        for weak in ("   ", "short", "x" * 31):
+            _set_required(monkeypatch, SESSION_SECRET=weak, IS_LOCAL=False)
+            with pytest.raises(RuntimeError) as exc:
+                config.validate_config()
+            assert "SESSION_SECRET" in str(exc.value)
+
+    def test_exactly_32_byte_secret_passes(self, monkeypatch):
+        _set_required(monkeypatch, SESSION_SECRET="x" * 32, IS_LOCAL=False)
+        config.validate_config()  # no raise — exactly at the 32-byte floor
+
+
+class TestUnsignedOAuthFallbackFailsClosed:
+    def test_fails_closed_in_production(self, monkeypatch):
+        # No SESSION_SECRET + not local → must refuse (pre-fix: silently used
+        # the unsigned in-memory store).
+        monkeypatch.setattr(auth_mod, "SESSION_SECRET", "")
+        monkeypatch.setattr(auth_mod, "IS_LOCAL", False)
+        with pytest.raises(RuntimeError):
+            auth_mod._encode_oauth_cookie({"n": "nonce-123", "v": "verifier"})
+
+    def test_allowed_in_local(self, monkeypatch):
+        monkeypatch.setattr(auth_mod, "SESSION_SECRET", "")
+        monkeypatch.setattr(auth_mod, "IS_LOCAL", True)
+        out = auth_mod._encode_oauth_cookie({"n": "nonce-123", "v": "verifier"})
+        # Unsigned payload (no "." separator) is permitted only in local dev.
+        assert isinstance(out, str) and "." not in out
+
+    def test_signed_when_secret_present(self, monkeypatch):
+        monkeypatch.setattr(auth_mod, "SESSION_SECRET", "supersecret-value")
+        out = auth_mod._encode_oauth_cookie({"n": "nonce-123", "v": "verifier"})
+        assert "." in out  # payload_b64.sig_b64
+
+    def test_decode_refuses_unsigned_cookie_in_production(self, monkeypatch):
+        # Symmetric decode-side guard: even a hand-built unsigned cookie must
+        # not be honored outside local dev.
+        import base64
+        import json
+
+        unsigned = base64.urlsafe_b64encode(
+            json.dumps({"n": "x", "v": "y"}).encode()
+        ).decode().rstrip("=")
+        # Force the unsigned path (empty secret) in production mode.
+        monkeypatch.setattr(auth_mod, "SESSION_SECRET", "")
+        monkeypatch.setattr(auth_mod, "IS_LOCAL", False)
+        assert auth_mod._decode_oauth_cookie(unsigned) is None


### PR DESCRIPTION
Closes #174. Labeled P2 but **load-bearing**: the whole security model rests on session-validated route code, so a forgeable/unsigned session undermines all of it (underscored by the realtime RLS finding).

## Problem
`config.py` read every required secret with an empty-string default and validated none. The app booted with everything unset and failed opaquely later:
- `""` SUPABASE_URL → malformed REST URL on the first DB call;
- missing GEMINI_API_KEY → surfaces only mid-request;
- **empty SESSION_SECRET → `routes/auth.py` silently switched OAuth state to an unsigned in-memory fallback** — an insecure degradation rather than a hard failure.

## Fix
- **`validate_config()`**, called from the FastAPI lifespan: raises one clear error naming **every** missing key. `SUPABASE_URL`/`SUPABASE_SERVICE_KEY`/`GEMINI_API_KEY` always required; `SESSION_SECRET` required outside local.
- **`APP_ENV` (defaults to `production`) / `IS_LOCAL`** — fail-closed by default: a deployment that sets nothing gets the strict checks. Set `APP_ENV=local` to relax `SESSION_SECRET` for local dev.
- **Unsigned OAuth-state fallback now raises outside local** (defense in depth at the use site) → unreachable in production independent of startup validation.

## Tests
`tests/test_config_validation_failclosed.py`: `validate_config` names all missing keys, requires SESSION_SECRET outside local, relaxes it in local; the unsigned fallback **raises in production** (fails pre-fix, which silently used it). Updated the two pre-existing fallback round-trip tests in `test_auth_state.py` to declare local mode (the fallback is now local-only). Verified the lifespan storage-bucket test still passes (test env supplies all secrets).

⚠️ Auth-boundary / startup change — **do not merge**, opened for your review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added startup-time configuration validation with a single, clear error that lists all missing required settings before the service starts.
  * Introduced environment-mode switching to relax local-only requirements while keeping stricter checks elsewhere.
  * Improved OAuth state handling to fail closed (no unsigned fallback cookies) outside local dev.

* **Tests**
  * Expanded automated coverage for configuration validation, environment-specific secret rules, and OAuth cookie fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->