### PR TITLE
feat(auth): configurable email-domain allowlist + staging setup templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ dist/
 .env
 .env.*
 !.env.example
+!.env.staging.example
 
 # ---- OS ----
 .DS_Store

--- a/backend/.env.staging.example
+++ b/backend/.env.staging.example
@@ -1,0 +1,46 @@
+# Staging backend environment — TEMPLATE (placeholders only, safe to commit).
+#
+# DO NOT put real secrets in this file. Copy it to `.env.staging` (gitignored)
+# for LOCAL tooling runs (migrate.py / seed), and paste the same values into the
+# Railway "staging" environment for the deployed backend. Never commit real keys.
+#
+#   cp .env.staging.example .env.staging   # then fill .env.staging with real values
+#
+# Each line notes WHERE the value comes from.
+
+# Deployment mode. "staging" keeps prod's fail-closed config checks (NOT local).
+APP_ENV=staging
+
+# Supabase staging project → Settings → API
+SUPABASE_URL=https://<staging-ref>.supabase.co
+SUPABASE_SERVICE_KEY=<staging service_role key — backend only, never the frontend>
+
+# Supabase staging project → Settings → Database → Connection string → "Direct"
+# (port 5432, NOT the pooler). Used by db/migrate.py.
+SUPABASE_DB_URL=postgresql://postgres:<password>@db.<staging-ref>.supabase.co:5432/postgres
+
+# Fresh, STAGING-ONLY secrets — never reuse prod's:
+#   python -c "import secrets; print(secrets.token_hex(32))"
+ENCRYPTION_KEY=<fresh 64 hex chars>
+SESSION_SECRET=<fresh, >= 32 bytes>
+
+# Google Cloud → "Sapling Staging" OAuth client
+GOOGLE_CLIENT_ID=<staging oauth client id>
+GOOGLE_CLIENT_SECRET=<staging oauth client secret>
+GOOGLE_AUTH_REDIRECT_URI=https://api.staging.saplinglearn.com/api/auth/google/callback
+GOOGLE_REDIRECT_URI=https://api.staging.saplinglearn.com/api/calendar/callback
+
+# Allowed sign-in domains (comma-separated; empty = any). Staging is gated by
+# Cloudflare Access, so widening or emptying this is safe. Default is "bu.edu".
+ALLOWED_EMAIL_DOMAINS=bu.edu
+
+# The staging frontend origin (CORS + post-login redirects).
+FRONTEND_URL=https://staging.saplinglearn.com
+
+# Gemini — reuse the prod key or provision a separate staging key.
+GEMINI_API_KEY=<gemini api key>
+
+PORT=5000
+
+# Optional, ONLY during early testing on the temporary *.workers.dev URL:
+# CORS_ORIGINS=https://frontend-staging.<account>.workers.dev

--- a/backend/config.py
+++ b/backend/config.py
@@ -22,6 +22,16 @@ SESSION_SECRET = os.getenv("SESSION_SECRET", "")
 APP_ENV = os.getenv("APP_ENV", "production").strip().lower()
 IS_LOCAL = APP_ENV in {"local", "development", "dev", "test"}
 
+# Sign-in email-domain allowlist. Comma-separated; empty value = allow any domain.
+# Default preserves prod's @bu.edu-only behavior. Staging can widen this (e.g.
+# "bu.edu,saplinglearn.com") or set it empty to allow any Google account — safe
+# on staging because Cloudflare Access already gates who reaches the app at all.
+ALLOWED_EMAIL_DOMAINS = [
+    d.strip().lstrip("@").lower()
+    for d in os.getenv("ALLOWED_EMAIL_DOMAINS", "bu.edu").split(",")
+    if d.strip()
+]
+
 GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/calendar.events",
     "https://www.googleapis.com/auth/calendar.readonly",

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -25,6 +25,7 @@ from config import (
     FRONTEND_URL,
     SESSION_SECRET,
     IS_LOCAL,
+    ALLOWED_EMAIL_DOMAINS,
 )
 from db.connection import table
 from services.encryption import encrypt, encrypt_if_present, decrypt_if_present
@@ -40,6 +41,19 @@ except ImportError:
     GOOGLE_AVAILABLE = False
 
 router = APIRouter()
+
+
+def _email_domain_allowed(email: str) -> bool:
+    """Whether `email`'s domain is permitted to sign in.
+
+    Controlled by config.ALLOWED_EMAIL_DOMAINS (default ["bu.edu"]). An empty
+    allowlist permits any domain — used on staging, which is already gated by
+    Cloudflare Access.
+    """
+    if not ALLOWED_EMAIL_DOMAINS:
+        return True
+    domain = email.strip().lower().rsplit("@", 1)[-1]
+    return domain in ALLOWED_EMAIL_DOMAINS
 
 
 def _stamp_last_sign_in_for_test(user_id: str) -> None:
@@ -327,8 +341,8 @@ def google_callback(request: Request, code: str = Query(...), state: str = Query
     first_name = name_parts[0] if name_parts else ""
     last_name = name_parts[1] if len(name_parts) > 1 else ""
 
-    # Restrict to @bu.edu accounts
-    if not email.endswith("@bu.edu"):
+    # Restrict sign-in to the configured email-domain allowlist (default @bu.edu)
+    if not _email_domain_allowed(email):
         return _fail_redirect("invalid_domain")
 
     # Determine user_id: check if this Google ID already exists

--- a/backend/tests/test_auth_domain.py
+++ b/backend/tests/test_auth_domain.py
@@ -1,0 +1,24 @@
+import routes.auth as auth
+
+
+def test_default_allows_bu_edu(monkeypatch):
+    monkeypatch.setattr(auth, "ALLOWED_EMAIL_DOMAINS", ["bu.edu"])
+    assert auth._email_domain_allowed("student@bu.edu") is True
+    assert auth._email_domain_allowed("someone@gmail.com") is False
+
+
+def test_case_insensitive(monkeypatch):
+    monkeypatch.setattr(auth, "ALLOWED_EMAIL_DOMAINS", ["bu.edu"])
+    assert auth._email_domain_allowed("Student@BU.EDU") is True
+
+
+def test_multiple_domains(monkeypatch):
+    monkeypatch.setattr(auth, "ALLOWED_EMAIL_DOMAINS", ["bu.edu", "saplinglearn.com"])
+    assert auth._email_domain_allowed("dev@saplinglearn.com") is True
+    assert auth._email_domain_allowed("x@bu.edu") is True
+    assert auth._email_domain_allowed("x@other.com") is False
+
+
+def test_empty_allowlist_allows_any(monkeypatch):
+    monkeypatch.setattr(auth, "ALLOWED_EMAIL_DOMAINS", [])
+    assert auth._email_domain_allowed("anyone@example.com") is True

--- a/docs/staging/setup-checklist.md
+++ b/docs/staging/setup-checklist.md
@@ -1,0 +1,85 @@
+# Staging Setup Checklist (operator)
+
+The step-by-step for standing up staging in the dashboards. Companion to the design
+(`docs/superpowers/specs/2026-06-21-staging-environment-design.md`) and plan
+(`docs/superpowers/plans/2026-06-21-staging-environment.md`).
+
+**Mental model:** staging runs the *same code* as prod; only **environment variables**
+differ. **Secrets never live in a git-tracked file** — they go straight into Railway
+variables, Cloudflare worker secrets, or a local gitignored `backend/.env.staging`.
+
+---
+
+## Do it in this order (each step feeds the next)
+
+### Step 1 — Supabase (the staging database)
+- [ ] Create a new project `sapling-staging` (same region as prod).
+- [ ] Copy **Settings → API → Project URL** → `SUPABASE_URL`.
+- [ ] Copy **Settings → API → service_role key** → `SUPABASE_SERVICE_KEY` (backend only — never the frontend).
+- [ ] Copy **Settings → Database → Connection string → "Direct connection" (port 5432, not the pooler)** → `SUPABASE_DB_URL`.
+- [ ] Generate a staging encryption key → `ENCRYPTION_KEY`:
+      `python -c "import secrets; print(secrets.token_hex(32))"`
+- [ ] Create storage buckets `avatars` and `cosmetic-assets` (match prod).
+- [ ] Once you have the keys locally (Step 6), apply schema: `SUPABASE_DB_URL=<direct> python -m db.migrate`.
+
+### Step 2 — Google Cloud (OAuth) — you can do this NOW
+- [ ] Create OAuth client "Sapling Staging" (Web application).
+- [ ] Authorized **redirect URIs** (must match exactly):
+  - `https://api.staging.saplinglearn.com/api/auth/google/callback`
+  - `https://api.staging.saplinglearn.com/api/calendar/callback`
+- [ ] Authorized **JavaScript origin**: `https://staging.saplinglearn.com`
+- [ ] Copy client id/secret → `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`.
+- [ ] If the consent screen is in "testing", add your testers as test users.
+- [ ] Decide sign-in domains: keep `ALLOWED_EMAIL_DOMAINS=bu.edu`, widen (`bu.edu,saplinglearn.com`), or leave empty to allow any account (safe — Access gates it).
+
+### Step 3 — Railway (the backend service)
+- [ ] In the existing Railway project: **Environments → create `staging`** (duplicate of production).
+- [ ] Set its **Variables** from `backend/.env.staging.example` (real values; this is where the backend secrets live).
+- [ ] Set **deploy branch = `main`** (trunk-based: main → staging).
+- [ ] Add **custom domain `api.staging.saplinglearn.com`** to the staging service — Railway shows you the DNS target for Step 5.
+
+### Step 4 — Cloudflare Workers (the frontend service)
+- [ ] The `[env.staging]` block in `frontend/wrangler.toml` is already in the repo (Phase 4). Deploy: `cd frontend && npm run cf:deploy:staging` → publishes a `frontend-staging` worker.
+- [ ] Add the worker secrets for the Access hop (Step 5):
+      `wrangler secret put CF_ACCESS_CLIENT_ID --env staging` and `... CF_ACCESS_CLIENT_SECRET --env staging`.
+
+### Step 5 — DNS + Cloudflare Access (the security gate)
+- [ ] `api.staging.saplinglearn.com` → point at the Railway target from Step 3 (proxied).
+- [ ] `staging.saplinglearn.com` → bind as a **custom domain** on the `frontend-staging` worker (wires route + DNS together).
+- [ ] **Cloudflare Access (Zero Trust)** application on **both** hostnames; policy = allowlist of admin emails (IdP: Google).
+- [ ] Create an Access **service token**; allow it on the `api.staging` app; its id/secret are the worker secrets from Step 4.
+
+### Step 6 — Local tooling + smoke test
+- [ ] `cp backend/.env.staging.example backend/.env.staging` and fill real values (gitignored — for running migrate/seed against staging from your machine).
+- [ ] Apply schema + seed (once `seed_staging.py` lands): `python -m db.migrate`, then the seed.
+- [ ] Visit `https://staging.saplinglearn.com`: Access wall → Google login → upload a doc → graph renders.
+
+---
+
+## What secret goes where
+
+| Secret | Railway (staging env) | Cloudflare worker | Local `backend/.env.staging` | In git? |
+|---|---|---|---|---|
+| `SUPABASE_SERVICE_KEY` | ✅ | ❌ | ✅ (for migrate/seed) | ❌ never |
+| `SUPABASE_DB_URL` | ✅ | ❌ | ✅ | ❌ |
+| `ENCRYPTION_KEY` / `SESSION_SECRET` | ✅ | ❌ | ✅ (encryption key only, for seed) | ❌ |
+| `GOOGLE_CLIENT_ID` / `_SECRET` | ✅ | ❌ | ✅ | ❌ |
+| `CF_ACCESS_CLIENT_ID` / `_SECRET` | ❌ | ✅ (`wrangler secret put`) | ❌ | ❌ |
+| `BACKEND_URL` / `COOKIE_DOMAIN` (non-secret) | ❌ | ✅ (`wrangler.toml` vars) | ❌ | ✅ (config, not secret) |
+
+## URLs — create now vs. later
+
+| URL | When | How |
+|---|---|---|
+| Google OAuth redirect URIs | **Now** | Just strings in the OAuth client; endpoints needn't exist yet. |
+| `api.staging.saplinglearn.com` | When you make the Railway staging env (Step 3) | Add as a Railway custom domain → it gives the DNS target. |
+| `staging.saplinglearn.com` | After the `frontend-staging` worker exists (Step 4–5) | Bind as a worker custom domain in Cloudflare. |
+
+Don't create bare DNS records before their targets exist — they'd point at nothing.
+
+## Security must-dos
+- Fresh `ENCRYPTION_KEY` + `SESSION_SECRET` — never prod's.
+- `COOKIE_DOMAIN=.staging.saplinglearn.com` — **not** `.saplinglearn.com` (that would share cookies with prod).
+- `SUPABASE_SERVICE_KEY` lives only in Railway / local `.env.staging` — never in the frontend or git.
+- Fake data only in staging.
+- Both hostnames behind Cloudflare Access; `noindex` on staging (Phase 6).


### PR DESCRIPTION
## What

Backend + docs slice of staging wiring (kept separate from the frontend Phase-4 PR so it can merge independently of the currently-red Frontend CI).

### Configurable sign-in domain
`routes/auth.py` hard-rejected any non-`@bu.edu` account. Staging needs to admit the team's accounts (it's gated by Cloudflare Access anyway), so this replaces the constant with `config.ALLOWED_EMAIL_DOMAINS`:
- Comma-separated, default `"bu.edu"` → **prod behavior unchanged**.
- Empty value = allow any domain (safe on staging behind Access).
- Logic extracted to `_email_domain_allowed()` with unit tests.

### Operator templates
- `backend/.env.staging.example` — placeholder env sheet (no real secrets; copy to gitignored `.env.staging`).
- `docs/staging/setup-checklist.md` — the dashboard runbook: what to do per service, **which secret goes where**, and **when to create which URL/DNS record**.
- `.gitignore` — `!.env.staging.example` so the template is tracked.

## Testing
`pytest tests/test_auth_domain.py` — 4 passed (default bu.edu, case-insensitivity, multi-domain, empty=any).

Relates to #246 (plan). Backend-only; the Frontend CI check (red repo-wide for unrelated lockfile/eslint reasons) does not exercise this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email domain allowlist for Google sign-in is now configurable per environment, replacing hard-coded restrictions. Empty configuration allows any domain.

* **Documentation**
  * Added comprehensive staging environment setup guide with step-by-step configuration instructions, security best practices, and reference tables for secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->