### PR TITLE
db/study-code: study artifacts → offering_id (epic slice PR7)

### DIFF
--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -30,6 +30,7 @@ from sse_starlette.sse import EventSourceResponse
 from pydantic_ai.exceptions import UsageLimitExceeded, UnexpectedModelBehavior
 
 from db.connection import table
+from services.academics import offering_course_id, resolve_offering
 from services.auth_guard import get_session_user_id, require_self
 from services.encryption import encrypt_if_present, encrypt_json, decrypt_if_present, decrypt_json
 from services.extraction_service import extract_text_from_file
@@ -259,8 +260,8 @@ def list_documents(user_id: str, request: Request):
     require_self(user_id, request)
     _validate_user(user_id)
     docs = table("documents").select(
-        "id,user_id,course_id,file_name,category,summary,concept_notes,created_at,processed_at",
-        filters={"user_id": f"eq.{user_id}"},
+        "id,user_id,offering_id,file_name,category,summary,concept_notes,created_at,processed_at",
+        filters={"user_id": f"eq.{user_id}", "deleted_at": "is.null"},
         order="created_at.desc",
     ) or []
     for d in docs:
@@ -278,11 +279,21 @@ def delete_document(document_id: str, request: Request, user_id: str | None = No
         _validate_user(user_id)
     else:
         user_id = get_session_user_id(request)
-    # Ensure the document belongs to the requesting user
-    docs = table("documents").select("id", filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"}, limit=1)
+    # Ensure the document belongs to the requesting user (and isn't already
+    # soft-deleted)
+    docs = table("documents").select(
+        "id",
+        filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}", "deleted_at": "is.null"},
+        limit=1,
+    )
     if not docs:
         raise HTTPException(status_code=404, detail="Document not found.")
-    table("documents").delete(filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"})
+    # Soft delete (0025): stamp deleted_at; reads filter it out. The
+    # enrollments.syllabus_doc_id FK (ON DELETE SET NULL) stays intact.
+    table("documents").update(
+        {"deleted_at": datetime.now(timezone.utc).isoformat()},
+        filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"},
+    )
     return {"deleted": True}
 
 
@@ -303,7 +314,11 @@ def update_document(document_id: str, request: Request, body: dict = Body(...)):
         _validate_user(user_id)
     else:
         user_id = get_session_user_id(request)
-    docs = table("documents").select("id", filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"}, limit=1)
+    docs = table("documents").select(
+        "id",
+        filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}", "deleted_at": "is.null"},
+        limit=1,
+    )
     if not docs:
         raise HTTPException(status_code=404, detail="Document not found.")
     updated = table("documents").update(updates, filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"})
@@ -338,8 +353,12 @@ def _existing_doc_by_request_id(user_id: str, request_id: str) -> dict | None:
     """
     try:
         rows = table("documents").select(
-            "id,user_id,course_id,file_name,category,summary,concept_notes,created_at,processed_at",
-            filters={"user_id": f"eq.{user_id}", "request_id": f"eq.{request_id}"},
+            "id,user_id,offering_id,file_name,category,summary,concept_notes,created_at,processed_at",
+            filters={
+                "user_id": f"eq.{user_id}",
+                "request_id": f"eq.{request_id}",
+                "deleted_at": "is.null",
+            },
             limit=1,
         )
     except Exception:
@@ -363,7 +382,7 @@ def _existing_doc_by_request_id(user_id: str, request_id: str) -> dict | None:
 def _persist_document(
     *,
     user_id: str,
-    course_id: str,
+    offering_id: str,
     filename: str,
     result: DocumentProcessingResult,
     request_id: str | None = None,
@@ -371,6 +390,7 @@ def _persist_document(
     """Insert a documents row from an orchestrator result.
 
     Shared by both upload_document_sync and the streaming upload_document.
+    The document keys on the OFFERING (0025), not the abstract course.
     summary + concept_notes are encrypted at the insert boundary; the
     returned row carries the plaintext shape so callers can pass it
     straight back to the client without an extra decrypt step.
@@ -386,7 +406,7 @@ def _persist_document(
     row = {
         "id": str(uuid.uuid4()),
         "user_id": user_id,
-        "course_id": course_id,
+        "offering_id": offering_id,
         "file_name": filename,
         "category": result.classification.category,
         "summary": encrypt_if_present(summary),
@@ -507,6 +527,12 @@ async def upload_document_sync(
 
     extracted_text = _extract_text_or_422(file_bytes, filename, file.content_type or "")
 
+    # The upload form sends the ABSTRACT course id; documents key on the
+    # OFFERING. Resolve to the current-term offering once (create=True so a
+    # fresh upload lands in the real semester). The abstract course_id stays
+    # the key for the graph + course-context + calendar side effects below.
+    offering_id = resolve_offering(course_id, create=True)
+
     # ── AI: orchestrator (parallel workers + tool-driven graph update) ────────
     # Unify with the middleware-stamped request ID so agent traces and
     # client-facing error payloads share the same correlation key.
@@ -540,7 +566,7 @@ async def upload_document_sync(
         )
         return await _legacy_upload_pipeline(
             filename=filename, extracted_text=extracted_text,
-            course_id=course_id, user_id=user_id,
+            course_id=course_id, offering_id=offering_id, user_id=user_id,
             background_tasks=background_tasks,
             request_id=request_id,
         )
@@ -551,7 +577,7 @@ async def upload_document_sync(
         )
         return await _legacy_upload_pipeline(
             filename=filename, extracted_text=extracted_text,
-            course_id=course_id, user_id=user_id,
+            course_id=course_id, offering_id=offering_id, user_id=user_id,
             background_tasks=background_tasks,
             request_id=request_id,
         )
@@ -560,11 +586,11 @@ async def upload_document_sync(
                                 filename=filename, result=result)
     _graph_backstop(user_id=user_id, course_id=course_id,
                     filename=filename, result=result)
-    _, full_row = _persist_document(user_id=user_id, course_id=course_id,
+    _, full_row = _persist_document(user_id=user_id, offering_id=offering_id,
                                     filename=filename, result=result,
                                     request_id=request_id)
 
-    background_tasks.add_task(_invalidate_study_guide_cache, user_id, course_id)
+    background_tasks.add_task(_invalidate_study_guide_cache, user_id, offering_id)
     background_tasks.add_task(update_course_context, course_id)
     background_tasks.add_task(_check_upload_achievements, user_id)
 
@@ -613,6 +639,9 @@ async def upload_document(
         or current_request_id()
         or str(uuid.uuid4())  # ultimate fallback if middleware somehow didn't run
     )
+    # Documents key on the offering (0025); the graph + course-context key on
+    # the abstract course id (kept in SaplingDeps for the agent's graph tools).
+    offering_id = resolve_offering(course_id, create=True)
     deps = SaplingDeps(
         user_id=user_id,
         course_id=course_id,
@@ -773,7 +802,7 @@ async def upload_document(
                                         filename=filename, result=final_output)
             _graph_backstop(user_id=user_id, course_id=course_id,
                             filename=filename, result=final_output)
-            doc_id, _ = _persist_document(user_id=user_id, course_id=course_id,
+            doc_id, _ = _persist_document(user_id=user_id, offering_id=offering_id,
                                           filename=filename, result=final_output,
                                           request_id=request_id)
 
@@ -782,7 +811,7 @@ async def upload_document(
             # but attaches a done-callback so exceptions land in the log
             # instead of disappearing.
             _spawn_post_roll(
-                ("invalidate_study_guide_cache", _invalidate_study_guide_cache, user_id, course_id),
+                ("invalidate_study_guide_cache", _invalidate_study_guide_cache, user_id, offering_id),
                 ("update_course_context", update_course_context, course_id),
                 ("check_upload_achievements", _check_upload_achievements, user_id),
             )
@@ -804,7 +833,7 @@ async def upload_document(
             ))
             async for sse_event in _stream_legacy_fallback(
                 filename=filename, extracted_text=extracted_text,
-                course_id=course_id, user_id=user_id,
+                course_id=course_id, offering_id=offering_id, user_id=user_id,
                 request_id=request_id,
             ):
                 yield sse_event
@@ -817,7 +846,7 @@ async def upload_document(
             ))
             async for sse_event in _stream_legacy_fallback(
                 filename=filename, extracted_text=extracted_text,
-                course_id=course_id, user_id=user_id,
+                course_id=course_id, offering_id=offering_id, user_id=user_id,
                 request_id=request_id,
             ):
                 yield sse_event
@@ -826,8 +855,8 @@ async def upload_document(
 
 
 async def _stream_legacy_fallback(
-    *, filename: str, extracted_text: str, course_id: str, user_id: str,
-    request_id: str | None = None,
+    *, filename: str, extracted_text: str, course_id: str, offering_id: str,
+    user_id: str, request_id: str | None = None,
 ):
     """Run _legacy_upload_pipeline and yield SSE progress/result/done events.
 
@@ -850,7 +879,7 @@ async def _stream_legacy_fallback(
     try:
         legacy_response = await _legacy_upload_pipeline(
             filename=filename, extracted_text=extracted_text,
-            course_id=course_id, user_id=user_id,
+            course_id=course_id, offering_id=offering_id, user_id=user_id,
             request_id=request_id,
         )
     except Exception:
@@ -877,16 +906,20 @@ async def _stream_legacy_fallback(
     ))
 
 
-def _invalidate_study_guide_cache(user_id: str, course_id: str) -> None:
-    """Background task: delete cached study guides so they regenerate fresh."""
+def _invalidate_study_guide_cache(user_id: str, offering_id: str) -> None:
+    """Background task: delete cached study guides so they regenerate fresh.
+
+    Study guides key on the offering (0025), matching the documents that
+    feed them.
+    """
     try:
         table("study_guides").delete(
-            filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"}
+            filters={"user_id": f"eq.{user_id}", "offering_id": f"eq.{offering_id}"}
         )
     except Exception:
         logger.exception(
-            "Failed to invalidate study guides cache for user=%s course=%s",
-            user_id, course_id,
+            "Failed to invalidate study guides cache for user=%s offering=%s",
+            user_id, offering_id,
         )
 
 
@@ -922,6 +955,7 @@ async def _legacy_upload_pipeline(
     filename: str,
     extracted_text: str,
     course_id: str,
+    offering_id: str,
     user_id: str,
     background_tasks: BackgroundTasks | None = None,
     request_id: str | None = None,
@@ -931,6 +965,10 @@ async def _legacy_upload_pipeline(
     Verbatim copy of the previous upload_document body from text-extraction
     onward. File validation already happened in the caller, so this function
     starts at the AI processing step.
+
+    The documents row keys on ``offering_id`` (0025); the graph,
+    assignment-calendar, and course-context side effects key on the abstract
+    ``course_id``.
 
     background_tasks is optional: in streaming-fallback contexts there is
     no FastAPI BackgroundTasks to attach to (the response IS the stream),
@@ -966,7 +1004,7 @@ async def _legacy_upload_pipeline(
     row = {
         "id": str(uuid.uuid4()),
         "user_id": user_id,
-        "course_id": course_id,
+        "offering_id": offering_id,
         "file_name": filename,
         "category": ai["category"],
         "summary": encrypt_if_present(ai["summary"] or None),
@@ -988,12 +1026,12 @@ async def _legacy_upload_pipeline(
             raise
 
     if background_tasks is not None:
-        background_tasks.add_task(_invalidate_study_guide_cache, user_id, course_id)
+        background_tasks.add_task(_invalidate_study_guide_cache, user_id, offering_id)
         background_tasks.add_task(update_course_context, course_id)
         background_tasks.add_task(_check_upload_achievements, user_id)
     else:
         _spawn_post_roll(
-            ("invalidate_study_guide_cache", _invalidate_study_guide_cache, user_id, course_id),
+            ("invalidate_study_guide_cache", _invalidate_study_guide_cache, user_id, offering_id),
             ("update_course_context", update_course_context, course_id),
             ("check_upload_achievements", _check_upload_achievements, user_id),
         )
@@ -1076,14 +1114,16 @@ def scan_document_concepts(document_id: str, request: Request, body: dict = Body
     _validate_user(user_id)
 
     rows = table("documents").select(
-        "id,user_id,course_id,file_name,summary,concept_notes",
-        filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}"},
+        "id,user_id,offering_id,file_name,summary,concept_notes",
+        filters={"id": f"eq.{document_id}", "user_id": f"eq.{user_id}", "deleted_at": "is.null"},
         limit=1,
     )
     if not rows:
         raise HTTPException(status_code=404, detail="Document not found.")
     doc = rows[0]
-    course_id = doc.get("course_id")
+    # The document keys on the offering; the concept graph keys on the
+    # abstract course. Resolve offering → abstract course before scanning.
+    course_id = offering_course_id(doc.get("offering_id"))
     if not course_id:
         raise HTTPException(status_code=400, detail="Document is not associated with a course.")
 

--- a/backend/routes/flashcards.py
+++ b/backend/routes/flashcards.py
@@ -11,6 +11,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from db.connection import table
+from services.academics import resolve_offering
 from services.gemini_service import generate_flashcards as _generate
 from services.auth_guard import require_self, get_session_user_id
 from services.achievement_service import check_achievements
@@ -109,21 +110,28 @@ def _get_course_documents(user_id: str, course_name: str) -> list[dict]:
     """
     Return all library documents for the user that belong to the course
     matching `course_name`. Falls back to all user documents if no course match.
+
+    Documents key on the offering (0025): match the abstract course by name,
+    resolve it to the current-term offering, then read documents by offering.
     """
     try:
         course_rows = table("courses").select(
             "id", filters={"user_id": f"eq.{user_id}", "course_name": f"eq.{course_name}"}, limit=1
         )
         if course_rows:
-            course_id = course_rows[0]["id"]
+            offering_id = resolve_offering(course_rows[0]["id"])
             docs = table("documents").select(
                 "file_name,category,summary,concept_notes",
-                filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
+                filters={
+                    "user_id": f"eq.{user_id}",
+                    "offering_id": f"eq.{offering_id}",
+                    "deleted_at": "is.null",
+                },
             )
         else:
             docs = table("documents").select(
                 "file_name,category,summary,concept_notes",
-                filters={"user_id": f"eq.{user_id}"},
+                filters={"user_id": f"eq.{user_id}", "deleted_at": "is.null"},
             )
         docs = docs or []
         for d in docs:
@@ -248,7 +256,7 @@ def get_flashcards(user_id: str, request: Request, topic: str | None = None):
 
     try:
         rows = table("flashcards").select(
-            "id,user_id,topic,course_id,front,back,times_reviewed,last_rating,last_reviewed_at,created_at",
+            "id,user_id,topic,offering_id,front,back,times_reviewed,last_rating,last_reviewed_at,created_at",
             filters=filters, order="created_at.desc"
         )
         return {"flashcards": rows or []}
@@ -316,12 +324,16 @@ _MAX_UPLOAD_BYTES = 5 * 1024 * 1024
 def import_commit(body: ImportCommitBody, request: Request):
     require_self(body.user_id, request)
 
+    # The body carries an abstract course id (optional); flashcards key on the
+    # offering. Resolve it (None stays None — flashcards.offering_id is nullable).
+    offering_id = resolve_offering(body.course_id) if body.course_id else None
+
     cards = [{"front": c.front, "back": c.back} for c in body.cards]
     skipped_count = 0
 
     if body.dedup:
         keep, skipped = dedup_against_existing(
-            body.user_id, body.course_id, cards, topic=body.topic
+            body.user_id, offering_id, cards, topic=body.topic
         )
         cards = keep
         skipped_count = len(skipped)
@@ -332,7 +344,7 @@ def import_commit(body: ImportCommitBody, request: Request):
             "id": str(uuid.uuid4()),
             "user_id": body.user_id,
             "topic": body.topic,
-            "course_id": body.course_id,
+            "offering_id": offering_id,
             "front": c["front"],
             "back": c["back"],
             "times_reviewed": 0,
@@ -415,7 +427,11 @@ def import_generate(body: ImportGenerateBody, request: Request):
             raise HTTPException(status_code=400, detail="`document_id` is required for library_doc source")
         rows = table("documents").select(
             "id,user_id,summary,concept_notes,file_name",
-            filters={"id": f"eq.{body.document_id}", "user_id": f"eq.{body.user_id}"},
+            filters={
+                "id": f"eq.{body.document_id}",
+                "user_id": f"eq.{body.user_id}",
+                "deleted_at": "is.null",
+            },
             limit=1,
         )
         if not rows:

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -14,6 +14,7 @@ from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserProm
 from agents.chat_tutor import agent_for_mode
 from agents.deps import SaplingDeps
 from db.connection import table
+from services.academics import offering_course_id, resolve_offering
 from models import StartSessionBody, ChatBody, EndSessionBody, ActionBody, ModeSwitchBody, RenameSessionBody
 from services.auth_guard import require_self, get_session_user_id
 from services.encryption import encrypt_if_present, encrypt_json, decrypt_if_present, decrypt_json
@@ -197,22 +198,34 @@ def _get_course_id_for_topic(topic: str, user_id: str) -> str:
     return ""
 
 
-def _get_session_course_id(session_id: str) -> str:
-    """Get the course_id from a session if it exists."""
-    rows = table("sessions").select("course_id", filters={"id": f"eq.{session_id}"}, limit=1)
-    if rows and rows[0].get("course_id"):
-        return rows[0]["course_id"]
+def _get_session_offering_id(session_id: str) -> str:
+    """Get the offering_id a session is scoped to, if any.
+
+    Sessions key on the offering (0025); the abstract course id (the graph
+    key) is derived from it via ``offering_course_id`` where needed.
+    """
+    rows = table("sessions").select("offering_id", filters={"id": f"eq.{session_id}"}, limit=1)
+    if rows and rows[0].get("offering_id"):
+        return rows[0]["offering_id"]
     return ""
 
 
-def _get_course_documents(user_id: str, course_id: str) -> list:
-    """Fetch uploaded document summaries and concept notes for a user's course."""
-    if not course_id:
+def _get_course_documents(user_id: str, offering_id: str) -> list:
+    """Fetch uploaded document summaries + concept notes for a user's offering.
+
+    Documents key on the offering (0025), so the tutor grounds itself in the
+    materials uploaded for this term's offering.
+    """
+    if not offering_id:
         return []
     try:
         docs = table("documents").select(
             "file_name,category,summary,concept_notes",
-            filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
+            filters={
+                "user_id": f"eq.{user_id}",
+                "offering_id": f"eq.{offering_id}",
+                "deleted_at": "is.null",
+            },
         ) or []
         for d in docs:
             d["summary"] = decrypt_if_present(d.get("summary"))
@@ -289,7 +302,9 @@ def build_system_prompt(
             )
 
     if use_shared_context and course_id:
-        # TODO(db/study-code): pass the session's offering_id once sessions carry it; abstract id degrades to {} for now
+        # `course_id` is the abstract course id (resolved from the session's
+        # offering by the caller). course_context keys on the abstract course,
+        # so shared class-aggregate context resolves here.
         ctx = get_course_context(course_id)
         if ctx:
             course_info = _get_course_info(course_id)
@@ -378,16 +393,17 @@ def _consume_pending(session_id: str, user_id: str) -> None:
     if pending["user_id"] != user_id:
         raise HTTPException(status_code=403, detail="Session user mismatch")
     
-    # Include course_id in session creation
+    # Sessions key on the offering (0025). The pending payload carries the
+    # offering id (resolved at start-session) alongside the abstract course id.
     session_data = {
         "id": session_id,
         "user_id": user_id,
         "mode": pending["mode"],
         "topic": pending["topic"],
     }
-    if pending.get("course_id"):
-        session_data["course_id"] = pending["course_id"]
-    
+    if pending.get("offering_id"):
+        session_data["offering_id"] = pending["offering_id"]
+
     table("sessions").insert(session_data)
     save_message(session_id, "assistant", pending["assistant_reply"], pending["graph_update"])
 
@@ -408,10 +424,13 @@ def start_session(body: StartSessionBody, request: Request):
     student_name = get_user_name(body.user_id)
     graph_data = get_graph(body.user_id)
     
-    # Use course_id from body, or try to resolve from topic
+    # Use abstract course_id from body, or resolve it from the topic. The graph
+    # + shared context key on this abstract id; documents + the session row key
+    # on the offering it resolves to (current term).
     course_id = body.course_id or _get_course_id_for_topic(body.topic, body.user_id)
-    documents = _get_course_documents(body.user_id, course_id)
-    
+    offering_id = resolve_offering(course_id, create=True) if course_id else ""
+    documents = _get_course_documents(body.user_id, offering_id)
+
     system_prompt = build_system_prompt(
         body.mode, student_name, json.dumps(graph_data, indent=2),
         course_id=course_id, use_shared_context=body.use_shared_context,
@@ -436,7 +455,8 @@ def start_session(body: StartSessionBody, request: Request):
         "user_id": body.user_id,
         "mode": body.mode,
         "topic": body.topic,
-        "course_id": course_id,
+        "course_id": course_id,        # abstract — graph + shared-context key
+        "offering_id": offering_id,    # term-scoped — the session-row key
         "use_shared_context": body.use_shared_context,
         "assistant_reply": reply,
         "graph_update": graph_update,
@@ -533,9 +553,11 @@ async def _legacy_chat(body: ChatBody, request: Request) -> dict:
     # Exclude the just-saved user message so history is prior turns only
     history = get_conversation_history(body.session_id)[:-1]
 
-    # Get course_id from session if available
-    course_id = _get_session_course_id(body.session_id)
-    documents = _get_course_documents(body.user_id, course_id)
+    # The session keys on the offering; documents read by offering, while the
+    # graph + shared context key on the abstract course derived from it.
+    offering_id = _get_session_offering_id(body.session_id)
+    course_id = offering_course_id(offering_id) if offering_id else ""
+    documents = _get_course_documents(body.user_id, offering_id)
 
     system_prompt = build_system_prompt(
         body.mode, student_name, json.dumps(graph_data, indent=2),
@@ -570,7 +592,10 @@ async def chat(body: ChatBody, request: Request):
         or str(uuid.uuid4())
     )
 
-    course_id = _get_session_course_id(body.session_id)
+    # The session keys on the offering; the agent's graph tools key on the
+    # abstract course derived from it.
+    offering_id = _get_session_offering_id(body.session_id)
+    course_id = offering_course_id(offering_id) if offering_id else ""
     # Load prior turns BEFORE writing the new user row, so the
     # message_history we hand the agent contains only the conversation
     # state up to (but not including) the current turn.
@@ -701,19 +726,25 @@ def end_session(body: EndSessionBody, request: Request):
 def list_sessions(user_id: str, request: Request, limit: int = 10):
     require_self(user_id, request)
     sessions = table("sessions").select(
-        "id,user_id,topic,mode,course_id,started_at,ended_at",
+        "id,user_id,topic,mode,offering_id,started_at,ended_at",
         filters={"user_id": f"eq.{user_id}"},
         order="started_at.desc",
         limit=limit,
     )
+    # Sessions key on the offering; the frontend speaks abstract course ids.
+    # Map each offering → its abstract course once.
+    offering_to_course: dict[str, str | None] = {}
     result = []
     for s in sessions:
+        off_id = s.get("offering_id")
+        if off_id and off_id not in offering_to_course:
+            offering_to_course[off_id] = offering_course_id(off_id)
         msgs = table("messages").select("id", filters={"session_id": f"eq.{s['id']}"})
         result.append({
             "id": s["id"],
             "topic": s["topic"],
             "mode": s["mode"],
-            "course_id": s.get("course_id"),
+            "course_id": offering_to_course.get(off_id),
             "started_at": s["started_at"],
             "ended_at": s.get("ended_at"),
             "message_count": len(msgs),
@@ -803,7 +834,7 @@ def resume_session(session_id: str, request: Request):
         }
 
     session_rows = table("sessions").select(
-        "id,user_id,topic,mode,started_at,ended_at,course_id",
+        "id,user_id,topic,mode,started_at,ended_at,offering_id",
         filters={"id": f"eq.{session_id}"},
     )
     if not session_rows:
@@ -811,13 +842,18 @@ def resume_session(session_id: str, request: Request):
     if session_rows[0].get("user_id") != user_id:
         raise HTTPException(status_code=403, detail="Session user mismatch")
 
+    # Expose the abstract course id (derived from the offering) for the
+    # frontend, alongside the stored offering id.
+    session = dict(session_rows[0])
+    session["course_id"] = offering_course_id(session.get("offering_id"))
+
     msgs = table("messages").select(
         "id,role,content,created_at",
         filters={"session_id": f"eq.{session_id}"},
         order="created_at.asc",
     )
     return {
-        "session": session_rows[0],
+        "session": session,
         "messages": [
             {**m, "content": decrypt_if_present(m["content"])} for m in msgs
         ],
@@ -840,11 +876,13 @@ def action(body: ActionBody, request: Request):
     student_name = get_user_name(body.user_id)
     graph_data = get_graph(body.user_id)
     history = get_conversation_history(body.session_id)
-    
-    # Get course_id from session
-    course_id = _get_session_course_id(body.session_id)
-    documents = _get_course_documents(body.user_id, course_id)
-    
+
+    # Session keys on the offering; docs read by offering, graph + shared
+    # context key on the abstract course derived from it.
+    offering_id = _get_session_offering_id(body.session_id)
+    course_id = offering_course_id(offering_id) if offering_id else ""
+    documents = _get_course_documents(body.user_id, offering_id)
+
     system_prompt = build_system_prompt(
         body.mode, student_name, json.dumps(graph_data, indent=2),
         course_id=course_id, use_shared_context=body.use_shared_context,

--- a/backend/routes/notes.py
+++ b/backend/routes/notes.py
@@ -14,6 +14,7 @@ from agents.note_concepts import note_concepts_agent
 from agents.note_summary import note_summary_agent
 from agents.tools.graph import apply_concepts_to_graph
 from db.connection import table
+from services.academics import offering_course_id, resolve_offering
 from services.auth_guard import get_session_user_id, require_self
 from services.notes_service import (
     create_note,
@@ -54,16 +55,22 @@ async def list_user_notes(
     course_id: str | None = None,
 ):
     require_self(user_id, request)
-    notes = await list_notes(user_id=user_id, course_id=course_id)
+    # The API speaks abstract course ids; notes key on the offering. Resolve
+    # the (current-term) offering for the requested course before filtering.
+    offering_id = resolve_offering(course_id) if course_id else None
+    notes = await list_notes(user_id=user_id, offering_id=offering_id)
     return {"notes": notes}
 
 
 @router.post("")
 async def create(body: CreateNoteBody, request: Request):
     require_self(body.user_id, request)
+    # Abstract course id from the client → the current-term offering the note
+    # is stored against (create=True so a fresh note lands in the real term).
+    offering_id = resolve_offering(body.course_id, create=True)
     note = await create_note(
         user_id=body.user_id,
-        course_id=body.course_id,
+        offering_id=offering_id,
         title=body.title,
         body=body.body,
         tags=body.tags,
@@ -91,7 +98,8 @@ async def patch(note_id: str, body: UpdateNoteBody, request: Request):
     if body.tags is not None:
         patch_dict["tags"] = body.tags
     if body.course_id is not None:
-        patch_dict["course_id"] = body.course_id
+        # Re-home the note onto the offering for the new abstract course.
+        patch_dict["offering_id"] = resolve_offering(body.course_id, create=True)
     if not patch_dict:
         raise HTTPException(status_code=400, detail="No fields to update.")
     updated = await update_note(
@@ -200,7 +208,9 @@ async def summarize(note_id: str, body: AgentActionBody, request: Request):
         f"Title: {note.get('title') or '(untitled)'}\n\n"
         f"Body:\n{note.get('body') or '(empty)'}"
     )
-    deps = _deps_for(body.user_id, note.get("course_id"), note_id)
+    # The graph keys on the abstract course; the note carries the offering.
+    course_id = offering_course_id(note.get("offering_id"))
+    deps = _deps_for(body.user_id, course_id, note_id)
     result = await note_summary_agent.run(user_prompt, deps=deps)
     summary_text = result.output.summary
     await save_summary(note_id=note_id, user_id=body.user_id, summary=summary_text)
@@ -219,10 +229,11 @@ async def extract_concepts(
         f"Title: {note.get('title') or '(untitled)'}\n\n"
         f"Body:\n{note.get('body') or '(empty)'}"
     )
-    deps = _deps_for(body.user_id, note.get("course_id"), note_id)
+    # Concepts land in the abstract-course graph; resolve offering → course.
+    course_id = offering_course_id(note.get("offering_id"))
+    deps = _deps_for(body.user_id, course_id, note_id)
     result = await note_concepts_agent.run(user_prompt, deps=deps)
     names = [n.strip() for n in (result.output.concepts or []) if n and n.strip()]
-    course_id = note.get("course_id")
     await apply_concepts_to_graph(
         user_id=body.user_id, course_id=course_id, concept_names=names
     )
@@ -248,7 +259,8 @@ async def note_chat(note_id: str, body: NoteChatBody, request: Request):
     note = await get_note(note_id=note_id, user_id=body.user_id)
     if not note:
         raise HTTPException(status_code=404, detail="Note not found.")
-    deps = _deps_for(body.user_id, note.get("course_id"), note_id)
+    course_id = offering_course_id(note.get("offering_id"))
+    deps = _deps_for(body.user_id, course_id, note_id)
     result = await note_chat_agent.run(body.message, deps=deps)
     return {"reply": result.output}
 
@@ -272,7 +284,8 @@ async def send_to_tutor(
     preface = "\n\n".join(preface_parts)
     return {
         "topic": topic,
-        "course_id": note.get("course_id"),
+        # The tutor session starts from the abstract course id (the graph key).
+        "course_id": offering_course_id(note.get("offering_id")),
         "preface": preface,
     }
 

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -10,13 +10,12 @@ from pydantic_ai.exceptions import UsageLimitExceeded, UnexpectedModelBehavior
 
 from agents.quiz import quiz_agent, Quiz, QuizQuestion
 from agents.deps import SaplingDeps
-from config import get_mastery_tier
 from db.connection import table
 from models import GenerateQuizBody, SubmitQuizBody
 from services.auth_guard import require_self
 from services.encryption import decrypt_if_present
 from services.gemini_service import MODEL_LITE, MODEL_SMART, call_gemini_json
-from services.graph_service import get_graph, update_streak
+from services.graph_service import apply_graph_update, get_graph
 from services.quiz_context_service import get_quiz_context, save_quiz_context
 from services.fingerprint import fingerprint
 from services.request_context import current_request_id
@@ -26,6 +25,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 PROMPTS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "prompts")
+
+# quiz_attempts.difficulty CHECK enum (0025).
+VALID_DIFFICULTIES = {"easy", "medium", "hard"}
 
 
 def _load_prompt(name: str) -> str:
@@ -297,6 +299,14 @@ async def _legacy_generate_quiz(body: GenerateQuizBody, request: Request) -> lis
 @router.post("/generate")
 async def generate_quiz(body: GenerateQuizBody, request: Request):
     require_self(body.user_id, request)
+    # quiz_attempts.difficulty is CHECK-constrained (0025); reject drift before
+    # we run the agent or write an attempt row.
+    if body.difficulty not in VALID_DIFFICULTIES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid difficulty '{body.difficulty}'. "
+                   f"Must be one of {sorted(VALID_DIFFICULTIES)}.",
+        )
     node_rows = table("graph_nodes").select(
         "*",
         filters={"id": f"eq.{body.concept_node_id}", "user_id": f"eq.{body.user_id}"},
@@ -389,20 +399,21 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
 
     total = len(questions)
 
+    # Owner-scoped read: the attempt's concept node must belong to the
+    # attempt's owner. A missing/foreign node means we'd otherwise write
+    # mastery to someone else's row (IDOR) — refuse before any write.
+    # mastery_events was DROPPED in 0023 (events moved to node_mastery_events);
+    # we no longer read or write that column here.
     node_rows = table("graph_nodes").select(
-        "mastery_score,times_studied,mastery_events",
+        "concept_name,mastery_score,course_id",
         filters={"id": f"eq.{concept_node_id}", "user_id": f"eq.{user_id}"},
     )
     if not node_rows:
-        # The attempt's concept node must belong to the attempt's owner.
-        # A missing/foreign node means we'd otherwise write mastery to
-        # someone else's row (IDOR) — refuse before any write.
         raise HTTPException(status_code=404, detail="Concept node not found")
     node = node_rows[0]
     mastery_before = node["mastery_score"]
     mastery_after = max(0.0, min(1.0, mastery_before + (score * 0.03) - ((total - score) * 0.02)))
-    new_tier = get_mastery_tier(mastery_after)
-    times_studied = node["times_studied"] + 1
+    mastery_delta = mastery_after - mastery_before
 
     score_ratio = score / total if total > 0 else 0.0
     if score_ratio >= 0.7:
@@ -412,25 +423,27 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
     else:
         event_type = "confusion"
 
-    existing_events = node.get("mastery_events") or []
-    quiz_event = {
-        "ts": datetime.utcnow().isoformat(),
-        "delta": round(mastery_after - mastery_before, 4),
-        "reason": f"Quiz: {score}/{total} correct",
-        "event_type": event_type,
-    }
-    updated_events = (existing_events + [quiz_event])[-20:]
-
-    table("graph_nodes").update(
+    # Route the mastery write through the sanctioned graph path. The graph
+    # keys on the ABSTRACT course id; apply_graph_update looks the node up by
+    # (normalized) concept_name within (user_id, course_id), clamps mastery,
+    # bumps times_studied/last_studied_at, records the event (now in
+    # node_mastery_events), and updates the streak. We don't touch graph_nodes
+    # or node_mastery_events directly — that's the graph slice's territory.
+    apply_graph_update(
+        user_id,
         {
-            "mastery_score": mastery_after,
-            "mastery_tier": new_tier,
-            "times_studied": times_studied,
-            "last_studied_at": datetime.utcnow().isoformat(),
-            "mastery_events": updated_events,
+            "updated_nodes": [
+                {
+                    "concept_name": node["concept_name"],
+                    "mastery_delta": mastery_delta,
+                    "reason": f"Quiz: {score}/{total} correct",
+                    "event_type": event_type,
+                }
+            ]
         },
-        filters={"id": f"eq.{concept_node_id}", "user_id": f"eq.{user_id}"},
+        course_id=node.get("course_id"),
     )
+
     table("quiz_attempts").update(
         {
             "score": score,
@@ -440,8 +453,6 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
         },
         filters={"id": f"eq.{body.quiz_id}"},
     )
-
-    update_streak(user_id)
 
     node2_rows = table("graph_nodes").select(
         "concept_name",

--- a/backend/routes/study_guide.py
+++ b/backend/routes/study_guide.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Body, HTTPException, Query, Request
 
 from db.connection import table
+from services.academics import offering_course_id, resolve_offering
 from services.auth_guard import require_self
 from services.encryption import decrypt_if_present, decrypt_json
 from services.gemini_service import call_gemini_json
@@ -17,8 +18,13 @@ from services.gemini_service import call_gemini_json
 router = APIRouter()
 
 
-def _generate_and_insert(user_id: str, course_id: str, exam_id: str) -> dict:
-    """Generate a study guide, insert it into study_guides, and return {content, generated_at}."""
+def _generate_and_insert(user_id: str, offering_id: str, exam_id: str) -> dict:
+    """Generate a study guide, insert it into study_guides, and return
+    {content, generated_at}.
+
+    Study guides + the documents that feed them key on the OFFERING (0025);
+    the caller resolves the abstract course id to an offering first.
+    """
     # 1. Fetch exam info
     exams = table("assignments").select(
         "id,user_id,title,due_date,assignment_type,course_id",
@@ -31,10 +37,14 @@ def _generate_and_insert(user_id: str, course_id: str, exam_id: str) -> dict:
     exam_title = exam.get("title", "")
     due_date = exam.get("due_date", "")
 
-    # 2. Fetch documents for this user+course
+    # 2. Fetch documents for this user+offering
     docs = table("documents").select(
         "summary,concept_notes",
-        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
+        filters={
+            "user_id": f"eq.{user_id}",
+            "offering_id": f"eq.{offering_id}",
+            "deleted_at": "is.null",
+        },
     ) or []
 
     # 3. Build combined context
@@ -103,7 +113,7 @@ def _generate_and_insert(user_id: str, course_id: str, exam_id: str) -> dict:
     row = {
         "id": str(uuid.uuid4()),
         "user_id": user_id,
-        "course_id": course_id,
+        "offering_id": offering_id,
         "exam_id": exam_id,
         "generated_at": now,
         "content": content,
@@ -117,26 +127,35 @@ def _generate_and_insert(user_id: str, course_id: str, exam_id: str) -> dict:
 def get_cached_guides(user_id: str, request: Request):
     require_self(user_id, request)
     guides = table("study_guides").select(
-        "id,course_id,exam_id,generated_at,content",
+        "id,offering_id,exam_id,generated_at,content",
         filters={"user_id": f"eq.{user_id}"},
         order="generated_at.desc",
     )
-    # Enrich with course_name
-    course_ids = list({g["course_id"] for g in guides})
+    # Each guide keys on an offering; the frontend speaks abstract course ids.
+    # Map each offering → its abstract course id, then enrich with course_name.
+    offering_to_course: dict[str, str | None] = {}
     course_map: dict[str, str] = {}
-    for cid in course_ids:
-        rows = table("courses").select("id,course_name", filters={"id": f"eq.{cid}"}, limit=1)
-        if rows:
-            course_map[cid] = rows[0]["course_name"]
+    for g in guides:
+        off_id = g.get("offering_id")
+        if off_id and off_id not in offering_to_course:
+            cid = offering_course_id(off_id)
+            offering_to_course[off_id] = cid
+            if cid and cid not in course_map:
+                rows = table("courses").select(
+                    "id,course_name", filters={"id": f"eq.{cid}"}, limit=1
+                )
+                if rows:
+                    course_map[cid] = rows[0]["course_name"]
 
     result = []
     for g in guides:
         content = g.get("content") or {}
+        course_id = offering_to_course.get(g.get("offering_id"))
         result.append({
             "id": g["id"],
-            "course_id": g["course_id"],
+            "course_id": course_id,
             "exam_id": g["exam_id"],
-            "course_name": course_map.get(g["course_id"], ""),
+            "course_name": course_map.get(course_id or "", ""),
             "exam_title": content.get("exam", ""),
             "overview": content.get("overview", ""),
             "generated_at": g["generated_at"],
@@ -182,11 +201,14 @@ def get_guide(
     exam_id: str = Query(...),
 ):
     require_self(user_id, request)
+    # The query param is the abstract course id; study guides key on the
+    # offering. Resolve to the current-term offering for cache + generation.
+    offering_id = resolve_offering(course_id)
     cached = table("study_guides").select(
-        "id,user_id,course_id,exam_id,content,generated_at",
+        "id,user_id,offering_id,exam_id,content,generated_at",
         filters={
             "user_id": f"eq.{user_id}",
-            "course_id": f"eq.{course_id}",
+            "offering_id": f"eq.{offering_id}",
             "exam_id": f"eq.{exam_id}",
         },
         limit=1,
@@ -195,7 +217,7 @@ def get_guide(
         row = cached[0]
         return {"guide": row["content"], "generated_at": row["generated_at"], "cached": True}
 
-    result = _generate_and_insert(user_id, course_id, exam_id)
+    result = _generate_and_insert(user_id, offering_id, exam_id)
     return {"guide": result["content"], "generated_at": result["generated_at"], "cached": False}
 
 
@@ -208,12 +230,13 @@ def regenerate_guide(request: Request, body: dict = Body(...)):
         raise HTTPException(status_code=400, detail="user_id, course_id, and exam_id are required.")
     require_self(user_id, request)
 
+    offering_id = resolve_offering(course_id)
     table("study_guides").delete(
         filters={
             "user_id": f"eq.{user_id}",
-            "course_id": f"eq.{course_id}",
+            "offering_id": f"eq.{offering_id}",
             "exam_id": f"eq.{exam_id}",
         }
     )
-    result = _generate_and_insert(user_id, course_id, exam_id)
+    result = _generate_and_insert(user_id, offering_id, exam_id)
     return {"success": True, "guide": result["content"], "generated_at": result["generated_at"]}

--- a/backend/services/notes_service.py
+++ b/backend/services/notes_service.py
@@ -4,10 +4,14 @@ The encryption boundary lives entirely in this module: every write
 encrypts `title` and `body` before reaching Supabase; every read
 decrypts before returning. Routes never touch ciphertext directly.
 
-Schema (see backend/db/migration_notes.sql):
-    notes(id, user_id, course_id, title*, body*, tags text[],
-          last_summary*, last_summary_at, created_at, updated_at)
+Schema (see backend/db/migrations/0025_study_integrity.sql):
+    notes(id, user_id, offering_id, title*, body*, tags text[],
+          last_summary*, last_summary_at, created_at, updated_at, deleted_at)
     * = AES-GCM encrypted at rest.
+
+Notes key on the OFFERING (a course taught in a specific term), not the
+abstract catalog course. Soft-delete via `deleted_at`: deletes stamp the
+column and every read filters `deleted_at IS NULL`.
 """
 from __future__ import annotations
 
@@ -24,7 +28,7 @@ from services.encryption import (
 
 
 _SELECT_COLS = (
-    "id,user_id,course_id,title,body,tags,"
+    "id,user_id,offering_id,title,body,tags,"
     "last_summary,last_summary_at,created_at,updated_at"
 )
 
@@ -44,7 +48,7 @@ def _decrypt_row(row: dict) -> dict:
 
 async def create_note(
     user_id: str,
-    course_id: str,
+    offering_id: str,
     title: str = "",
     body: str = "",
     tags: list[str] | None = None,
@@ -54,7 +58,7 @@ async def create_note(
     row = {
         "id": note_id,
         "user_id": user_id,
-        "course_id": course_id,
+        "offering_id": offering_id,
         "title": encrypt_if_present(title) if title else None,
         "body": encrypt_if_present(body) if body else None,
         "tags": list(tags or []),
@@ -73,7 +77,11 @@ async def get_note(note_id: str, user_id: str) -> dict | None:
     def _fetch() -> list[dict]:
         return table("notes").select(
             _SELECT_COLS,
-            filters={"id": f"eq.{note_id}", "user_id": f"eq.{user_id}"},
+            filters={
+                "id": f"eq.{note_id}",
+                "user_id": f"eq.{user_id}",
+                "deleted_at": "is.null",
+            },
             limit=1,
         ) or []
 
@@ -85,11 +93,11 @@ async def get_note(note_id: str, user_id: str) -> dict | None:
 
 async def list_notes(
     user_id: str,
-    course_id: str | None = None,
+    offering_id: str | None = None,
 ) -> list[dict]:
-    filters: dict[str, str] = {"user_id": f"eq.{user_id}"}
-    if course_id:
-        filters["course_id"] = f"eq.{course_id}"
+    filters: dict[str, str] = {"user_id": f"eq.{user_id}", "deleted_at": "is.null"}
+    if offering_id:
+        filters["offering_id"] = f"eq.{offering_id}"
 
     def _fetch() -> list[dict]:
         return table("notes").select(
@@ -114,8 +122,8 @@ async def update_note(
         update["body"] = encrypt_if_present(patch["body"]) if patch["body"] else None
     if "tags" in patch:
         update["tags"] = list(patch["tags"] or [])
-    if "course_id" in patch:
-        update["course_id"] = patch["course_id"]
+    if "offering_id" in patch:
+        update["offering_id"] = patch["offering_id"]
 
     def _do() -> list[dict]:
         return table("notes").update(
@@ -130,8 +138,12 @@ async def update_note(
 
 
 async def delete_note(note_id: str, user_id: str) -> None:
+    """Soft delete (0025): stamp ``deleted_at`` instead of removing the row,
+    so reads filter it out while the data stays recoverable. Stays scoped to
+    the owner."""
     def _do() -> None:
-        table("notes").delete(
+        table("notes").update(
+            {"deleted_at": _now_iso()},
             filters={"id": f"eq.{note_id}", "user_id": f"eq.{user_id}"},
         )
 
@@ -153,7 +165,11 @@ async def save_summary(
     def _do() -> list[dict]:
         return table("notes").update(
             update,
-            filters={"id": f"eq.{note_id}", "user_id": f"eq.{user_id}"},
+            filters={
+                "id": f"eq.{note_id}",
+                "user_id": f"eq.{user_id}",
+                "deleted_at": "is.null",
+            },
         ) or []
 
     rows = await asyncio.to_thread(_do)
@@ -166,7 +182,11 @@ async def _note_belongs_to_user(note_id: str, user_id: str) -> bool:
     def _fetch() -> list[dict]:
         return table("notes").select(
             "id",
-            filters={"id": f"eq.{note_id}", "user_id": f"eq.{user_id}"},
+            filters={
+                "id": f"eq.{note_id}",
+                "user_id": f"eq.{user_id}",
+                "deleted_at": "is.null",
+            },
             limit=1,
         ) or []
     rows = await asyncio.to_thread(_fetch)

--- a/backend/tests/test_documents_routes.py
+++ b/backend/tests/test_documents_routes.py
@@ -72,13 +72,20 @@ class TestDeleteDocument:
         assert r.status_code == 200
         assert r.json() == {"deleted": True}
 
-    def test_calls_delete_with_correct_id(self):
+    def test_soft_deletes_with_correct_id(self):
+        """Delete is a soft delete (0025): it stamps deleted_at via an
+        update scoped to the document id, not a hard row removal."""
         with patch("routes.documents.table") as t:
             t.return_value.delete.return_value = None
             client.delete("/api/documents/doc/my-doc-uuid")
             t.assert_called_with("documents")
-            call_kwargs = t.return_value.delete.call_args
-            assert "my-doc-uuid" in str(call_kwargs)
+            # No hard delete fired.
+            t.return_value.delete.assert_not_called()
+            # A deleted_at stamp went out, scoped to the doc id.
+            update_args = t.return_value.update.call_args
+            assert "my-doc-uuid" in str(update_args)
+            payload = update_args[0][0]
+            assert payload.get("deleted_at") is not None
 
     def test_delete_with_user_validation(self):
         with _mock_validate_user(), patch("routes.documents.table") as t:
@@ -521,7 +528,10 @@ class TestUploadDocument:
 
     # ── Row persistence ───────────────────────────────────────────────────────
 
-    def test_persisted_row_contains_user_and_course(self):
+    def test_persisted_row_contains_user_and_offering(self):
+        """The documents row keys on the OFFERING (0025). The upload form
+        sends the abstract course id, which the route resolves to the
+        current-term offering before persisting."""
         ai_result = {
             "category": "other",
             "summary": "s",
@@ -530,6 +540,7 @@ class TestUploadDocument:
         }
         with (
             _mock_validate_user(),
+            patch("routes.documents.resolve_offering", return_value="off-99") as ro,
             patch("routes.documents.extract_text_from_file", return_value="t"),
             patch("routes.documents.call_gemini_json", return_value=ai_result),
             patch("routes.documents.table") as t,
@@ -538,8 +549,11 @@ class TestUploadDocument:
             _make_upload(course_id="c-99", user_id="user_andres")
             insert_call = t.return_value.insert.call_args[0][0]
 
+        # The abstract course id was resolved to the offering for the row.
+        ro.assert_called_once_with("c-99", create=True)
         assert insert_call["user_id"] == "user_andres"
-        assert insert_call["course_id"] == "c-99"
+        assert insert_call["offering_id"] == "off-99"
+        assert "course_id" not in insert_call
 
     def test_falls_back_to_row_dict_when_insert_returns_empty(self):
         """If table.insert returns [], the endpoint should return the constructed row dict."""

--- a/backend/tests/test_flashcard_import_routes.py
+++ b/backend/tests/test_flashcard_import_routes.py
@@ -29,6 +29,7 @@ class TestImportCommit:
             "dedup": False,
         }
         with _mock_self(), \
+             patch("routes.flashcards.resolve_offering", return_value="off1") as ro, \
              patch("routes.flashcards.table") as t, \
              patch("routes.flashcards.check_achievements"):
             t.return_value.insert.return_value = []
@@ -37,6 +38,11 @@ class TestImportCommit:
         assert r.status_code == 200, r.text
         assert r.json()["inserted"] == 2
         assert r.json()["skipped_duplicates"] == 0
+        # Abstract course id resolved to the offering; the row keys on it.
+        ro.assert_called_once_with("c1")
+        inserted_rows = t.return_value.insert.call_args[0][0]
+        assert all(row["offering_id"] == "off1" for row in inserted_rows)
+        assert all("course_id" not in row for row in inserted_rows)
 
     def test_skips_duplicates_when_dedup_true(self):
         body = {

--- a/backend/tests/test_learn_routes.py
+++ b/backend/tests/test_learn_routes.py
@@ -450,9 +450,9 @@ class TestChatViaAgent:
     Mirror's PR #71's pattern in `tests/test_quiz_routes.py`.
     """
 
-    def _make_table_factory(self, *, history_rows=None, course_id="course1"):
+    def _make_table_factory(self, *, history_rows=None, offering_id="off1"):
         """Default table factory: messages reads return `history_rows` (or
-        empty), sessions reads return a course id, users return a name.
+        empty), sessions reads return an offering id (0025), users a name.
         """
         rows = history_rows or []
 
@@ -461,7 +461,7 @@ class TestChatViaAgent:
             if name == "messages":
                 mock.select.return_value = rows
             elif name == "sessions":
-                mock.select.return_value = [{"course_id": course_id}]
+                mock.select.return_value = [{"offering_id": offering_id}]
             elif name == "users":
                 mock.select.return_value = [{"name": "Andres"}]
             elif name == "graph_nodes":
@@ -621,7 +621,7 @@ class TestChatViaAgent:
 
                 mock.insert.side_effect = _capture
             elif name == "sessions":
-                mock.select.return_value = [{"course_id": "course1"}]
+                mock.select.return_value = [{"offering_id": "off1"}]
             elif name == "users":
                 mock.select.return_value = [{"name": "Andres"}]
             else:

--- a/backend/tests/test_notes_routes.py
+++ b/backend/tests/test_notes_routes.py
@@ -22,46 +22,59 @@ def client():
 class TestListNotes:
     def test_returns_notes_for_user(self, client):
         notes = [
-            {"id": "n1", "user_id": "u1", "course_id": "c1",
+            {"id": "n1", "user_id": "u1", "offering_id": "off1",
              "title": "A", "body": "", "tags": [],
              "last_summary": None, "last_summary_at": None,
              "created_at": "2026-05-11T00:00:00Z",
              "updated_at": "2026-05-11T00:00:00Z"},
         ]
-        async def fake_list(user_id, course_id=None):
+        async def fake_list(user_id, offering_id=None):
             assert user_id == "u1"
-            assert course_id is None
+            assert offering_id is None
             return notes
         with patch("routes.notes.list_notes", side_effect=fake_list):
             r = client.get("/api/notes/user/u1")
         assert r.status_code == 200
         assert r.json() == {"notes": notes}
 
-    def test_course_filter_passes_through(self, client):
-        async def fake_list(user_id, course_id=None):
-            assert course_id == "c2"
+    def test_course_filter_resolves_to_offering(self, client):
+        # The query param is the abstract course id; the service is called
+        # with the resolved offering id.
+        async def fake_list(user_id, offering_id=None):
+            assert offering_id == "off-c2"
             return []
-        with patch("routes.notes.list_notes", side_effect=fake_list):
+        with (
+            patch("routes.notes.resolve_offering", return_value="off-c2") as ro,
+            patch("routes.notes.list_notes", side_effect=fake_list),
+        ):
             r = client.get("/api/notes/user/u1?course_id=c2")
         assert r.status_code == 200
+        ro.assert_called_once_with("c2")
 
 
 class TestCreateNote:
     def test_creates_with_required_fields(self, client):
-        async def fake_create(user_id, course_id, title, body, tags):
-            return {"id": "n1", "user_id": user_id, "course_id": course_id,
+        async def fake_create(user_id, offering_id, title, body, tags):
+            return {"id": "n1", "user_id": user_id, "offering_id": offering_id,
                     "title": title, "body": body, "tags": tags,
                     "last_summary": None, "last_summary_at": None,
                     "created_at": "2026-05-11T00:00:00Z",
                     "updated_at": "2026-05-11T00:00:00Z"}
-        with patch("routes.notes.create_note", side_effect=fake_create):
+        with (
+            patch("routes.notes.resolve_offering", return_value="off1") as ro,
+            patch("routes.notes.create_note", side_effect=fake_create),
+        ):
             r = client.post(
                 "/api/notes",
                 json={"user_id": "u1", "course_id": "c1",
                       "title": "T", "body": "B", "tags": ["a"]},
             )
         assert r.status_code == 200
-        assert r.json()["id"] == "n1"
+        body = r.json()
+        assert body["id"] == "n1"
+        # Abstract course id resolved to the current-term offering on create.
+        ro.assert_called_once_with("c1", create=True)
+        assert body["offering_id"] == "off1"
 
     def test_missing_course_id_returns_422(self, client):
         r = client.post(
@@ -179,7 +192,7 @@ class TestSummarizeRoute:
             captured["called"] = True
             return FakeResult()
         async def fake_get_note(note_id, user_id):
-            return {"id": note_id, "user_id": user_id, "course_id": "c1",
+            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
                     "title": "T", "body": "Long body…", "tags": [],
                     "last_summary": None, "last_summary_at": None,
                     "created_at": "", "updated_at": ""}
@@ -187,10 +200,11 @@ class TestSummarizeRoute:
             captured["saved"] = summary
             return {"id": note_id, "last_summary": summary,
                     "last_summary_at": "2026-05-11T00:00:00Z",
-                    "user_id": user_id, "course_id": "c1",
+                    "user_id": user_id, "offering_id": "off1",
                     "title": "T", "body": "Long body…", "tags": [],
                     "created_at": "", "updated_at": ""}
         with patch("routes.notes.note_summary_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
              patch("routes.notes.get_note", side_effect=fake_get_note), \
              patch("routes.notes.save_summary", side_effect=fake_save_summary):
             r = client.post(
@@ -219,12 +233,14 @@ class TestExtractConceptsRoute:
         async def fake_run(*args, **kwargs):
             return FakeResult()
         async def fake_get_note(note_id, user_id):
-            return {"id": note_id, "user_id": user_id, "course_id": "c1",
+            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
                     "title": "T", "body": "B", "tags": [],
                     "last_summary": None, "last_summary_at": None,
                     "created_at": "", "updated_at": ""}
         merged: list[str] = []
         async def fake_apply(user_id, course_id, concept_names):
+            # The graph keys on the abstract course id (offering → course).
+            assert course_id == "c1"
             merged.extend(concept_names)
             return len(concept_names)
         async def fake_lookup(user_id, course_id, names):
@@ -235,6 +251,7 @@ class TestExtractConceptsRoute:
             return True
 
         with patch("routes.notes.note_concepts_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
              patch("routes.notes.get_note", side_effect=fake_get_note), \
              patch("routes.notes.apply_concepts_to_graph", side_effect=fake_apply), \
              patch("routes.notes._lookup_concept_nodes_by_name", side_effect=fake_lookup), \
@@ -257,11 +274,12 @@ class TestNoteChatRoute:
         async def fake_run(*args, **kwargs):
             return FakeResult()
         async def fake_get_note(note_id, user_id):
-            return {"id": note_id, "user_id": user_id, "course_id": "c1",
+            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
                     "title": "T", "body": "B", "tags": [],
                     "last_summary": None, "last_summary_at": None,
                     "created_at": "", "updated_at": ""}
         with patch("routes.notes.note_chat_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
              patch("routes.notes.get_note", side_effect=fake_get_note):
             r = client.post(
                 "/api/notes/n1/chat",
@@ -274,19 +292,21 @@ class TestNoteChatRoute:
 class TestSendToTutorRoute:
     def test_returns_topic_and_course(self, client):
         async def fake_get_note(note_id, user_id):
-            return {"id": note_id, "user_id": user_id, "course_id": "c1",
+            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
                     "title": "Photosynthesis — light vs dark reactions",
                     "body": "B", "tags": [],
                     "last_summary": "A short summary",
                     "last_summary_at": "2026-05-11T00:00:00Z",
                     "created_at": "", "updated_at": ""}
-        with patch("routes.notes.get_note", side_effect=fake_get_note):
+        with patch("routes.notes.get_note", side_effect=fake_get_note), \
+             patch("routes.notes.offering_course_id", return_value="c1"):
             r = client.post(
                 "/api/notes/n1/send-to-tutor",
                 json={"user_id": "u1"},
             )
         assert r.status_code == 200
         body = r.json()
+        # The tutor session starts from the abstract course id (graph key).
         assert body["course_id"] == "c1"
         # topic uses the note title (first 80 chars, single line).
         assert body["topic"].startswith("Photosynthesis")

--- a/backend/tests/test_notes_service.py
+++ b/backend/tests/test_notes_service.py
@@ -53,7 +53,7 @@ def test_create_note_encrypts_title_and_body():
     with patch("services.notes_service.table", return_value=fake):
         out = _run(create_note(
             user_id="u1",
-            course_id="c1",
+            offering_id="off1",
             title="Photosynthesis",
             body="Light reactions happen in the thylakoid",
             tags=["lecture"],
@@ -64,12 +64,15 @@ def test_create_note_encrypts_title_and_body():
     # Title and body must NOT be plaintext in the row written to Supabase.
     assert row["title"] != "Photosynthesis"
     assert row["body"] != "Light reactions happen in the thylakoid"
+    # The note keys on the OFFERING, not the abstract course (0025).
+    assert row["offering_id"] == "off1"
+    assert "course_id" not in row
     # Return shape must hand back plaintext for the caller to render.
     assert out["title"] == "Photosynthesis"
     assert out["body"] == "Light reactions happen in the thylakoid"
     assert out["tags"] == ["lecture"]
     assert out["user_id"] == "u1"
-    assert out["course_id"] == "c1"
+    assert out["offering_id"] == "off1"
     assert isinstance(out["id"], str) and len(out["id"]) > 0
 
 
@@ -78,7 +81,7 @@ def test_get_note_decrypts_and_enforces_ownership():
     fake = FakeTable(rows=[{
         "id": "n1",
         "user_id": "u1",
-        "course_id": "c1",
+        "offering_id": "off1",
         "title": encrypt("My title"),
         "body": encrypt("My body"),
         "tags": ["a"],
@@ -97,6 +100,8 @@ def test_get_note_decrypts_and_enforces_ownership():
     filters = call_kwargs.get("filters", {})
     assert filters.get("id") == "eq.n1"
     assert filters.get("user_id") == "eq.u1"
+    # Soft-deleted notes are excluded from reads (0025 deleted_at).
+    assert filters.get("deleted_at") == "is.null"
 
 
 def test_get_note_returns_none_when_missing():
@@ -109,7 +114,7 @@ def test_get_note_returns_none_when_missing():
 def test_update_note_only_encrypts_present_fields():
     from services.encryption import encrypt
     fake = FakeTable(rows=[{
-        "id": "n1", "user_id": "u1", "course_id": "c1",
+        "id": "n1", "user_id": "u1", "offering_id": "off1",
         "title": encrypt("Old"), "body": encrypt("Old body"),
         "tags": [], "last_summary": None, "last_summary_at": None,
         "created_at": "2026-05-11T00:00:00Z",
@@ -132,21 +137,31 @@ def test_update_note_only_encrypts_present_fields():
     assert out["title"] == "New title"
 
 
-def test_list_notes_filters_by_user_and_optional_course():
+def test_list_notes_filters_by_user_and_optional_offering():
     fake = FakeTable(rows=[])
     with patch("services.notes_service.table", return_value=fake):
-        _run(list_notes(user_id="u1", course_id="c1"))
+        _run(list_notes(user_id="u1", offering_id="off1"))
     args, kwargs = fake.select_calls[0]
     filters = kwargs.get("filters", {})
     assert filters.get("user_id") == "eq.u1"
-    assert filters.get("course_id") == "eq.c1"
+    assert filters.get("offering_id") == "eq.off1"
+    # Soft-deleted notes are excluded from list reads.
+    assert filters.get("deleted_at") == "is.null"
 
 
-def test_delete_note_scopes_by_user():
-    fake = FakeTable()
+def test_delete_note_soft_deletes_and_scopes_by_user():
+    """0025: delete is a soft delete — sets deleted_at instead of removing
+    the row, and stays scoped to (id, user_id)."""
+    fake = FakeTable(rows=[{"id": "n1", "user_id": "u1"}])
     with patch("services.notes_service.table", return_value=fake):
         _run(delete_note(note_id="n1", user_id="u1"))
-    assert fake.deleted == [{"id": "eq.n1", "user_id": "eq.u1"}]
+    # No hard delete fired.
+    assert fake.deleted == []
+    # A soft-delete update stamped deleted_at, scoped to the owner.
+    assert fake.updated, "soft-delete update was not called"
+    data, filters = fake.updated[0]
+    assert data.get("deleted_at") is not None
+    assert filters == {"id": "eq.n1", "user_id": "eq.u1"}
 
 
 from services.notes_service import (

--- a/backend/tests/test_quiz_routes.py
+++ b/backend/tests/test_quiz_routes.py
@@ -107,7 +107,9 @@ def _make_table(questions=None):
 def _submit_quiz_mocks(questions=None):
     with (
         patch("routes.quiz.table", side_effect=_make_table(questions)),
-        patch("routes.quiz.update_streak"),
+        # Mastery writes now route through apply_graph_update (the sanctioned
+        # graph path) instead of a direct graph_nodes.update.
+        patch("routes.quiz.apply_graph_update"),
         patch("routes.quiz.get_quiz_context", return_value={}),
         patch("routes.quiz.call_gemini_json", return_value={}),
     ):
@@ -225,7 +227,7 @@ class TestSubmitQuiz:
             return mock
 
         with patch("routes.quiz.table", side_effect=factory):
-            with patch("routes.quiz.update_streak"):
+            with patch("routes.quiz.apply_graph_update"):
                 with patch("routes.quiz.get_quiz_context", return_value={}):
                     with patch("routes.quiz.call_gemini_json", return_value={}):
                         r = client.post("/api/quiz/submit", json={
@@ -343,9 +345,10 @@ class TestQuizNodeOwnership:
                 mock.update.return_value = []
             return mock
 
+        apply_mock = MagicMock()
         with (
             patch("routes.quiz.table", side_effect=factory),
-            patch("routes.quiz.update_streak"),
+            patch("routes.quiz.apply_graph_update", new=apply_mock),
             patch("routes.quiz.get_quiz_context", return_value={}),
             patch("routes.quiz.call_gemini_json", return_value={}),
         ):
@@ -358,11 +361,128 @@ class TestQuizNodeOwnership:
             })
 
         assert r.status_code == 404
-        # No mastery write to the victim's node (or any node) occurred.
+        # No mastery write to the victim's node (or any node) occurred — neither
+        # a direct graph_nodes.update nor the sanctioned apply_graph_update path.
         assert update_calls == [], (
             "submit_quiz wrote to graph_nodes for a foreign concept node — "
             "IDOR regression (issue #157)."
         )
+        apply_mock.assert_not_called()
+
+
+# ── POST /api/quiz/generate — difficulty enum (0025 CHECK) ──────────────────
+
+
+class TestGenerateQuizDifficultyEnum:
+    """quiz_attempts.difficulty is CHECK-constrained to easy|medium|hard
+    (0025). The route rejects drift with a 400 before running the agent or
+    writing an attempt row."""
+
+    def test_invalid_difficulty_returns_400(self):
+        agent_run = AsyncMock()
+        with (
+            patch("routes.quiz.table", side_effect=_generate_table_factory()),
+            patch("routes.quiz.quiz_agent.run", new=agent_run),
+        ):
+            r = client.post("/api/quiz/generate", json={
+                "user_id": "user_andres",
+                "concept_node_id": "node1",
+                "num_questions": 1,
+                "difficulty": "impossible",  # not in the CHECK set
+                "use_shared_context": False,
+            })
+        assert r.status_code == 400
+        # The agent must not run for an invalid difficulty.
+        agent_run.assert_not_called()
+
+    def test_valid_difficulty_passes_validation(self):
+        from types import SimpleNamespace
+        fake_quiz = Quiz(questions=[
+            QuizQuestion(
+                question="Q?", type="multiple_choice", difficulty="hard",
+                options=["a", "b", "c", "d"], correct_answer="a",
+                explanation="x", concept="X",
+            ),
+        ])
+        with (
+            patch("routes.quiz.table", side_effect=_generate_table_factory()),
+            patch(
+                "routes.quiz.quiz_agent.run",
+                new=AsyncMock(return_value=SimpleNamespace(output=fake_quiz)),
+            ),
+        ):
+            r = client.post("/api/quiz/generate", json={
+                "user_id": "user_andres",
+                "concept_node_id": "node1",
+                "num_questions": 1,
+                "difficulty": "hard",
+                "use_shared_context": False,
+            })
+        assert r.status_code == 200
+
+
+# ── POST /api/quiz/submit — mastery routes through apply_graph_update ────────
+
+
+class TestSubmitQuizMasteryWrite:
+    """0023 dropped graph_nodes.mastery_events; submit_quiz must NOT touch
+    that column. Mastery writes route through apply_graph_update (the
+    sanctioned graph path), keyed by concept_name + the abstract course id."""
+
+    def test_mastery_write_routes_through_apply_graph_update(self):
+        apply_mock = MagicMock()
+
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                mock.select.return_value = [{
+                    "id": "quiz1",
+                    "user_id": "user_andres",
+                    "concept_node_id": "node1",
+                    "difficulty": "medium",
+                    "questions_json": SAMPLE_QUESTIONS,
+                }]
+            elif name == "graph_nodes":
+                mock.select.return_value = [{
+                    "mastery_score": 0.5,
+                    "concept_name": "Loops",
+                    "course_id": "course1",
+                }]
+            elif name == "users":
+                mock.select.return_value = [{"name": "Andres"}]
+            else:
+                mock.select.return_value = []
+            mock.update.return_value = []
+            return mock
+
+        with (
+            patch("routes.quiz.table", side_effect=factory),
+            patch("routes.quiz.apply_graph_update", new=apply_mock),
+            patch("routes.quiz.get_quiz_context", return_value={}),
+            patch("routes.quiz.call_gemini_json", return_value={}),
+        ):
+            r = client.post("/api/quiz/submit", json={
+                "quiz_id": "quiz1",
+                "answers": [
+                    {"question_id": 1, "selected_label": "A"},
+                    {"question_id": 2, "selected_label": "D"},
+                ],
+            })
+
+        assert r.status_code == 200
+        apply_mock.assert_called_once()
+        args, kwargs = apply_mock.call_args
+        # user_id first, abstract course id passed (graph keys on abstract).
+        assert args[0] == "user_andres"
+        assert kwargs["course_id"] == "course1"
+        updated = args[1]["updated_nodes"]
+        assert len(updated) == 1
+        assert updated[0]["concept_name"] == "Loops"
+        # Perfect score → positive mastery delta.
+        assert updated[0]["mastery_delta"] > 0
+        # The response still reports before/after.
+        data = r.json()
+        assert data["mastery_after"] > data["mastery_before"]
 
 
 # ── POST /api/quiz/generate ──────────────────────────────────────────────────

--- a/backend/tests/test_shared_course_context.py
+++ b/backend/tests/test_shared_course_context.py
@@ -444,19 +444,20 @@ class TestLearnHelpers(unittest.TestCase):
         self.assertEqual(result, "")
 
     @patch("routes.learn.table")
-    def test_get_session_course_id_found(self, mock_table):
-        mock_table.return_value.select.return_value = [{"course_id": "course-1"}]
+    def test_get_session_offering_id_found(self, mock_table):
+        # Sessions key on the offering (0025); the helper returns it.
+        mock_table.return_value.select.return_value = [{"offering_id": "off-1"}]
 
-        from routes.learn import _get_session_course_id
-        result = _get_session_course_id("session-abc")
-        self.assertEqual(result, "course-1")
+        from routes.learn import _get_session_offering_id
+        result = _get_session_offering_id("session-abc")
+        self.assertEqual(result, "off-1")
 
     @patch("routes.learn.table")
-    def test_get_session_course_id_not_found(self, mock_table):
+    def test_get_session_offering_id_not_found(self, mock_table):
         mock_table.return_value.select.return_value = []
 
-        from routes.learn import _get_session_course_id
-        result = _get_session_course_id("session-missing")
+        from routes.learn import _get_session_offering_id
+        result = _get_session_offering_id("session-missing")
         self.assertEqual(result, "")
 
     @patch("services.course_context_service.get_course_context", return_value={})

--- a/backend/tests/test_study_guide_routes.py
+++ b/backend/tests/test_study_guide_routes.py
@@ -45,8 +45,10 @@ class TestGetExams:
 
 class TestGetCachedGuides:
     def test_enriches_with_course_name(self):
+        # Guides key on the offering (0025); the response exposes the abstract
+        # course id (resolved via offering_course_id) and its course name.
         guides = [{
-            "id": "g1", "course_id": "c1", "exam_id": "e1",
+            "id": "g1", "offering_id": "off1", "exam_id": "e1",
             "generated_at": "2026-04-01T00:00:00Z",
             "content": {"exam": "Midterm", "overview": "Covers ch1-5"},
         }]
@@ -61,11 +63,13 @@ class TestGetCachedGuides:
                 m.select.return_value = []
             return m
 
-        with patch("routes.study_guide.table", side_effect=table_side_effect):
+        with patch("routes.study_guide.table", side_effect=table_side_effect), \
+             patch("routes.study_guide.offering_course_id", return_value="c1"):
             r = client.get(f"/api/study-guide/{USER_ID}/cached")
 
         assert r.status_code == 200
         out = r.json()["guides"][0]
+        assert out["course_id"] == "c1"
         assert out["course_name"] == "Calc II"
         assert out["exam_title"] == "Midterm"
         assert out["overview"] == "Covers ch1-5"
@@ -100,12 +104,16 @@ class TestGetGuide:
 
     def test_generates_and_inserts_when_not_cached(self):
         fresh_content = {"exam": "Final", "topics": [{"name": "Topic 1"}]}
+        captured = {}
 
         def table_side_effect(name):
             m = MagicMock()
             if name == "study_guides":
                 m.select.return_value = []  # nothing cached
-                m.insert.return_value = [{}]
+                def _insert(row):
+                    captured["row"] = row
+                    return [{}]
+                m.insert.side_effect = _insert
             elif name == "assignments":
                 m.select.return_value = [{"title": "Final", "due_date": "2026-05-01"}]
             elif name == "documents":
@@ -115,6 +123,7 @@ class TestGetGuide:
             return m
 
         with patch("routes.study_guide.table", side_effect=table_side_effect), \
+             patch("routes.study_guide.resolve_offering", return_value="off1") as ro, \
              patch("routes.study_guide.call_gemini_json", return_value=fresh_content) as gem:
             r = client.get(f"/api/study-guide/{USER_ID}/guide?course_id={COURSE_ID}&exam_id={EXAM_ID}")
         assert r.status_code == 200
@@ -122,6 +131,10 @@ class TestGetGuide:
         assert body["cached"] is False
         assert body["guide"]["exam"] == "Final"
         gem.assert_called_once()
+        # Abstract course id resolved to the offering, and the row keys on it.
+        ro.assert_called_once_with(COURSE_ID)
+        assert captured["row"]["offering_id"] == "off1"
+        assert "course_id" not in captured["row"]
 
     def test_unknown_exam_returns_404(self):
         def table_side_effect(name):

--- a/docs/superpowers/plans/2026-06-24-db-study-code.md
+++ b/docs/superpowers/plans/2026-06-24-db-study-code.md
@@ -1,0 +1,207 @@
+# db/study-code — repoint study artifacts onto the offering
+
+Branch: `db/study-code` (based on `db/academics-code`).
+Schema source of truth: `backend/db/migrations/0025_study_integrity.sql` (+ 0023 for graph).
+
+## LOCKED CONTRACT recap
+
+- The API boundary keeps the **abstract `course_id`** (catalog id). Request bodies / query
+  params still send `course_id`.
+- Study artifacts (`documents`, `notes`, `sessions`, `study_guides`, `flashcards`) now key on
+  **`offering_id`** (a course taught in a specific term). The route resolves the abstract
+  `course_id` → `offering_id` via `services.academics.resolve_offering(course_id)` (current term
+  default) before reading/writing.
+- The **knowledge graph** (`graph_nodes`, `apply_graph_update`) stays on the **abstract
+  `course_id`** — mastery is cumulative across terms. So every `apply_graph_update(..., course_id=...)`
+  call keeps passing the abstract id, NOT the offering id.
+
+## Exact CHECK-enum value sets (from 0025 / 0023)
+
+- `documents.category` ∈ `{syllabus, lecture_notes, slides, reading, assignment, study_guide, other}`
+  (already enforced by `VALID_CATEGORIES` in routes/documents.py — matches verbatim).
+- `sessions.mode` ∈ `{socratic, expository, teachback}` (NEW CHECK — validate at write).
+- `quiz_attempts.difficulty` ∈ `{easy, medium, hard}` (NEW CHECK — validate at write).
+- `messages.role` — left **unconstrained** in 0025 (`'user'/'assistant' set in code`). Code already
+  writes only `user`/`assistant`. No new DB enum; keep code disciplined (no change needed, but
+  documented).
+- `graph_nodes.mastery_tier` ∈ `{unexplored, struggling, learning, mastered, subject_root}` (0023) —
+  not in my write path (owned by graph slice).
+- `node_mastery_events(node_id, delta, reason, created_at)` (0023) — replaces the dropped
+  `graph_nodes.mastery_events` jsonb column.
+
+## Column renames (0025): `course_id` → `offering_id`
+
+`documents`, `notes`, `sessions`, `study_guides`, `flashcards` no longer have a `course_id` column.
+`flashcards.offering_id` and `sessions.offering_id` are **nullable** (ON DELETE SET NULL);
+`documents.offering_id`, `notes.offering_id`, `study_guides.offering_id` are **NOT NULL**.
+`enrollments.syllabus_doc_id` FK → `documents(id)` re-added (no code change; FK only).
+`note_concepts.concept_node_id` FK → `graph_nodes(id)` (no code change; FK only).
+
+## Offering resolution helper
+
+Add a small private helper per route module that imports
+`from services.academics import resolve_offering` (imported into the route module namespace so
+tests can patch `routes.<x>.resolve_offering`). The route resolves the abstract `course_id` to an
+offering id once, then uses it for every artifact read/write in that request. Where a
+`session`/`document` row already carries `offering_id`, use it directly (no re-resolution).
+
+## File-by-file change map (current → new)
+
+### services/notes_service.py
+- `_SELECT_COLS`: `course_id` → `offering_id`.
+- `create_note(user_id, offering_id, ...)`: param renamed `course_id` → `offering_id`; insert row
+  writes `offering_id`; `_decrypt_row` unchanged. Reads filter out soft-deleted (`deleted_at` is
+  NULL) — add `deleted_at: "is.null"` filter to `get_note`, `list_notes`, `_note_belongs_to_user`.
+- `list_notes(user_id, offering_id=None)`: filter key → `offering_id`.
+- `update_note`: `course_id` patch key → `offering_id`.
+- `delete_note`: SOFT delete → `table("notes").update({"deleted_at": now}, filters=...)` instead of
+  hard `.delete`.
+- `list_linked_concepts`: graph_nodes still selects `course_id` (abstract graph) — unchanged.
+
+### routes/notes.py
+- `CreateNoteBody.course_id`, `UpdateNoteBody.course_id` stay (API boundary).
+- `create`: resolve `offering_id = resolve_offering(body.course_id, create=True)` then
+  `create_note(..., offering_id=offering_id)`. (create=True so a fresh note lands in the real
+  current-term offering.)
+- `list_user_notes`: when `course_id` query param present, resolve → `offering_id`; pass to
+  `list_notes(offering_id=...)`.
+- `patch`: if `body.course_id` set, resolve → offering and pass `offering_id` in patch.
+- Agent actions (`summarize`/`extract-concepts`/`chat`/`send-to-tutor`/`generate-quiz`): the note row
+  now returns `offering_id`. For graph ops (`apply_concepts_to_graph`, `_lookup_concept_nodes_by_name`)
+  the graph keys on the ABSTRACT course id → translate `offering_id` → abstract via
+  `services.academics.offering_course_id(offering_id)` and pass that as `course_id` to the graph
+  helpers. `send-to-tutor` returns `course_id` (abstract) in its payload → translate offering→abstract.
+- `_deps_for`: SaplingDeps.course_id is the abstract id for graph tools → pass abstract
+  (`offering_course_id(note.offering_id)`).
+
+### routes/documents.py
+- `VALID_CATEGORIES` already correct.
+- `list_documents`: select `offering_id` (not `course_id`); filter out `deleted_at` (is.null).
+- `delete_document`: SOFT delete → `update({"deleted_at": now})`.
+- `_existing_doc_by_request_id`: select `offering_id`.
+- `_persist_document(offering_id=...)`: insert row writes `offering_id`. Caller resolves
+  `course_id` → offering once.
+- `upload_document_sync` / `upload_document`: resolve `offering_id = resolve_offering(course_id,
+  create=True)` near the top. Use offering for `_persist_document` and `_invalidate_study_guide_cache`.
+  Keep passing the **abstract `course_id`** to `apply_graph_update` / `_graph_backstop` /
+  `update_course_context` / `apply_concepts_to_graph` (graph + course_context key on abstract).
+- `_legacy_upload_pipeline(offering_id=..., course_id=...)`: takes both — writes `offering_id` on the
+  documents row, passes abstract `course_id` to `apply_graph_update` + assignment save +
+  course-context.
+- `_invalidate_study_guide_cache(user_id, offering_id)`: filter `offering_id`.
+- `scan_document_concepts`: the doc row now has `offering_id`; graph scan keys on abstract →
+  translate `offering_id` → abstract `course_id` via `offering_course_id` for
+  `_scan_concepts_for_course` (which writes graph_nodes by abstract course_id — unchanged).
+- `scan_course_concepts(course_id)`: course_id is abstract (graph) — unchanged (graph scan).
+- `_save_orchestrator_syllabus`: assignments carry `course_id` (abstract, calendar/gradebook keyed) —
+  keep abstract.
+
+### routes/study_guide.py
+- `_generate_and_insert(user_id, offering_id, exam_id)`: documents read filter → `offering_id`; insert
+  row writes `offering_id`. Caller resolves abstract course_id → offering.
+- `get_cached_guides`: select `offering_id`; enrich course name via
+  `offering_course_id(offering_id)` → courses lookup. Response still exposes `course_id` (abstract)
+  for the frontend.
+- `get_guide(course_id, exam_id)`: resolve abstract `course_id` → offering for the cache lookup and
+  generation.
+- `regenerate_guide`: resolve abstract → offering for delete + regen.
+- `get_courses` reads `courses` (abstract) — unchanged. `get_exams` reads `assignments` — unchanged.
+
+### routes/flashcards.py
+- `_get_course_documents`: documents filter `course_id` → `offering_id`; resolve the course (by name)
+  → abstract course_id → offering before the documents read.
+- `_get_weak_concepts`: reads `graph_nodes.subject` (abstract graph) — unchanged.
+- `generate` insert: `flashcards` row has no `course_id`/`offering_id` today; leave offering NULL
+  (topic-based AI generation isn't course-scoped here) — unchanged except the helper's documents read.
+- `get_flashcards`: select `offering_id` (was `course_id`).
+- `import_commit`: body keeps `course_id` (abstract, optional). Resolve → `offering_id`
+  (create=False; None stays None). Insert writes `offering_id`. Pass the resolved offering to
+  `dedup_against_existing` (its param is positionally `course_id` but filters the flashcards column;
+  the column is now `offering_id` — see Out-of-scope note).
+
+### routes/learn.py (doc-context + offering wiring)
+- `_get_session_course_id` → keep name but read `sessions.offering_id`; rename to
+  `_get_session_offering_id` returning the offering id.
+- `_get_course_documents(user_id, offering_id)`: filter `documents.offering_id`.
+- `_consume_pending`: session insert writes `offering_id` (resolve pending abstract course_id →
+  offering). `sessions` has no `course_id` column.
+- `start_session`: resolve abstract `course_id` (from body or topic) → offering for the documents
+  read + session persistence; keep abstract `course_id` for `apply_graph_update`,
+  `get_course_context`, `build_system_prompt`'s shared-context block, and `_get_course_info`.
+  Store BOTH in PENDING (abstract `course_id` for graph, `offering_id` for the session row).
+- `_chat_via_agent` / `_legacy_chat` / `chat`: a session row carries `offering_id`. For documents,
+  read by `offering_id`. For graph + shared-context, translate `offering_id` → abstract via
+  `offering_course_id` and pass that as `course_id` to `build_system_prompt`, `apply_graph_update`,
+  and SaplingDeps.course_id.
+- `build_system_prompt`: **resolve the TODO** — it already takes an abstract `course_id` and calls
+  `get_course_context(course_id)`. The fix is upstream: pass the session's offering→abstract course
+  id so shared context resolves. The signature stays `course_id` (abstract); callers now derive it
+  from the session's offering. (course_context_service is out of scope; it keys on abstract course_id
+  per the academics slice, so passing the abstract id is correct — the `{}`-degrade TODO is removed.)
+- `list_sessions` / `resume_session`: select `offering_id`; expose `course_id` (abstract) in the
+  response by translating offering→abstract so the frontend contract is unchanged.
+
+### routes/quiz.py (mastery_events fix + difficulty enum)
+- `generate_quiz`: validate `body.difficulty ∈ {easy,medium,hard}` (400 otherwise). quiz_attempts
+  insert already writes `difficulty` — keep, now validated.
+- `_legacy_generate_quiz`: graph reads unchanged (graph_nodes keyed on abstract course_id; course
+  context keyed on abstract).
+- `submit_quiz` — **the mastery_events fix**:
+  - STOP selecting/writing `graph_nodes.mastery_events` (DROPPED by 0023).
+  - Keep the owner-scoped node read (`mastery_score,times_studied,concept_name,course_id`) — needed
+    for the 404 IDOR guard and the response's `mastery_before`/`mastery_after`. 404 BEFORE any write
+    (preserves IDOR test).
+  - Route the mastery WRITE through `services.graph_service.apply_graph_update(user_id,
+    {"updated_nodes": [{concept_name, mastery_delta, reason, event_type}]}, course_id=<abstract>)` —
+    the sanctioned path. apply_graph_update looks up the node by normalized concept_name within
+    (user_id, course_id), applies the same clamp, bumps times_studied, and appends the mastery event
+    (the graph slice owns whether that lands in node_mastery_events vs the column — I just call it).
+  - Compute `mastery_after` for the RESPONSE with the existing formula (so the response shape is
+    unchanged) and derive `mastery_delta = mastery_after - mastery_before` to hand to
+    apply_graph_update, so the persisted delta matches the reported one.
+  - Do NOT reimplement apply_graph_update internals. Do NOT read/write the column.
+  - quiz_attempts.update (score/total/answers/completed_at) unchanged.
+
+## How each artifact resolves its offering_id
+
+| artifact      | source of offering_id |
+|---------------|------------------------|
+| documents (upload) | `resolve_offering(course_id, create=True)` from the upload form's abstract course_id |
+| documents (read/scan) | the document row's `offering_id`; for graph scan translate → abstract via `offering_course_id` |
+| notes         | `resolve_offering(body.course_id, create=True)` on create; existing row's `offering_id` on read |
+| sessions      | `resolve_offering(course_id, create=True)` at session persist; `sessions.offering_id` thereafter |
+| study_guides  | `resolve_offering(course_id)` from the abstract course_id in the query/body |
+| flashcards    | `resolve_offering(course_id)` (nullable) on import_commit; NULL for topic-only generate |
+| graph (quiz/notes/docs) | NEVER offering — always the abstract course_id (translate offering→abstract when only the offering is in hand) |
+
+## Test list (TDD)
+
+- test_notes_service: rename `course_id`→`offering_id` in mocks/asserts; add soft-delete assertion
+  (delete_note calls `.update({deleted_at})`, not `.delete`); add `deleted_at is.null` read filter
+  assertion.
+- test_notes_routes: patch `routes.notes.resolve_offering` + `routes.notes.offering_course_id`;
+  create passes `offering_id`; graph lookups get abstract course_id.
+- test_documents_routes: patch `routes.documents.resolve_offering`; insert row asserts `offering_id`;
+  `apply_graph_update` still asserts abstract `course_id`; delete asserts soft-delete update.
+- test_study_guide_routes: patch `routes.study_guide.resolve_offering` (+ `offering_course_id` for
+  cached-guide enrichment); documents read + insert assert `offering_id`.
+- test_flashcards / test_flashcard_import_routes: patch `routes.flashcards.resolve_offering`; import
+  insert asserts `offering_id`.
+- test_learn_routes: session reads/writes `offering_id`; doc context reads `offering_id`; build_system_prompt
+  shared-context gets the abstract course id (no `{}` degrade). Patch `routes.learn.resolve_offering`
+  + `routes.learn.offering_course_id`.
+- test_quiz_routes: submit no longer references `mastery_events`; mastery write goes through
+  `apply_graph_update` (patch `routes.quiz.apply_graph_update`, assert called with updated_nodes +
+  abstract course_id); IDOR test still 404s with no graph write; add difficulty-enum validation test.
+
+## Out of scope (do NOT touch)
+
+- `services/academics.py`, `services/graph_service.py` internals (apply_graph_update body, graph_nodes
+  upserts, the column-vs-node_mastery_events decision), `services/course_context_service.py`.
+- gradebook, analytics, identity, ops.
+- `services/flashcard_import_service.py`: its `dedup_against_existing` still filters the flashcards
+  table on a column literally named `course_id`. That column is now `offering_id`. The service file is
+  NOT in this slice's file list and editing it risks the flashcard_import_service tests (which pin the
+  `course_id` filter key). KNOWN SEAM: the route passes the resolved offering id into the existing
+  `course_id` parameter; aligning the service's filter column to `offering_id` is a one-line follow-up
+  owned by whoever owns flashcard_import_service. Flagged, not fixed here.


### PR DESCRIPTION
Study slice (migration 0025). documents/notes/sessions/study_guides/flashcards re-keyed to `offering_id` (resolved via `services/academics`); soft-delete `deleted_at`; CHECK enums; wired learn's session offering→abstract for the graph/shared-context (resolved the academics TODO); quiz mastery routed through `apply_graph_update`. Green; ruff clean.

Plan: `docs/superpowers/plans/2026-06-24-db-study-code.md`.

**Merge AFTER db/graph-code.** Follow-up flagged: `flashcard_import_service.dedup_against_existing` still filters a column named `course_id` (now `offering_id`).