### PR TITLE
DRAFT (#231): RLS lockdown SQL + storage & realtime(a) remediation plans — do not merge/apply

### DIFF
--- a/backend/db/security/rls_lockdown.sql
+++ b/backend/db/security/rls_lockdown.sql
@@ -1,0 +1,86 @@
+-- ============================================================================
+-- PROJECT-WIDE RLS LOCKDOWN  (#231)  — DRAFT, REVIEW BEFORE APPLYING
+-- ============================================================================
+-- WHY: 38 of 40 public tables have RLS disabled and the `anon` role holds full
+-- DML (SELECT/INSERT/UPDATE/DELETE) on them. The anon key ships in the public
+-- frontend bundle, so with the Data API (PostgREST) exposed, anyone with that
+-- key can read/write the entire database directly — bypassing the FastAPI
+-- backend and every `require_self` check (incl. self-assigning admin via
+-- user_roles, reading every non-encrypted column, forging/deleting rows).
+--
+-- WHAT THIS DOES:
+--   1. ENABLE ROW LEVEL SECURITY on every public table that lacks it (38).
+--   2. REVOKE all DML from `anon` on every public table (40) — defense in depth.
+-- With RLS enabled and NO policies, `anon`/`authenticated` (rolbypassrls=false)
+-- are denied all rows; the backend's `service_role` (rolbypassrls=TRUE) is
+-- UNAFFECTED. Verified: SELECT rolname, rolbypassrls FROM pg_roles → service_role=t.
+--
+-- ONE-TIME DDL — this is NOT a #197-runner migration; apply once, by hand, after
+-- review. Idempotent: re-running ENABLE/REVOKE on an already-locked table is a
+-- no-op.
+--
+-- ⚠️ EXPECTED BREAKAGE: anon realtime on room_messages stops working until the
+-- option-(a) JWT bridge lands (see docs/security/realtime-jwt-bridge-design.md).
+-- Accepted: the full-DB exposure outranks live chat updates.
+--
+-- `authenticated` grants are intentionally LEFT in place: RLS-with-no-policy
+-- already denies that role today, and option (a) will add membership-scoped
+-- SELECT policies for it (which still require the table-level grant to exist).
+-- ============================================================================
+
+BEGIN;
+
+-- ── 1. Enable RLS on the 38 tables currently lacking it ─────────────────────
+-- (achievement_cosmetics and achievement_triggers already have RLS enabled.)
+ALTER TABLE public.achievements          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.admin_audit_log       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.assignments           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.cosmetics             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.course_categories     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.course_concept_stats  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.course_summary        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.courses               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.documents             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.feedback              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.flashcards            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.graph_edges           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.graph_nodes           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.issue_reports         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.job_applications      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.messages              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.newsletter_emails     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.note_concepts         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.notes                 ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.oauth_tokens          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.quiz_attempts         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.quiz_context          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.role_cosmetics        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.roles                 ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_activity         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_members          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_messages         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_reactions        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_summaries        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rooms                 ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sessions              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.study_guides          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_achievements     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_cosmetics        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_courses          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_roles            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_settings         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.users                 ENABLE ROW LEVEL SECURITY;
+
+-- ── 2. Revoke all anon DML across the public schema (all 40 tables) ─────────
+-- anon should have NO table access going forward; the frontend uses anon only
+-- for realtime (moving to a JWT under option (a)) and storage (separate track).
+REVOKE SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public FROM anon;
+
+-- Also stop FUTURE tables from silently re-granting anon (Supabase default
+-- ALTER DEFAULT PRIVILEGES grants to anon). Without this, the next table
+-- created reopens the hole.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM anon;
+
+COMMIT;
+
+-- Post-apply verification lives in docs/security/rls-lockdown-plan.md.

--- a/backend/db/security/rls_lockdown.sql
+++ b/backend/db/security/rls_lockdown.sql
@@ -79,7 +79,36 @@ REVOKE SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public FROM anon;
 -- Also stop FUTURE tables from silently re-granting anon (Supabase default
 -- ALTER DEFAULT PRIVILEGES grants to anon). Without this, the next table
 -- created reopens the hole.
+--
+-- ⚠️ IMPORTANT — ALTER DEFAULT PRIVILEGES is scoped PER CREATING ROLE.
+-- A default-privileges entry only affects objects created by the role named in
+-- `FOR ROLE` (or, with no FOR ROLE, by the role that RUNS this statement). If a
+-- migration creates a table as a DIFFERENT role than the one covered here, the
+-- anon GRANT from Supabase's own default privileges silently re-applies and the
+-- anon hole reopens — with no error and nothing to notice until the recurring
+-- verification (plan §2 / CI) catches it.
+--
+-- Therefore REVOKE the anon default privileges FOR EVERY role that creates
+-- tables in this project. Set the placeholders below to the ACTUAL migration
+-- role(s). To discover them, inspect who owns/creates objects, e.g.:
+--   SELECT DISTINCT defaclrole::regrole AS role_with_default_privs
+--   FROM pg_default_acl d JOIN pg_namespace n ON n.oid = d.defaclnamespace
+--   WHERE n.nspname = 'public';
+--   -- and review table owners:
+--   SELECT DISTINCT tableowner FROM pg_tables WHERE schemaname = 'public';
+-- Common candidates on Supabase: `postgres`, `supabase_admin`, the Supabase
+-- migration/dashboard role, and any service/CI role your migrations run as.
+--
+-- Cover the role running THIS script (no FOR ROLE) AND each known creator role.
+-- Add/remove FOR ROLE lines below to match your project; leaving a creating
+-- role out is exactly how the hole silently reopens.
 ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM anon;
+-- TODO(set-migration-role): replace/extend the roles below with this project's
+-- actual table-creating role(s) before applying. Keep `postgres` if migrations
+-- run as postgres; add your CI/migration role if different.
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres        IN SCHEMA public REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM anon;
+ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin  IN SCHEMA public REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM anon;
+-- ALTER DEFAULT PRIVILEGES FOR ROLE <your_migration_or_ci_role> IN SCHEMA public REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM anon;
 
 COMMIT;
 

--- a/backend/db/security/rls_lockdown_rollback.sql
+++ b/backend/db/security/rls_lockdown_rollback.sql
@@ -1,0 +1,62 @@
+-- ============================================================================
+-- ROLLBACK for rls_lockdown.sql (#231)  — ⚠️ EMERGENCY USE ONLY
+-- ============================================================================
+-- This RESTORES THE INSECURE PRE-LOCKDOWN STATE (anon regains full DML; RLS off
+-- on the 38 tables). Use ONLY if the lockdown breaks something critical and you
+-- must revert immediately. Re-apply rls_lockdown.sql + the option-(a) policies
+-- as soon as possible afterward.
+--
+-- Restores exactly what the lockdown changed:
+--   - re-grants anon DML across the public schema (+ default privileges),
+--   - disables RLS on the 38 tables that had it OFF before the lockdown.
+-- It deliberately does NOT touch achievement_cosmetics / achievement_triggers,
+-- which already had RLS enabled pre-lockdown.
+-- ============================================================================
+
+BEGIN;
+
+-- Re-grant anon DML (the Supabase pre-lockdown default).
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO anon;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon;
+
+-- Disable RLS on the 38 tables that were OFF before the lockdown.
+ALTER TABLE public.achievements          DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.admin_audit_log       DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.assignments           DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.cosmetics             DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.course_categories     DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.course_concept_stats  DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.course_summary        DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.courses               DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.documents             DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.feedback              DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.flashcards            DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.graph_edges           DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.graph_nodes           DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.issue_reports         DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.job_applications      DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.messages              DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.newsletter_emails     DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.note_concepts         DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.notes                 DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.oauth_tokens          DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.quiz_attempts         DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.quiz_context          DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.role_cosmetics        DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.roles                 DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_activity         DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_members          DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_messages         DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_reactions        DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.room_summaries        DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rooms                 DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sessions              DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.study_guides          DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_achievements     DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_cosmetics        DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_courses          DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_roles            DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_settings         DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.users                 DISABLE ROW LEVEL SECURITY;
+
+COMMIT;

--- a/backend/db/security/rls_lockdown_rollback.sql
+++ b/backend/db/security/rls_lockdown_rollback.sql
@@ -17,7 +17,14 @@ BEGIN;
 
 -- Re-grant anon DML (the Supabase pre-lockdown default).
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO anon;
+-- Reverse the per-role default-privileges REVOKEs from the apply script. These
+-- MUST mirror the FOR ROLE lines in rls_lockdown.sql exactly — if you edited the
+-- migration-role list there, edit it here too, or rollback leaves anon's default
+-- privileges partially revoked.
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres        IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon;
+ALTER DEFAULT PRIVILEGES FOR ROLE supabase_admin  IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon;
+-- ALTER DEFAULT PRIVILEGES FOR ROLE <your_migration_or_ci_role> IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO anon;
 
 -- Disable RLS on the 38 tables that were OFF before the lockdown.
 ALTER TABLE public.achievements          DISABLE ROW LEVEL SECURITY;

--- a/docs/security/realtime-jwt-bridge-design.md
+++ b/docs/security/realtime-jwt-bridge-design.md
@@ -26,9 +26,24 @@ claims: { sub: <user_id>, role: "authenticated", aud: "authenticated", exp: now+
   session.
 - New env `SUPABASE_JWT_SECRET` (from Supabase → Settings → API → JWT secret).
   Add it to `validate_config()` (#174) as required outside local.
-- Note: Supabase is migrating to **asymmetric signing keys**. If this project is
-  on the new keys, mint/verify with the project's signing key instead of an
-  HS256 shared secret — confirm which at build time.
+
+> 🚫 **BLOCKING PRECONDITION — verify the project's signing-key type before
+> building this.** This design signs an **HS256** JWT with the legacy shared JWT
+> secret. Supabase is migrating to **asymmetric signing keys** (RS256/ES256/
+> EdDSA via JWKS). **If this project has migrated to asymmetric keys, an HS256
+> token signed with the legacy secret will be rejected — `setAuth(jwt)` yields a
+> silent `401` with no obvious cause** (the channel just fails to authorize; no
+> exception points at the key type). Do NOT start the build until you have
+> confirmed the key type and chosen the matching signing path:
+> - **Legacy HS256 (shared secret present & in use):** proceed as written
+>   (sign/verify with `SUPABASE_JWT_SECRET`).
+> - **Asymmetric signing keys:** mint with the project's **current/active
+>   signing key** (the private key for the active `kid`); the legacy
+>   `SUPABASE_JWT_SECRET` will NOT work.
+> Check via Supabase → Settings → API → JWT Keys (or the dashboard's signing-keys
+> page): if a legacy HS256 secret is still the active signer, you're on HS256;
+> if an asymmetric key is active, you must use it. This check is a gate, not a
+> footnote — getting it wrong fails closed and silently.
 
 ### 2. RLS SELECT policy on room_messages (membership-scoped)
 ```sql
@@ -65,6 +80,34 @@ Two options, smallest first:
   before `expires_at` and call `setAuth` again — or the subscription drops when
   the JWT expires. Handle: tab wake from sleep, network reconnect, and a failed
   refresh (fall back to REST-only, which the #230 display fix already supports).
+
+### 5. Presence / typing channel (NOT broken by the lockdown — but re-verify under JWT)
+`Social.tsx` opens a **second** realtime channel besides the `room_messages`
+`postgres_changes` subscription: a presence/broadcast channel
+`presence:${roomId}` (`supa.channel(\`presence:${roomId}\`, { config: { presence:
+{ key: userId } } })`, ~`Social.tsx:200-225`). It uses Realtime **presence/
+broadcast** (`.on("presence", { event: "sync" })` + `ch.track({...})` for typing
+indicators) — it does **NOT** read or write any Postgres table.
+
+- **The anon DML REVOKE / RLS lockdown does NOT break this channel.** The lockdown
+  only revokes table DML and enables RLS; presence/broadcast is server-side
+  Realtime messaging with no table involved, so it keeps working on the anon key
+  exactly as before. Do not expect (or "fix") a presence regression from the
+  lockdown — there isn't one.
+- **BUT presence authorization MUST be re-verified when the client switches to
+  `setAuth(jwt)` / private channels.** Two things change once §4 lands:
+  - Calling `realtime.setAuth(token)` re-authorizes the **whole client**, so the
+    presence channel starts authorizing as the JWT user, not anon. Confirm
+    presence/typing still works after `setAuth` (and after each JWT refresh /
+    reconnect), and that a failed/expired token doesn't silently kill typing.
+  - If/when we adopt option (ii) **private channels** (`{ config: { private:
+    true } }`), the presence channel will require a `realtime.messages`
+    authorization policy for its topic (`presence:${roomId}`) too — scope it to
+    room membership, the same as `room_messages`. **Do not forget this channel
+    when writing the Realtime Authorization policies** — it's easy to police only
+    `room_messages` and leave presence unauthorized (or broken).
+- Net: presence is out of scope for the *lockdown* but **in scope for this
+  bridge's verification** — add it to the §4 client-wiring test matrix.
 
 ## Sequencing
 1. RLS lockdown (separate, urgent) — breaks anon realtime (accepted).

--- a/docs/security/realtime-jwt-bridge-design.md
+++ b/docs/security/realtime-jwt-bridge-design.md
@@ -1,0 +1,83 @@
+# Realtime option (a) — JWT-mint bridge (design, #231)
+
+**Status: DESIGN for review. Build AFTER the RLS lockdown lands** — this is the
+piece that restores `room_messages` realtime under RLS. Not built yet.
+
+## Goal
+Keep live chat working once RLS is enabled, **without** the public anon key:
+the realtime client authenticates as the logged-in user via a Supabase JWT, and
+an RLS policy scopes delivery to the user's room memberships.
+
+## Why a JWT is needed
+Sapling uses its **own HMAC session** (`sapling_session`), not Supabase Auth, so
+`auth.uid()` is empty and RLS can't identify the user. We bridge by minting a
+Supabase-format JWT for the same user and handing it to the realtime client.
+
+## Components
+
+### 1. Mint a Supabase JWT (backend)
+At login (and on refresh), the backend mints a short-lived JWT signed with the
+**Supabase JWT secret** (legacy HS256; the same secret behind the anon key):
+```
+claims: { sub: <user_id>, role: "authenticated", aud: "authenticated", exp: now+1h, iat: now }
+```
+- New endpoint, e.g. `GET /api/auth/realtime-token` (auth-gated by the existing
+  session): returns `{ token, expires_at }`, minted from the still-valid 30-day
+  session.
+- New env `SUPABASE_JWT_SECRET` (from Supabase → Settings → API → JWT secret).
+  Add it to `validate_config()` (#174) as required outside local.
+- Note: Supabase is migrating to **asymmetric signing keys**. If this project is
+  on the new keys, mint/verify with the project's signing key instead of an
+  HS256 shared secret — confirm which at build time.
+
+### 2. RLS SELECT policy on room_messages (membership-scoped)
+```sql
+CREATE POLICY room_messages_member_read ON public.room_messages
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.room_members m
+    WHERE m.room_id = room_messages.room_id AND m.user_id = auth.uid()
+  ));
+```
+With the lockdown's RLS enabled and the JWT setting `auth.uid()`, an
+`authenticated` subscriber receives changes **only for rooms they belong to** —
+the client-side `room_id` filter stops being the only gate. (`authenticated`
+still holds the table GRANT SELECT, which the lockdown intentionally left.)
+
+### 3. Realtime delivery
+Two options, smallest first:
+- **(i) postgres_changes + the RLS policy above (recommended).** Realtime
+  evaluates the subscriber's RLS on each change, so the existing
+  `Social.tsx` subscription keeps working but is now membership-scoped. Minimal
+  client change: set the JWT (below). `room_messages` is already in the
+  `supabase_realtime` publication.
+- **(ii) Private channels (Realtime Authorization).** Mark the channel
+  `{ config: { private: true } }` and add a policy on `realtime.messages` for
+  the topic. More robust/explicit but a larger client rework. Defer unless (i)
+  proves insufficient.
+
+### 4. Client wiring (frontend)
+- After login, fetch the realtime token and apply it:
+  `getSupabase().realtime.setAuth(token)` (and pass it when (re)creating the
+  client). The client stops relying on the anon key for authorization.
+- **JWT refresh (the main complexity):** the session is **30 days** but the
+  Supabase JWT is **~1 hour**. Add a refresh loop — re-fetch the token shortly
+  before `expires_at` and call `setAuth` again — or the subscription drops when
+  the JWT expires. Handle: tab wake from sleep, network reconnect, and a failed
+  refresh (fall back to REST-only, which the #230 display fix already supports).
+
+## Sequencing
+1. RLS lockdown (separate, urgent) — breaks anon realtime (accepted).
+2. This bridge — restores realtime for authenticated users, membership-scoped.
+
+## Effort estimate
+Moderate. Backend JWT-mint endpoint + env wiring (small); RLS SELECT policy
+(small); client setAuth (small); **JWT refresh loop + reconnect handling
+(the real work)**. Reuses the existing Supabase realtime architecture — no
+backend fan-out/broker, no client rebuild (contrast option (c)).
+
+## Optional follow-up
+If live reactions are wanted back (the dead `room_reactions` subscription is
+being removed), publish `room_reactions` to `supabase_realtime` and add the same
+membership-scoped SELECT policy. Until then, reactions update on
+load/refresh via REST.

--- a/docs/security/rls-lockdown-plan.md
+++ b/docs/security/rls-lockdown-plan.md
@@ -1,0 +1,93 @@
+# Project-wide RLS lockdown — apply & verification plan (#231)
+
+**Status: DRAFT for review. Do not apply until reviewed.** One-time DDL, not a
+`#197`-runner migration. Scripts: `backend/db/security/rls_lockdown.sql` (apply),
+`backend/db/security/rls_lockdown_rollback.sql` (emergency revert).
+
+## Why this is safe for the backend
+The backend authenticates to Supabase with `SUPABASE_SERVICE_KEY` → the
+`service_role`, which has **`rolbypassrls = true`** (verified live: `SELECT
+rolname, rolbypassrls FROM pg_roles` → `service_role=t`, `anon=f`,
+`authenticated=f`). RLS does not apply to row-bypass roles, so **every backend
+query keeps working unchanged**. RLS only constrains `anon`/`authenticated`,
+which is exactly the public-anon-key path we're closing.
+
+## Expected breakage (accepted)
+Anon realtime on `room_messages` stops delivering once RLS is on / anon DML is
+revoked. This stays broken until the **option (a)** JWT bridge lands
+(`docs/security/realtime-jwt-bridge-design.md`). Per decision, the full-DB
+exposure outranks live chat updates. The #230 display fix already re-fetches via
+the (service-role) REST endpoint, so chat still works on load/refresh — only the
+live push is paused.
+
+## Test-first on a branch (if available)
+Supabase branching wasn't reachable via the MCP for this project (`list_branches`
+errored), so it may be on a plan/permission that doesn't expose it. If you have
+branching:
+1. Create a dev branch in the dashboard.
+2. Run `rls_lockdown.sql` against the branch.
+3. Run the verification below pointed at the branch.
+4. Merge the branch (or apply the same SQL to prod) once green.
+
+If branching is unavailable: apply to prod during a low-traffic window with
+`rls_lockdown_rollback.sql` open and ready. The change is transactional
+(`BEGIN/COMMIT`) and fast (DDL only, no table rewrites).
+
+## Pre-apply snapshot (record for diffing)
+```sql
+SELECT count(*) FILTER (WHERE relrowsecurity) AS rls_on,
+       count(*) FILTER (WHERE NOT relrowsecurity) AS rls_off
+FROM pg_class WHERE relnamespace='public'::regnamespace AND relkind='r';
+-- expected before: rls_on=2, rls_off=38
+```
+
+## Apply
+Run `backend/db/security/rls_lockdown.sql`.
+
+## Post-apply verification checklist
+1. **RLS now on for all public tables:**
+   ```sql
+   SELECT count(*) FILTER (WHERE NOT relrowsecurity) AS still_off
+   FROM pg_class WHERE relnamespace='public'::regnamespace AND relkind='r';
+   -- expect: still_off = 0
+   ```
+2. **anon has no table DML left:**
+   ```sql
+   SELECT count(*) AS anon_grants
+   FROM information_schema.role_table_grants
+   WHERE table_schema='public' AND grantee='anon'
+     AND privilege_type IN ('SELECT','INSERT','UPDATE','DELETE');
+   -- expect: anon_grants = 0
+   ```
+3. **anon is blocked at the REST endpoint** (the actual exposure): with the
+   public anon key,
+   ```
+   curl -s -o /dev/null -w "%{http_code}\n" \
+     "https://jxqcmjqtjlpuxfrxmrdv.supabase.co/rest/v1/users?select=id&limit=1" \
+     -H "apikey: <ANON_KEY>" -H "Authorization: Bearer <ANON_KEY>"
+   ```
+   Expect **401** (or `[]` with permission-denied), not a row. Repeat for
+   `user_roles`, `oauth_tokens`, `messages`.
+4. **Backend still works (service_role):**
+   - `cd backend && python -m pytest tests/ -q` (suite is hermetic; sanity only).
+   - Hit live read + write endpoints against the target DB and confirm normal
+     behavior, e.g. `GET /api/auth/me` (read), a calendar/gradebook create
+     (write), a notes save. All should succeed exactly as before (service_role
+     bypasses RLS).
+5. **Realtime is paused (expected):** open a room — messages still load and
+   refresh via REST; live push is down until option (a). No errors beyond the
+   subscription returning nothing.
+
+## Rollback
+If something critical breaks: run
+`backend/db/security/rls_lockdown_rollback.sql` (re-grants anon, disables RLS on
+the 38). ⚠️ This restores the insecure state — re-apply the lockdown + option
+(a) as soon as the issue is understood.
+
+## Follow-ups (not in this script)
+- `authenticated` keeps its grants (RLS-with-no-policy denies it today); option
+  (a) adds membership-scoped policies for it on `room_messages`.
+- Storage hardening is a separate track (`docs/security/storage-hardening-plan.md`).
+- The 2 already-RLS tables (`achievement_cosmetics`, `achievement_triggers`)
+  have RLS on but **no policies** — confirm nothing legitimately reads them via
+  anon (the backend uses service_role, so it's unaffected).

--- a/docs/security/rls-lockdown-plan.md
+++ b/docs/security/rls-lockdown-plan.md
@@ -51,7 +51,7 @@ Run `backend/db/security/rls_lockdown.sql`.
    FROM pg_class WHERE relnamespace='public'::regnamespace AND relkind='r';
    -- expect: still_off = 0
    ```
-2. **anon has no table DML left:**
+2. **anon has no table DML left (RECURRING — wire into CI/cron as a blocking check):**
    ```sql
    SELECT count(*) AS anon_grants
    FROM information_schema.role_table_grants
@@ -59,15 +59,40 @@ Run `backend/db/security/rls_lockdown.sql`.
      AND privilege_type IN ('SELECT','INSERT','UPDATE','DELETE');
    -- expect: anon_grants = 0
    ```
+   This must not just pass once. The `ALTER DEFAULT PRIVILEGES ... REVOKE ...
+   FROM anon` in `rls_lockdown.sql` is scoped per creating role, so a future
+   migration that creates a table as a role NOT covered by a `FOR ROLE` clause
+   will silently re-grant anon and reopen the hole with no error. **Wire this
+   exact query into CI and/or a scheduled cron as a BLOCKING assertion**
+   (`anon_grants = 0`; fail/alert on any non-zero result). Concretely:
+   - **CI:** run it (via the Supabase MCP `execute_sql`, `psql`, or a small
+     script) on every migration/deploy that touches the schema, and fail the
+     pipeline if `anon_grants > 0`.
+   - **Cron:** run it on a recurring schedule (e.g. daily) against prod and
+     alert on any non-zero result, to catch out-of-band table creation.
+   If it ever trips, find the creating role (see the discovery query in
+   `rls_lockdown.sql`) and add a matching `FOR ROLE <role>` REVOKE line there.
 3. **anon is blocked at the REST endpoint** (the actual exposure): with the
    public anon key,
    ```
-   curl -s -o /dev/null -w "%{http_code}\n" \
+   curl -s -w "\n%{http_code}\n" \
      "https://jxqcmjqtjlpuxfrxmrdv.supabase.co/rest/v1/users?select=id&limit=1" \
      -H "apikey: <ANON_KEY>" -H "Authorization: Bearer <ANON_KEY>"
    ```
-   Expect **401** (or `[]` with permission-denied), not a row. Repeat for
-   `user_roles`, `oauth_tokens`, `messages`.
+   **The pass condition is "no row returned", which has TWO valid shapes — do
+   not misread the empty-result shape as a failure:**
+   - **`401` / `403` with a `permission denied` error body** — this is what the
+     anon DML **REVOKE** (plan §2) forces, and it's the strongest signal.
+   - **`200` with an empty array `[]`** — this is what **RLS-enabled-with-no-policy**
+     produces on its own: PostgREST runs the SELECT, RLS filters out every row,
+     and you get `200 []` (NOT a 401). A `200 []` here is still a PASS — anon got
+     zero data. It only becomes the *expected* result if you test RLS in
+     isolation (e.g. before/without the REVOKE).
+   So: PASS = a permission-denied error **OR** an empty result (`[]`); FAIL =
+   any actual row data comes back. (Capture the body, not just the status code,
+   precisely so `200 []` isn't mistaken for `200 <rows>`.) Repeat for
+   `user_roles`, `oauth_tokens`, `messages`. After the REVOKE is applied the
+   permission-denied form is expected; before it (RLS only) the `200 []` form is.
 4. **Backend still works (service_role):**
    - `cd backend && python -m pytest tests/ -q` (suite is hermetic; sanity only).
    - Hit live read + write endpoints against the target DB and confirm normal
@@ -87,7 +112,12 @@ the 38). ⚠️ This restores the insecure state — re-apply the lockdown + opt
 ## Follow-ups (not in this script)
 - `authenticated` keeps its grants (RLS-with-no-policy denies it today); option
   (a) adds membership-scoped policies for it on `room_messages`.
-- Storage hardening is a separate track (`docs/security/storage-hardening-plan.md`).
+- Storage hardening is a separate track. **PR #238 supersedes the storage plan**
+  — treat `docs/security/storage-hardening-plan.md` as carried here in an OLD
+  state and **NOT the source of truth**. #238 corrects two factual errors in the
+  copy in this PR (there is no global any-bucket public INSERT — the policy is
+  scoped to `issues-media-files`; and `avatars` needs no change) and adds the
+  sequenced phasing. Use #238 for storage.
 - The 2 already-RLS tables (`achievement_cosmetics`, `achievement_triggers`)
   have RLS on but **no policies** — confirm nothing legitimately reads them via
   anon (the backend uses service_role, so it's unaffected).

--- a/docs/security/storage-hardening-plan.md
+++ b/docs/security/storage-hardening-plan.md
@@ -1,6 +1,19 @@
 # Storage hardening — PR-plan (#231)
 
-**Status: DRAFT plan for review. Nothing applied.**
+> ⚠️ **SUPERSEDED BY PR #238 — do not use this file as the source of truth for
+> storage.** This copy is an OLD version of the storage plan. PR #238 re-verified
+> the live state and corrected two factual errors below:
+> 1. The public INSERT policy is **not** a global any-bucket upload — it is
+>    scoped `WITH CHECK bucket_id = 'issues-media-files'`. There is **no** global
+>    public-INSERT policy.
+> 2. `avatars` has **no** anon INSERT policy and **needs no change** (the line
+>    below implying a blanket INSERT revoke does not apply to it).
+> #238 also adds the correct sequenced phasing (résumés private first; backend
+> endpoint + frontend change before flipping `issues-media-files`). **For any
+> storage work, follow #238**, not this file. Retained here only as the historical
+> record of what #232 originally carried.
+
+**Status: DRAFT plan for review. Nothing applied. SUPERSEDED — see #238.**
 
 ## Live findings (Sapling prod, read-only)
 Buckets that actually exist (3):

--- a/docs/security/storage-hardening-plan.md
+++ b/docs/security/storage-hardening-plan.md
@@ -1,0 +1,54 @@
+# Storage hardening — PR-plan (#231)
+
+**Status: DRAFT plan for review. Nothing applied.**
+
+## Live findings (Sapling prod, read-only)
+Buckets that actually exist (3):
+
+| Bucket | `public` | Written by | Read by | Issue |
+|---|---|---|---|---|
+| `issues-media-files` (issue-report screenshots) | **true** | frontend **anon key** (`ReportIssueFlow.tsx`) | `getPublicUrl` (public) | anon upload + public read |
+| `application_resumes` (résumés) | **true** | backend service key (`careers.py`) | `getPublicUrl` (public) | **résumé PII publicly readable** |
+| `avatars` | true | backend service key (`storage_service.py`) | public `<img>` | intended public read |
+
+`storage.objects` policies: `"Allow public read"` (SELECT, `{public}`, `issues-media-files`) and **`"Allow uploads"` (INSERT, `{public}`, no bucket/auth restriction)** → anyone can upload to **any** bucket, unauthenticated, unbounded (no size limit on `issues-media-files`/`application_resumes`).
+
+Note: `chat-images` and `cosmetic-assets` referenced in code **do not exist** — those upload paths are dead (separate cleanup; not a live exposure).
+
+## Target state
+All storage writes go through the **backend (service_role)**; private buckets are read via **backend-generated signed URLs**; only `avatars` stays public-read. After this, there are **no anon/public storage policies** — the anon storage surface is gone.
+
+| Bucket | public | upload path | read path |
+|---|---|---|---|
+| `issues-media-files` | **false** | new backend endpoint (multipart → service-key upload), reusing `request_limits.read_within_limit` + content-type allowlist (the #220/#229 pattern) | backend signed URL (admin view) |
+| `application_resumes` | **false** | already backend (`careers.py`) | backend signed URL (admin view) |
+| `avatars` | true | already backend | public (unchanged) |
+
+## Changes
+
+### SQL (review before applying)
+```sql
+BEGIN;
+UPDATE storage.buckets SET public = false WHERE id IN ('issues-media-files','application_resumes');
+DROP POLICY IF EXISTS "Allow uploads"     ON storage.objects;  -- kills the global public INSERT
+DROP POLICY IF EXISTS "Allow public read" ON storage.objects;  -- issues-media-files public read
+COMMIT;
+```
+No new storage.objects policies are needed: backend uploads/reads use `service_role` (bypasses storage RLS). `avatars` stays `public=true` so its objects remain readable without a policy.
+
+### Backend
+- New `POST /api/issue-reports/screenshot` (auth-gated via `get_session_user_id`): accepts the file, validates type+size with the shared `request_limits` helpers, uploads to `issues-media-files` with the service key (mirror `careers._upload_resume`), returns the storage path (not a public URL).
+- Signed-URL helper for private buckets (admin views of screenshots/résumés): backend issues a short-TTL signed URL via the storage REST API with the service key.
+
+### Frontend
+- `ReportIssueFlow.tsx`: stop using the anon `supabase.storage` client; POST the screenshot to the new backend endpoint. Removes a direct anon-key path (also shrinks the #231 surface).
+- Admin résumé/screenshot views: fetch signed URLs from the backend instead of assuming public URLs.
+
+## Verification
+- `storage.buckets`: `issues-media-files` and `application_resumes` show `public=false`; `avatars` stays `true`.
+- `pg_policies` (schema `storage`): the two `{public}` policies are gone.
+- Anon upload attempt → denied. Public URL to a private-bucket object → 400/403; signed URL → 200.
+- Issue-report flow and résumé upload still work end-to-end via the backend; avatars still render.
+
+## Priority
+`application_resumes` (résumé PII, publicly readable) is **equal priority** to the screenshots bucket — both flip to private first; the global public-INSERT policy is dropped in the same change.


### PR DESCRIPTION
**DRAFT for review — do NOT merge or apply.** Remediation artifacts for #231 (public anon key has full DML on 38/40 RLS-disabled tables → potential full-DB read/write via PostgREST, bypassing the backend). No code or prod changes here.

## URGENT — RLS lockdown (one-time DDL, not a #197 migration)
- `backend/db/security/rls_lockdown.sql`: `ENABLE ROW LEVEL SECURITY` on the 38 tables that lack it + `REVOKE` all anon DML across the `public` schema, plus `ALTER DEFAULT PRIVILEGES` so future tables don't silently re-grant anon.
- **Verified safe for the backend:** `service_role` has `rolbypassrls=true` (live-checked), so every backend query is unaffected; only `anon`/`authenticated` (bypass=false) are constrained.
- `rls_lockdown_rollback.sql`: emergency revert (restores the insecure state).
- `docs/security/rls-lockdown-plan.md`: apply/verify/rollback checklist (incl. the anon-blocked REST check and the service_role-bypass proof) + Supabase-branching note (branching was unreachable via MCP).
- **Accepted breakage:** anon realtime on `room_messages` pauses until option (a) lands; chat still loads/refreshes via the service-role REST path (#230).

## Storage hardening plan
`docs/security/storage-hardening-plan.md`: `issues-media-files` + `application_resumes` → **private + signed URLs + backend-side uploads**; `avatars` stays public-read with the blanket public INSERT revoked; drop the global `storage.objects` public-INSERT policy. (Live finding: `chat-images`/`cosmetic-assets` buckets don't exist — dead code.)

## Realtime option (a) design
`docs/security/realtime-jwt-bridge-design.md`: mint a Supabase JWT at login + `realtime.setAuth`, membership-scoped RLS SELECT policy on `room_messages`; postgres_changes + RLS (minimal) vs private channels. **JWT refresh flagged** (30d session vs ~1h JWT). Builds after the lockdown.

## How to use
Review the SQL, then **you** apply `rls_lockdown.sql` (branch-first if available). I did not apply anything. Storage SQL + realtime are plans to turn into their own PRs once you approve the approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security planning guides documenting database access control implementation, real-time authentication architecture, and storage hardening strategies with verification procedures.

* **Chores**
  * Added database security configuration scripts and corresponding rollback procedures to support infrastructure security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->