### PR TITLE
feat(frontend): staging Worker environment (Phase 4)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "test:watch": "vitest",
     "cf:build": "opennextjs-cloudflare build",
     "cf:preview": "opennextjs-cloudflare build && wrangler dev",
-    "cf:deploy": "opennextjs-cloudflare build && wrangler deploy"
+    "cf:deploy": "opennextjs-cloudflare build && wrangler deploy",
+    "cf:deploy:staging": "opennextjs-cloudflare build && wrangler deploy --env staging"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.99.3",

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -20,3 +20,17 @@ COOKIE_DOMAIN = ".saplinglearn.com"
 
 [observability]
 enabled = true
+
+# --- Staging environment (deploy: `npm run cf:deploy:staging`) ---
+# Same code as prod; points at the staging backend and scopes cookies to the
+# staging subdomain only (NOT .saplinglearn.com — that would share with prod).
+[env.staging]
+name = "frontend-staging"
+
+[env.staging.vars]
+NEXT_PUBLIC_API_URL = "https://api.staging.saplinglearn.com"
+BACKEND_URL = "https://api.staging.saplinglearn.com"
+COOKIE_DOMAIN = ".staging.saplinglearn.com"
+
+[env.staging.observability]
+enabled = true


### PR DESCRIPTION
## What

Phase 4 of the staging plan (#246): a Cloudflare Workers **named environment** so the frontend can deploy a parallel `frontend-staging` worker — **no separate Cloudflare project**, same repo and config.

- `wrangler.toml` — `[env.staging]` overriding `BACKEND_URL` / `NEXT_PUBLIC_API_URL` → `https://api.staging.saplinglearn.com`, and `COOKIE_DOMAIN = .staging.saplinglearn.com` (scoped to staging only, so sessions never bleed into prod).
- `package.json` — `cf:deploy:staging` → `opennextjs-cloudflare build && wrangler deploy --env staging`.

## Operator follow-up (not in this PR)
- Bind the custom domain `staging.saplinglearn.com` to the `frontend-staging` worker.
- `wrangler secret put CF_ACCESS_CLIENT_ID/SECRET --env staging` for the Access hop.

See `docs/staging/setup-checklist.md` (PR #256).

## Testing
`wrangler.toml` parses and exposes `env.staging` with the expected vars; `package.json` parses with the new script. The full deploy is exercised when you run `npm run cf:deploy:staging`.

> Note: the Frontend CI check is red repo-wide right now for unrelated lockfile/eslint reasons — not caused by this config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)