### PR TITLE
fix(security): lowercase-normalize COOKIE_DOMAIN before validation (follow-up #190)

### DIFF
--- a/frontend/src/lib/cookieDomain.test.ts
+++ b/frontend/src/lib/cookieDomain.test.ts
@@ -12,6 +12,11 @@ describe('sanitizeCookieDomain', () => {
     expect(sanitizeCookieDomain('  saplinglearn.com  ')).toBe('saplinglearn.com');
   });
 
+  it('normalizes case (DNS is case-insensitive)', () => {
+    expect(sanitizeCookieDomain('.SaplingLearn.com')).toBe('.saplinglearn.com');
+    expect(sanitizeCookieDomain('APP.Example.COM')).toBe('app.example.com');
+  });
+
   it('rejects overly-broad bare suffixes', () => {
     expect(sanitizeCookieDomain('.com')).toBeUndefined();
     expect(sanitizeCookieDomain('com')).toBeUndefined();

--- a/frontend/src/lib/cookieDomain.ts
+++ b/frontend/src/lib/cookieDomain.ts
@@ -21,7 +21,9 @@ export function sanitizeCookieDomain(
   raw: string | undefined | null,
 ): string | undefined {
   if (!raw) return undefined;
-  const value = raw.trim();
+  // DNS is case-insensitive; normalize to lowercase so a config like
+  // ".SaplingLearn.com" isn't wrongly rejected by the lowercase-only regex.
+  const value = raw.trim().toLowerCase();
   if (!value || !DOMAIN_RE.test(value)) return undefined;
 
   // Require ≥2 labels in the registrable portion so a bare suffix like ".com"


### PR DESCRIPTION
Queued nit from the cross-PR review. `sanitizeCookieDomain`'s regex is lowercase-only, so a valid config like `.SaplingLearn.com` was rejected and silently degraded to a host-only cookie. DNS is case-insensitive — `.toLowerCase()` the input before validating. Test covers normalization.

⚠️ Nit, **do not merge** without your review (queued per your instruction).