### PR TITLE
feat(graph): re-port 3D knowledge-graph fixes onto main's 2D/3D split (supersedes #96)

### DIFF
--- a/frontend/src/components/KnowledgeGraph2D.tsx
+++ b/frontend/src/components/KnowledgeGraph2D.tsx
@@ -12,7 +12,7 @@ import {
   type SimulationNodeDatum,
   type SimulationLinkDatum,
 } from "d3-force";
-import type { GraphEdge, GraphNode } from "@/lib/data";
+import { hashSeed, type GraphEdge, type GraphNode } from "@/lib/data";
 
 export type GraphVariant = "orb" | "constellation" | "organism";
 
@@ -53,12 +53,9 @@ type Props = {
 // Deterministic per-node shade derived from the course color + node id.
 // Keeps each course visually unified while giving every node its own tone,
 // and produces identical output across pages because it depends only on the
-// stable inputs (no per-screen overrides).
-function hashId(id: string): number {
-  let h = 0;
-  for (let i = 0; i < id.length; i++) h = ((h << 5) - h + id.charCodeAt(i)) | 0;
-  return Math.abs(h);
-}
+// stable inputs (no per-screen overrides). Hashing is delegated to the
+// shared, overflow-safe `hashSeed` in lib/data (the old local copy used
+// `Math.abs(h)`, which stays negative for INT_MIN).
 
 function hexToHsl(hex: string): { h: number; s: number; l: number } | null {
   const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
@@ -81,7 +78,7 @@ function hexToHsl(hex: string): { h: number; s: number; l: number } | null {
 function shadeFor(baseHex: string, nodeId: string): string {
   const hsl = hexToHsl(baseHex);
   if (!hsl) return baseHex;
-  const seed = hashId(nodeId);
+  const seed = hashSeed(nodeId);
   const dh = (seed % 51) - 25;
   const ds = ((seed >> 5) % 17) - 8;
   const dl = ((seed >> 10) % 25) - 12;

--- a/frontend/src/components/KnowledgeGraph3D.test.tsx
+++ b/frontend/src/components/KnowledgeGraph3D.test.tsx
@@ -5,9 +5,13 @@
  * and the `react-force-graph-3d` library:
  *   1. Renders without crashing on empty data.
  *   2. `graphData` memo produces the {nodes, links:{source,target,strength}} shape.
- *   3. `nodeColor` returns "#ffffff" for the highlighted node and an
- *      `hsl(...)` shade for everything else.
- *   4. `nodeVal` scales 4..10 with `mastery_score`.
+ *   3. `nodeColor` returns the brand --accent for the highlighted node
+ *      and a deterministic hex shade for everything else (hex, not
+ *      `hsl(...)`, because Three.js's Color parser only accepts the
+ *      comma-separated HSL form and silently renders space-separated
+ *      HSL as black).
+ *   4. `nodeVal` scales 4..10 with `mastery_score`, and course-root
+ *      nodes (`is_subject_root: true`) render at a fixed larger size.
  *   5. `onNodeClick` whitelists the original GraphNode by id so
  *      library-injected fields (x/y/z, vx/vy/vz, fx/fy/fz,
  *      __threeObj, ...) never leak to callers.
@@ -149,7 +153,7 @@ describe("KnowledgeGraph3D — adapter behavior", () => {
     expect(graphData.nodes[0]).not.toBe(nodes[0]);
   });
 
-  it("nodeColor returns the brand accent for the highlighted id and an hsl() shade otherwise", () => {
+  it("nodeColor returns the brand accent for the highlighted id and a hex shade otherwise", () => {
     render(
       <KnowledgeGraph3D
         nodes={[makeNode({ id: "abc" })]}
@@ -165,19 +169,28 @@ describe("KnowledgeGraph3D — adapter behavior", () => {
     // against the cream light theme; the accent pops on both themes.
     expect(nodeColor({ id: "abc", color: "#88aa55" })).toBe("#8a9a5b");
 
-    // Non-highlight branch: deterministic hsl(...) string from shadeFor.
+    // Non-highlight branch: deterministic 7-char hex from shadeFor.
+    // Hex (not hsl) because Three.js parses hex reliably; the modern
+    // space-separated `hsl(120 50% 50%)` syntax silently renders BLACK.
     const other = nodeColor({ id: "xyz", color: "#88aa55" });
-    expect(other.startsWith("hsl(")).toBe(true);
+    expect(other).toMatch(/^#[0-9a-f]{6}$/);
+    expect(other.startsWith("hsl(")).toBe(false);
   });
 
-  it("nodeVal scales 4..10 with mastery_score (0 -> 4, 1 -> 10)", () => {
+  it("nodeVal scales 4..10 with mastery_score and pins course-root nodes larger", () => {
     render(<KnowledgeGraph3D nodes={[makeNode()]} edges={[]} />);
 
     expect(lastProps).not.toBeNull();
     const nodeVal = lastProps!.nodeVal as (n: object) => number;
 
+    // Concept nodes scale linearly with mastery.
     expect(nodeVal({ mastery_score: 0 })).toBe(4);
     expect(nodeVal({ mastery_score: 1 })).toBe(10);
+
+    // Course-root nodes anchor the family — fixed larger size that
+    // dominates any concept node regardless of mastery.
+    expect(nodeVal({ is_subject_root: true, mastery_score: 0 })).toBe(22);
+    expect(nodeVal({ is_subject_root: true, mastery_score: 1 })).toBe(22);
   });
 
   it("onNodeClick whitelists the original GraphNode by id so lib-injected fields never leak", () => {

--- a/frontend/src/components/KnowledgeGraph3D.tsx
+++ b/frontend/src/components/KnowledgeGraph3D.tsx
@@ -15,7 +15,7 @@
 
 import React from "react";
 import dynamic from "next/dynamic";
-import type { GraphEdge, GraphNode } from "@/lib/data";
+import { hashSeed, type GraphEdge, type GraphNode } from "@/lib/data";
 
 // `react-force-graph-3d`'s default export touches `document` at
 // module evaluation, so it can't be SSR'd. ssr: false ensures the
@@ -34,12 +34,6 @@ type Props = {
   highlightId?: string;
   onNodeClick?: (n: GraphNode) => void;
 };
-
-function hashId(id: string): number {
-  let h = 0;
-  for (let i = 0; i < id.length; i++) h = ((h << 5) - h + id.charCodeAt(i)) | 0;
-  return Math.abs(h);
-}
 
 function hexToHsl(hex: string): { h: number; s: number; l: number } | null {
   const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
@@ -62,17 +56,43 @@ function hexToHsl(hex: string): { h: number; s: number; l: number } | null {
   return { h, s: s * 100, l: l * 100 };
 }
 
+function hslToHex(h: number, s: number, l: number): string {
+  const sN = s / 100;
+  const lN = l / 100;
+  const c = (1 - Math.abs(2 * lN - 1)) * sN;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = lN - c / 2;
+  let r = 0,
+    g = 0,
+    b = 0;
+  if (h < 60) [r, g, b] = [c, x, 0];
+  else if (h < 120) [r, g, b] = [x, c, 0];
+  else if (h < 180) [r, g, b] = [0, c, x];
+  else if (h < 240) [r, g, b] = [0, x, c];
+  else if (h < 300) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const to = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${to(r)}${to(g)}${to(b)}`;
+}
+
 function shadeFor(baseHex: string, nodeId: string): string {
   const hsl = hexToHsl(baseHex);
   if (!hsl) return baseHex;
-  const seed = hashId(nodeId);
+  const seed = hashSeed(nodeId);
   const dh = (seed % 51) - 25;
   const ds = ((seed >> 5) % 17) - 8;
   const dl = ((seed >> 10) % 25) - 12;
   const h = (hsl.h + dh + 360) % 360;
   const s = Math.max(20, Math.min(85, hsl.s + ds));
   const l = Math.max(28, Math.min(62, hsl.l + dl));
-  return `hsl(${h.toFixed(0)} ${s.toFixed(0)}% ${l.toFixed(0)}%)`;
+  // Return hex (#RRGGBB), not `hsl(...)`. Three.js's Color.setStyle only
+  // accepts comma-separated `hsl(h, s%, l%)`, not the modern
+  // space-separated form; the space-separated string silently renders
+  // BLACK. Hex is unambiguous across consumers.
+  return hslToHex(h, s, l);
 }
 
 type FG3DNode = GraphNode & {
@@ -157,6 +177,10 @@ export function KnowledgeGraph3D({
 
   const nodeVal = React.useCallback((raw: object) => {
     const n = raw as FG3DNode;
+    // Course (root) nodes anchor each family — render them noticeably
+    // larger than concept nodes so the eye lands on the family center
+    // first. Concept nodes scale 4..10 with mastery_score.
+    if (n.is_subject_root) return 22;
     return 4 + (typeof n.mastery_score === "number" ? n.mastery_score : 0) * 6;
   }, []);
 

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -21,7 +21,7 @@ import {
   type Assignment,
 } from "@/lib/api";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
-import { paletteFor, type GraphNode, type GraphEdge } from "@/lib/data";
+import { apiToGraphNode, type GraphNode, type GraphEdge } from "@/lib/data";
 
 const QUOTES = [
   "Learning is the only thing the mind never exhausts, never fears, and never regrets. — da Vinci",
@@ -31,24 +31,6 @@ const QUOTES = [
   "The beautiful thing about learning is that no one can take it away from you. — B.B. King",
   "Tell me and I forget. Teach me and I remember. Involve me and I learn. — Franklin",
 ];
-
-function apiToGraphNode(n: ApiNode, courses: EnrolledCourse[]): GraphNode {
-  const course = courses.find((c) => c.course_name === n.subject);
-  return {
-    id: n.id,
-    name: n.concept_name,
-    subject: n.subject,
-    color:
-      n.course_color ||
-      course?.color ||
-      paletteFor(n.course_id || course?.course_id || n.subject),
-    is_subject_root: n.is_subject_root,
-    mastery_tier: n.mastery_tier === "subject_root" ? "mastered" : n.mastery_tier,
-    mastery_score: n.mastery_score,
-    course_id: n.course_id || course?.course_id || "",
-    last_studied_at: n.last_studied_at || undefined,
-  };
-}
 
 function apiToGraphEdge(e: ApiEdge): GraphEdge {
   return { source: e.source as string, target: e.target as string, strength: e.strength };

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -34,25 +34,7 @@ import {
   type EnrolledCourse,
 } from "@/lib/api";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
-import { paletteFor, type GraphNode, type GraphEdge } from "@/lib/data";
-
-function apiToGraphNode(n: ApiNode, courses: EnrolledCourse[]): GraphNode {
-  const course = courses.find((c) => c.course_name === n.subject);
-  return {
-    id: n.id,
-    name: n.concept_name,
-    subject: n.subject,
-    color:
-      n.course_color ||
-      course?.color ||
-      paletteFor(n.course_id || course?.course_id || n.subject),
-    is_subject_root: n.is_subject_root,
-    mastery_tier: n.mastery_tier === "subject_root" ? "mastered" : n.mastery_tier,
-    mastery_score: n.mastery_score,
-    course_id: n.course_id || course?.course_id || "",
-    last_studied_at: n.last_studied_at || undefined,
-  };
-}
+import { apiToGraphNode, type GraphNode, type GraphEdge } from "@/lib/data";
 
 function apiToGraphEdge(e: ApiEdge): GraphEdge {
   return { source: e.source as string, target: e.target as string, strength: e.strength };

--- a/frontend/src/components/screens/Tree.tsx
+++ b/frontend/src/components/screens/Tree.tsx
@@ -12,7 +12,7 @@ import { getGraph, getCourses, getSessions, deleteGraphNode, type EnrolledCourse
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
-import { paletteFor, type GraphNode, type GraphEdge } from "@/lib/data";
+import { apiToGraphNode, type GraphNode, type GraphEdge } from "@/lib/data";
 
 type Tier = "all" | "mastered" | "learning" | "struggling" | "unexplored";
 
@@ -22,24 +22,6 @@ const TIER_META: Record<Exclude<Tier, "all">, { label: string; color: string }> 
   struggling: { label: "Struggling", color: "var(--state-struggle)" },
   unexplored: { label: "Unexplored", color: "var(--state-neutral)" },
 };
-
-function apiToGraphNode(n: ApiNode, courses: EnrolledCourse[]): GraphNode {
-  const course = courses.find((c) => c.course_name === n.subject);
-  return {
-    id: n.id,
-    name: n.concept_name,
-    subject: n.subject,
-    color:
-      n.course_color ||
-      course?.color ||
-      paletteFor(n.course_id || course?.course_id || n.subject),
-    is_subject_root: n.is_subject_root,
-    mastery_tier: n.mastery_tier === "subject_root" ? "mastered" : n.mastery_tier,
-    mastery_score: n.mastery_score,
-    course_id: n.course_id || course?.course_id || "",
-    last_studied_at: n.last_studied_at || undefined,
-  };
-}
 
 export function Tree() {
   const router = useRouter();

--- a/frontend/src/lib/data.test.ts
+++ b/frontend/src/lib/data.test.ts
@@ -120,16 +120,13 @@ describe("hashSeed", () => {
   });
 
   it("returns a non-negative integer even when the raw 32-bit hash is negative", () => {
-    // OVERFLOW REGRESSION GUARD. The naive implementation did
-    // `return Math.abs(h)` where `h` is a `| 0` 32-bit int. That is
-    // broken at exactly INT_MIN (-2^31), whose magnitude has no positive
-    // 32-bit counterpart — `Math.abs(-2147483648) === -2147483648` stays
-    // NEGATIVE, yielding a negative array index and an `undefined` color.
-    //
-    // "overflow10" hashes to -2114666079 (negative raw 32-bit). We assert
-    // the unsigned-coerced result is a non-negative integer and that the
-    // downstream palette lookup is in-range and defined — a test the
-    // buggy `Math.abs` path would fail for the INT_MIN class of seeds.
+    // NEGATIVE-HASH REGRESSION GUARD. "overflow10" is a seed whose raw
+    // signed 32-bit hash (the `| 0` value before `>>> 0`) is negative. We
+    // assert that `hashSeed` still returns a non-negative integer thanks to
+    // the unsigned `>>> 0` coercion, and that the downstream palette lookup
+    // stays in-range and resolves to a defined color. This guards the
+    // general "negative raw hash" case for the index math; it is not the
+    // INT_MIN (-2^31) edge specifically.
     const h = hashSeed("overflow10");
     expect(Number.isInteger(h)).toBe(true);
     expect(h).toBeGreaterThanOrEqual(0);

--- a/frontend/src/lib/data.test.ts
+++ b/frontend/src/lib/data.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { apiToGraphNode, hashSeed, paletteFor } from "./data";
+import type { GraphNode as ApiNode } from "./types";
+import type { EnrolledCourse } from "./api";
+
+function makeApiNode(over: Partial<ApiNode> = {}): ApiNode {
+  return {
+    id: "n1",
+    concept_name: "Eigenvalues",
+    mastery_score: 0.5,
+    mastery_tier: "learning",
+    times_studied: 3,
+    last_studied_at: null,
+    subject: "Linear Algebra",
+    course_id: "c1",
+    course_color: null,
+    color: null,
+    is_subject_root: false,
+    ...over,
+  };
+}
+
+function makeCourse(over: Partial<EnrolledCourse> = {}): EnrolledCourse {
+  return {
+    enrollment_id: "e1",
+    course_id: "c1",
+    course_code: "MATH 242",
+    course_name: "Linear Algebra",
+    school: "BU",
+    department: "MATH",
+    color: null,
+    nickname: null,
+    node_count: 8,
+    enrolled_at: "2026-01-01",
+    ...over,
+  };
+}
+
+// First entry of COURSE_PALETTE in data.ts. Asserted directly so the
+// palette stays internal to data.ts. (Darkened sage — chosen to clear
+// WCAG AA 3:1 contrast against the cream `--bg`.)
+const PALETTE_FIRST = "#7a874f";
+
+describe("paletteFor", () => {
+  it("returns the first palette entry for empty / nullish seeds", () => {
+    expect(paletteFor(null)).toBe(PALETTE_FIRST);
+    expect(paletteFor(undefined)).toBe(PALETTE_FIRST);
+    expect(paletteFor("")).toBe(PALETTE_FIRST);
+  });
+
+  it("is deterministic for a given seed", () => {
+    expect(paletteFor("course-42")).toBe(paletteFor("course-42"));
+  });
+
+  it("produces multiple distinct outputs across varied seeds", () => {
+    const colors = new Set(["alpha", "beta", "gamma", "delta"].map(paletteFor));
+    expect(colors.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("always returns a defined #RRGGBB color, even for negative-raw-hash seeds", () => {
+    // "overflow10"'s raw DJB2 hash is a NEGATIVE 32-bit int (-2114666079).
+    // Under the buggy `Math.abs(h)` path this could index out of range
+    // (and at exactly -2^31, `Math.abs` stays negative). The `>>> 0`
+    // unsigned coercion guarantees an in-range, defined palette color.
+    const color = paletteFor("overflow10");
+    expect(color).toBeDefined();
+    expect(color).toMatch(/^#[0-9a-f]{6}$/);
+  });
+});
+
+describe("apiToGraphNode color resolution", () => {
+  it("prefers n.course_color over everything else", () => {
+    const n = makeApiNode({ course_color: "#abcdef" });
+    const course = makeCourse({ color: "#fedcba" });
+    expect(apiToGraphNode(n, [course]).color).toBe("#abcdef");
+  });
+
+  it("falls back to course?.color when course_color is missing", () => {
+    const n = makeApiNode({ course_color: null });
+    const course = makeCourse({ color: "#123456" });
+    expect(apiToGraphNode(n, [course]).color).toBe("#123456");
+  });
+
+  it("falls back to paletteFor when both course_color and course.color are missing", () => {
+    const n = makeApiNode({ course_color: null, course_id: "c1" });
+    const course = makeCourse({ color: null, course_id: "c1" });
+    expect(apiToGraphNode(n, [course]).color).toBe(paletteFor("c1"));
+  });
+
+  it("seeds palette from course.course_id, not n.course_id (round-2 fix)", () => {
+    // Round 2 fixed a bug where two nodes in the same family could
+    // hash to different palette colors if some carried n.course_id
+    // and others fell through to subject. The hoisted adapter must
+    // prefer the course-record id so all family members agree.
+    const n = makeApiNode({
+      course_color: null,
+      course_id: "different-from-course",
+    });
+    const course = makeCourse({ color: null, course_id: "stable-family-id" });
+    expect(apiToGraphNode(n, [course]).color).toBe(paletteFor("stable-family-id"));
+  });
+
+  it("remaps subject_root tier to mastered", () => {
+    const n = makeApiNode({ mastery_tier: "subject_root", is_subject_root: true });
+    expect(apiToGraphNode(n, []).mastery_tier).toBe("mastered");
+  });
+});
+
+describe("hashSeed", () => {
+  it("is deterministic", () => {
+    expect(hashSeed("hello")).toBe(hashSeed("hello"));
+  });
+
+  it("returns a non-negative integer for typical inputs", () => {
+    for (const s of ["", "x", "concept-1", "a longer string with spaces"]) {
+      const h = hashSeed(s);
+      expect(Number.isInteger(h)).toBe(true);
+      expect(h).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("returns a non-negative integer even when the raw 32-bit hash is negative", () => {
+    // OVERFLOW REGRESSION GUARD. The naive implementation did
+    // `return Math.abs(h)` where `h` is a `| 0` 32-bit int. That is
+    // broken at exactly INT_MIN (-2^31), whose magnitude has no positive
+    // 32-bit counterpart — `Math.abs(-2147483648) === -2147483648` stays
+    // NEGATIVE, yielding a negative array index and an `undefined` color.
+    //
+    // "overflow10" hashes to -2114666079 (negative raw 32-bit). We assert
+    // the unsigned-coerced result is a non-negative integer and that the
+    // downstream palette lookup is in-range and defined — a test the
+    // buggy `Math.abs` path would fail for the INT_MIN class of seeds.
+    const h = hashSeed("overflow10");
+    expect(Number.isInteger(h)).toBe(true);
+    expect(h).toBeGreaterThanOrEqual(0);
+    // `>>> 0` guarantees the full unsigned 32-bit range.
+    expect(h).toBe(2180301217);
+    expect(paletteFor("overflow10")).toBeDefined();
+    expect(paletteFor("overflow10")).toMatch(/^#[0-9a-f]{6}$/);
+  });
+});

--- a/frontend/src/lib/data.ts
+++ b/frontend/src/lib/data.ts
@@ -1,3 +1,6 @@
+import type { GraphNode as ApiNode } from "@/lib/types";
+import type { EnrolledCourse } from "@/lib/api";
+
 export type Course = {
   id: string;
   course_code: string;
@@ -6,21 +9,41 @@ export type Course = {
 };
 
 // Deterministic course palette used as a fallback when the backend doesn't
-// supply a per-course color. SVG `fill=` doesn't resolve `var(--…)`, so a
-// missing color previously rendered black; this maps a stable seed to a hue.
+// supply a per-course color. SVG `fill=` and Three.js can't resolve
+// `var(--…)`, so a missing color previously rendered black; this maps a
+// stable seed to a hue.
+//
+// Each entry hits >=3:1 contrast against the cream `--bg` (#faf8f3) — the
+// WCAG AA threshold for non-text UI elements. Sage and ochre were nudged
+// darker (from #8a9a5b -> #7a874f and #c89c4a -> #a87d2e) so the nodes
+// stay legible on the light theme. Brand --accent (#8a9a5b) remains
+// unchanged elsewhere; this palette is only the backend-color fallback.
 const COURSE_PALETTE = [
-  "#8a9a5b", "#3e6f8a", "#7b4b99", "#b4562c",
-  "#3f8a7c", "#c89c4a", "#a06b8e", "#6b8a3e",
+  "#7a874f", "#3e6f8a", "#7b4b99", "#b4562c",
+  "#3f8a7c", "#a87d2e", "#a06b8e", "#6b8a3e",
 ];
+
+// DJB2-ish string hash -> non-negative 32-bit integer. Shared by
+// `paletteFor` (palette index seeding) and `KnowledgeGraph3D`'s `shadeFor`
+// (per-node HSL jitter seeding). Keep the body identical across consumers
+// so the same input always maps to the same downstream color.
+//
+// OVERFLOW SAFETY: the naive `Math.abs(h)` is broken — `Math.abs(-2^31)`
+// stays NEGATIVE (the value has no positive 32-bit counterpart), which
+// would produce a negative array index and an `undefined` color. We coerce
+// to an unsigned 32-bit integer with `>>> 0` instead, which is always in
+// `[0, 2^32)`, so every `% COURSE_PALETTE.length` is non-negative.
+export function hashSeed(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+  return h >>> 0;
+}
 
 export function paletteFor(seed: string | null | undefined): string {
   if (!seed) return COURSE_PALETTE[0];
-  let h = 0;
-  for (let i = 0; i < seed.length; i++) h = ((h << 5) - h + seed.charCodeAt(i)) | 0;
-  // `Math.abs` overflows on -2^31; do a positive-modulo dance instead so
-  // we always land in-range.
-  const idx = ((h % COURSE_PALETTE.length) + COURSE_PALETTE.length) % COURSE_PALETTE.length;
-  return COURSE_PALETTE[idx];
+  // `hashSeed` returns an unsigned 32-bit int, so the modulo is always
+  // non-negative — no positive-modulo dance needed.
+  return COURSE_PALETTE[hashSeed(seed) % COURSE_PALETTE.length];
 }
 
 export type GraphNode = {
@@ -40,6 +63,33 @@ export type GraphEdge = {
   target: string;
   strength: number;
 };
+
+// Adapter from the backend `ApiNode` shape to the frontend `GraphNode`
+// shape consumed by `KnowledgeGraph`. Hoisted here from Tree/Learn/
+// Dashboard so the three screens share a single source of truth.
+export function apiToGraphNode(n: ApiNode, courses: EnrolledCourse[]): GraphNode {
+  const course = courses.find((c) => c.course_name === n.subject);
+  return {
+    id: n.id,
+    name: n.concept_name,
+    subject: n.subject,
+    // Resolved hex (not CSS custom property): the 3D KnowledgeGraph feeds
+    // this into Three.js which can't resolve `var(--…)`.
+    // Seed prefers the course-record id so every node in the same family
+    // hashes to the same palette color, even if some nodes arrive without
+    // `n.course_id` set (round-2 fix — two siblings could otherwise land
+    // on different fallback colors).
+    color:
+      n.course_color ||
+      course?.color ||
+      paletteFor(course?.course_id || n.course_id || n.subject),
+    is_subject_root: n.is_subject_root,
+    mastery_tier: n.mastery_tier === "subject_root" ? "mastered" : n.mastery_tier,
+    mastery_score: n.mastery_score,
+    course_id: n.course_id || course?.course_id || "",
+    last_studied_at: n.last_studied_at || undefined,
+  };
+}
 
 export type Assignment = {
   id: string;

--- a/frontend/src/lib/data.ts
+++ b/frontend/src/lib/data.ts
@@ -28,11 +28,12 @@ const COURSE_PALETTE = [
 // (per-node HSL jitter seeding). Keep the body identical across consumers
 // so the same input always maps to the same downstream color.
 //
-// OVERFLOW SAFETY: the naive `Math.abs(h)` is broken — `Math.abs(-2^31)`
-// stays NEGATIVE (the value has no positive 32-bit counterpart), which
-// would produce a negative array index and an `undefined` color. We coerce
-// to an unsigned 32-bit integer with `>>> 0` instead, which is always in
-// `[0, 2^32)`, so every `% COURSE_PALETTE.length` is non-negative.
+// UNSIGNED NORMALIZATION: `h` is a signed 32-bit int (the `| 0` keeps it in
+// `[-2^31, 2^31)`), so its raw value can be negative. We coerce it to an
+// unsigned 32-bit integer with `>>> 0`, which is always in `[0, 2^32)`. This
+// gives consistent, deterministic indexing for every `% COURSE_PALETTE.length`
+// and keeps the hash semantics identical across both consumers (the 2D
+// `paletteFor` and the 3D `KnowledgeGraph3D`'s `shadeFor`).
 export function hashSeed(s: string): number {
   let h = 0;
   for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;


### PR DESCRIPTION
## What

Re-ports the still-valuable fixes from #96 ("Feat/knowledge-graph-3d") onto the **current** `main`, which has since split the monolithic `KnowledgeGraph.tsx` into `KnowledgeGraph2D.tsx` + a lazy-loaded `KnowledgeGraph3D.tsx`. #96 was ~127 commits behind and `CONFLICTING`, so this is a clean re-apply (1 commit off `main`) rather than a rebase — **supersedes #96**.

## Changes

- **Fix black 3D nodes:** `KnowledgeGraph3D.tsx` returned a space-separated `hsl(h s% l%)` string that Three.js `Color.setStyle` renders **black**. Added `hslToHex` and emit hex. This is the genuine rendering fix in this PR.
- **Shared `hashSeed`:** removed duplicated local `hashId` from both `KnowledgeGraph3D.tsx` and `KnowledgeGraph2D.tsx`; both now use one helper in `lib/data.ts`.
- **Unsigned hash normalization (`>>> 0`):** the shared `hashSeed` now coerces its signed 32-bit result to unsigned with `h >>> 0` instead of the old `Math.abs(h)`. Note: in JS, numbers are doubles, so `Math.abs` never actually returns a negative value and the old code did **not** crash or produce a negative index — the previous "overflow bug" framing was inaccurate. The switch to `>>> 0` is a cleanup for consistent, deterministic unsigned-hash semantics shared across both the 2D (`paletteFor`) and 3D (`shadeFor`) consumers, and it unified a third copy of the helper that lived in `KnowledgeGraph2D.tsx`.
- **Root sizing:** `nodeVal` enlarges `is_subject_root` nodes (→ 22).
- **`apiToGraphNode` hoisted** into `lib/data.ts`; `Tree.tsx` / `Learn.tsx` / `Dashboard.tsx` import the shared version (3 byte-identical copies removed).
- **WCAG-AA palette:** darkened `COURSE_PALETTE` (`#8a9a5b→#7a874f`, `#c89c4a→#a87d2e`) for ≥3:1 contrast on the cream background.

## Behavior note

The shared `apiToGraphNode` adopts #96's family-color seed order (`course?.course_id || n.course_id || n.subject`) so a course family with mixed `course_id`s resolves to one consistent color. This is asserted by `data.test.ts` and changes colors only in that edge case.

## Verification

- Targeted + full frontend suite: **67/67 tests pass**
- `tsc --noEmit`: clean
- `eslint`: clean (only 2 pre-existing warnings on `main`, none introduced)

Supersedes #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
