### PR TITLE
db/analytics-code: social.py offering re-keying (epic slice PR4)

### DIFF
--- a/backend/routes/social.py
+++ b/backend/routes/social.py
@@ -427,12 +427,23 @@ def get_students(request: Request):
     """Return a lightweight profile for every user in the DB."""
     user_id = get_session_user_id(request)
     users = table("users").select("id,name,streak_count")
-    courses_rows = table("courses").select("user_id,course_name")
+    # A user's courses now resolve through the enrollment chain
+    # (enrollments → course_offerings → courses); the abstract `courses` catalog
+    # no longer carries a per-user row. Read the offering's abstract course name
+    # via the embedded join and dedup, since one abstract course may have several
+    # offerings (per term/section) the user is enrolled in.
+    enrollment_rows = table("enrollments").select(
+        "user_id,course_offerings(courses(course_name))"
+    )
     nodes_rows = table("graph_nodes").select("user_id,mastery_tier,concept_name,mastery_score")
 
-    courses_by_user: dict = defaultdict(list)
-    for c in courses_rows:
-        courses_by_user[c["user_id"]].append(c["course_name"])
+    courses_by_user: dict = defaultdict(set)
+    for e in enrollment_rows:
+        offering = e.get("course_offerings") or {}
+        course = offering.get("courses") or {} if isinstance(offering, dict) else {}
+        course_name = course.get("course_name") if isinstance(course, dict) else None
+        if course_name:
+            courses_by_user[e["user_id"]].add(course_name)
 
     mastery_by_user: dict = defaultdict(
         lambda: {"mastered": 0, "learning": 0, "struggling": 0, "unexplored": 0, "total": 0}

--- a/backend/tests/test_social_students.py
+++ b/backend/tests/test_social_students.py
@@ -1,0 +1,140 @@
+"""
+Unit tests for GET /api/social/students (routes/social.py::get_students).
+
+After the academics split (migration 0020) the abstract `courses` table no
+longer has a `user_id` column or per-enrollment rows. A user's courses are now
+resolved through the enrollment chain:
+
+    enrollments(user_id) -> course_offerings(course_id) -> courses(course_name)
+
+These tests pin the new offering-aware resolution and the (unchanged) response
+shape of the endpoint.
+"""
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def _enrollment(user_id: str, course_name: str) -> dict:
+    """An enrollments row with the PostgREST embedded course-offering -> course join."""
+    return {
+        "user_id": user_id,
+        "course_offerings": {"courses": {"course_name": course_name}},
+    }
+
+
+def _table_factory(users, enrollment_rows, node_rows):
+    def table_side_effect(name):
+        m = MagicMock()
+        if name == "users":
+            m.select.return_value = users
+        elif name == "enrollments":
+            m.select.return_value = enrollment_rows
+        elif name == "graph_nodes":
+            m.select.return_value = node_rows
+        else:
+            m.select.return_value = []
+        return m
+
+    return table_side_effect
+
+
+class TestGetStudents:
+    def test_courses_resolved_via_enrollments(self):
+        users = [{"id": "u1", "name": "Alice", "streak_count": 3}]
+        enrollments = [
+            _enrollment("u1", "Intro CS"),
+            _enrollment("u1", "Calculus I"),
+        ]
+        with patch(
+            "routes.social.table",
+            side_effect=_table_factory(users, enrollments, []),
+        ):
+            r = client.get("/api/social/students")
+
+        assert r.status_code == 200
+        students = r.json()["students"]
+        assert len(students) == 1
+        assert students[0]["user_id"] == "u1"
+        assert students[0]["courses"] == ["Calculus I", "Intro CS"]  # sorted
+
+    def test_courses_deduped_across_offerings(self):
+        # Same abstract course taught in two offerings -> appears once.
+        users = [{"id": "u1", "name": "Alice", "streak_count": 0}]
+        enrollments = [
+            _enrollment("u1", "Intro CS"),
+            _enrollment("u1", "Intro CS"),
+            _enrollment("u1", "Calculus I"),
+        ]
+        with patch(
+            "routes.social.table",
+            side_effect=_table_factory(users, enrollments, []),
+        ):
+            r = client.get("/api/social/students")
+
+        assert r.status_code == 200
+        courses = r.json()["students"][0]["courses"]
+        assert courses == ["Calculus I", "Intro CS"]
+
+    def test_courses_grouped_per_user(self):
+        users = [
+            {"id": "u1", "name": "Alice", "streak_count": 1},
+            {"id": "u2", "name": "Bob", "streak_count": 2},
+        ]
+        enrollments = [
+            _enrollment("u1", "Intro CS"),
+            _enrollment("u2", "Physics"),
+        ]
+        with patch(
+            "routes.social.table",
+            side_effect=_table_factory(users, enrollments, []),
+        ):
+            r = client.get("/api/social/students")
+
+        assert r.status_code == 200
+        by_id = {s["user_id"]: s for s in r.json()["students"]}
+        assert by_id["u1"]["courses"] == ["Intro CS"]
+        assert by_id["u2"]["courses"] == ["Physics"]
+
+    def test_no_enrollments_yields_empty_courses(self):
+        users = [{"id": "u1", "name": "Alice", "streak_count": 0}]
+        with patch(
+            "routes.social.table",
+            side_effect=_table_factory(users, [], []),
+        ):
+            r = client.get("/api/social/students")
+
+        assert r.status_code == 200
+        students = r.json()["students"]
+        assert len(students) == 1
+        assert students[0]["courses"] == []
+
+    def test_response_shape_preserved(self):
+        users = [{"id": "u1", "name": "Alice", "streak_count": 5}]
+        enrollments = [_enrollment("u1", "Intro CS")]
+        node_rows = [
+            {"user_id": "u1", "mastery_tier": "mastered",
+             "concept_name": "Loops", "mastery_score": 0.9},
+            {"user_id": "u1", "mastery_tier": "struggling",
+             "concept_name": "Recursion", "mastery_score": 0.2},
+        ]
+        with patch(
+            "routes.social.table",
+            side_effect=_table_factory(users, enrollments, node_rows),
+        ):
+            r = client.get("/api/social/students")
+
+        assert r.status_code == 200
+        student = r.json()["students"][0]
+        assert set(student.keys()) == {
+            "user_id", "name", "streak", "courses", "stats", "top_concepts"
+        }
+        assert student["streak"] == 5
+        assert student["top_concepts"] == ["Loops"]
+        assert student["stats"]["mastered"] == 1
+        assert student["stats"]["struggling"] == 1
+        assert student["stats"]["total"] == 2

--- a/docs/superpowers/plans/2026-06-24-db-analytics-code.md
+++ b/docs/superpowers/plans/2026-06-24-db-analytics-code.md
@@ -1,0 +1,101 @@
+# db/analytics-code — slice plan (2026-06-24)
+
+Base branch: `db/academics-code` (has academics spine + `services/academics.py` + migrations 0019–0027).
+Branch: `db/analytics-code`.
+
+## Context: what academics already did vs. what's left
+
+The analytics re-key (migration `0022_analytics.sql`) renamed the class-analytics
+tables and dropped the last free-text `semester` columns:
+
+- `course_concept_stats` → `offering_concept_stats` (PK `offering_id` → `course_offerings`)
+- `course_summary` → `offering_summary` (PK `offering_id`)
+
+The academics slice (PR2 on this base) **already**:
+
+- Rewired `services/course_context_service.py` to key entirely on `offering_id`,
+  read `enrollments`/`course_offerings`/`courses`, and upsert the new
+  `offering_*` tables. (0 refs to the old analytics tables remain there.)
+- Reshaped `courses` into the **abstract catalog** (`id, school_id, course_code,
+  course_name, department, credits, description, …`) via `0020_academics_split.sql`.
+  The old offering-shaped `courses` (with `user_id`, `semester`, `course_name`
+  per enrollment) became `course_offerings`; per-user links became `enrollments`
+  (`user_id`, `offering_id`).
+
+Verified residuals (grep over `routes/` + `services/`, excluding tests):
+- **No** `table("course_concept_stats")` / `table("course_summary")` calls remain
+  anywhere. (The two grep hits in `course_context_service.py` are a response dict
+  key `"course_summary"` and a stale comment — not table calls, out of scope.)
+
+## What's LEFT — the holdout: `routes/social.py`
+
+One offending line:
+
+```python
+# routes/social.py  (get_students, GET /api/social/students)
+courses_rows = table("courses").select("user_id,course_name")   # line 430
+...
+courses_by_user[c["user_id"]].append(c["course_name"])          # line 435
+```
+
+After `0020`, the abstract `courses` table has **no** `user_id` column and no
+per-user rows — `course_name` is a single catalog value per abstract course.
+This query is reading the *old* offering-shaped `courses`. It must be repointed
+to resolve each user's courses through the enrollment chain:
+
+`enrollments(user_id) → course_offerings(course_id) → courses(course_name)`
+
+The canonical PostgREST shape for this (already used in `routes/profile.py:183`
+and asserted in `tests/test_shared_course_context.py`) is an embedded select:
+
+```python
+table("enrollments").select("user_id,course_offerings(courses(course_name))")
+```
+
+Each enrollment row then yields `row["course_offerings"]["courses"]["course_name"]`.
+This is per-offering, so a student in two offerings of the same abstract course
+would list it twice — the existing code already `sorted()`s the list but does not
+dedup; to preserve the "lightweight profile" intent and avoid term-driven
+duplicates, dedup per user before sorting.
+
+Everything else in `social.py` is unrelated to analytics/offerings:
+`rooms`, `room_members`, `room_messages`, `room_reactions`, `room_activity`,
+`users`, `graph_nodes` — all unchanged, untouched.
+
+## File-by-file change map
+
+- `backend/routes/social.py` — `get_students`: replace the
+  `table("courses").select("user_id,course_name")` read with an
+  `table("enrollments")` embedded read through `course_offerings(courses(...))`;
+  build `courses_by_user` from the joined rows; dedup per user. Preserve the
+  exact `/api/social/students` response shape (`students[].courses` = sorted list
+  of course-name strings).
+
+No other files in scope require edits (residual grep is clean).
+
+## Test list (new, in `tests/test_social_students.py`)
+
+TDD — written first, must fail against the old `table("courses")` read, pass after:
+
+1. `test_students_courses_resolved_via_enrollments` — enrollments embed returns
+   course names per user; response groups them under the right `user_id`.
+2. `test_students_courses_deduped_and_sorted` — same abstract course across two
+   offerings appears once; list is sorted.
+3. `test_students_no_enrollments_yields_empty_courses` — user with no enrollments
+   gets `courses: []` (and still appears in the list).
+4. `test_students_response_shape_preserved` — top-level `students[]` items keep
+   `user_id,name,streak,courses,stats,top_concepts`.
+
+Patch `routes.social.table` with a MagicMock-per-table factory (mirrors
+`tests/test_social_messages.py` + `tests/test_shared_course_context.py`); the
+endpoint requires a session, so patch `get_session_user_id` via the existing
+auth test pattern / dependency override.
+
+## Out of scope (do NOT touch)
+
+- `services/course_context_service.py` (already done; read-only reference).
+- `routes/study_guide.py`, `onboarding.py`, `flashcards.py`, `learn.py`,
+  `documents.py`, `services/graph_service.py` — their `table("courses")` calls
+  already key on the abstract `id` (correct).
+- `services/academics.py` (locked).
+- graph / gradebook / study / identity / ops files.


### PR DESCRIPTION
Analytics slice (migration 0022). Academics already did the table renames + all of `course_context_service`; the only holdout was `routes/social.py::get_students`, now reading `enrollments → course_offerings → courses`. +5 tests; green; ruff clean.

Plan: `docs/superpowers/plans/2026-06-24-db-analytics-code.md`. Independent — safe to merge early.