### PR TITLE
fix(social): re-fetch realtime messages via decrypting REST + drop dead reactions sub (#124, #231)

### DIFF
--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -233,7 +233,7 @@
   },
   "src/components/screens/Social.tsx": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 11
+      "count": 9
     },
     "react-hooks/purity": {
       "count": 1

--- a/frontend/src/components/screens/Social.realtime.test.ts
+++ b/frontend/src/components/screens/Social.realtime.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { planMessageRealtimeAction } from './Social';
+
+/**
+ * #124: room_messages realtime payloads carry ciphertext `text`. The component
+ * must treat a foreign message event as a "re-fetch via the decrypting REST
+ * endpoint" signal rather than rendering payload.new.text. This tests the pure
+ * decision that drives that behavior.
+ */
+const ME = 'user_me';
+const THEM = 'user_other';
+
+describe('planMessageRealtimeAction (#124)', () => {
+  it('re-fetches on a foreign INSERT (never renders ciphertext payload)', () => {
+    expect(planMessageRealtimeAction('INSERT', { id: 'm1', user_id: THEM }, ME))
+      .toEqual({ type: 'refetch' });
+  });
+
+  it('ignores own INSERT echo (optimistic UI already has it)', () => {
+    expect(planMessageRealtimeAction('INSERT', { id: 'm1', user_id: ME }, ME))
+      .toEqual({ type: 'ignore' });
+  });
+
+  it('re-fetches on a foreign UPDATE (edit/delete carries ciphertext)', () => {
+    expect(planMessageRealtimeAction('UPDATE', { id: 'm1', user_id: THEM }, ME))
+      .toEqual({ type: 'refetch' });
+  });
+
+  it('applies only server flags on own UPDATE, keeping optimistic plaintext', () => {
+    expect(
+      planMessageRealtimeAction(
+        'UPDATE',
+        { id: 'm1', user_id: ME, is_deleted: true, edited_at: '2026-06-13T00:00:00Z' },
+        ME,
+      ),
+    ).toEqual({ type: 'applyOwnFlags', id: 'm1', is_deleted: true, edited_at: '2026-06-13T00:00:00Z' });
+  });
+
+  it('ignores malformed events (no row / no id)', () => {
+    expect(planMessageRealtimeAction('INSERT', null, ME)).toEqual({ type: 'ignore' });
+    expect(planMessageRealtimeAction('UPDATE', { user_id: THEM }, ME)).toEqual({ type: 'ignore' });
+  });
+});

--- a/frontend/src/components/screens/Social.tsx
+++ b/frontend/src/components/screens/Social.tsx
@@ -53,6 +53,45 @@ function supabaseClient() {
   }
 }
 
+// #124: room_messages.text is column-encrypted at rest; only the REST read path
+// decrypts it. Realtime postgres_changes payloads carry the raw CIPHERTEXT, so
+// rendering payload.new.text directly shows other users' messages as gibberish
+// until a manual reload. Treat a realtime message event as a "something changed"
+// signal and re-fetch through the decrypting REST endpoint instead of trusting
+// the payload — mirroring how this component already handles room_reactions.
+//
+// (This fixes DISPLAY only. It does not address the realtime channel's missing
+// authorization — that's the separate RLS/Realtime-Authorization work.)
+type RealtimeMsgAction =
+  | { type: "ignore" }
+  | { type: "refetch" }
+  | { type: "applyOwnFlags"; id: string; is_deleted: boolean; edited_at: string | null };
+
+export function planMessageRealtimeAction(
+  event: "INSERT" | "UPDATE",
+  row: { id?: string; user_id?: string; is_deleted?: boolean; edited_at?: string | null } | null | undefined,
+  currentUserId: string | null | undefined,
+): RealtimeMsgAction {
+  if (!row || !row.id) return { type: "ignore" };
+  const isOwn = row.user_id === currentUserId;
+  if (event === "INSERT") {
+    // Own inserts are shown optimistically and reconciled by the POST response;
+    // foreign inserts carry ciphertext text → re-fetch decrypted via REST.
+    return isOwn ? { type: "ignore" } : { type: "refetch" };
+  }
+  // UPDATE (edit / soft-delete): own edits keep their optimistic plaintext and
+  // take only the server-side flags; foreign edits re-fetch (ciphertext text).
+  if (isOwn) {
+    return {
+      type: "applyOwnFlags",
+      id: row.id,
+      is_deleted: !!row.is_deleted,
+      edited_at: row.edited_at ?? null,
+    };
+  }
+  return { type: "refetch" };
+}
+
 function CreateJoinBar({ onDone }: { onDone: () => void }) {
   const { userId } = useUser();
   const toast = useToast();
@@ -144,33 +183,27 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
       .on("postgres_changes",
         { event: "INSERT", schema: "public", table: "room_messages", filter: `room_id=eq.${roomId}` },
         (payload: any) => {
-          const row = payload.new as RoomMessageRow;
-          setMessages(prev => {
-            // Dedup by real id: the sender already has this row (optimistic tmp
-            // reconciled by the POST response, or a prior echo). Never append a
-            // realtime row that's already present, and don't clobber the loaded
-            // reply_to/reactions on a row we already have (issue #131).
-            if (prev.some(m => m.id === row.id)) return prev;
-            // Own messages are handled by send()'s POST reconciliation; skip the
-            // echo so we don't briefly render a ciphertext duplicate.
-            if (row.user_id === userId) return prev;
-            return [...prev, { ...row, reactions: [], reply_to: null }];
-          });
+          // #124: foreign inserts carry ciphertext text — re-fetch decrypted via
+          // REST rather than appending payload.new. Own echoes are ignored (the
+          // optimistic UI + POST reconciliation already have them).
+          const action = planMessageRealtimeAction("INSERT", payload.new, userId);
+          if (action.type === "refetch") void load();
         })
       .on("postgres_changes",
         { event: "UPDATE", schema: "public", table: "room_messages", filter: `room_id=eq.${roomId}` },
         (payload: any) => {
-          const row = payload.new as RoomMessageRow;
-          setMessages(prev => prev.map(m => {
-            if (m.id !== row.id) return m;
-            // Own edits/deletes are applied optimistically with plaintext; the
-            // echo carries ciphertext `text`, so don't overwrite it. Keep our
-            // text/edited_at, take server-side flags like is_deleted (issue #131).
-            if (row.user_id === userId) {
-              return { ...m, is_deleted: row.is_deleted, edited_at: row.edited_at ?? m.edited_at };
-            }
-            return { ...m, ...row, reply_to: m.reply_to, reactions: m.reactions };
-          }));
+          const action = planMessageRealtimeAction("UPDATE", payload.new, userId);
+          if (action.type === "refetch") {
+            // #124: foreign edit/delete — re-fetch decrypted via REST.
+            void load();
+          } else if (action.type === "applyOwnFlags") {
+            // Own edit/delete keeps its optimistic plaintext; take server flags.
+            setMessages(prev => prev.map(m =>
+              m.id === action.id
+                ? { ...m, is_deleted: action.is_deleted, edited_at: action.edited_at ?? m.edited_at }
+                : m,
+            ));
+          }
         })
       .on("postgres_changes",
         { event: "INSERT", schema: "public", table: "room_reactions" },

--- a/frontend/src/components/screens/Social.tsx
+++ b/frontend/src/components/screens/Social.tsx
@@ -58,7 +58,7 @@ function supabaseClient() {
 // rendering payload.new.text directly shows other users' messages as gibberish
 // until a manual reload. Treat a realtime message event as a "something changed"
 // signal and re-fetch through the decrypting REST endpoint instead of trusting
-// the payload — mirroring how this component already handles room_reactions.
+// the payload.
 //
 // (This fixes DISPLAY only. It does not address the realtime channel's missing
 // authorization — that's the separate RLS/Realtime-Authorization work.)
@@ -205,25 +205,12 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
             ));
           }
         })
-      .on("postgres_changes",
-        { event: "INSERT", schema: "public", table: "room_reactions" },
-        (payload: any) => {
-          // Scope the reload to this room: only reload if the reaction targets a
-          // message we have loaded, otherwise a reaction in any other room would
-          // refetch this open room (issue #131).
-          const mid = payload.new?.message_id;
-          if (mid) setMessages(prev => { if (prev.some(m => m.id === mid)) void load(); return prev; });
-        })
-      .on("postgres_changes",
-        { event: "DELETE", schema: "public", table: "room_reactions" },
-        (payload: any) => {
-          // DELETE payloads only carry the primary key (id), not message_id,
-          // unless the table has REPLICA IDENTITY FULL. Reload only when the
-          // affected message is loaded; if we can't tell, fall back to a reload.
-          const mid = payload.old?.message_id;
-          if (mid === undefined) { void load(); return; }
-          setMessages(prev => { if (prev.some(m => m.id === mid)) void load(); return prev; });
-        })
+      // #231: the room_reactions realtime subscription was dead code — the
+      // table is not in the supabase_realtime publication, so these handlers
+      // never fired. Removed. Reactions still update on load/refresh via REST;
+      // live reactions can be restored post-RLS by publishing room_reactions
+      // with a membership-scoped policy (see
+      // docs/security/realtime-jwt-bridge-design.md).
       .subscribe();
 
     return () => { supa.removeChannel(channel); };


### PR DESCRIPTION
Closes #124 (display bug). Also removes the dead room_reactions realtime subscription surfaced by the #231 audit.

## #124 — display fix
`room_messages.text` is column-encrypted; only the REST read path decrypts. The realtime subscription rendered `payload.new.text` (ciphertext) for other users' messages until a manual reload. Now: treat a realtime message event as a change signal and re-fetch via the decrypting `getRoomMessages` (mirroring how reactions used to). Own messages keep optimistic plaintext; own edits/deletes take only server flags. Decision logic is the pure, unit-tested `planMessageRealtimeAction`. **Display-only — does not address authorization (#231).**

## #231 cleanup — drop dead room_reactions subscription
Live check confirmed `room_reactions` is **not in the `supabase_realtime` publication**, so its INSERT/DELETE realtime handlers never fired. Removed as dead code; pruned the two now-unused `no-explicit-any` eslint baseline entries (11→9). Reactions still update on load/refresh via REST; live reactions can return post-RLS by publishing the table with a membership-scoped policy.

## Tests
`Social.realtime.test.ts` covers the planner (foreign INSERT/UPDATE → refetch; own INSERT → ignore; own UPDATE → applyOwnFlags; malformed → ignore). `eslint .` exits clean after the prune; tsc clean.

⚠️ **Do not merge** — opened for your review.