### PR TITLE
fix(ci): unbreak the Frontend check (eslint flag + prune stale suppressions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,10 @@ jobs:
         run: npm install -g npm@10.9.2 --engine-strict=false
       - run: npm ci
       - name: Lint (eslint flat config — replaces the removed `next lint`)
-        run: npx eslint . --max-warnings -1
+        # --max-warnings=-1 (with '=') means "no warning limit" so warnings don't
+        # fail CI. Written as `--max-warnings -1` the bare `-1` is parsed as an
+        # option ("No -NUM option defined") and eslint exits 2 before tsc/vitest run.
+        run: npx eslint . --max-warnings=-1
       - name: Typecheck
         run: npx tsc --noEmit
       - name: Test

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -1,14 +1,4 @@
 {
-  "src/app/(shell)/notetaker/page.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(shell)/profile/[userId]/page.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
   "src/app/page.tsx": {
     "@next/next/no-html-link-for-pages": {
       "count": 1
@@ -17,14 +7,6 @@
       "count": 2
     },
     "react-hooks/immutability": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/components/ChatPanel.tsx": {
-    "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
@@ -46,50 +28,16 @@
   "src/components/DocumentUploadModal.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 3
     }
   },
   "src/components/FeedbackFlow.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    },
     "react/no-unescaped-entities": {
       "count": 1
-    }
-  },
-  "src/components/Gradebook/AssignmentModal.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/components/Gradebook/EditWeightsModal.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/components/Gradebook/LetterScaleEditor.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 2
     }
   },
   "src/components/Gradebook/SyllabusUploadFlow.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/components/HowItWorks.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/components/KnowledgeGraph.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
     }
   },
   "src/components/KnowledgeGraph2D.tsx": {
@@ -103,11 +51,6 @@
   "src/components/KnowledgeGraph3D.test.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 6
-    }
-  },
-  "src/components/ManageCoursesModal.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 2
     }
   },
   "src/components/ModelToggle.tsx": {
@@ -125,17 +68,7 @@
       "count": 1
     }
   },
-  "src/components/SideNav.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
   "src/components/SignInModal.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/components/ToastProvider.tsx": {
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
@@ -145,49 +78,15 @@
       "count": 3
     }
   },
-  "src/components/TopNav.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/components/flashcards/FlashcardImportModal.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/components/flashcards/tabs/PasteTab.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/components/screens/Achievements.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
   "src/components/screens/Admin.tsx": {
     "react-hooks/exhaustive-deps": {
       "count": 3
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 6
     },
     "react/no-unescaped-entities": {
       "count": 2
     }
   },
-  "src/components/screens/Calendar.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
   "src/components/screens/Dashboard.tsx": {
-    "react-hooks/purity": {
-      "count": 3
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 6
-    },
     "react/no-unescaped-entities": {
       "count": 2
     }
@@ -195,17 +94,11 @@
   "src/components/screens/Gradebook/Course.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 1
     }
   },
   "src/components/screens/Gradebook/Landing.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 2
     }
   },
   "src/components/screens/Learn.tsx": {
@@ -216,48 +109,16 @@
   "src/components/screens/Library.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 3
-    }
-  },
-  "src/components/screens/Onboarding.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/components/screens/Settings.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 2
     }
   },
   "src/components/screens/Social.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 9
-    },
-    "react-hooks/purity": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 4
-    }
-  },
-  "src/components/screens/Study.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 5
     }
   },
   "src/components/screens/Tree.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/context/UserContext.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 2
     }
   },
   "src/lib/api.test.ts": {


### PR DESCRIPTION
Fixes the chronically-red **Frontend (lint + tsc + vitest)** check (red on `main` and every PR). Two stacked causes, two commits:

### 1. Malformed eslint flag
The lint step ran `npx eslint . --max-warnings -1`. With a space, the bare `-1` is parsed as an option → `No -NUM option defined`, exit 2 — eslint died before linting anything. Fixed to `--max-warnings=-1` (no warning limit; warnings don't fail CI).

### 2. Stale bulk-suppressions baseline
Fixing the flag let eslint run, which exposed the real blocker: `frontend/eslint-suppressions.json` listed suppressions that no longer occur (mostly `react-hooks/set-state-in-effect`, which the `eslint-config-next` bump stopped reporting). ESLint exits 2 on leftover suppressions regardless of `--max-warnings`. Pruned the dead entries (`eslint . --prune-suppressions`, −139 lines).

## Verified locally (CI-matching deps via fresh `npm ci` against the synced lockfile)
- `npx eslint . --max-warnings=-1` → **exit 0** (35 warnings, 0 errors)
- `npx tsc --noEmit` → **exit 0**
- `npm test` → **exit 0** (10 files, 68 tests passed)

Once this lands on `main`, the Frontend check goes green repo-wide — including #261, which inherits the fix via its merge ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected ESLint command flag syntax in the CI/CD workflow configuration to ensure reliable build validation behavior and consistent proper execution during continuous integration processes
  * Removed and consolidated outdated linting rule suppressions across multiple frontend components and modules, improving overall code quality standards and promoting strict adherence to established development guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->