### PR TITLE
fix(ci): drop unused MagicMock import flagged by ruff gate (main is red)

### DIFF
--- a/backend/tests/test_assignment_notes_encryption.py
+++ b/backend/tests/test_assignment_notes_encryption.py
@@ -7,7 +7,7 @@ This is an encryption-boundary correctness test (not a cross-user-access test):
 it asserts the value handed to the DB insert is ciphertext, and that it
 round-trips back to the original plaintext via decrypt.
 """
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from services.calendar_service import insert_new_assignments
 from services.encryption import decrypt


### PR DESCRIPTION
**Hotfix — main is currently red.** `tests/test_assignment_notes_encryption.py` (added in #226, before the #193/#223 ruff gate) imports `MagicMock` but only uses `patch`. Once #223's ruff gate landed on main, `ruff check .` failed on this F401 and turned the Backend job red on every commit (caught via the docs PR #233's CI).

One-line fix: remove the unused import. `ruff check .` clean, test passes. The file postdates the ruff baseline, so it gets full enforcement (correct ratchet behavior — it just needs the import gone).