### PR TITLE
db/ops-code: feedback/issue_reports PKs + FKs (epic slice PR8)

### DIFF
--- a/backend/routes/feedback.py
+++ b/backend/routes/feedback.py
@@ -23,7 +23,12 @@ ALLOWED_SCREENSHOT_TYPES = {"image/png", "image/jpeg", "image/webp", "image/gif"
 
 @router.post("/feedback")
 def submit_feedback(body: SubmitFeedbackBody):
+    # 0026_ops: feedback.id is now a TEXT PK (was SERIAL). Follow the repo
+    # convention (services/academics.py, graph_service.py) and hand-build it
+    # rather than relying on the DB default. user_id/session_id now carry real
+    # FKs (users / sessions), which the request body / session already satisfy.
     table("feedback").insert({
+        "id": str(uuid.uuid4()),
         "user_id": body.user_id,
         "type": body.type,
         "rating": body.rating,
@@ -37,7 +42,10 @@ def submit_feedback(body: SubmitFeedbackBody):
 
 @router.post("/issue-reports")
 def submit_issue_report(body: SubmitIssueReportBody):
+    # 0026_ops: issue_reports.id is now a TEXT PK (was SERIAL); user_id now has
+    # a real FK to users(id). Hand-build the text PK per repo convention.
     table("issue_reports").insert({
+        "id": str(uuid.uuid4()),
         "user_id": body.user_id,
         "topic": body.topic,
         "description": body.description,

--- a/backend/tests/test_feedback_routes.py
+++ b/backend/tests/test_feedback_routes.py
@@ -1,0 +1,148 @@
+"""Tests for routes/feedback.py POST endpoints after the 0026_ops schema change.
+
+0026_ops.sql dropped the SERIAL integer PKs on `feedback` and `issue_reports`
+and recreated them with `TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text`, plus
+real FKs to `users(id)` (and `sessions(id)` for feedback). Following the repo
+convention (services/academics.py, services/graph_service.py), the routes now
+hand-build the text PK with `str(uuid.uuid4())` rather than leaning on the DB
+default, so the insert shape is explicit and consistent with the rest of the
+redesign.
+
+These tests patch `routes.feedback.table` with a MagicMock-per-table factory
+that records `.insert()` payloads — the same hermetic pattern as
+tests/test_academics.py.
+"""
+import uuid
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def _factory(recorder):
+    """Return a `table(name)` stand-in that records `.insert()` payloads."""
+    cache: dict = {}
+
+    def make(name):
+        if name in cache:
+            return cache[name]
+        m = MagicMock(name=f"table({name})")
+
+        def _insert(data):
+            recorder.append((name, data))
+            return [data]
+
+        m.insert.side_effect = _insert
+        cache[name] = m
+        return m
+
+    return make
+
+
+def _is_uuid(value):
+    try:
+        uuid.UUID(str(value))
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
+class TestSubmitFeedback:
+    def test_inserts_with_text_uuid_pk(self):
+        recorded: list = []
+        with patch("routes.feedback.table", side_effect=_factory(recorded)):
+            r = client.post(
+                "/api/feedback",
+                json={
+                    "user_id": "user_andres",
+                    "type": "session",
+                    "rating": 5,
+                    "selected_options": ["clear", "fast"],
+                    "comment": "great",
+                    "session_id": "sess_1",
+                    "topic": "calculus",
+                },
+            )
+        assert r.status_code == 200
+        assert r.json() == {"ok": True}
+
+        assert len(recorded) == 1
+        name, data = recorded[0]
+        assert name == "feedback"
+        # Text PK is hand-built and parses as a UUID (no SERIAL default reliance).
+        assert _is_uuid(data["id"])
+
+    def test_insert_payload_round_trips_body_fields(self):
+        recorded: list = []
+        with patch("routes.feedback.table", side_effect=_factory(recorded)):
+            client.post(
+                "/api/feedback",
+                json={
+                    "user_id": "user_andres",
+                    "type": "session",
+                    "rating": 4,
+                    "selected_options": ["clear"],
+                    "comment": "ok",
+                    "session_id": "sess_42",
+                    "topic": "algebra",
+                },
+            )
+        _name, data = recorded[0]
+        assert data["user_id"] == "user_andres"
+        assert data["type"] == "session"
+        assert data["rating"] == 4
+        assert data["selected_options"] == ["clear"]
+        assert data["comment"] == "ok"
+        assert data["session_id"] == "sess_42"
+        assert data["topic"] == "algebra"
+        # Regression guard: the insert must carry exactly these keys.
+        assert set(data.keys()) == {
+            "id", "user_id", "type", "rating",
+            "selected_options", "comment", "session_id", "topic",
+        }
+
+    def test_session_id_may_be_null(self):
+        # session_id FK is ON DELETE SET NULL and the column is nullable; a
+        # global (non-session) feedback submission carries session_id=None.
+        recorded: list = []
+        with patch("routes.feedback.table", side_effect=_factory(recorded)):
+            r = client.post(
+                "/api/feedback",
+                json={"user_id": "user_andres", "type": "global", "rating": 3},
+            )
+        assert r.status_code == 200
+        _name, data = recorded[0]
+        assert data["session_id"] is None
+        assert _is_uuid(data["id"])
+
+
+class TestSubmitIssueReport:
+    def test_inserts_with_text_uuid_pk(self):
+        recorded: list = []
+        with patch("routes.feedback.table", side_effect=_factory(recorded)):
+            r = client.post(
+                "/api/issue-reports",
+                json={
+                    "user_id": "user_andres",
+                    "topic": "bug",
+                    "description": "something broke",
+                    "screenshot_urls": ["user_andres/a.png"],
+                },
+            )
+        assert r.status_code == 200
+        assert r.json() == {"ok": True}
+
+        assert len(recorded) == 1
+        name, data = recorded[0]
+        assert name == "issue_reports"
+        assert _is_uuid(data["id"])
+        assert data["user_id"] == "user_andres"
+        assert data["topic"] == "bug"
+        assert data["description"] == "something broke"
+        assert data["screenshot_urls"] == ["user_andres/a.png"]
+        assert set(data.keys()) == {
+            "id", "user_id", "topic", "description", "screenshot_urls",
+        }

--- a/docs/superpowers/plans/2026-06-24-db-ops-code.md
+++ b/docs/superpowers/plans/2026-06-24-db-ops-code.md
@@ -1,0 +1,78 @@
+# db/ops-code — ops cleanup slice (feedback / issue_reports / newsletter)
+
+Branch: `db/ops-code` (off `db/academics-code`). Smallest slice of the DB modular
+redesign. Rewires the ops domain's CODE onto the already-landed schema from
+`db/migrations/0026_ops.sql`. No new migrations.
+
+## Contract recap
+
+- API boundary keeps the abstract `course_id`; term/semester is a real second axis;
+  class artifacts key on `offering_id`/`enrollment_id`; the knowledge graph keys on
+  the abstract `course_id`. (Ops touches none of these — feedback/issue_reports key on
+  `user_id`/`session_id` only — so the contract is irrelevant here but not violated.)
+- All DB via `db/connection.py::table()`. Text PKs are hand-built with `str(uuid.uuid4())`
+  in the insert dict, matching the convention in `services/academics.py` and
+  `services/graph_service.py`.
+
+## Schema delta (0026_ops.sql)
+
+`feedback` and `issue_reports` were `DROP … CASCADE` + recreated:
+
+- `feedback.id`: was `SERIAL` integer → now `TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text`.
+  - `user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE` (was a bare `TEXT`, no FK).
+  - `session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL` (was a bare `TEXT`, no FK).
+- `issue_reports.id`: was `SERIAL` integer → now `TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text`.
+  - `user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE` (was a bare `TEXT`, no FK).
+- `newsletter_emails.approved_at TIMESTAMPTZ` added `IF NOT EXISTS` (drift absorb; prod had it).
+
+The FK additions are enforced server-side; no code change is needed for them beyond
+ensuring `user_id`/`session_id` continue to carry valid ids (they already do — they come
+straight from the request body / session). The PK change is the only thing the code must
+react to: with a text PK we follow the repo convention and supply `id = str(uuid.uuid4())`
+explicitly rather than leaning on the DB default, so the insert shape is correct and
+consistent with the rest of the redesign.
+
+## File-by-file change map
+
+### `backend/routes/feedback.py`
+- Add `import uuid` is already present.
+- `submit_feedback`: add `"id": str(uuid.uuid4())` to the `feedback` insert dict
+  (current: relies on dropped SERIAL default → new: explicit text PK).
+- `submit_issue_report`: add `"id": str(uuid.uuid4())` to the `issue_reports` insert dict
+  (same rationale). `screenshot_urls` stays a JSON list (column is `JSONB`).
+- No change to `upload_issue_screenshot` (storage-only, no PK).
+
+### `backend/routes/admin.py` — VERIFY ONLY (issue #267)
+- `approve_allowlist`: `upsert({"email", "approved_at": now_iso}, on_conflict="email")`.
+- `revoke_allowlist`: `update({"approved_at": None}, filters={"email": "eq.<email>"})`.
+- Both already read/write `newsletter_emails.approved_at` exactly as 0026 declares it.
+  Confirmed: NO code change needed. Note it in the report.
+
+## Tests
+
+New file `backend/tests/test_feedback_routes.py` (POST endpoints had no coverage):
+- `test_submit_feedback_inserts_with_text_uuid_pk` — patch `routes.feedback.table`
+  with a recording factory; assert the recorded `feedback` insert carries an `id` that
+  parses as a UUID and the body fields round-trip (`user_id`, `type`, `rating`,
+  `selected_options`, `comment`, `session_id`, `topic`).
+- `test_submit_feedback_omits_no_required_fields` — assert the insert dict has the
+  expected keys (regression guard against dropping a field).
+- `test_submit_issue_report_inserts_with_text_uuid_pk` — same shape for `issue_reports`
+  (`id` is a UUID, `user_id`/`topic`/`description`/`screenshot_urls` round-trip).
+
+Uses the same MagicMock-per-table factory pattern as `tests/test_academics.py`.
+The existing `tests/test_issue_screenshot_auth.py` (storage upload) is unaffected.
+
+## Out of scope
+
+- Any migration authoring (schema already landed).
+- `services/academics.py` and every other domain's files.
+- The 2 pre-existing `tests/test_storage_service.py` failures (env-only:
+  SUPABASE_URL/SERVICE_KEY unset in the worktree) — not ops, left untouched.
+- `models/__init__.py` (`SubmitFeedbackBody`/`SubmitIssueReportBody` are unchanged —
+  the API body shape is identical; only the server-side PK generation moves).
+
+## Gate
+
+`$PY -m pytest tests/ -q` stays green (baseline 722 passed + 2 unrelated storage
+failures; target ≥ 722 passed, +3 new feedback tests → 725 passed). `$RUFF check .` clean.


### PR DESCRIPTION
Ops slice of the DB modular redesign (migration 0026, already landed). text-uuid PKs + FKs on `feedback`/`issue_reports`; verified #267 newsletter allowlist needs no change. +4 feedback tests; suite green; ruff clean.

Plan: `docs/superpowers/plans/2026-06-24-db-ops-code.md`. Smallest slice, independent — safe to merge first.