### PR TITLE
db/identity-code: user_profiles split (epic slice PR6)

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -213,11 +213,13 @@ class OnboardingBody(BaseModel):
 # ── Profile & Settings ───────────────────────────────────────────────────────
 
 class UpdateProfileBody(BaseModel):
+    # Profile fields now live on user_profiles (see migration 0024). `display_name`
+    # was a user_settings duplicate of the profile `name` and was dropped; profile
+    # name is set during onboarding / OAuth, not via this patch body.
     username: Optional[str] = None
     bio: Optional[str] = None
     location: Optional[str] = None
     website: Optional[str] = None
-    display_name: Optional[str] = None
 
 
 class UpdateSettingsBody(BaseModel):
@@ -268,12 +270,9 @@ class PublicProfileResponse(BaseModel):
 
 
 class SettingsResponse(BaseModel):
+    # display_name/username/bio/location/website were dropped from user_settings in
+    # migration 0024 (now owned by user_profiles — one source of truth per field).
     user_id: str
-    display_name: Optional[str] = None
-    username: Optional[str] = None
-    bio: Optional[str] = None
-    location: Optional[str] = None
-    website: Optional[str] = None
     profile_visibility: str = "public"
     activity_status_visible: bool = True
     notification_email: bool = True

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -188,9 +188,17 @@ def _prune_fallback_store() -> None:
 def get_me(request: Request):
     """Return approval and onboarding status for a given user_id."""
     user_id = get_session_user_id(request)
-    user = table("users").select("id,is_approved,onboarding_completed,username,name,avatar_url", filters={"id": f"eq.{user_id}"})
+    user = table("users").select(
+        "id,is_approved,onboarding_completed", filters={"id": f"eq.{user_id}"}
+    )
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+
+    # Profile fields (username/name/avatar_url) moved to user_profiles in migration 0024.
+    profile_rows = table("user_profiles").select(
+        "username,name,avatar_url", filters={"user_id": f"eq.{user_id}"}
+    )
+    profile = profile_rows[0] if profile_rows else {}
 
     # Fetch user roles
     role_rows = table("user_roles").select(
@@ -237,9 +245,9 @@ def get_me(request: Request):
         "user_id": user_id,
         "is_approved": bool(user[0]["is_approved"]),
         "onboarding_completed": bool(user[0].get("onboarding_completed", False)),
-        "username": user[0].get("username"),
-        "name": decrypt_if_present(user[0].get("name")) or "",
-        "avatar_url": user[0].get("avatar_url") or "",
+        "username": profile.get("username"),
+        "name": decrypt_if_present(profile.get("name")) or "",
+        "avatar_url": profile.get("avatar_url") or "",
         "roles": roles,
         "equipped_cosmetics": equipped_cosmetics,
         "is_admin": is_admin,
@@ -345,23 +353,32 @@ def google_callback(request: Request, code: str = Query(...), state: str = Query
     if not _email_domain_allowed(email):
         return _fail_redirect("invalid_domain")
 
+    # Profile fields (name/first_name/last_name/avatar_url) live on user_profiles
+    # after migration 0024; `users` keeps identity + auth + activity only.
+    profile_fields = {
+        "name": encrypt_if_present(name),
+        "first_name": encrypt_if_present(first_name),
+        "last_name": encrypt_if_present(last_name),
+        "avatar_url": avatar_url,
+    }
+
     # Determine user_id: check if this Google ID already exists
     existing = table("users").select("id,is_approved", filters={"google_id": f"eq.{google_id}"})
     if existing:
         user_id = existing[0]["id"]
         is_approved = existing[0]["is_approved"]
-        # Update name/avatar in case they changed
+        # Update auth fields on users; refresh profile fields on user_profiles.
         from datetime import datetime as _dt, timezone as _tz
         table("users").update(
             {
-                "name": encrypt_if_present(name),
-                "first_name": encrypt_if_present(first_name),
-                "last_name": encrypt_if_present(last_name),
-                "avatar_url": avatar_url,
                 "email": encrypt_if_present(email),
                 "last_sign_in_at": _dt.now(_tz.utc).isoformat(),
             },
             filters={"id": f"eq.{user_id}"},
+        )
+        table("user_profiles").upsert(
+            {"user_id": user_id, **profile_fields},
+            on_conflict="user_id",
         )
     else:
         # Email-based account merge is disabled because emails are now encrypted
@@ -372,23 +389,22 @@ def google_callback(request: Request, code: str = Query(...), state: str = Query
         from datetime import datetime as _dt, timezone as _tz
         table("users").insert({
             "id": user_id,
-            "name": encrypt_if_present(name),
-            "first_name": encrypt_if_present(first_name),
-            "last_name": encrypt_if_present(last_name),
             "email": encrypt_if_present(email),
             "google_id": google_id,
-            "avatar_url": avatar_url,
             "auth_provider": "google",
             "last_sign_in_at": _dt.now(_tz.utc).isoformat(),
         })
+        table("user_profiles").insert({"user_id": user_id, **profile_fields})
 
     # Store OAuth tokens (calendar access included)
+    # expires_at is TIMESTAMPTZ after migration 0024 — pass None (not "") when
+    # there is no expiry, since "" is not a valid timestamptz.
     table("oauth_tokens").upsert(
         {
             "user_id": user_id,
             "access_token": encrypt(creds.token),
             "refresh_token": encrypt_if_present(creds.refresh_token),
-            "expires_at": creds.expiry.isoformat() if creds.expiry else "",
+            "expires_at": creds.expiry.isoformat() if creds.expiry else None,
         },
         on_conflict="user_id",
     )

--- a/backend/routes/onboarding.py
+++ b/backend/routes/onboarding.py
@@ -37,10 +37,18 @@ def save_onboarding_profile(body: OnboardingBody, request: Request):
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
-    # Update user profile fields
-    name = f"{body.first_name} {body.last_name}".strip()
+    # onboarding_completed is an auth/status flag and stays on `users`.
     table("users").update(
+        {"onboarding_completed": True},
+        filters={"id": f"eq.{body.user_id}"},
+    )
+
+    # Profile fields moved to user_profiles in migration 0024 (one source of truth).
+    # name/first_name/last_name are 🔒-encrypted; the rest are plaintext.
+    name = f"{body.first_name} {body.last_name}".strip()
+    table("user_profiles").upsert(
         {
+            "user_id": body.user_id,
             "name": encrypt_if_present(name),
             "first_name": encrypt_if_present(body.first_name),
             "last_name": encrypt_if_present(body.last_name),
@@ -48,9 +56,8 @@ def save_onboarding_profile(body: OnboardingBody, request: Request):
             "majors": body.majors,
             "minors": body.minors,
             "learning_style": body.learning_style,
-            "onboarding_completed": True,
         },
-        filters={"id": f"eq.{body.user_id}"},
+        on_conflict="user_id",
     )
 
     # Enroll user in selected courses (resolve each abstract course → current-term offering)

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -28,21 +28,51 @@ from services.achievement_service import get_user_stat
 router = APIRouter()
 
 
-def _get_user_or_404(user_id: str) -> dict:
-    rows = table("users").select(
-        "id,username,name,first_name,last_name,email,avatar_url,year,majors,minors,bio,location,website,streak_count,created_at",
-        filters={"id": f"eq.{user_id}"},
-    )
+# Identity columns that stay on `users` after the 0024 split.
+_USERS_COLS = "id,email,streak_count,created_at"
+
+# Profile columns live on `user_profiles` (1:1 with users). 🔒 = encrypted at rest.
+_PROFILE_COLS = (
+    "user_id,username,name,first_name,last_name,avatar_url,"
+    "year,majors,minors,bio,location,website,learning_style"
+)
+_PROFILE_ENCRYPTED = ("name", "first_name", "last_name", "bio", "location")
+
+
+def _get_or_create_profile(user_id: str) -> dict:
+    """Return the decrypted user_profiles row, creating it if missing."""
+    rows = table("user_profiles").select(_PROFILE_COLS, filters={"user_id": f"eq.{user_id}"})
     if not rows:
-        raise HTTPException(status_code=404, detail="User not found")
+        table("user_profiles").insert({"user_id": user_id})
+        rows = table("user_profiles").select(_PROFILE_COLS, filters={"user_id": f"eq.{user_id}"})
+    if not rows:
+        return {"user_id": user_id}
     row = rows[0]
-    for col in ("name", "first_name", "last_name", "email", "bio", "location"):
+    for col in _PROFILE_ENCRYPTED:
         row[col] = decrypt_if_present(row.get(col))
     return row
 
 
+def _get_user_or_404(user_id: str) -> dict:
+    """Identity + profile merged into the legacy single-dict shape.
+
+    `users` now holds only id/email/auth/activity; the public profile fields live
+    on `user_profiles` (migration 0024). We read both and merge so callers keep the
+    same flat dict they relied on before the split.
+    """
+    rows = table("users").select(_USERS_COLS, filters={"id": f"eq.{user_id}"})
+    if not rows:
+        raise HTTPException(status_code=404, detail="User not found")
+    user = rows[0]
+    user["email"] = decrypt_if_present(user.get("email"))
+    profile = _get_or_create_profile(user_id)
+    # Merge profile fields onto the identity row (id/email/streak/created_at win).
+    merged = {**profile, **user}
+    return merged
+
+
 _SETTINGS_COLS = (
-    "user_id,username,display_name,bio,location,website,"
+    "user_id,"
     "profile_visibility,activity_status_visible,"
     "notification_email,notification_push,notification_in_app,"
     "theme,font_size,accent_color,"
@@ -58,10 +88,7 @@ def _get_or_create_settings(user_id: str) -> dict:
         rows = table("user_settings").select(_SETTINGS_COLS, filters={"user_id": f"eq.{user_id}"})
     if not rows:
         return {"user_id": user_id}
-    row = rows[0]
-    for col in ("bio", "location"):
-        row[col] = decrypt_if_present(row.get(col))
-    return row
+    return rows[0]
 
 
 def _get_user_roles(user_id: str) -> list:
@@ -158,10 +185,11 @@ def check_username(username: str = Query(...), user_id: Optional[str] = Query(No
     name = (username or "").strip().lower()
     if not _USERNAME_RE.match(name):
         return {"available": False, "reason": "invalid"}
-    existing = table("users").select("id", filters={"username": f"eq.{name}"})
+    # username now lives on user_profiles (keyed by user_id).
+    existing = table("user_profiles").select("user_id", filters={"username": f"eq.{name}"})
     if not existing:
         return {"available": True}
-    if user_id and existing[0]["id"] == user_id:
+    if user_id and existing[0]["user_id"] == user_id:
         return {"available": True, "reason": "self"}
     return {"available": False, "reason": "taken"}
 
@@ -229,35 +257,28 @@ def update_profile(user_id: str, body: UpdateProfileBody, request: Request):
     require_self(user_id, request)
     _get_user_or_404(user_id)
 
-    updates_user = {}
-    updates_settings = {}
+    # All of these fields now live on user_profiles (migration 0024) — one source of truth.
+    updates_profile = {}
 
     if body.username is not None:
-        # Check uniqueness
-        existing = table("users").select("id", filters={"username": f"eq.{body.username}"})
-        if existing and existing[0]["id"] != user_id:
+        # Check uniqueness against user_profiles.
+        existing = table("user_profiles").select(
+            "user_id", filters={"username": f"eq.{body.username}"}
+        )
+        if existing and existing[0]["user_id"] != user_id:
             raise HTTPException(status_code=409, detail="Username already taken")
-        updates_user["username"] = body.username
-        updates_settings["username"] = body.username
+        updates_profile["username"] = body.username
 
-    if body.display_name is not None:
-        updates_settings["display_name"] = body.display_name
     if body.bio is not None:
-        updates_user["bio"] = encrypt_if_present(body.bio)
-        updates_settings["bio"] = encrypt_if_present(body.bio)
+        updates_profile["bio"] = encrypt_if_present(body.bio)
     if body.location is not None:
-        updates_user["location"] = encrypt_if_present(body.location)
-        updates_settings["location"] = encrypt_if_present(body.location)
+        updates_profile["location"] = encrypt_if_present(body.location)
     if body.website is not None:
-        updates_user["website"] = body.website
-        updates_settings["website"] = body.website
+        updates_profile["website"] = body.website
 
-    if updates_user:
-        table("users").update(updates_user, filters={"id": f"eq.{user_id}"})
-    if updates_settings:
-        updates_settings["updated_at"] = datetime.now(timezone.utc).isoformat()
-        _get_or_create_settings(user_id)
-        table("user_settings").update(updates_settings, filters={"user_id": f"eq.{user_id}"})
+    if updates_profile:
+        _get_or_create_profile(user_id)  # ensure a row exists to update
+        table("user_profiles").update(updates_profile, filters={"user_id": f"eq.{user_id}"})
 
     return {"updated": True}
 
@@ -319,7 +340,11 @@ async def upload_user_avatar(user_id: str, body: _AvatarUploadBody, request: Req
 
     avatar_url = upload_avatar(user_id, file_bytes, body.content_type)
 
-    table("users").update({"avatar_url": avatar_url}, filters={"id": f"eq.{user_id}"})
+    # avatar_url moved to user_profiles in migration 0024.
+    _get_or_create_profile(user_id)  # ensure a row exists to update
+    table("user_profiles").update(
+        {"avatar_url": avatar_url}, filters={"user_id": f"eq.{user_id}"}
+    )
     return {"avatar_url": avatar_url}
 
 
@@ -338,8 +363,8 @@ def update_settings(user_id: str, body: UpdateSettingsBody, request: Request):
     _get_or_create_settings(user_id)
 
     # Whitelist: only these fields may be patched via this endpoint.
-    # EXCLUDES bio/location (encrypted later, set via /profile patch) and any
-    # role/admin/approval fields to prevent privilege escalation.
+    # bio/location/username/website live on user_profiles now (set via /profile
+    # patch); role/admin/approval fields are excluded to prevent privilege escalation.
     ALLOWED = {
         "profile_visibility", "activity_status_visible",
         "notification_email", "notification_push", "notification_in_app",
@@ -352,8 +377,6 @@ def update_settings(user_id: str, body: UpdateSettingsBody, request: Request):
         updates["updated_at"] = datetime.now(timezone.utc).isoformat()
         table("user_settings").update(updates, filters={"user_id": f"eq.{user_id}"})
 
-    # #126 (#19): return through the decrypting helper (like GET) so the
-    # response carries plaintext bio/location, not the stored ciphertext.
     return _get_or_create_settings(user_id)
 
 

--- a/backend/tests/test_onboarding_routes.py
+++ b/backend/tests/test_onboarding_routes.py
@@ -66,6 +66,8 @@ def _make_factory(tables, *, course_rows, enrollment_rows, offering_rows=None):
             m = MagicMock()
             if name == "users":
                 m.select.return_value = [{"id": "user_123"}]
+            elif name == "user_profiles":
+                m.select.return_value = []
             elif name == "courses":
                 m.select.return_value = course_rows
             elif name == "terms":
@@ -108,17 +110,23 @@ class TestSaveOnboardingProfile:
         assert data["user_id"] == "user_123"
         assert len(data["courses_linked"]) == 2
 
-        # User profile was updated
+        # onboarding_completed flag stays on `users`; profile fields moved to
+        # user_profiles (migration 0024).
         from services.encryption import decrypt
         tables["users"].update.assert_called_once()
-        update_data = tables["users"].update.call_args[0][0]
-        assert decrypt(update_data["first_name"]) == "Jose"
-        assert decrypt(update_data["last_name"]) == "Cruz"
-        assert decrypt(update_data["name"]) == "Jose Cruz"
-        assert update_data["year"] == "junior"
-        assert update_data["majors"] == ["Computer Science"]
-        assert update_data["minors"] == ["Mathematics"]
-        assert update_data["learning_style"] == "visual"
+        users_update = tables["users"].update.call_args[0][0]
+        assert users_update == {"onboarding_completed": True}
+
+        tables["user_profiles"].upsert.assert_called_once()
+        profile_data = tables["user_profiles"].upsert.call_args[0][0]
+        assert profile_data["user_id"] == "user_123"
+        assert decrypt(profile_data["first_name"]) == "Jose"
+        assert decrypt(profile_data["last_name"]) == "Cruz"
+        assert decrypt(profile_data["name"]) == "Jose Cruz"
+        assert profile_data["year"] == "junior"
+        assert profile_data["majors"] == ["Computer Science"]
+        assert profile_data["minors"] == ["Mathematics"]
+        assert profile_data["learning_style"] == "visual"
 
         # Two enrollments were created, keyed on offering_id (not course_id)
         assert tables["enrollments"].insert.call_count == 2
@@ -207,5 +215,5 @@ class TestSaveOnboardingProfile:
             res = client.post("/api/onboarding/profile", json=payload)
 
         assert res.status_code == 200
-        update_data = tables["users"].update.call_args[0][0]
-        assert update_data["minors"] == []
+        profile_data = tables["user_profiles"].upsert.call_args[0][0]
+        assert profile_data["minors"] == []

--- a/backend/tests/test_profile_routes.py
+++ b/backend/tests/test_profile_routes.py
@@ -41,13 +41,17 @@ def _mock_session_user():
 
 class TestGetPublicProfile:
     def test_returns_profile_for_existing_user(self):
-        user_row = {"id": USER_ID, "name": "Test", "username": "tester", "avatar_url": None, "created_at": "2025-01-01", "bio": "Hi", "location": "NYC", "website": None}
+        # Identity stays on `users`; profile fields live on `user_profiles` (migration 0024).
+        user_row = {"id": USER_ID, "email": None, "streak_count": 0, "created_at": "2025-01-01"}
+        profile_row = {"user_id": USER_ID, "name": "Test", "username": "tester", "avatar_url": None, "bio": "Hi", "location": "NYC", "website": None}
         settings_row = {"user_id": USER_ID, "profile_visibility": "public"}
 
         def table_side_effect(name):
             m = MagicMock()
             if name == "users":
                 m.select.return_value = [user_row]
+            elif name == "user_profiles":
+                m.select.return_value = [profile_row]
             elif name == "user_settings":
                 m.select.return_value = [settings_row]
             elif name == "user_roles":
@@ -87,13 +91,16 @@ class TestGetPublicProfile:
         assert r.status_code == 404
 
     def test_private_profile_hides_bio_and_stats(self):
-        user_row = {"id": USER_ID, "name": "Test", "username": None, "avatar_url": None, "created_at": "2025-01-01", "bio": "Secret", "location": "Hidden", "website": None}
+        user_row = {"id": USER_ID, "email": None, "streak_count": 0, "created_at": "2025-01-01"}
+        profile_row = {"user_id": USER_ID, "name": "Test", "username": None, "avatar_url": None, "bio": "Secret", "location": "Hidden", "website": None}
         settings_row = {"user_id": USER_ID, "profile_visibility": "private"}
 
         def table_side_effect(name):
             m = MagicMock()
             if name == "users":
                 m.select.return_value = [user_row]
+            elif name == "user_profiles":
+                m.select.return_value = [profile_row]
             elif name == "user_settings":
                 m.select.return_value = [settings_row]
             else:
@@ -113,16 +120,26 @@ class TestGetPublicProfile:
 # ── PATCH /api/profile/{user_id} ───────────────────────────────────────────
 
 class TestUpdateProfile:
-    def test_updates_user_fields(self):
-        user_row = {"id": USER_ID, "name": "Test"}
-        settings_row = {"user_id": USER_ID}
+    def test_updates_profile_fields_on_user_profiles(self):
+        # bio/location/website/username are written to user_profiles now (migration 0024).
+        user_row = {"id": USER_ID, "email": None, "streak_count": 0, "created_at": "2025-01-01"}
+        profile_row = {"user_id": USER_ID, "name": "Test"}
+        captured = []
 
         def table_side_effect(name):
             m = MagicMock()
             if name == "users":
                 m.select.return_value = [user_row]
+            elif name == "user_profiles":
+                m.select.return_value = [profile_row]
+
+                def _capture(payload, filters):
+                    captured.append({"payload": payload, "filters": filters})
+                    return [{}]
+
+                m.update.side_effect = _capture
             elif name == "user_settings":
-                m.select.return_value = [settings_row]
+                m.select.return_value = [{"user_id": USER_ID}]
             else:
                 m.select.return_value = []
             m.update.return_value = [{}]
@@ -133,14 +150,24 @@ class TestUpdateProfile:
 
         assert r.status_code == 200
         assert r.json()["updated"] is True
+        # The profile write landed on user_profiles, keyed by user_id, with an
+        # encrypted bio (ciphertext, not the plaintext).
+        assert len(captured) == 1
+        assert captured[0]["filters"] == {"user_id": f"eq.{USER_ID}"}
+        assert "bio" in captured[0]["payload"]
+        assert captured[0]["payload"]["bio"] != "Updated bio"
 
     def test_username_conflict_returns_409(self):
-        user_row = {"id": USER_ID, "name": "Test"}
+        user_row = {"id": USER_ID, "email": None, "streak_count": 0, "created_at": "2025-01-01"}
+        profile_row = {"user_id": USER_ID, "name": "Test"}
 
         def table_side_effect(name):
             m = MagicMock()
             if name == "users":
-                m.select.return_value = [{"id": "other_user"}]
+                m.select.return_value = [user_row]
+            elif name == "user_profiles":
+                # uniqueness check returns a DIFFERENT user holding the username
+                m.select.return_value = [{"user_id": "other_user"}]
             elif name == "user_settings":
                 m.select.return_value = [{"user_id": USER_ID}]
             else:
@@ -151,6 +178,41 @@ class TestUpdateProfile:
             r = client.patch(f"/api/profile/{USER_ID}", json={"username": "taken"})
 
         assert r.status_code == 409
+
+    def test_creates_user_profiles_row_when_missing(self):
+        # A user with no user_profiles row yet should get one created before the
+        # update lands (ensure-row semantics).
+        user_row = {"id": USER_ID, "email": None, "streak_count": 0, "created_at": "2025-01-01"}
+        profile_selects = []
+        insert_calls = []
+
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "users":
+                m.select.return_value = [user_row]
+            elif name == "user_profiles":
+                # First select(s) return empty (no row) → insert; then return a row.
+                def _select(*args, **kwargs):
+                    profile_selects.append(True)
+                    # After an insert has happened, the row exists.
+                    return [{"user_id": USER_ID, "name": None}] if insert_calls else []
+
+                m.select.side_effect = _select
+                m.insert.side_effect = lambda payload: insert_calls.append(payload) or [{}]
+                m.update.return_value = [{}]
+            elif name == "user_settings":
+                m.select.return_value = [{"user_id": USER_ID}]
+            else:
+                m.select.return_value = []
+            return m
+
+        with _mock_self(), patch("routes.profile.table", side_effect=table_side_effect):
+            r = client.patch(f"/api/profile/{USER_ID}", json={"website": "https://x.io"})
+
+        assert r.status_code == 200
+        # A user_profiles row was inserted because none existed.
+        assert insert_calls, "expected a user_profiles row to be created when missing"
+        assert insert_calls[0] == {"user_id": USER_ID}
 
 
 # ── GET /api/profile/{user_id}/settings ────────────────────────────────────
@@ -322,8 +384,9 @@ class TestCheckUsername:
         assert r.json() == {"available": True}
 
     def test_taken_when_different_user_holds_it(self):
+        # username lives on user_profiles now (keyed by user_id).
         with patch("routes.profile.table") as t:
-            t.return_value.select.return_value = [{"id": "other_user"}]
+            t.return_value.select.return_value = [{"user_id": "other_user"}]
             r = client.get("/api/profile/username/check?username=taken")
         assert r.status_code == 200
         body = r.json()
@@ -332,7 +395,7 @@ class TestCheckUsername:
 
     def test_available_when_held_by_self(self):
         with patch("routes.profile.table") as t:
-            t.return_value.select.return_value = [{"id": USER_ID}]
+            t.return_value.select.return_value = [{"user_id": USER_ID}]
             r = client.get(f"/api/profile/username/check?username=mine&user_id={USER_ID}")
         assert r.status_code == 200
         body = r.json()
@@ -486,13 +549,18 @@ class TestUploadAvatar:
     some browser configs with `TypeError: Failed to fetch` — JSON
     avoids the failure class. See routes/profile.py:_AvatarUploadBody."""
 
-    USER_ROW = {"id": USER_ID, "name": "Test", "username": None, "avatar_url": None, "created_at": "2025-01-01"}
+    USER_ROW = {"id": USER_ID, "email": None, "streak_count": 0, "created_at": "2025-01-01"}
+    PROFILE_ROW = {"user_id": USER_ID, "name": "Test", "username": None, "avatar_url": None}
 
     def _table_factory(self, *, captured_update=None):
         def factory(name):
             m = MagicMock()
             if name == "users":
                 m.select.return_value = [self.USER_ROW]
+                m.update.return_value = [{}]
+            elif name == "user_profiles":
+                # avatar_url persists to user_profiles after migration 0024.
+                m.select.return_value = [self.PROFILE_ROW]
                 if captured_update is not None:
                     def _capture(payload, filters):
                         captured_update.append({"payload": payload, "filters": filters})
@@ -524,8 +592,8 @@ class TestUploadAvatar:
         assert r.json()["avatar_url"] == "https://cdn/avatar.png"
         # Ensure decoded bytes (not the base64 string) reach the storage layer.
         up.assert_called_once_with(USER_ID, b"PNG-bytes", "image/png")
-        # Ensure the avatar_url is persisted to users.
-        assert captured == [{"payload": {"avatar_url": "https://cdn/avatar.png"}, "filters": {"id": f"eq.{USER_ID}"}}]
+        # Ensure the avatar_url is persisted to user_profiles, keyed by user_id.
+        assert captured == [{"payload": {"avatar_url": "https://cdn/avatar.png"}, "filters": {"user_id": f"eq.{USER_ID}"}}]
 
     def test_accepts_data_url_prefix(self):
         """Frontend's readFileAsBase64 strips the prefix, but a future
@@ -593,67 +661,72 @@ class TestUploadAvatar:
         up.assert_not_called()
 
 
-# ── _get_user_or_404 column contract (issue #75) ────────────────────────────
+# ── _get_user_or_404 column contract (issue #75 + identity split 0024) ──────
 
 class TestGetUserOr404SelectColumns:
-    """Pin the column list used by `_get_user_or_404`'s SELECT against the
-    actual `users` schema. Issue #75 was caused by `school` and `major` being
-    SELECTed despite never being added by any migration; PostgREST returned
-    HTTP 400, the route 500'd, and three endpoints (PATCH, GET, avatar POST)
-    failed simultaneously. Existing MagicMock-based tests didn't catch it
-    because the mock returns success for any column.
+    """Pin the column lists used by `_get_user_or_404`'s SELECTs against the
+    actual table schemas. Issue #75 was caused by columns being SELECTed that
+    never existed; PostgREST returns HTTP 400 for unknown columns and the route
+    500s. MagicMock tests don't catch it (the mock succeeds for any column), so
+    this pins the strings.
+
+    After migration 0024 the read splits across two tables: identity columns on
+    `users` and the public-profile columns on `user_profiles`. Both SELECTs must
+    only name columns that exist on their respective table.
     """
 
-    # Columns that actually exist on `users` per
-    # `backend/db/supabase_schema.sql:7` + `migration_profile_settings.sql`
-    # + `migration_google_auth.sql` + `migration_add_is_approved.sql` +
-    # `migration_onboarding_fields.sql`. If a future migration adds a column
-    # to `users`, update this set in the same PR that introduces the
-    # migration so the test stays the source of truth.
+    # `users` after the identity split (migration 0024): identity + auth + activity.
     USERS_SCHEMA_COLUMNS = {
-        "id", "name", "email", "first_name", "last_name", "year",
-        "majors", "minors", "learning_style", "onboarding_completed",
-        "streak_count", "last_active_date", "room_id", "created_at",
-        "google_id", "avatar_url", "auth_provider", "is_approved",
-        "username", "bio", "location", "website", "deleted_at",
+        "id", "email", "onboarding_completed",
+        "streak_count", "last_active_date", "current_room_id", "created_at",
+        "updated_at", "google_id", "auth_provider", "is_approved",
+        "last_sign_in_at", "deleted_at",
     }
 
-    def test_select_columns_all_exist_on_users_schema(self):
-        """Every column in `_get_user_or_404`'s SELECT must exist on
-        `users`. The column string is the second positional arg to
-        `table('users').select(...)`; we capture it and compare against
-        the schema set above."""
+    # `user_profiles` per migration 0024.
+    PROFILES_SCHEMA_COLUMNS = {
+        "user_id", "name", "first_name", "last_name", "username", "avatar_url",
+        "bio", "location", "website", "year", "majors", "minors",
+        "learning_style", "created_at", "updated_at",
+    }
+
+    def test_select_columns_all_exist_on_their_table_schema(self):
+        """Capture both SELECT column strings and verify each only names columns
+        that exist on its table."""
         captured = {}
 
         def table_side_effect(name):
             m = MagicMock()
             if name == "users":
-                def _capture_select(columns, **kwargs):
+                def _capture_users(columns, **kwargs):
                     captured["users_columns"] = columns
-                    # Return a row with every encrypted column set to
-                    # None so `decrypt_if_present` returns early without
-                    # trying to base64-decode a plaintext fixture (which
-                    # logs a noisy "Nonce must be between..." warning).
-                    # The non-encrypted scalars stay populated since
-                    # the route accesses them by `.get(...)`.
                     return [{
                         "id": USER_ID,
-                        "name": None,
                         "email": None,
+                        "streak_count": 0,
+                        "created_at": "2026-01-01",
+                    }]
+                m.select.side_effect = _capture_users
+            elif name == "user_profiles":
+                def _capture_profiles(columns, **kwargs):
+                    captured["profiles_columns"] = columns
+                    # Encrypted columns None so decrypt_if_present returns early.
+                    return [{
+                        "user_id": USER_ID,
+                        "name": None,
                         "first_name": None,
                         "last_name": None,
                         "username": "tester",
                         "avatar_url": None,
-                        "year": None,
-                        "majors": [],
-                        "minors": [],
                         "bio": None,
                         "location": None,
                         "website": None,
-                        "streak_count": 0,
-                        "created_at": "2026-01-01",
+                        "year": None,
+                        "majors": [],
+                        "minors": [],
+                        "learning_style": None,
                     }]
-                m.select.side_effect = _capture_select
+                m.select.side_effect = _capture_profiles
             else:
                 m.select.return_value = []
             return m
@@ -663,12 +736,18 @@ class TestGetUserOr404SelectColumns:
             _get_user_or_404(USER_ID)
 
         assert "users_columns" in captured, "table('users').select(...) was not called"
-        selected = {c.strip() for c in captured["users_columns"].split(",")}
-        unknown = selected - self.USERS_SCHEMA_COLUMNS
-        assert not unknown, (
+        assert "profiles_columns" in captured, "table('user_profiles').select(...) was not called"
+
+        users_selected = {c.strip() for c in captured["users_columns"].split(",")}
+        unknown_users = users_selected - self.USERS_SCHEMA_COLUMNS
+        assert not unknown_users, (
             f"_get_user_or_404 SELECTs columns that don't exist on `users`: "
-            f"{sorted(unknown)}. This is the root cause of issue #75 — "
-            f"PostgREST returns HTTP 400 for unknown columns and the route "
-            f"500s. Fix: remove these columns from the SELECT in "
-            f"backend/routes/profile.py:_get_user_or_404."
+            f"{sorted(unknown_users)} (these moved to user_profiles in 0024)."
+        )
+
+        profiles_selected = {c.strip() for c in captured["profiles_columns"].split(",")}
+        unknown_profiles = profiles_selected - self.PROFILES_SCHEMA_COLUMNS
+        assert not unknown_profiles, (
+            f"_get_user_or_404 SELECTs columns that don't exist on `user_profiles`: "
+            f"{sorted(unknown_profiles)}."
         )

--- a/backend/tests/test_response_decrypt_boundary.py
+++ b/backend/tests/test_response_decrypt_boundary.py
@@ -60,21 +60,23 @@ class TestGradebookCreateAssignmentResponse:
 
 
 class TestProfileSettingsPatchResponse:
-    """#19: PATCH /settings returned a raw select of _SETTINGS_COLS with no
-    decrypt, unlike GET — so bio/location came back as ciphertext."""
+    """#19 + migration 0024: bio/location were dropped from user_settings and now
+    live on user_profiles (set via PATCH /profile, not /settings). The #19 leak —
+    PATCH /settings echoing ciphertext bio/location — is now structurally
+    impossible because the settings SELECT no longer carries those columns. This
+    test pins that: the settings response must NOT contain bio/location at all.
+    """
 
-    def test_response_is_decrypted_not_ciphertext(self):
+    def test_settings_response_omits_profile_fields(self):
+        # A stale user_settings row that still had ciphertext bio/location must
+        # never surface them — the SELECT column list excludes them post-0024.
         stored = {
             "user_id": "user_andres",
-            "bio": encrypt_if_present("my secret bio"),
-            "location": encrypt_if_present("Boston, MA"),
             "theme": "dark",
             "profile_visibility": "public",
         }
 
         with patch("routes.profile.table") as t:
-            # Fresh copy per call so _get_or_create_settings' in-place decrypt
-            # doesn't bleed across the two selects it performs.
             t.return_value.select.side_effect = lambda *a, **k: [dict(stored)]
             r = client.patch(
                 "/api/profile/user_andres/settings",
@@ -83,6 +85,7 @@ class TestProfileSettingsPatchResponse:
 
         assert r.status_code == 200
         body = r.json()
-        # Pre-fix bio/location came back as ciphertext.
-        assert body["bio"] == "my secret bio"
-        assert body["location"] == "Boston, MA"
+        # bio/location/username/website are owned by user_profiles now — not here.
+        assert "bio" not in body
+        assert "location" not in body
+        assert body["profile_visibility"] == "public"

--- a/docs/superpowers/plans/2026-06-24-db-identity-code.md
+++ b/docs/superpowers/plans/2026-06-24-db-identity-code.md
@@ -1,0 +1,121 @@
+# db/identity-code — identity split (user_profiles)
+
+Branch: `db/identity-code` (off `db/academics-code`). Slice of the DB modular redesign.
+
+## Contract recap
+
+- API boundary keeps the ABSTRACT `course_id`. Term/semester is a second axis. KG keys on
+  abstract `course_id`; class artifacts key on `offering_id`/`enrollment_id`. (Mostly irrelevant
+  to identity — this slice touches no course/enrollment logic.)
+- All DB via `db/connection.py::table()`. Encryption via `services/encryption.py`:
+  `encrypt_if_present` at write, `decrypt_if_present` at read. 🔒 columns stay TEXT.
+
+## Schema (migration `db/migrations/0024_identity_split.sql`, already applied)
+
+New table `user_profiles` (1:1 with `users`, PK `user_id` → `users.id`):
+`name`🔒, `first_name`🔒, `last_name`🔒, `username` (UNIQUE), `avatar_url`, `bio`🔒,
+`location`🔒, `website`, `year`, `majors TEXT[]`, `minors TEXT[]`, `learning_style`,
+`created_at`, `updated_at`.
+
+`users` DROPPED: name, first_name, last_name, username, avatar_url, bio, location, website,
+year, majors, minors, learning_style. `users.last_active_date` → DATE; +`updated_at`;
+`room_id` → `current_room_id`.
+
+`user_settings` DROPPED: display_name, username, bio, location, website (now owned by
+user_profiles — one source of truth).
+
+`oauth_tokens.expires_at` → TIMESTAMPTZ; +`updated_at`.
+
+**One source of truth:** every profile field lives ONLY on `user_profiles`. No field is written
+to both `users` and `user_profiles`, nor duplicated onto `user_settings`.
+
+## Encryption boundary (unchanged semantics, moved to user_profiles)
+
+🔒 columns on `user_profiles`: `name`, `first_name`, `last_name`, `bio`, `location`.
+- WRITE: `encrypt_if_present(value)` before upsert/update into `user_profiles`.
+- READ: `decrypt_if_present(row[col])` after select from `user_profiles`, including before
+  returning to clients / injecting into prompts.
+- `users.email` stays 🔒 on `users` (NOT moved). `username`/`avatar_url`/`website`/`year`/
+  `majors`/`minors`/`learning_style` are plaintext (not 🔒).
+
+## File-by-file change map (current → new)
+
+### routes/auth.py (my scope: the profile-FIELD writes)
+- `get_me` (`/me`): SELECT `username,name,avatar_url` currently from `users`. NEW: SELECT
+  `id,is_approved,onboarding_completed` from `users`; fetch `username,name,avatar_url` from
+  `user_profiles` (decrypt `name`).
+- `google_callback` existing-user branch: currently `users.update({name, first_name, last_name,
+  avatar_url, email, last_sign_in_at})`. NEW: `users.update({email, last_sign_in_at})` only;
+  upsert `user_profiles` (on_conflict=user_id) with encrypted name/first_name/last_name +
+  avatar_url.
+- `google_callback` new-user branch: currently `users.insert({id,name,first_name,last_name,
+  email,google_id,avatar_url,auth_provider,last_sign_in_at})`. NEW: `users.insert({id,email,
+  google_id,auth_provider,last_sign_in_at})`; insert `user_profiles` row with encrypted
+  name/first_name/last_name + avatar_url + username NULL.
+- `oauth_tokens.upsert`: `expires_at` is now TIMESTAMPTZ. Keep `creds.expiry.isoformat()`
+  when present, but pass `None` (not `""`) when absent — `""` is not a valid timestamptz.
+
+### routes/profile.py (my scope: profile-FIELD read/writes; NOT the enrollment school-read)
+- `_get_user_or_404`: split into (a) `users` SELECT `id,email,streak_count,created_at` and
+  (b) `user_profiles` SELECT the profile fields; merge into one dict; decrypt
+  `name/first_name/last_name/email/bio/location`. Returns same shape as today so downstream
+  `get_public_profile` is unchanged. (Keeps the issue-#75 column-contract intent: only SELECT
+  columns that exist on each table.)
+- `_get_or_create_settings` + `_SETTINGS_COLS`: drop `username,display_name,bio,location,
+  website` from the settings SELECT and the bio/location decrypt loop (those columns no longer
+  exist on `user_settings`).
+- `check_username`: lookup `username` on `user_profiles` (not `users`).
+- `get_public_profile`: unchanged logic — reads from the merged `_get_user_or_404` dict. The
+  `enrollments` school-read stays exactly as academics left it (out of scope).
+- `update_profile`: write profile fields to `user_profiles` only (ensure-row via upsert/
+  insert-if-missing). Drop the parallel `updates_settings` writes for username/bio/location/
+  website/display_name. Username uniqueness check moves to `user_profiles`.
+- `upload_user_avatar`: persist `avatar_url` to `user_profiles` (not `users`).
+- helper `_get_or_create_profile(user_id)` added to centralize the user_profiles
+  ensure-row + decrypt.
+
+### routes/onboarding.py (my scope: ONLY the profile-field write; NOT the enrollment loop)
+- `save_onboarding_profile`: the `users.update({name,first_name,last_name,year,majors,minors,
+  learning_style})` block moves to a `user_profiles` upsert (encrypt name/first_name/last_name).
+  `onboarding_completed=True` STAYS on `users` (it's an auth/status flag, not a profile field).
+  The course/enrollment loop (`resolve_offering`, `enrollments`) is untouched (academics owns it).
+
+### models/__init__.py (my scope)
+- `UpdateProfileBody`: keep `username/bio/location/website`; drop `display_name` (no longer a
+  user_settings field — display name is the profile `name`). Add nothing else.
+- `SettingsResponse`: drop `display_name,username,bio,location,website` (moved off
+  user_settings). These models are documentation-only (not used as `response_model`), but kept
+  consistent with the schema.
+- `PublicProfileResponse`: unchanged (it already describes the merged public profile shape).
+
+### tests/test_profile_routes.py (my scope — update for new layout)
+- Update factories so `users`/`user_profiles`/`user_settings` are separate mocks and the
+  profile fields come from `user_profiles`.
+- `TestGetUserOr404SelectColumns`: split assertion — `users` SELECT must only contain slimmed
+  columns; `user_profiles` SELECT carries the profile fields. Rewrite the schema sets.
+- `TestUpdateProfile.test_updates_user_fields`: assert the write lands on `user_profiles`.
+- `TestUploadAvatar`: assert `avatar_url` persisted to `user_profiles`.
+- Add a test asserting a `user_profiles` row is ensured when missing.
+
+### tests/test_onboarding_routes.py (touched because it asserts the moved write)
+- `TestSaveOnboardingProfile`: assert name/first_name/last_name/year/majors/minors/
+  learning_style land on `user_profiles` (not `users`); `onboarding_completed` stays on `users`.
+
+## Test list
+
+- `tests/test_profile_routes.py` — full file, updated for user_profiles.
+- `tests/test_onboarding_routes.py` — `TestSaveOnboardingProfile` updated.
+- `tests/test_auth_domain.py` — unaffected (domain allowlist only); must stay green.
+- Whole suite: `$PY -m pytest tests/ -q` stays at baseline (722 passed; the 2 pre-existing
+  `test_storage_service.py` failures are env-config, not mine).
+
+## Out of scope (do NOT touch)
+
+- The `enrollments` school-read in `profile.py::get_public_profile` and the enrollment loop in
+  `onboarding.py` — academics owns these (already committed on this base).
+- `services/academics.py`, `graph_service.py`, `course_context_service.py`.
+- Other readers of `users.name`/profile fields in OTHER domains' files: `routes/social.py`,
+  `routes/quiz.py`, `routes/learn.py`, `services/users_search.py`,
+  `services/graph_service.py::ensure_user_exists`. These will need their own slices to read from
+  `user_profiles`; their tests mock `table()` so they stay green here. **Cross-domain dependency
+  noted** — flagged for the social/quiz/learn/graph slices.


### PR DESCRIPTION
Identity slice (migration 0024). 1:1 `user_profiles`; slim `users`; onboarding profile-write moved to `user_profiles`; oauth `expires_at` timestamptz. Encryption boundary preserved. Green; ruff clean.

Plan: `docs/superpowers/plans/2026-06-24-db-identity-code.md`.

**Integration notes:**
- Touches `models/__init__.py` + `tests/test_response_decrypt_boundary.py` (also edited by db/gradebook-code — small additive conflict).
- Drops `users.name`/profile cols still read/written by `graph_service.ensure_user_exists`, `social.py`, `quiz.py`, `learn.py`, `users_search.py` — **reconcile before the epic→main cutover.**