### PR TITLE
fix(security): auth + size cap + rate limit on OCR extract endpoints (#182)

### DIFF
--- a/backend/routes/extract.py
+++ b/backend/routes/extract.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from fastapi import APIRouter, File, HTTPException, Query, UploadFile
+from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
 
 from services.extraction_service import (
     extract_text_from_image_bytes,
@@ -11,8 +11,33 @@ from services.extraction_service import (
 from services.extraction_backends.docling_backend import docling_available
 from services.extraction_backends.got_ocr_backend import got_ocr_available
 from services.extraction_backends.tesseract_backend import tesseract_available
+from services.auth_guard import get_session_user_id
+from services.request_limits import check_rate_limit, read_within_limit
 
 router = APIRouter()
+
+# #182: these endpoints run multi-second Docling/tesseract OCR. They were
+# unauthenticated, unbounded, and unthrottled — an anonymous caller could drive
+# unbounded OCR load/cost. Require a session, cap upload size, and rate-limit.
+MAX_OCR_BYTES = 20 * 1024 * 1024  # 20 MB
+_OCR_RATE_LIMIT = 10              # requests...
+_OCR_RATE_WINDOW = 60             # ...per 60s, per user
+
+
+def _enforce_ocr_limits(request: Request) -> str:
+    """Require an authenticated session (401) and a per-user rate limit (429).
+    Returns the authenticated user_id."""
+    user_id = get_session_user_id(request)
+    retry = check_rate_limit(f"ocr:{user_id}", limit=_OCR_RATE_LIMIT, window_sec=_OCR_RATE_WINDOW)
+    if retry is not None:
+        # NB: the app's global HTTPException handler (main.py) doesn't forward
+        # exc.headers, so the retry budget is conveyed in the detail string
+        # rather than a Retry-After header.
+        raise HTTPException(
+            status_code=429,
+            detail=f"Too many OCR requests. Retry in {retry}s.",
+        )
+    return user_id
 
 
 def _ocr_unavailable_error(detail: str) -> HTTPException:
@@ -44,14 +69,16 @@ def extraction_health():
 
 @router.post("/pdf")
 async def extract_pdf(
+    request: Request,
     file: UploadFile = File(...),
     force_ocr: bool = Query(False),
     max_pages: int = Query(25, ge=1, le=200),
     lang: str = Query("eng"),
 ):
+    _enforce_ocr_limits(request)  # 401 unauthenticated, 429 rate-limited (#182)
     if file.content_type not in ALLOWED_PDF_TYPES:
         raise HTTPException(status_code=400, detail="Only PDF files are supported")
-    pdf_bytes = await file.read()
+    pdf_bytes = await read_within_limit(file, MAX_OCR_BYTES)  # 413 if oversize (#182)
     if not pdf_bytes:
         raise HTTPException(status_code=400, detail="Empty file")
 
@@ -94,12 +121,14 @@ async def extract_pdf(
 
 @router.post("/image")
 async def extract_image(
+    request: Request,
     file: UploadFile = File(...),
     lang: str = Query("eng"),
 ):
+    _enforce_ocr_limits(request)  # 401 unauthenticated, 429 rate-limited (#182)
     if file.content_type not in ALLOWED_IMAGE_TYPES:
         raise HTTPException(status_code=400, detail="Only PNG/JPG/WEBP images are supported")
-    image_bytes = await file.read()
+    image_bytes = await read_within_limit(file, MAX_OCR_BYTES)  # 413 if oversize (#182)
     if not image_bytes:
         raise HTTPException(status_code=400, detail="Empty file")
 

--- a/backend/services/request_limits.py
+++ b/backend/services/request_limits.py
@@ -1,0 +1,46 @@
+"""Shared request-resource guards: per-key rate limiting and upload size bounds.
+
+Factored for reuse across CPU/cost-heavy endpoints (OCR extraction, LLM). The
+flashcard import service has an older copy of the same sliding-window limiter
+(`services/flashcard_import_service.check_rate_limit`) that can migrate here.
+"""
+import time
+
+from fastapi import HTTPException, UploadFile
+
+# In-memory sliding-window state, keyed by an arbitrary string (e.g.
+# "ocr:<user_id>"). Process-local — fine for a single-instance deployment; a
+# multi-instance rollout would move this to Redis.
+_rate_state: dict[str, list[float]] = {}
+
+
+def check_rate_limit(key: str, *, limit: int, window_sec: int) -> int | None:
+    """Sliding-window per-key limiter.
+
+    Returns None if the call is allowed (and records it), else the number of
+    seconds until the next call would be allowed.
+    """
+    now = time.time()
+    bucket = [t for t in _rate_state.get(key, []) if now - t < window_sec]
+    if len(bucket) >= limit:
+        retry = int(window_sec - (now - bucket[0])) + 1
+        _rate_state[key] = bucket
+        return retry
+    bucket.append(now)
+    _rate_state[key] = bucket
+    return None
+
+
+async def read_within_limit(upload: UploadFile, max_bytes: int) -> bytes:
+    """Read at most ``max_bytes`` (+1 to detect overflow) from an UploadFile so
+    an oversize upload can't be pulled fully into memory before we reject it.
+
+    Raises 413 if the upload exceeds ``max_bytes``.
+    """
+    data = await upload.read(max_bytes + 1)
+    if len(data) > max_bytes:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large. Maximum size is {max_bytes // (1024 * 1024)} MB.",
+        )
+    return data

--- a/backend/tests/test_extract_auth_bounds.py
+++ b/backend/tests/test_extract_auth_bounds.py
@@ -1,0 +1,70 @@
+"""
+Regression tests for #182: /api/extract/pdf and /api/extract/image were
+unauthenticated, unbounded, unthrottled OCR endpoints. They now require an
+authenticated session (401), cap upload size (413), and rate-limit per user
+(429).
+
+Each negative test fails on pre-fix code (no auth, no size cap, no limiter).
+"""
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+import services.request_limits as request_limits
+
+client = TestClient(app)
+
+
+def _pdf_files():
+    # Fresh dict per request — the upload stream is consumed on read.
+    return {"file": ("doc.pdf", b"%PDF-1.4 hello world", "application/pdf")}
+
+
+def _png_files():
+    return {"file": ("img.png", b"\x89PNG\r\n\x1a\n payload", "image/png")}
+
+
+class TestExtractRequiresAuth:
+    def test_pdf_unauthenticated_returns_401(self):
+        from services import auth_guard
+
+        with patch("routes.extract.get_session_user_id", auth_guard._real_get_session_user_id), \
+             patch.object(auth_guard, "_decode_session", auth_guard._real_decode_session):
+            r = client.post("/api/extract/pdf", files=_pdf_files())
+        assert r.status_code == 401
+
+    def test_image_unauthenticated_returns_401(self):
+        from services import auth_guard
+
+        with patch("routes.extract.get_session_user_id", auth_guard._real_get_session_user_id), \
+             patch.object(auth_guard, "_decode_session", auth_guard._real_decode_session):
+            r = client.post("/api/extract/image", files=_png_files())
+        assert r.status_code == 401
+
+
+class TestExtractSizeBound:
+    def test_oversize_pdf_returns_413(self, monkeypatch):
+        request_limits._rate_state.clear()
+        # Shrink the cap so we don't have to ship 20 MB in a test.
+        monkeypatch.setattr("routes.extract.MAX_OCR_BYTES", 100)
+        with patch("routes.extract.extract_text_from_pdf_native", return_value=("x" * 100, 1)):
+            files = {"file": ("doc.pdf", b"P" * 200, "application/pdf")}
+            r = client.post("/api/extract/pdf", files=files)
+        assert r.status_code == 413
+
+
+class TestExtractRateLimit:
+    def test_pdf_rate_limited_after_threshold(self, monkeypatch):
+        request_limits._rate_state.clear()
+        monkeypatch.setattr("routes.extract._OCR_RATE_LIMIT", 2)
+        with patch("routes.extract.extract_text_from_pdf_native", return_value=("x" * 100, 1)):
+            r1 = client.post("/api/extract/pdf", files=_pdf_files())
+            r2 = client.post("/api/extract/pdf", files=_pdf_files())
+            r3 = client.post("/api/extract/pdf", files=_pdf_files())
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r3.status_code == 429
+        # Retry budget is conveyed in the detail (the app's global exception
+        # handler strips HTTPException headers).
+        assert "Retry in" in r3.json()["detail"]


### PR DESCRIPTION
Closes #182. P2.

## Vulnerability
`/api/extract/pdf` and `/api/extract/image` (`routes/extract.py`) took no `Request` and no auth guard, ran CPU-heavy Docling/tesseract OCR (up to 200 pages) for **any anonymous caller**, with **no size cap** and **no rate limit**. An attacker could drive unbounded OCR load/cost.

## Fix
- **Auth (401):** `get_session_user_id(request)` on both routes.
- **Size cap (413):** 20 MB via a **bounded read** (`read_within_limit`), reusing the #220 (#220/PR #220) bound/validate pattern — factored into a shared `services/request_limits.py`.
- **Rate limit (429):** per-user sliding window (`check_rate_limit`, 10/60s), same shape as the flashcard limiter, now in the shared module.

## Tests — `tests/test_extract_auth_bounds.py`
Unauthenticated PDF/image → **401**; oversize → **413**; over-threshold → **429**. All **fail on pre-fix code** (no auth/bounds/limiter).

## Follow-ups (noted, out of scope)
- `flashcard_import_service.check_rate_limit` is a duplicate of the now-shared limiter and can migrate to `request_limits` (would make it truly "shared" per the issue). Left untouched to avoid scope creep.
- `main.py`'s global `HTTPException` handler drops `exc.headers`, so the 429 conveys the retry budget in the `detail` string rather than a `Retry-After` header. Forwarding headers is a cross-cutting change worth its own PR.

⚠️ Auth-boundary change — **do not merge**, opened for your review.