### PR TITLE
db/academics-code: rewire app onto courses/offerings/terms/enrollments (epic slice PR2)

### DIFF
--- a/backend/agents/tools/graph_read.py
+++ b/backend/agents/tools/graph_read.py
@@ -100,33 +100,30 @@ class Misconception(BaseModel):
 
 
 async def read_misconceptions_for_course(
-    course_id: str | None,
+    offering_id: str | None,
 ) -> list[Misconception]:
-    """Return aggregated misconception strings for a course. Anonymized
-    (sourced from class-wide patterns, not from any single student).
-    Returns [] when course_id is None or the underlying table is empty.
+    """Return aggregated misconception strings for an offering (a class in a
+    term). Anonymized (sourced from class-wide patterns, not any single student).
+    Returns [] when offering_id is None or the underlying table is empty.
 
-    Source: `course_concept_stats` rows for the course. Each row
+    Source: `offering_concept_stats` rows for the offering. Each row
     represents one concept and carries a `common_misconceptions` array
     (populated by the hash-gated aggregation in
     `services/course_context_service.py`). We flatten each array entry
     into its own Misconception, tagging `related_concept` with the
     concept name so the agent can route distractors per-concept.
 
-    The spec referenced a hypothetical `misconceptions` table — that
-    table does not exist in this schema. `course_concept_stats` is the
-    real source of class-wide misconception strings, so we read that.
     The tool contract (returning Misconception[]) is unchanged.
     """
-    if not course_id:
+    if not offering_id:
         return []
 
     def _fetch() -> list[dict[str, Any]]:
         try:
             return (
-                table("course_concept_stats").select(
+                table("offering_concept_stats").select(
                     "concept_name,common_misconceptions",
-                    filters={"course_id": f"eq.{course_id}"},
+                    filters={"offering_id": f"eq.{offering_id}"},
                     order="updated_at.desc",
                     limit=20,
                 )
@@ -134,8 +131,8 @@ async def read_misconceptions_for_course(
             )
         except Exception:
             logger.exception(
-                "read_misconceptions_for_course failed for course=%s",
-                course_id,
+                "read_misconceptions_for_course failed for offering=%s",
+                offering_id,
             )
             return []
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,7 +21,7 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 
-from routes import graph, learn, quiz, calendar, social, extract, auth, documents, flashcards, study_guide, feedback, careers, onboarding, gradebook, notes
+from routes import graph, learn, quiz, calendar, social, extract, auth, documents, flashcards, study_guide, feedback, careers, onboarding, gradebook, notes, academics
 from routes.profile import router as profile_router
 from routes.admin import router as admin_router
 from routes.newsletter import router as newsletter_router
@@ -165,6 +165,7 @@ app.include_router(admin_router,       prefix="/api/admin")
 app.include_router(newsletter_router,  prefix="/api/newsletter")
 app.include_router(gradebook.router,   prefix="/api/gradebook")
 app.include_router(notes.router,       prefix="/api/notes")
+app.include_router(academics.router,   prefix="/api", tags=["academics"])
 
 
 @app.get("/api/health")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -102,7 +102,11 @@ class ImportSaveBody(BaseModel):
 # ── Graph (Courses) ─────────────────────────────────────────────────────────
 
 class AddCourseBody(BaseModel):
-    """Body for enrolling a user in a course (creating a user_courses record)."""
+    """Body for enrolling a user in a course.
+
+    ``course_id`` is the abstract catalog course id; enrollment resolves it to a
+    current-term offering (see services/academics.resolve_offering).
+    """
     course_id: str
     color: Optional[str] = None
     nickname: Optional[str] = None
@@ -202,7 +206,7 @@ class OnboardingBody(BaseModel):
     year: str
     majors: list[str] = Field(min_length=1)
     minors: list[str] = []
-    course_ids: list[str] = Field(min_length=1)
+    course_ids: list[str] = Field(min_length=1)  # abstract catalog course ids; enroll resolves each to a current-term offering
     learning_style: str
 
 

--- a/backend/routes/academics.py
+++ b/backend/routes/academics.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+
+from services.academics import list_terms
+
+router = APIRouter()
+
+
+@router.get("/semesters")
+def get_semesters():
+    """All terms (semesters), most recent first — for the frontend SemesterChips (#138)."""
+    return {"semesters": list_terms()}

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -135,27 +135,35 @@ def _get_course_id_for_topic(topic: str, user_id: str) -> str:
     if not topic_trim:
         return ""
     
-    # First, check if topic matches a course code or name in user's enrolled courses
+    # First, check if topic matches a course code or name in user's enrolled
+    # courses. Enrollment keys on an offering; the abstract course (which the
+    # session + knowledge graph key on) sits behind
+    # offering_id → course_offerings.course_id → courses. Match the topic against
+    # the abstract course's code/name and return the abstract course_id.
     try:
-        enrolled = table("user_courses").select(
-            "course_id,courses!inner(course_code,course_name)",
+        enrolled = table("enrollments").select(
+            "offering_id,course_offerings!inner(course_id,courses!inner(course_code,course_name))",
             filters={"user_id": f"eq.{user_id}"},
         )
         for row in enrolled:
-            course = row.get("courses", {}) if isinstance(row.get("courses"), dict) else {}
-            course_code = course.get("course_code", "")
-            course_name = course.get("course_name", "")
-            
+            offering = row.get("course_offerings", {})
+            if not isinstance(offering, dict):
+                continue
+            abstract_course_id = offering.get("course_id")
+            course = offering.get("courses", {}) if isinstance(offering.get("courses"), dict) else {}
+            course_code = course.get("course_code", "") or ""
+            course_name = course.get("course_name", "") or ""
+
             # Match on course_code (exact or case-insensitive)
-            if topic_trim.upper() == course_code.upper():
-                return row["course_id"]
+            if course_code and topic_trim.upper() == course_code.upper():
+                return abstract_course_id
             # Match on course_name
-            if topic_trim.lower() == course_name.lower():
-                return row["course_id"]
+            if course_name and topic_trim.lower() == course_name.lower():
+                return abstract_course_id
             # Same label as graph subject roots (graph_service)
             label = f"{course_code} - {course_name}" if course_code else course_name
             if label and topic_trim == label:
-                return row["course_id"]
+                return abstract_course_id
     except Exception as e:
         print(f"Failed to resolve course_id for topic={topic_trim!r} user_id={user_id!r}: {e}")
     
@@ -281,6 +289,7 @@ def build_system_prompt(
             )
 
     if use_shared_context and course_id:
+        # TODO(db/study-code): pass the session's offering_id once sessions carry it; abstract id degrades to {} for now
         ctx = get_course_context(course_id)
         if ctx:
             course_info = _get_course_info(course_id)

--- a/backend/routes/onboarding.py
+++ b/backend/routes/onboarding.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 
 from db.connection import table
 from models import OnboardingBody
+from services.academics import resolve_offering
 from services.auth_guard import require_self
 from services.encryption import encrypt_if_present
 
@@ -52,30 +53,36 @@ def save_onboarding_profile(body: OnboardingBody, request: Request):
         filters={"id": f"eq.{body.user_id}"},
     )
 
-    # Enroll user in selected courses
+    # Enroll user in selected courses (resolve each abstract course → current-term offering)
     enrolled_ids = []
     for course_id in body.course_ids:
-        # Verify course exists
+        # Verify abstract course exists in the catalog
         course = table("courses").select("id", filters={"id": f"eq.{course_id}"})
         if not course:
             continue
 
-        # Enroll if not already enrolled
-        existing = table("user_courses").select(
+        # Resolve the abstract course to a current-term offering, creating a
+        # NULL-section offering if the catalog lacks one for this term.
+        offering_id = resolve_offering(course_id, create=True)
+        if not offering_id:
+            continue
+
+        # Enroll if not already enrolled in this offering
+        existing = table("enrollments").select(
             "id",
             filters={
                 "user_id": f"eq.{body.user_id}",
-                "course_id": f"eq.{course_id}",
+                "offering_id": f"eq.{offering_id}",
             },
         )
         if not existing:
-            table("user_courses").insert({
+            table("enrollments").insert({
                 "id": str(uuid.uuid4()),
                 "user_id": body.user_id,
-                "course_id": course_id,
+                "offering_id": offering_id,
             })
 
-        enrolled_ids.append(course_id)
+        enrolled_ids.append(course_id)  # response still reports abstract course ids
 
     return {
         "user_id": body.user_id,

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -175,15 +175,21 @@ def get_public_profile(user_id: str):
     roles = _get_user_roles(user_id)
     equipped = _get_equipped_cosmetics(settings)
 
-    # Resolve school from user's enrolled courses
+    # Resolve school from user's enrolled courses.
+    # School now lives behind enrollments.offering_id → course_offerings.course_id
+    # → courses.school_id (a FK, currently unpopulated). Read through the join but
+    # tolerate a missing/None school; it surfaces as None until school_id is linked.
     school = None
-    enrollments = table("user_courses").select(
-        "courses(school)",
+    enrollments = table("enrollments").select(
+        "course_offerings(courses(school_id))",
         filters={"user_id": f"eq.{user_id}"},
         limit=1,
     )
-    if enrollments and enrollments[0].get("courses", {}).get("school"):
-        school = enrollments[0]["courses"]["school"]
+    if enrollments:
+        offering = enrollments[0].get("course_offerings") or {}
+        course = offering.get("courses") or {} if isinstance(offering, dict) else {}
+        if isinstance(course, dict) and course.get("school_id"):
+            school = course["school_id"]
 
     profile = {
         "id": user["id"],

--- a/backend/services/academics.py
+++ b/backend/services/academics.py
@@ -1,0 +1,137 @@
+"""services/academics.py
+
+Term / offering / enrollment resolution for the academics-split schema.
+
+The public API speaks in **abstract** course ids (the catalog), while the
+storage layer keys enrollments and class artifacts on a **course_offering**
+(a course taught in a specific term). These helpers bridge the two:
+
+- the knowledge graph stays on the abstract ``course_id`` (cumulative mastery),
+- enrollments / gradebook / analytics resolve to an ``offering_id`` per term.
+
+"Current term" is date-derived: the term whose ``[start_date, end_date]``
+contains today. When today falls outside every seeded range we fall back to the
+latest term by ``sort_key`` so resolution never dead-ends.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from db.connection import table
+
+
+def current_term(today: date | None = None) -> dict | None:
+    """The current term row, or None if no terms are seeded.
+
+    Date-derived: today ∈ [start_date, end_date]. Falls back to the most recent
+    term (highest sort_key) so a date in a gap between terms still resolves.
+    """
+    d = (today or date.today()).isoformat()
+    rows = table("terms").select(
+        "*",
+        filters={"start_date": f"lte.{d}", "end_date": f"gte.{d}"},
+        order="sort_key.desc",
+        limit=1,
+    )
+    if rows:
+        return rows[0]
+    latest = table("terms").select("*", order="sort_key.desc", limit=1)
+    return latest[0] if latest else None
+
+
+def list_terms() -> list[dict]:
+    """All terms, most recent first — backs GET /api/semesters."""
+    return table("terms").select(
+        "id,term,year,label,start_date,end_date,sort_key",
+        order="sort_key.desc",
+    ) or []
+
+
+def resolve_offering(
+    course_id: str,
+    term_id: str | None = None,
+    *,
+    create: bool = False,
+) -> str | None:
+    """Return the offering id for (course, term).
+
+    ``term_id`` defaults to the current term. If no matching offering exists:
+    - ``create=True`` inserts one (NULL section) and returns its id, so a fresh
+      enrollment lands in the real current semester instead of a legacy term;
+    - ``create=False`` falls back to any existing offering of the course.
+    Returns None only when the course has no offering and we can't/shouldn't make one.
+    """
+    if not course_id:
+        return None
+    if not term_id:
+        t = current_term()
+        term_id = t["id"] if t else None
+
+    if term_id:
+        rows = table("course_offerings").select(
+            "id",
+            filters={"course_id": f"eq.{course_id}", "term_id": f"eq.{term_id}"},
+            order="created_at.asc",
+            limit=1,
+        )
+        if rows:
+            return rows[0]["id"]
+
+    if create and term_id:
+        new_id = str(uuid.uuid4())
+        table("course_offerings").insert(
+            {"id": new_id, "course_id": course_id, "term_id": term_id}
+        )
+        return new_id
+
+    # No offering in the target term and not creating — fall back to any offering
+    # of this course so reads still resolve to something sensible.
+    any_off = table("course_offerings").select(
+        "id", filters={"course_id": f"eq.{course_id}"}, limit=1
+    )
+    return any_off[0]["id"] if any_off else None
+
+
+def offering_course_id(offering_id: str) -> str | None:
+    """The abstract course id an offering belongs to (offering → graph bridge)."""
+    if not offering_id:
+        return None
+    rows = table("course_offerings").select(
+        "course_id", filters={"id": f"eq.{offering_id}"}, limit=1
+    )
+    return rows[0]["course_id"] if rows else None
+
+
+def user_offering_ids_for_course(user_id: str, course_id: str) -> list[str]:
+    """The offerings of an abstract course that ``user_id`` is enrolled in.
+
+    Two-step (offerings of the course, then the user's enrollments intersected)
+    to avoid fragile PostgREST embedded-filter syntax.
+    """
+    offs = table("course_offerings").select(
+        "id", filters={"course_id": f"eq.{course_id}"}
+    ) or []
+    off_ids = {o["id"] for o in offs}
+    if not off_ids:
+        return []
+    enr = table("enrollments").select(
+        "offering_id", filters={"user_id": f"eq.{user_id}"}
+    ) or []
+    return [e["offering_id"] for e in enr if e.get("offering_id") in off_ids]
+
+
+def term_for_offering(offering_id: str) -> dict | None:
+    """The term row for an offering (for semester labels)."""
+    if not offering_id:
+        return None
+    rows = table("course_offerings").select(
+        "term_id", filters={"id": f"eq.{offering_id}"}, limit=1
+    )
+    if not rows:
+        return None
+    term_id = rows[0].get("term_id")
+    if not term_id:
+        return None
+    terms = table("terms").select("*", filters={"id": f"eq.{term_id}"}, limit=1)
+    return terms[0] if terms else None

--- a/backend/services/course_context_service.py
+++ b/backend/services/course_context_service.py
@@ -1,12 +1,14 @@
 """
 services/course_context_service.py
 
-Builds and caches shared course-level context from real DB data.
-Aggregates graph_nodes mastery data and quiz_context across all students in a course.
+Builds and caches shared class-level context from real DB data.
+Aggregates graph_nodes mastery data and quiz_context across all students in an
+offering (a course taught in a term). The graph is keyed on the abstract course;
+analytics are keyed on the offering.
 
 Stores data in:
-- course_concept_stats: per-concept aggregated metrics
-- course_summary: course-wide summary with Gemini-generated text
+- offering_concept_stats: per-concept aggregated metrics (per offering)
+- offering_summary: class-wide summary with Gemini-generated text (per offering)
 """
 
 import json
@@ -63,36 +65,34 @@ Write in a professional but approachable tone. Be specific and data-driven."""
         )
 
 
-def get_course_context(course_id: str) -> dict:
+def get_course_context(offering_id: str) -> dict:
     """
-    Return the cached course context including summary and concept stats.
-    Returns dict with course_summary + course_concept_stats, or {} if not found.
+    Return the cached class context for an offering: summary + concept stats.
+    Offering-scoped (one class instance in one term). Returns {} if not found.
     """
-    if not course_id:
+    if not offering_id:
         return {}
-    
+
     try:
-        # Get course summary
-        summary_rows = table("course_summary").select(
+        # Get the offering summary
+        summary_rows = table("offering_summary").select(
             "*",
-            filters={"course_id": f"eq.{course_id}"},
+            filters={"offering_id": f"eq.{offering_id}"},
         )
         if not summary_rows:
             return {}
-        
-        summary = summary_rows[0]
-        semester = summary["semester"]
 
-        # Get concept stats for this course, scoped to the same semester
-        stats_rows = table("course_concept_stats").select(
+        summary = summary_rows[0]
+
+        # Get concept stats for this offering
+        stats_rows = table("offering_concept_stats").select(
             "*",
-            filters={"course_id": f"eq.{course_id}", "semester": f"eq.{semester}"},
+            filters={"offering_id": f"eq.{offering_id}"},
         )
-        
+
         return {
             "course_summary": {
-                "course_id": summary["course_id"],
-                "semester": summary["semester"],
+                "offering_id": summary["offering_id"],
                 "student_count": summary["student_count"],
                 "avg_class_mastery": summary["avg_class_mastery"],
                 "top_struggling_concepts": summary.get("top_struggling_concepts", []),
@@ -106,43 +106,49 @@ def get_course_context(course_id: str) -> dict:
         return {}
 
 
-def update_course_context(course_id: str) -> None:
+def update_course_context(offering_id: str) -> None:
     """
-    Aggregate mastery + quiz data for all students enrolled in the course and upsert
-    into course_concept_stats and course_summary tables.
-    Called automatically after any graph update.
+    Aggregate mastery + quiz data for all students enrolled in an **offering**
+    (a course taught in a term) and upsert into offering_concept_stats and
+    offering_summary. Offering-scoped. Called automatically after any graph update.
+
+    The knowledge graph is keyed on the *abstract* course id, so we resolve the
+    offering → its abstract course to read graph_nodes.
     """
-    if not course_id:
+    if not offering_id:
         return
 
-    # ── 1. Get all students enrolled in this course via user_courses ───────────
-    enrollment_rows = table("user_courses").select(
+    # ── 1. Get all students enrolled in this offering via enrollments ─────────
+    enrollment_rows = table("enrollments").select(
         "user_id",
-        filters={"course_id": f"eq.{course_id}"},
+        filters={"offering_id": f"eq.{offering_id}"},
     )
     if not enrollment_rows:
         # No students enrolled — purge any stale aggregates
-        table("course_concept_stats").delete({"course_id": f"eq.{course_id}"})
-        table("course_summary").delete({"course_id": f"eq.{course_id}"})
+        table("offering_concept_stats").delete({"offering_id": f"eq.{offering_id}"})
+        table("offering_summary").delete({"offering_id": f"eq.{offering_id}"})
         return
 
     user_ids = [r["user_id"] for r in enrollment_rows]
     student_count = len(user_ids)
 
-    # ── 2. Get course info (including canonical semester) for the summary ──────
+    # ── 2. Resolve the offering → abstract course (graph key) + term label ────
+    from services.academics import offering_course_id
+    abstract_course_id = offering_course_id(offering_id)
+    if not abstract_course_id:
+        return
     course_rows = table("courses").select(
-        "course_code,course_name,semester",
-        filters={"id": f"eq.{course_id}"},
+        "course_code,course_name",
+        filters={"id": f"eq.{abstract_course_id}"},
     )
-    course_info = course_rows[0] if course_rows else {"course_code": "", "course_name": "", "semester": "Spring 2026"}
-    semester = course_info.get("semester") or "Spring 2026"
+    course_info = course_rows[0] if course_rows else {"course_code": "", "course_name": ""}
 
-    # ── 3. All graph nodes for this course across every enrolled student ──────
+    # ── 3. All graph nodes for this (abstract) course across enrolled students ─
     # Build user_id filter for PostgREST
     user_filter = ",".join(user_ids)
     node_rows = table("graph_nodes").select(
         "id,concept_name,mastery_score,mastery_tier,user_id",
-        filters={"course_id": f"eq.{course_id}", "user_id": f"in.({user_filter})"},
+        filters={"course_id": f"eq.{abstract_course_id}", "user_id": f"in.({user_filter})"},
     )
     if not node_rows:
         return  # No graph data yet for this course
@@ -247,11 +253,10 @@ def update_course_context(course_id: str) -> None:
         ctx_rows = _fetch_quiz_context_rows(node_ids_for_concept)
         cm, ee, pg = _parse_quiz_context_to_arrays(ctx_rows)
 
-        table("course_concept_stats").upsert(
+        table("offering_concept_stats").upsert(
             {
-                "course_id": course_id,
+                "offering_id": offering_id,
                 "concept_name": name,
-                "semester": semester,
                 "student_count": metrics["student_count"],
                 "avg_mastery_score": metrics["avg_mastery_score"],
                 "pct_mastered": metrics["pct_mastered"],
@@ -262,7 +267,7 @@ def update_course_context(course_id: str) -> None:
                 "prerequisite_gaps": pg,
                 "updated_at": datetime.now(timezone.utc).isoformat(),
             },
-            on_conflict="course_id,concept_name,semester",
+            on_conflict="offering_id,concept_name",
         )
 
     # ── 8. Compute course-wide summary metrics ────────────────────────────────
@@ -296,9 +301,9 @@ def update_course_context(course_id: str) -> None:
     current_hash = _generate_data_hash(stats_for_hash)
 
     # ── 9. Check if summary needs regeneration ─────────────────────────────────
-    existing_summary_rows = table("course_summary").select(
+    existing_summary_rows = table("offering_summary").select(
         "summary_hash,summary_text",
-        filters={"course_id": f"eq.{course_id}", "semester": f"eq.{semester}"},
+        filters={"offering_id": f"eq.{offering_id}"},
     )
     
     existing_hash = existing_summary_rows[0]["summary_hash"] if existing_summary_rows else None
@@ -316,11 +321,10 @@ def update_course_context(course_id: str) -> None:
     else:
         summary_text = existing_summary_rows[0].get("summary_text", "")
 
-    # ── 10. Upsert into course_summary ────────────────────────────────────────
-    table("course_summary").upsert(
+    # ── 10. Upsert into offering_summary ──────────────────────────────────────
+    table("offering_summary").upsert(
         {
-            "course_id": course_id,
-            "semester": semester,
+            "offering_id": offering_id,
             "student_count": student_count,
             "avg_class_mastery": avg_class_mastery,
             "top_struggling_concepts": top_struggling_concepts,
@@ -329,5 +333,5 @@ def update_course_context(course_id: str) -> None:
             "summary_hash": current_hash,
             "updated_at": datetime.now(timezone.utc).isoformat(),
         },
-        on_conflict="course_id,semester",
+        on_conflict="offering_id",
     )

--- a/backend/services/graph_service.py
+++ b/backend/services/graph_service.py
@@ -7,16 +7,56 @@ from config import get_mastery_tier
 from db.connection import table
 
 
+def _reshape_enrollment(r: dict) -> dict:
+    """Flatten an enrollments→course_offerings→courses/terms join row into the
+    legacy flat shape consumers expect:
+
+    - ``course_id`` = the *abstract* course id (the knowledge-graph key),
+    - ``courses``   = {course_code, course_name, department, school},
+    - plus the new ``offering_id`` and ``term`` (label).
+    """
+    off = r.get("course_offerings") or {}
+    if not isinstance(off, dict):
+        off = {}
+    course = off.get("courses") or {}
+    if not isinstance(course, dict):
+        course = {}
+    term = off.get("terms") or {}
+    if not isinstance(term, dict):
+        term = {}
+    return {
+        "id": r.get("id"),
+        "offering_id": r.get("offering_id"),
+        "course_id": off.get("course_id"),  # ABSTRACT course id — graph keys on this
+        "color": r.get("color"),
+        "nickname": r.get("nickname"),
+        "enrolled_at": r.get("enrolled_at"),
+        "term": term.get("label", ""),
+        "courses": {
+            "course_code": course.get("course_code", ""),
+            "course_name": course.get("course_name", ""),
+            "department": course.get("department", ""),
+            # Free-text school retired in the academics split; school_id is unpopulated.
+            "school": "",
+        },
+    }
+
+
 def _user_enrolled_courses(user_id: str) -> list[dict]:
-    """Get all courses a user is enrolled in via user_courses join."""
+    """All courses a user is enrolled in, via enrollments → course_offerings →
+    courses/terms, reshaped to the legacy flat shape (abstract course_id + nested
+    courses dict + offering_id + term label)."""
     try:
-        rows = table("user_courses").select(
-            "id,course_id,color,nickname,enrolled_at,courses!inner(course_code,course_name,department,school)",
+        rows = table("enrollments").select(
+            "id,offering_id,color,nickname,enrolled_at,"
+            "course_offerings!inner(course_id,"
+            "courses!inner(course_code,course_name,department),terms!inner(label))",
             filters={"user_id": f"eq.{user_id}"},
+            order="enrolled_at.asc",
         )
     except Exception:
         return []
-    return rows or []
+    return [_reshape_enrollment(r) for r in (rows or [])]
 
 
 def _get_course_nodes(user_id: str, course_id: str) -> list:
@@ -208,30 +248,23 @@ def get_graph(user_id: str) -> dict:
 
 def get_courses(user_id: str) -> list:
     """
-    Return user's enrolled courses joined with canonical course data.
-    Returns list of dicts with: enrollment_id, course_id, course_code, course_name, 
-    school, department, color, nickname, node_count, enrolled_at
+    Return user's enrolled courses joined with abstract catalog data + term.
+    Returns list of dicts with: enrollment_id, course_id (abstract), course_code,
+    course_name, school, department, color, nickname, term, node_count, enrolled_at.
     """
-    try:
-        rows = table("user_courses").select(
-            "id,course_id,color,nickname,enrolled_at,courses!inner(course_code,course_name,school,department)",
-            filters={"user_id": f"eq.{user_id}"},
-            order="enrolled_at.asc",
-        )
-    except Exception:
-        return []
-    
+    rows = _user_enrolled_courses(user_id)
+
     result = []
     for r in rows:
         course = r.get("courses", {}) if isinstance(r.get("courses"), dict) else {}
-        course_id = r["course_id"]
-        
-        # Count nodes for this course
+        course_id = r.get("course_id")  # abstract
+
+        # Count nodes for this course (graph keys on the abstract course id)
         node_rows = table("graph_nodes").select(
             "id",
             filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
-        )
-        
+        ) if course_id else []
+
         result.append({
             "enrollment_id": r["id"],
             "course_id": course_id,
@@ -241,59 +274,75 @@ def get_courses(user_id: str) -> list:
             "department": course.get("department", ""),
             "color": r.get("color"),
             "nickname": r.get("nickname"),
+            "term": r.get("term", ""),
             "node_count": len(node_rows),
-            "enrolled_at": r["enrolled_at"],
+            "enrolled_at": r.get("enrolled_at"),
         })
     return result
 
 
 def add_course(user_id: str, course_id: str, color: str | None = None, nickname: str | None = None) -> dict:
     """
-    Enroll a user in a course (insert into user_courses).
-    course_id refers to the canonical courses table.
+    Enroll a user in a course. ``course_id`` is the abstract catalog course id;
+    the enrollment is created against the **current term's offering** of that
+    course (created if the catalog lacks one), so new enrollments land in the
+    real current semester.
     """
-    # Check if already enrolled
-    existing = table("user_courses").select(
-        "id",
-        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
-    )
-    if existing:
-        return {"course_id": course_id, "already_existed": True}
-    
-    # Verify the course exists in canonical courses
+    # Verify the abstract course exists in the catalog
     course_check = table("courses").select("id", filters={"id": f"eq.{course_id}"})
     if not course_check:
         return {"course_id": course_id, "error": "Course not found in catalog"}
-    
-    table("user_courses").insert({
+
+    from services.academics import resolve_offering
+    offering_id = resolve_offering(course_id, create=True)
+    if not offering_id:
+        return {"course_id": course_id, "error": "No term available to enroll into"}
+
+    # Check if already enrolled in this offering
+    existing = table("enrollments").select(
+        "id",
+        filters={"user_id": f"eq.{user_id}", "offering_id": f"eq.{offering_id}"},
+    )
+    if existing:
+        return {"course_id": course_id, "already_existed": True}
+
+    table("enrollments").insert({
         "id": str(uuid.uuid4()),
         "user_id": user_id,
-        "course_id": course_id,
+        "offering_id": offering_id,
         "color": color,
         "nickname": nickname,
     })
     try:
         from services.course_context_service import update_course_context
-        update_course_context(course_id)
+        update_course_context(offering_id)
     except Exception:
         pass
     return {"course_id": course_id, "already_existed": False}
 
 
 def update_course_color(user_id: str, course_id: str, color: str) -> dict:
-    """Update the color for a user's course enrollment."""
-    table("user_courses").update(
+    """Update the color for a user's enrollment(s) of an abstract course."""
+    from services.academics import user_offering_ids_for_course
+    offering_ids = user_offering_ids_for_course(user_id, course_id)
+    if not offering_ids:
+        return {"updated": False}
+    table("enrollments").update(
         {"color": color},
-        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
+        filters={"user_id": f"eq.{user_id}", "offering_id": f"in.({','.join(offering_ids)})"},
     )
     return {"updated": True}
 
 
 def update_course_nickname(user_id: str, course_id: str, nickname: str) -> dict:
-    """Update the nickname for a user's course enrollment."""
-    table("user_courses").update(
+    """Update the nickname for a user's enrollment(s) of an abstract course."""
+    from services.academics import user_offering_ids_for_course
+    offering_ids = user_offering_ids_for_course(user_id, course_id)
+    if not offering_ids:
+        return {"updated": False}
+    table("enrollments").update(
         {"nickname": nickname},
-        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
+        filters={"user_id": f"eq.{user_id}", "offering_id": f"in.({','.join(offering_ids)})"},
     )
     return {"updated": True}
 
@@ -317,11 +366,15 @@ def delete_node(user_id: str, node_id: str) -> dict:
     table("graph_nodes").delete(filters={"id": f"eq.{node_id}", "user_id": f"eq.{user_id}"})
 
     if course_id:
-        try:
-            from services.course_context_service import update_course_context
-            update_course_context(course_id)
-        except Exception:
-            pass
+        # course_id from graph_nodes is the abstract course; refresh each of the
+        # user's offerings of that course (analytics is offering-scoped).
+        from services.course_context_service import update_course_context
+        from services.academics import user_offering_ids_for_course
+        for offering_id in user_offering_ids_for_course(user_id, course_id):
+            try:
+                update_course_context(offering_id)
+            except Exception:
+                pass
     return {"deleted": True}
 
 
@@ -343,18 +396,20 @@ def update_node_color(user_id: str, node_id: str, color: str | None) -> dict:
 
 def delete_course(user_id: str, course_id: str) -> dict:
     """
-    Unenroll a user from a course (delete from user_courses).
-    Note: We don't delete the graph nodes - they remain for potential re-enrollment.
+    Unenroll a user from a course (delete their enrollment(s) for the abstract
+    course's offerings). Graph nodes are kept for potential re-enrollment.
     """
-    # Just delete the enrollment, not the nodes
-    table("user_courses").delete(
-        {"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"}
-    )
-    try:
-        from services.course_context_service import update_course_context
-        update_course_context(course_id)
-    except Exception:
-        pass
+    from services.academics import user_offering_ids_for_course
+    offering_ids = user_offering_ids_for_course(user_id, course_id)
+    from services.course_context_service import update_course_context
+    for offering_id in offering_ids:
+        table("enrollments").delete(
+            {"user_id": f"eq.{user_id}", "offering_id": f"eq.{offering_id}"}
+        )
+        try:
+            update_course_context(offering_id)
+        except Exception:
+            pass
     return {"deleted": True}
 
 
@@ -520,12 +575,16 @@ def apply_graph_update(user_id: str, graph_update: dict, course_id: str | None =
             })
 
     if touched_courses:
+        # touched_courses holds abstract course ids (the graph key). Analytics is
+        # offering-scoped, so refresh each of this user's offerings of those courses.
         from services.course_context_service import update_course_context
+        from services.academics import user_offering_ids_for_course
         for cid in touched_courses:
-            try:
-                update_course_context(cid)
-            except Exception:
-                pass
+            for offering_id in user_offering_ids_for_course(user_id, cid):
+                try:
+                    update_course_context(offering_id)
+                except Exception:
+                    pass
 
     return mastery_changes
 

--- a/backend/tests/test_academics.py
+++ b/backend/tests/test_academics.py
@@ -1,0 +1,136 @@
+"""Tests for services/academics.py — the term/offering/enrollment resolver
+that the academics-split code slice is built on.
+
+Each test patches `services.academics.table` with a factory that returns a
+MagicMock per table name, seeded with canned `.select()` rows and recording
+`.insert()` calls — the same hermetic pattern the rest of the suite uses.
+"""
+from unittest.mock import MagicMock, patch
+
+import services.academics as ac
+
+
+def _factory(rows_by_table, recorder=None, select_seqs=None):
+    """Return a `table(name)` stand-in, caching one mock per table name so that
+    repeated `table(name)` calls share `.select` side-effect sequencing (the
+    helper queries some tables twice: a primary query then a fallback).
+
+    - `rows_by_table[name]` seeds a constant `.select()` return.
+    - `select_seqs[name]` (optional) seeds an ordered list of `.select()` results
+      for tables queried more than once.
+    - `.insert()` echoes its payload and records it.
+    """
+    cache: dict = {}
+    select_seqs = select_seqs or {}
+
+    def make(name):
+        if name in cache:
+            return cache[name]
+        m = MagicMock(name=f"table({name})")
+        if name in select_seqs:
+            m.select.side_effect = list(select_seqs[name])
+        else:
+            m.select.return_value = rows_by_table.get(name, [])
+
+        def _insert(data):
+            if recorder is not None:
+                recorder.append((name, data))
+            return [data]
+
+        m.insert.side_effect = _insert
+        cache[name] = m
+        return m
+    return make
+
+
+# ── current_term ──────────────────────────────────────────────────────────
+
+def test_current_term_returns_row_in_range():
+    rows = {"terms": [{"id": "t-spring", "label": "Spring 2026", "sort_key": 20261}]}
+    with patch.object(ac, "table", side_effect=_factory(rows)):
+        assert ac.current_term()["id"] == "t-spring"
+
+
+def test_current_term_falls_back_to_latest_when_no_range_matches():
+    # First select (range query) returns []; the fallback select returns the latest.
+    factory = _factory({}, select_seqs={"terms": [
+        [],  # range query: nothing contains today
+        [{"id": "t-summer", "label": "Summer 2026", "sort_key": 20262}],  # latest
+    ]})
+    with patch.object(ac, "table", side_effect=factory):
+        assert ac.current_term()["id"] == "t-summer"
+
+
+def test_current_term_none_when_no_terms():
+    with patch.object(ac, "table", side_effect=_factory({"terms": []})):
+        assert ac.current_term() is None
+
+
+# ── resolve_offering ────────────────────────────────────────────────────────
+
+def test_resolve_offering_returns_existing():
+    rows = {
+        "terms": [{"id": "t1", "label": "Spring 2026", "sort_key": 20261}],
+        "course_offerings": [{"id": "off-1"}],
+    }
+    with patch.object(ac, "table", side_effect=_factory(rows)):
+        assert ac.resolve_offering("course-1") == "off-1"
+
+
+def test_resolve_offering_creates_when_missing_and_create_true():
+    recorder = []
+    rows = {"terms": [{"id": "t1", "label": "Spring 2026", "sort_key": 20261}],
+            "course_offerings": []}
+    with patch.object(ac, "table", side_effect=_factory(rows, recorder)):
+        off_id = ac.resolve_offering("course-1", term_id="t1", create=True)
+    assert off_id  # a fresh uuid
+    assert recorder, "should have inserted an offering"
+    name, payload = recorder[0]
+    assert name == "course_offerings"
+    assert payload["course_id"] == "course-1"
+    assert payload["term_id"] == "t1"
+    assert payload["id"] == off_id
+
+
+def test_resolve_offering_no_create_falls_back_to_any_offering():
+    # No offering in the target term, but the course has one elsewhere.
+    factory = _factory(
+        {"terms": [{"id": "t1", "sort_key": 1}]},
+        select_seqs={"course_offerings": [[], [{"id": "off-legacy"}]]},  # term miss, then any
+    )
+    with patch.object(ac, "table", side_effect=factory):
+        assert ac.resolve_offering("course-1", create=False) == "off-legacy"
+
+
+# ── user_offering_ids_for_course ────────────────────────────────────────────
+
+def test_user_offering_ids_for_course_intersects():
+    rows = {
+        "course_offerings": [{"id": "off-1"}, {"id": "off-2"}],
+        "enrollments": [{"offering_id": "off-2"}, {"offering_id": "off-9"}],
+    }
+    with patch.object(ac, "table", side_effect=_factory(rows)):
+        got = ac.user_offering_ids_for_course("user-1", "course-1")
+    assert got == ["off-2"]  # off-9 isn't an offering of this course
+
+
+def test_user_offering_ids_for_course_empty_when_course_has_no_offerings():
+    with patch.object(ac, "table", side_effect=_factory({"course_offerings": []})):
+        assert ac.user_offering_ids_for_course("user-1", "course-1") == []
+
+
+# ── offering_course_id / term_for_offering ──────────────────────────────────
+
+def test_offering_course_id():
+    rows = {"course_offerings": [{"course_id": "course-7"}]}
+    with patch.object(ac, "table", side_effect=_factory(rows)):
+        assert ac.offering_course_id("off-1") == "course-7"
+
+
+def test_term_for_offering():
+    rows = {
+        "course_offerings": [{"term_id": "t-3"}],
+        "terms": [{"id": "t-3", "label": "Fall 2026"}],
+    }
+    with patch.object(ac, "table", side_effect=_factory(rows)):
+        assert ac.term_for_offering("off-1")["label"] == "Fall 2026"

--- a/backend/tests/test_graph_read_tools.py
+++ b/backend/tests/test_graph_read_tools.py
@@ -142,6 +142,6 @@ class TestReadMisconceptionsForCourse:
         assert result[1].related_concept == "pointers"
         assert result[2].related_concept == "recursion"
 
-        t.assert_called_with("course_concept_stats")
+        t.assert_called_with("offering_concept_stats")
         select_kwargs = t.return_value.select.call_args
         assert "course_cs101" in str(select_kwargs)

--- a/backend/tests/test_graph_service.py
+++ b/backend/tests/test_graph_service.py
@@ -44,14 +44,40 @@ def _simple_mock(select_returns=None):
     return mock
 
 
-def _enrollment_row(course_id: str, code: str = "", name: str = "Course"):
+def _cached_mock_table(data: dict):
+    """Like `_mock_table` but caches one mock per table name so a test can assert
+    on a specific table's `.insert`/`.delete`/`.update` calls (the factory is
+    shared between `services.graph_service.table` and `services.academics.table`)."""
+    mocks: dict = {}
+
+    def factory(name):
+        if name not in mocks:
+            m = MagicMock()
+            m.select.return_value = data.get(name, [])
+            m.insert.return_value = []
+            m.update.return_value = []
+            m.delete.return_value = []
+            m.upsert.return_value = []
+            mocks[name] = m
+        return mocks[name]
+    return factory, mocks
+
+
+def _enrollment_row(course_id: str, code: str = "", name: str = "Course",
+                    term: str = "Spring 2026", offering_id: str | None = None):
+    """A row in the enrollments→course_offerings→courses/terms join shape that
+    graph_service._reshape_enrollment expects. `course_id` is the ABSTRACT id."""
     return {
         "id": f"e-{course_id}",
-        "course_id": course_id,
+        "offering_id": offering_id or f"off-{course_id}",
         "color": None,
         "nickname": None,
         "enrolled_at": "2026-01-01",
-        "courses": {"course_code": code, "course_name": name, "school": "", "department": ""},
+        "course_offerings": {
+            "course_id": course_id,
+            "courses": {"course_code": code, "course_name": name, "department": ""},
+            "terms": {"label": term},
+        },
     }
 
 
@@ -63,7 +89,7 @@ class TestGetGraph:
             "users": [{"streak_count": 5}],
             "graph_nodes": [],
             "graph_edges": [],
-            "user_courses": [],
+            "enrollments": [],
         })
         with patch("services.graph_service.table", side_effect=factory):
             result = get_graph("u1")
@@ -84,7 +110,7 @@ class TestGetGraph:
             "users": [{"streak_count": 0}],
             "graph_nodes": nodes,
             "graph_edges": [],
-            "user_courses": [_enrollment_row("c1", "M", "Math")],
+            "enrollments": [_enrollment_row("c1", "M", "Math")],
         })
         with patch("services.graph_service.table", side_effect=factory):
             stats = get_graph("u1")["stats"]
@@ -102,10 +128,10 @@ class TestGetGraph:
             {"id": "n2", "concept_name": "Functions", "mastery_tier": "mastered", "mastery_score": 0.8,
              "subject": "CS101", "course_id": "c1", "times_studied": 3, "user_id": "u1"},
         ]
-        enrollment = [{"course_id": "c1", "courses": {"course_code": "CS101", "course_name": "Intro CS"}}]
+        enrollment = [_enrollment_row("c1", "CS101", "Intro CS")]
         factory = _mock_table({
             "users": [{"streak_count": 0}],
-            "user_courses": enrollment,
+            "enrollments": enrollment,
             "graph_nodes": nodes,
             "graph_edges": [],
         })
@@ -119,12 +145,10 @@ class TestGetGraph:
 
     def test_legacy_seed_same_as_course_title_shows_only_subject_hub(self):
         """Course enrolled but no concept nodes — only the subject hub appears."""
-        enrollment = [
-            {"course_id": "c1", "courses": {"course_code": "", "course_name": "EK 103: LINEAR ALGEBRA"}}
-        ]
+        enrollment = [_enrollment_row("c1", "", "EK 103: LINEAR ALGEBRA")]
         factory = _mock_table({
             "users": [{"streak_count": 0}],
-            "user_courses": enrollment,
+            "enrollments": enrollment,
             "graph_nodes": [],
             "graph_edges": [],
         })
@@ -137,10 +161,10 @@ class TestGetGraph:
         assert roots[0]["mastery_score"] == 0.0
 
     def test_course_with_no_graph_nodes_still_shows_subject_hub(self):
-        enrollment = [{"course_id": "c1", "courses": {"course_code": "", "course_name": "Philosophy"}}]
+        enrollment = [_enrollment_row("c1", "", "Philosophy")]
         factory = _mock_table({
             "users": [{"streak_count": 0}],
-            "user_courses": enrollment,
+            "enrollments": enrollment,
             "graph_nodes": [],
             "graph_edges": [],
         })
@@ -159,7 +183,7 @@ class TestGetGraph:
             "users": [{"streak_count": 0}],
             "graph_nodes": nodes,
             "graph_edges": edges,
-            "user_courses": [_enrollment_row("c-x", "", "X")],
+            "enrollments": [_enrollment_row("c-x", "", "X")],
         })
         with patch("services.graph_service.table", side_effect=factory):
             result = get_graph("u1")
@@ -170,7 +194,7 @@ class TestGetGraph:
         assert graph_edges[0]["strength"] == 0.9
 
     def test_streak_defaults_to_zero_when_no_user_row(self):
-        factory = _mock_table({"users": [], "graph_nodes": [], "graph_edges": [], "user_courses": []})
+        factory = _mock_table({"users": [], "graph_nodes": [], "graph_edges": [], "enrollments": []})
         with patch("services.graph_service.table", side_effect=factory):
             result = get_graph("u1")
         assert result["stats"]["streak"] == 0
@@ -182,13 +206,9 @@ class TestGetCourses:
     def test_returns_courses_with_node_count(self):
         def factory(name):
             mock = MagicMock()
-            if name == "user_courses":
-                mock.select.return_value = [{
-                    "id": "e1", "course_id": "c1", "color": "#fff",
-                    "nickname": None, "enrolled_at": "2026-01-01",
-                    "courses": {"course_code": "MATH101", "course_name": "Math",
-                                "school": "BU", "department": "Math"},
-                }]
+            if name == "enrollments":
+                mock.select.return_value = [_enrollment_row(
+                    "c1", "MATH101", "Math", term="Spring 2026", offering_id="off-1")]
             elif name == "graph_nodes":
                 mock.select.return_value = [{"id": "n1"}, {"id": "n2"}]
             else:
@@ -199,7 +219,9 @@ class TestGetCourses:
             result = get_courses("u1")
 
         assert len(result) == 1
+        assert result[0]["course_id"] == "c1"          # abstract course id
         assert result[0]["course_name"] == "Math"
+        assert result[0]["term"] == "Spring 2026"      # term surfaced
         assert result[0]["node_count"] == 2
 
     def test_returns_empty_on_exception(self):
@@ -217,49 +239,62 @@ class TestGetCourses:
 
 class TestAddCourse:
     def test_inserts_new_course(self):
-        def factory(name):
-            mock = MagicMock()
-            if name == "user_courses":
-                # First call: check existing enrollment → not found
-                mock.select.return_value = []
-            elif name == "courses":
-                # Check canonical course exists → found
-                mock.select.return_value = [{"id": "c1"}]
-            else:
-                mock.select.return_value = []
-            mock.insert.return_value = []
-            return mock
-
-        with patch("services.graph_service.table", side_effect=factory):
+        # `courses` (abstract) exists; resolve_offering finds an existing offering
+        # in the current term; no existing enrollment → insert against offering_id.
+        factory, mocks = _cached_mock_table({
+            "courses": [{"id": "c1"}],
+            "enrollments": [],                       # existing-enrollment check → none
+            "terms": [{"id": "t1", "sort_key": 1}],
+            "course_offerings": [{"id": "off-1"}],   # resolve_offering → existing
+        })
+        with patch("services.graph_service.table", side_effect=factory), \
+             patch("services.academics.table", side_effect=factory), \
+             patch("services.course_context_service.update_course_context"):
             result = add_course("u1", "c1")
 
         assert result["course_id"] == "c1"
         assert result["already_existed"] is False
+        inserted = mocks["enrollments"].insert.call_args[0][0]
+        assert inserted["offering_id"] == "off-1"
+        assert "course_id" not in inserted             # enrollments key on the offering
 
     def test_skips_insert_for_existing_course(self):
-        mock = _simple_mock(select_returns=[{"id": "existing"}])
-        with patch("services.graph_service.table", return_value=mock):
+        factory, mocks = _cached_mock_table({
+            "courses": [{"id": "c1"}],
+            "enrollments": [{"id": "existing"}],       # already enrolled in this offering
+            "terms": [{"id": "t1", "sort_key": 1}],
+            "course_offerings": [{"id": "off-1"}],
+        })
+        with patch("services.graph_service.table", side_effect=factory), \
+             patch("services.academics.table", side_effect=factory):
             result = add_course("u1", "c1")
 
         assert result["already_existed"] is True
+        mocks["enrollments"].insert.assert_not_called()
 
 
 # ── delete_course ─────────────────────────────────────────────────────────────
 
 class TestDeleteCourse:
     def test_unenrolls_user_from_course(self):
-        mock = MagicMock()
-        mock.delete.return_value = []
-        with patch("services.graph_service.table", return_value=mock):
+        # The user has one offering of the abstract course → delete that enrollment.
+        factory, mocks = _cached_mock_table({
+            "course_offerings": [{"id": "off-1"}],
+            "enrollments": [{"offering_id": "off-1"}],
+        })
+        with patch("services.graph_service.table", side_effect=factory), \
+             patch("services.academics.table", side_effect=factory), \
+             patch("services.course_context_service.update_course_context"):
             result = delete_course("u1", "course-id-1")
 
         assert result == {"deleted": True}
-        mock.delete.assert_called_once()
+        mocks["enrollments"].delete.assert_called_once()
 
     def test_unenroll_with_no_prior_nodes(self):
-        mock = MagicMock()
-        mock.delete.return_value = []
-        with patch("services.graph_service.table", return_value=mock):
+        # No offerings for the course → nothing to delete, still succeeds.
+        factory, _ = _cached_mock_table({"course_offerings": [], "enrollments": []})
+        with patch("services.graph_service.table", side_effect=factory), \
+             patch("services.academics.table", side_effect=factory):
             result = delete_course("u1", "empty-course-id")
         assert result == {"deleted": True}
 

--- a/backend/tests/test_learn_routes.py
+++ b/backend/tests/test_learn_routes.py
@@ -23,13 +23,21 @@ class TestGetCourseIdForTopic:
 
     def test_matches_enrolled_course_code(self):
         from routes.learn import _get_course_id_for_topic
+        # Enrollment keys on an offering; the abstract course id (returned to the
+        # session + graph) lives at course_offerings.course_id, behind the offering.
         uc = MagicMock()
         uc.select.return_value = [
-            {"course_id": "cid-math", "courses": {"course_code": "MATH", "course_name": "Calculus"}},
+            {
+                "offering_id": "off-math",
+                "course_offerings": {
+                    "course_id": "cid-math",
+                    "courses": {"course_code": "MATH", "course_name": "Calculus"},
+                },
+            },
         ]
 
         def factory(name):
-            if name == "user_courses":
+            if name == "enrollments":
                 return uc
             m = MagicMock()
             m.select.return_value = []
@@ -42,11 +50,17 @@ class TestGetCourseIdForTopic:
         from routes.learn import _get_course_id_for_topic
         uc = MagicMock()
         uc.select.return_value = [
-            {"course_id": "cid-bio", "courses": {"course_code": "", "course_name": "Biology 101"}},
+            {
+                "offering_id": "off-bio",
+                "course_offerings": {
+                    "course_id": "cid-bio",
+                    "courses": {"course_code": "", "course_name": "Biology 101"},
+                },
+            },
         ]
 
         def factory(name):
-            if name == "user_courses":
+            if name == "enrollments":
                 return uc
             m = MagicMock()
             m.select.return_value = []
@@ -60,13 +74,16 @@ class TestGetCourseIdForTopic:
         uc = MagicMock()
         uc.select.return_value = [
             {
-                "course_id": "cid-x",
-                "courses": {"course_code": "CS", "course_name": "Intro"},
+                "offering_id": "off-x",
+                "course_offerings": {
+                    "course_id": "cid-x",
+                    "courses": {"course_code": "CS", "course_name": "Intro"},
+                },
             },
         ]
 
         def factory(name):
-            if name == "user_courses":
+            if name == "enrollments":
                 return uc
             if name == "graph_nodes":
                 m = MagicMock()
@@ -88,7 +105,7 @@ class TestGetCourseIdForTopic:
         gn.select.return_value = [{"course_id": "cid-from-node"}]
 
         def factory(name):
-            if name == "user_courses":
+            if name == "enrollments":
                 return uc
             if name == "graph_nodes":
                 return gn

--- a/backend/tests/test_onboarding_routes.py
+++ b/backend/tests/test_onboarding_routes.py
@@ -50,23 +50,57 @@ class TestSearchCourses:
         assert len(res.json()["courses"]) == 2
 
 
+def _make_factory(tables, *, course_rows, enrollment_rows, offering_rows=None):
+    """Build a shared table() mock factory across onboarding + academics.
+
+    Seeds a current ``terms`` row and a matching ``course_offerings`` row so
+    ``resolve_offering(create=True)`` resolves to an EXISTING offering without
+    inserting (keeps tests deterministic). ``enrollment_rows`` controls the
+    "already enrolled?" check on ``enrollments``.
+    """
+    if offering_rows is None:
+        offering_rows = [{"id": "off-1"}]
+
+    def factory(name):
+        if name not in tables:
+            m = MagicMock()
+            if name == "users":
+                m.select.return_value = [{"id": "user_123"}]
+            elif name == "courses":
+                m.select.return_value = course_rows
+            elif name == "terms":
+                m.select.return_value = [
+                    {
+                        "id": "term-current",
+                        "term": "Summer",
+                        "year": 2026,
+                        "label": "Summer 2026",
+                        "start_date": "2026-05-01",
+                        "end_date": "2026-08-31",
+                        "sort_key": 20262,
+                    }
+                ]
+            elif name == "course_offerings":
+                m.select.return_value = offering_rows
+            elif name == "enrollments":
+                m.select.return_value = enrollment_rows
+            tables[name] = m
+        return tables[name]
+
+    return factory
+
+
 class TestSaveOnboardingProfile:
     def test_success_enrolls_in_courses(self):
         tables = {}
+        factory = _make_factory(
+            tables,
+            course_rows=[{"id": "some-id"}],
+            enrollment_rows=[],  # not enrolled
+        )
 
-        def factory(name):
-            if name not in tables:
-                m = MagicMock()
-                if name == "users":
-                    m.select.return_value = [{"id": "user_123"}]
-                elif name == "courses":
-                    m.select.return_value = [{"id": "some-id"}]
-                elif name == "user_courses":
-                    m.select.return_value = []  # not enrolled
-                tables[name] = m
-            return tables[name]
-
-        with patch("routes.onboarding.table", side_effect=factory):
+        with patch("routes.onboarding.table", side_effect=factory), \
+             patch("services.academics.table", side_effect=factory):
             res = client.post("/api/onboarding/profile", json=VALID_PAYLOAD)
 
         assert res.status_code == 200
@@ -86,51 +120,45 @@ class TestSaveOnboardingProfile:
         assert update_data["minors"] == ["Mathematics"]
         assert update_data["learning_style"] == "visual"
 
-        # Two enrollments were created
-        assert tables["user_courses"].insert.call_count == 2
+        # Two enrollments were created, keyed on offering_id (not course_id)
+        assert tables["enrollments"].insert.call_count == 2
+        insert_row = tables["enrollments"].insert.call_args[0][0]
+        assert insert_row["offering_id"] == "off-1"
+        assert insert_row["user_id"] == "user_123"
+        assert "course_id" not in insert_row
+        # The legacy user_courses table is no longer touched
+        assert "user_courses" not in tables
 
     def test_skips_nonexistent_course(self):
         tables = {}
+        factory = _make_factory(
+            tables,
+            course_rows=[],  # course not found
+            enrollment_rows=[],
+        )
 
-        def factory(name):
-            if name not in tables:
-                m = MagicMock()
-                if name == "users":
-                    m.select.return_value = [{"id": "user_123"}]
-                elif name == "courses":
-                    m.select.return_value = []  # course not found
-                elif name == "user_courses":
-                    m.select.return_value = []
-                tables[name] = m
-            return tables[name]
-
-        with patch("routes.onboarding.table", side_effect=factory):
+        with patch("routes.onboarding.table", side_effect=factory), \
+             patch("services.academics.table", side_effect=factory):
             res = client.post("/api/onboarding/profile", json=VALID_PAYLOAD)
 
         assert res.status_code == 200
         # No enrollments since courses don't exist
-        assert "user_courses" not in tables or tables.get("user_courses", MagicMock()).insert.call_count == 0
+        assert "enrollments" not in tables or tables["enrollments"].insert.call_count == 0
 
     def test_skips_enrollment_if_already_enrolled(self):
         tables = {}
+        factory = _make_factory(
+            tables,
+            course_rows=[{"id": "some-id"}],
+            enrollment_rows=[{"id": "enr-already"}],  # already enrolled
+        )
 
-        def factory(name):
-            if name not in tables:
-                m = MagicMock()
-                if name == "users":
-                    m.select.return_value = [{"id": "user_123"}]
-                elif name == "courses":
-                    m.select.return_value = [{"id": "some-id"}]
-                elif name == "user_courses":
-                    m.select.return_value = [{"id": "uc-already"}]
-                tables[name] = m
-            return tables[name]
-
-        with patch("routes.onboarding.table", side_effect=factory):
+        with patch("routes.onboarding.table", side_effect=factory), \
+             patch("services.academics.table", side_effect=factory):
             res = client.post("/api/onboarding/profile", json=VALID_PAYLOAD)
 
         assert res.status_code == 200
-        tables["user_courses"].insert.assert_not_called()
+        tables["enrollments"].insert.assert_not_called()
 
     def test_user_not_found_returns_404(self):
         mock = MagicMock()
@@ -168,20 +196,14 @@ class TestSaveOnboardingProfile:
         del payload["minors"]
 
         tables = {}
+        factory = _make_factory(
+            tables,
+            course_rows=[{"id": "some-id"}],
+            enrollment_rows=[],
+        )
 
-        def factory(name):
-            if name not in tables:
-                m = MagicMock()
-                if name == "users":
-                    m.select.return_value = [{"id": "user_123"}]
-                elif name == "courses":
-                    m.select.return_value = [{"id": "some-id"}]
-                elif name == "user_courses":
-                    m.select.return_value = []
-                tables[name] = m
-            return tables[name]
-
-        with patch("routes.onboarding.table", side_effect=factory):
+        with patch("routes.onboarding.table", side_effect=factory), \
+             patch("services.academics.table", side_effect=factory):
             res = client.post("/api/onboarding/profile", json=payload)
 
         assert res.status_code == 200

--- a/backend/tests/test_shared_course_context.py
+++ b/backend/tests/test_shared_course_context.py
@@ -48,8 +48,7 @@ class TestGetCourseContext(unittest.TestCase):
     @patch("services.course_context_service.table")
     def test_returns_context_json_when_found(self, mock_table):
         summary_row = {
-            "course_id": "CS101",
-            "semester": "Spring 2026",
+            "offering_id": "off-1",
             "student_count": 5,
             "avg_class_mastery": 0.6,
             "top_struggling_concepts": ["Pointers"],
@@ -58,9 +57,8 @@ class TestGetCourseContext(unittest.TestCase):
             "updated_at": "2026-04-01T00:00:00+00:00",
         }
         stat_row = {
-            "course_id": "CS101",
+            "offering_id": "off-1",
             "concept_name": "Pointers",
-            "semester": "Spring 2026",
             "avg_mastery_score": 0.2,
             "pct_struggling": 0.6,
             "pct_mastered": 0.1,
@@ -71,9 +69,9 @@ class TestGetCourseContext(unittest.TestCase):
 
         def _tbl(name):
             m = MagicMock()
-            if name == "course_summary":
+            if name == "offering_summary":
                 m.select.return_value = [summary_row]
-            elif name == "course_concept_stats":
+            elif name == "offering_concept_stats":
                 m.select.return_value = [stat_row]
             else:
                 m.select.return_value = []
@@ -81,10 +79,10 @@ class TestGetCourseContext(unittest.TestCase):
         mock_table.side_effect = _tbl
 
         from services.course_context_service import get_course_context
-        result = get_course_context("CS101")
+        result = get_course_context("off-1")
         self.assertIn("course_summary", result)
         self.assertIn("concept_stats", result)
-        self.assertEqual(result["course_summary"]["course_id"], "CS101")
+        self.assertEqual(result["course_summary"]["offering_id"], "off-1")
         self.assertEqual(result["concept_stats"][0]["concept_name"], "Pointers")
 
     @patch("services.course_context_service.table")
@@ -126,11 +124,14 @@ class TestUpdateCourseContext(unittest.TestCase):
         # upsert should never be called when there are no nodes
         mock_table.return_value.upsert.assert_not_called()
 
+    @patch("services.academics.table")
     @patch("services.course_context_service.table")
-    def test_aggregates_mastery_and_upserts(self, mock_table):
-        # Two students enrolled, same concept "Loops" — one struggling, one mastered
+    def test_aggregates_mastery_and_upserts(self, mock_table, mock_ac_table):
+        # Two students enrolled in offering "off-1", same concept "Loops".
         enrollment_rows = [{"user_id": "u1"}, {"user_id": "u2"}]
         course_rows = [{"course_code": "CS101", "course_name": "Intro CS"}]
+        # offering_course_id("off-1") resolves to the abstract course.
+        offering_rows = [{"course_id": "abstract-cs101"}]
         node_rows = [
             {"id": "n1", "concept_name": "Loops", "mastery_score": 0.2,
              "mastery_tier": "struggling", "user_id": "u1"},
@@ -147,42 +148,47 @@ class TestUpdateCourseContext(unittest.TestCase):
 
         def _table(name):
             m = MagicMock()
-            if name == "user_courses":
+            if name == "enrollments":
                 m.select.return_value = enrollment_rows
+            elif name == "course_offerings":
+                m.select.return_value = offering_rows
             elif name == "courses":
                 m.select.return_value = course_rows
             elif name == "graph_nodes":
                 m.select.return_value = node_rows
             elif name == "quiz_context":
                 m.select.return_value = []
-            elif name == "course_concept_stats":
+            elif name == "offering_concept_stats":
                 return stats_tbl
-            elif name == "course_summary":
+            elif name == "offering_summary":
                 return summary_tbl
             else:
                 m.select.return_value = []
             return m
 
         mock_table.side_effect = _table
+        mock_ac_table.side_effect = _table
 
         with patch("services.course_context_service._generate_summary_with_gemini", return_value="summary"):
             from services.course_context_service import update_course_context
-            update_course_context("c-cs101")
+            update_course_context("off-1")
 
-        # course_concept_stats should be upserted for "Loops"
+        # offering_concept_stats should be upserted for "Loops"
         stats_tbl.upsert.assert_called_once()
         upsert_payload = stats_tbl.upsert.call_args[0][0]
-        self.assertEqual(upsert_payload["course_id"], "c-cs101")
+        self.assertEqual(upsert_payload["offering_id"], "off-1")
         self.assertEqual(upsert_payload["concept_name"], "Loops")
         self.assertEqual(upsert_payload["student_count"], 2)
         # avg mastery for Loops = (0.2 + 0.9) / 2 = 0.55
         self.assertAlmostEqual(upsert_payload["avg_mastery_score"], 0.55, places=2)
 
+    @patch("services.academics.table")
     @patch("services.course_context_service.table")
-    def test_struggling_concepts_threshold(self, mock_table):
+    def test_struggling_concepts_threshold(self, mock_table, mock_ac_table):
         """Concepts with pct_struggling > 0 should appear in top_struggling_concepts."""
         enrollment_rows = [{"user_id": "u1"}, {"user_id": "u2"}]
         course_rows = [{"course_code": "CS101", "course_name": "Intro CS"}]
+        offering_rows = [{"course_id": "abstract-cs101"}]
         node_rows = [
             {"id": "n1", "concept_name": "Recursion", "mastery_score": 0.1,
              "mastery_tier": "struggling", "user_id": "u1"},
@@ -198,38 +204,43 @@ class TestUpdateCourseContext(unittest.TestCase):
 
         def _table(name):
             m = MagicMock()
-            if name == "user_courses":
+            if name == "enrollments":
                 m.select.return_value = enrollment_rows
+            elif name == "course_offerings":
+                m.select.return_value = offering_rows
             elif name == "courses":
                 m.select.return_value = course_rows
             elif name == "graph_nodes":
                 m.select.return_value = node_rows
             elif name == "quiz_context":
                 m.select.return_value = []
-            elif name == "course_concept_stats":
+            elif name == "offering_concept_stats":
                 return stats_tbl
-            elif name == "course_summary":
+            elif name == "offering_summary":
                 return summary_tbl
             else:
                 m.select.return_value = []
             return m
 
         mock_table.side_effect = _table
+        mock_ac_table.side_effect = _table
 
         with patch("services.course_context_service._generate_summary_with_gemini", return_value="summary"):
             from services.course_context_service import update_course_context
-            update_course_context("c-cs101")
+            update_course_context("off-1")
 
-        # course_summary upsert should have Recursion in top_struggling_concepts
+        # offering_summary upsert should have Recursion in top_struggling_concepts
         summary_tbl.upsert.assert_called_once()
         summary_payload = summary_tbl.upsert.call_args[0][0]
         self.assertIn("Recursion", summary_payload["top_struggling_concepts"])
         self.assertNotIn("Loops", summary_payload["top_struggling_concepts"])
 
+    @patch("services.academics.table")
     @patch("services.course_context_service.table")
-    def test_deduplicates_misconceptions_case_insensitive(self, mock_table):
+    def test_deduplicates_misconceptions_case_insensitive(self, mock_table, mock_ac_table):
         enrollment_rows = [{"user_id": "u1"}, {"user_id": "u2"}]
         course_rows = [{"course_code": "CS101", "course_name": "Intro CS"}]
+        offering_rows = [{"course_id": "abstract-cs101"}]
         node_rows = [
             {"id": "n1", "concept_name": "Loops", "mastery_score": 0.3,
              "mastery_tier": "learning", "user_id": "u1"},
@@ -249,27 +260,30 @@ class TestUpdateCourseContext(unittest.TestCase):
 
         def _table(name):
             m = MagicMock()
-            if name == "user_courses":
+            if name == "enrollments":
                 m.select.return_value = enrollment_rows
+            elif name == "course_offerings":
+                m.select.return_value = offering_rows
             elif name == "courses":
                 m.select.return_value = course_rows
             elif name == "graph_nodes":
                 m.select.return_value = node_rows
             elif name == "quiz_context":
                 m.select.return_value = quiz_rows
-            elif name == "course_concept_stats":
+            elif name == "offering_concept_stats":
                 return stats_tbl
-            elif name == "course_summary":
+            elif name == "offering_summary":
                 return summary_tbl
             else:
                 m.select.return_value = []
             return m
 
         mock_table.side_effect = _table
+        mock_ac_table.side_effect = _table
 
         with patch("services.course_context_service._generate_summary_with_gemini", return_value="summary"):
             from services.course_context_service import update_course_context
-            update_course_context("c-cs101")
+            update_course_context("off-1")
 
         # All three "off-by-one" variants are the same after .lower() — only one kept
         stats_tbl.upsert.assert_called_once()
@@ -284,13 +298,14 @@ class TestUpdateCourseContext(unittest.TestCase):
 
 class TestApplyGraphUpdateTriggersContext(unittest.TestCase):
 
+    @patch("services.academics.user_offering_ids_for_course", return_value=["off-1"])
     @patch("services.graph_service.table")
     @patch("services.course_context_service.update_course_context")
     def test_update_course_context_called_for_touched_subjects(
-        self, mock_update_ctx, mock_table
+        self, mock_update_ctx, mock_table, mock_uoff
     ):
-        # update_course_context is lazy-imported inside apply_graph_update;
-        # patch it at the source module so the import resolves to our mock.
+        # touched_courses holds the abstract course_id ("course-1"); the analytics
+        # refresh resolves it to the user's offering(s) and refreshes each one.
         node_tbl = MagicMock()
         node_tbl.select.return_value = [
             {"id": "n1", "concept_name": "Loops", "mastery_score": 0.4,
@@ -311,13 +326,15 @@ class TestApplyGraphUpdateTriggersContext(unittest.TestCase):
              "new_edges": []}
         )
 
-        mock_update_ctx.assert_called_once_with("course-1")
+        mock_uoff.assert_called_once_with("user1", "course-1")
+        mock_update_ctx.assert_called_once_with("off-1")
 
+    @patch("services.academics.user_offering_ids_for_course", return_value=["off-1"])
     @patch("services.graph_service.table")
     @patch("services.course_context_service.update_course_context",
            side_effect=RuntimeError("DB down"))
     def test_update_course_context_exception_does_not_raise(
-        self, mock_update_ctx, mock_table
+        self, mock_update_ctx, mock_table, mock_uoff
     ):
         """A failure in update_course_context must never surface to the caller."""
         node_tbl = MagicMock()
@@ -375,15 +392,18 @@ class TestLearnHelpers(unittest.TestCase):
 
     @patch("routes.learn.table")
     def test_resolve_course_when_topic_matches_course_code(self, mock_table):
+        # enrollments → course_offerings → courses; returns the ABSTRACT course_id.
         enrolled_tbl = MagicMock()
         enrolled_tbl.select.return_value = [
-            {"course_id": "course-1", "courses": {"course_code": "CS101", "course_name": "Intro CS"}}
+            {"offering_id": "off-1",
+             "course_offerings": {"course_id": "course-1",
+                                  "courses": {"course_code": "CS101", "course_name": "Intro CS"}}}
         ]
         node_tbl = MagicMock()
         node_tbl.select.return_value = []
 
         def _factory(name):
-            if name == "user_courses": return enrolled_tbl
+            if name == "enrollments": return enrolled_tbl
             return node_tbl
 
         mock_table.side_effect = _factory
@@ -401,7 +421,7 @@ class TestLearnHelpers(unittest.TestCase):
         node_tbl.select.side_effect = [[{"course_id": "course-1"}], []]
 
         def _factory(name):
-            if name == "user_courses": return enrolled_tbl
+            if name == "enrollments": return enrolled_tbl
             return node_tbl
 
         mock_table.side_effect = _factory

--- a/docs/superpowers/plans/2026-06-24-db-academics-code.md
+++ b/docs/superpowers/plans/2026-06-24-db-academics-code.md
@@ -1,0 +1,134 @@
+# `db/academics-code` Implementation Plan (epic slice PR2)
+
+> **For agentic workers:** code-only slice. The schema already landed in PR #264 (migrations
+> 0019–0027 on `epic/db-modular-redesign`). This slice rewires the application code onto the
+> new `courses` (abstract) / `course_offerings` / `terms` / `enrollments` schema. Branch:
+> `db/academics-code` → PR into `epic/db-modular-redesign`. The epic may stay WIP-red for
+> other domains; this slice must leave the **academics spine** green.
+
+**Goal:** Make the backend run against the academics split — enrollment keyed on an offering,
+the knowledge graph keyed on the abstract course, and the whole app term/semester-aware —
+without changing the public API's `course_id` contract.
+
+## Locked product contract (decided with the user 2026-06-24)
+
+- **API boundary keeps the abstract `course_id`.** No section/instructor anywhere in the
+  contract; those stay carried columns on `course_offerings`, defaulted/ignored.
+- **Semester/term is the real second axis.** `terms` is the source of truth. Add
+  `GET /api/semesters`. `get_courses` starts returning each course's term label.
+- **Enrollment = (user, offering)**, offering = (course, term, `section = NULL`). On enroll
+  with no term given, resolve to the **current term** (date-derived) and **create the offering
+  if the catalog lacks it** — new enrollments land in the real current semester, not legacy
+  `Spring 2026`.
+- **Knowledge graph stays on the abstract `course_id`** (cumulative across terms); resolve
+  `enrollment.offering_id → course_offerings.course_id` to reach it.
+- **`gradebook.py` is NOT in this slice** — it goes whole to `db/gradebook-code` (with curve +
+  drop-lowest, #266), built on this slice's enrollment-by-semester resolver.
+- **`course_context_service` (analytics) IS in this slice** — the migrated
+  `offering_concept_stats`/`offering_summary` tables force offering-keying, which is inseparable
+  from the enrollment spine. `db/analytics-code` (PR4) therefore shrinks to `social.py` + any
+  aggregation refinement.
+- **`school` is retired** (free-text `courses.school` dropped; `schools` table unpopulated). It
+  surfaces as `""`/None until a follow-up links `school_id`. Flag as a frontend/seed follow-up.
+
+## Schema facts (already landed)
+
+- `courses` (abstract): `id, school_id, course_code, course_name, department, credits, description`.
+- `course_offerings` (was old `courses`): `id, course_id→courses, term_id→terms, section,
+  instructor_name, meeting_times, location, syllabus_url`. Lost `course_name/department/credits/
+  description/semester/school`.
+- `terms`: `id, term, year, label ('Spring 2026'), start_date, end_date, sort_key`.
+  "current term" = `current_date BETWEEN start_date AND end_date`.
+- `enrollments` (was `user_courses`): `id, user_id, offering_id→course_offerings, color,
+  nickname, enrolled_at` (+ curve_*/syllabus_doc_id from other slices). `UNIQUE(user_id, offering_id)`.
+- `table()` API: `.select(cols, filters=, order=, limit=)` with PostgREST operators in filter
+  values (`eq.`, `in.(a,b)`, `lte.`, `gte.`, `ilike.`); `.insert(dict)`; `.update(dict, filters=)`;
+  `.delete(filters)`; `.upsert(dict, on_conflict=)`. Hand-build text ids with `uuid.uuid4()`
+  (existing convention).
+
+## Foundation — `services/academics.py` (NEW, build first)
+
+Pure functions over `table()`, easily mockable (each test patches `services.academics.table`):
+
+- `current_term(today=None) -> dict | None` — term whose date range contains today; **fallback**
+  to the latest term by `sort_key.desc` so a date outside all ranges still resolves.
+- `list_terms() -> list[dict]` — all terms, `sort_key.desc` (for `GET /api/semesters`).
+- `resolve_offering(course_id, term_id=None, *, create=False) -> str | None` — offering id for
+  (course, term); term defaults to `current_term()`. If none and `create`, insert
+  `{id, course_id, term_id}` (NULL section) and return the new id. If none and not `create`,
+  fall back to any existing offering of that course.
+- `offering_course_id(offering_id) -> str | None` — abstract course id for an offering.
+- `user_offering_ids_for_course(user_id, course_id) -> list[str]` — two-step (offerings of the
+  course, then the user's enrollments intersected) to avoid fragile embedded filters.
+- `term_for_offering(offering_id) -> dict | None` — the offering's term row (for labels).
+
+## Work groups (independent files — parallelizable after the helper lands)
+
+**A. `services/graph_service.py`** + `tests/test_graph_service.py`
+- `_user_enrolled_courses` / `get_courses`: query `enrollments` with nested
+  `course_offerings!inner(course_id,courses!inner(course_code,course_name,department),terms!inner(label))`;
+  **reshape** to the legacy flat shape consumers expect — `course_id` = the *abstract*
+  `course_offerings.course_id`, `courses` = `{course_code, course_name, department, school:""}`,
+  plus new `offering_id` and `term` (label). `get_courses` counts nodes by abstract `course_id`.
+- `add_course(user_id, course_id)`: verify abstract course in `courses`; `offering_id =
+  resolve_offering(course_id, create=True)`; dedupe enrollment by `(user_id, offering_id)`;
+  insert `{id, user_id, offering_id, color, nickname}`; `update_course_context(offering_id)`.
+- `update_course_color`/`update_course_nickname`/`delete_course(user_id, course_id)`: resolve
+  `user_offering_ids_for_course`; update/delete enrollments filtered `offering_id=in.(…)`;
+  refresh context per offering.
+- `apply_graph_update` / `delete_node` analytics refresh: for each touched **abstract**
+  course_id, `update_course_context(off)` for each `user_offering_ids_for_course(user_id, cid)`.
+- Graph node writes stay on abstract `course_id` (unchanged).
+
+**B. `services/course_context_service.py` + `agents/tools/graph_read.py`** +
+`tests/test_shared_course_context.py`, `tests/test_graph_read_tools.py`
+- `update_course_context(offering_id)`: enrolled users via `enrollments` filtered
+  `offering_id`; resolve `offering_course_id` for `graph_nodes` (abstract) + `term_for_offering`
+  for the label; upsert `offering_concept_stats` (`on_conflict="offering_id,concept_name"`, no
+  semester) and `offering_summary` (`on_conflict="offering_id"`). Empty-enrollment purge keys on
+  `offering_id`.
+- `get_course_context(offering_id)`: read `offering_summary`/`offering_concept_stats` by
+  `offering_id`; drop the `semester` filter/field; preserve the return dict shape otherwise.
+- `graph_read.read_misconceptions_for_course`: read `offering_concept_stats` filtered
+  `offering_id` (param stays named `course_id` at the tool boundary but is an offering id from
+  deps). `read_concepts_for_user` stays on abstract `course_id` (graph) — unchanged.
+
+**C. `routes/onboarding.py` + `routes/graph.py` + `routes/academics.py` (NEW) + `main.py` +
+`models/__init__.py`** + `tests/test_onboarding_routes.py`
+- `onboarding.search_courses`: already hits abstract `courses` — keep; it returns `id`
+  (abstract). No change beyond confirming columns exist.
+- `onboarding.save_onboarding_profile` enroll loop: for each abstract `course_id`, `offering_id
+  = resolve_offering(course_id, create=True)`; dedupe by `(user_id, offering_id)`; insert
+  `enrollments{id,user_id,offering_id}`.
+- `routes/graph.py`: unchanged call signatures (`get_courses`/`add_course` take abstract
+  `course_id`); responses now carry `term`.
+- `routes/academics.py`: `GET /semesters` → `{"semesters": list_terms()}`. Mount in `main.py`
+  at `/api` (yields `/api/semesters`). Update `models` docstrings (`AddCourseBody` etc.) to say
+  abstract course id.
+
+**D. `routes/profile.py` + `routes/learn.py`** + `tests/test_learn_routes.py`
+- `profile.get_public_profile`: `enrollments` join `course_offerings(courses(school_id))`;
+  school is `""`/None for now.
+- `learn._get_course_id_for_topic`: resolve via `enrollments` join `course_offerings(course_id,
+  courses(course_code,course_name))`; **return the abstract `course_id`** (graph + session key).
+  `_get_course_info(course_id)` reads the abstract `courses` row (already keyed by abstract id —
+  works once the resolver returns abstract ids). `get_course_context` call may pass the abstract
+  id and degrade to `{}` until a later study slice wires offering context into sessions — leave a
+  `# TODO(db/study-code)` note; do not break the session flow.
+
+## Test/verify
+
+- Per group: `cd backend && venv/bin/python -m pytest tests/<file> -q`.
+- Whole-slice gate: `venv/bin/python -m pytest tests/test_onboarding_routes.py
+  tests/test_learn_routes.py tests/test_graph_service.py tests/test_shared_course_context.py
+  tests/test_graph_read_tools.py tests/test_academics.py -q` green; `ruff check .` clean.
+- Acceptance: enroll → `get_courses` returns the course with its term; a fresh enroll with no
+  current-term offering creates one; `GET /api/semesters` lists terms; no `Spring 2026` literal
+  remains in academics code; graph still keys on abstract `course_id`.
+
+## Out of scope (other slices, leave broken-but-untouched)
+
+`gradebook.py`/`gradebook_service.py` (PR3) · `graph_nodes`/`graph_edges` integrity + mastery
+events (PR5) · `documents.py`/`notes.py`/`quiz.py`/`study_guide.py`/`flashcards.py` (PR7) ·
+`social.py` (PR4) · identity profile fields (PR6). These keep their current `course_id` calls;
+they degrade gracefully (empty reads / no-op writes) until their slice lands.


### PR DESCRIPTION
Code-only slice (PR2, the spine) of the DB modular redesign. Rewires the application onto the **already-landed** academics split (migrations 0019–0027 from #264) — no migrations here. Targets the **epic** branch.

## Locked contract (decided with the user)
- **API boundary keeps the abstract `course_id`.** No section/instructor in any contract.
- **Semester/term is the real second axis.** `GET /api/semesters` (from `terms`); `get_courses` returns each course's term.
- **Enrollment = (user, offering)** internally; offering = (course, current term, `section = NULL`), **created if the catalog lacks it** so new enrollments land in the real current semester (not legacy `Spring 2026`).
- **Knowledge graph stays on the abstract `course_id`** (cumulative); resolved via `enrollment.offering_id → course_offerings.course_id`.

## What changed
- **`services/academics.py` (new):** the term/offering/enrollment resolver everything builds on.
- **`graph_service`:** enrollments→course_offerings→courses/terms join reshaped to the legacy flat shape; enroll/color/nickname/delete resolve offerings; analytics refresh resolves abstract→offerings.
- **`course_context_service`:** offering-scoped analytics (`offering_concept_stats`/`offering_summary`); resolves offering→abstract course for `graph_nodes`; free-text `semester` gone.
- **`graph_read`:** misconceptions read `offering_concept_stats` by `offering_id`.
- **routes:** `onboarding` enrolls into the current-term offering; new `routes/academics.py` exposes `GET /api/semesters`; `learn`/`profile` course resolution via `enrollments`.

## Scope decisions
- **`gradebook.py` deliberately excluded** → goes whole to `db/gradebook-code` (PR3, with curve + drop-lowest, #266), built on this slice's enrollment-by-semester resolver.
- **`course_context_service` analytics absorbed here** (the migrated offering tables force offering-keying, inseparable from the spine) → PR4 shrinks to `social.py`.
- Other-slice callers (`documents`/`quiz`) degrade gracefully (empty reads / no-op) until their slices land — expected for the WIP-red epic.
- `school` is `""`/None for now (free-text `courses.school` retired; `schools` unpopulated) — frontend/seed follow-up.

## Verification
- Full backend suite: **724 passed**; `ruff check .` clean.
- New `tests/test_academics.py`; updated graph_service / shared_course_context / graph_read_tools / onboarding / learn suites.

Plan: `docs/superpowers/plans/2026-06-24-db-academics-code.md`. Spec: `docs/superpowers/specs/2026-06-23-db-modular-redesign-design.md`.

Unblocks the parallel code slices (graph / analytics / gradebook / identity / study / ops).