### PR TITLE
db/gradebook-code: semester-aware gradebook + curve + drop-lowest (epic slice PR3)

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -359,33 +359,44 @@ class CreateCosmeticBody(BaseModel):
 
 # ── Gradebook ────────────────────────────────────────────────────────────────
 
+# Enrollment / gradebook key on the abstract course_id + an optional `semester`
+# (a term label, e.g. "Spring 2026"; default = current term). The route maps
+# (course_id, semester) -> the user's enrollment via services.academics.
+AssignmentType = Literal["homework", "exam", "reading", "project", "quiz", "other"]
+
+
 class CategoryItem(BaseModel):
     id: Optional[str] = None              # null on create
     name: str
     weight: float = Field(ge=0, le=100)
     sort_order: int = 0
+    drop_lowest: int = Field(default=0, ge=0)  # gradebook_categories.drop_lowest
 
 
 class CreateCategoryBody(BaseModel):
     user_id: str
+    semester: Optional[str] = None        # term label; default = current term
     name: str
     weight: float = Field(ge=0, le=100)
+    drop_lowest: int = Field(default=0, ge=0)
 
 
 class BulkUpdateCategoriesBody(BaseModel):
     user_id: str
+    semester: Optional[str] = None
     categories: list[CategoryItem]        # full replacement set
 
 
 class CreateAssignmentBody(BaseModel):
     user_id: str
     course_id: str
+    semester: Optional[str] = None
     title: str
     category_id: Optional[str] = None
     points_possible: Optional[float] = Field(default=None, gt=0)
     points_earned: Optional[float] = Field(default=None, ge=0)
     due_date: Optional[str] = None
-    assignment_type: Optional[str] = None
+    assignment_type: Optional[AssignmentType] = None
     notes: Optional[str] = None
 
 
@@ -396,7 +407,7 @@ class UpdateAssignmentBody(BaseModel):
     points_possible: Optional[float] = Field(default=None, gt=0)
     points_earned: Optional[float] = Field(default=None, ge=0)
     due_date: Optional[str] = None
-    assignment_type: Optional[str] = None
+    assignment_type: Optional[AssignmentType] = None
     notes: Optional[str] = None
 
 
@@ -407,12 +418,23 @@ class LetterScaleTier(BaseModel):
 
 class SetLetterScaleBody(BaseModel):
     user_id: str
+    semester: Optional[str] = None
     scale: Optional[list[LetterScaleTier]] = None  # null clears the override
+
+
+class SetCurveBody(BaseModel):
+    """Per-enrollment bell-curve policy (enrollments.curve_*)."""
+    user_id: str
+    semester: Optional[str] = None
+    curve_mode: Literal["raw", "curved"] = "raw"
+    curve_avg_target: Optional[float] = None
+    curve_sd_delta: Optional[float] = None
 
 
 class SyllabusApplyBody(BaseModel):
     user_id: str
     course_id: str
+    semester: Optional[str] = None
     doc_id: str
     categories: list[CategoryItem]
     assignments: list[dict]               # uses the same shape as syllabus extraction

--- a/backend/routes/gradebook.py
+++ b/backend/routes/gradebook.py
@@ -1,8 +1,19 @@
 """
 backend/routes/gradebook.py
 
-User-driven gradebook: categories with weights, graded assignments,
-per-course letter-scale override, syllabus-apply.
+User-driven gradebook, semester-aware on the academics-split schema.
+
+The public API still speaks the **abstract** ``course_id`` plus an optional
+``semester`` (a term label, default = current term). Internally we resolve
+``(course_id, semester)`` to the user's **enrollment** (one offering of the
+course in that term) and key categories/assignments on ``enrollment_id``.
+
+- gradebook_categories / assignments key on enrollment_id (no user_id/course_id).
+- points_possible/points_earned/notes stay 🔒 TEXT: encrypt at write, decrypt at read.
+- bell-curve (enrollments.curve_*) + drop-lowest (gradebook_categories.drop_lowest)
+  feed the weighted-score computation in services/gradebook_service.py.
+- GPA: per-semester (one term) and cumulative/transcript (credit-weighted across
+  all the user's offerings of all enrolled courses).
 """
 from __future__ import annotations
 
@@ -17,162 +28,290 @@ from models import (
     CreateAssignmentBody,
     UpdateAssignmentBody,
     SetLetterScaleBody,
+    SetCurveBody,
     SyllabusApplyBody,
 )
-from services import gradebook_service
+from services import academics, gradebook_service
 from services.auth_guard import require_self
 from services.encryption import encrypt_if_present, decrypt_if_present, decrypt_numeric
 
 router = APIRouter()
 
 
-def _user_owns_course(user_id: str, course_id: str) -> bool:
-    rows = table("user_courses").select(
-        "id",
-        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
-        limit=1,
+# ── Enrollment resolution ────────────────────────────────────────────────────
+
+def _term_id_for_semester(semester: str | None) -> str | None:
+    """Map a `semester` query value to a term id.
+
+    `semester` is a term **label** (e.g. "Spring 2026"); fall back to treating
+    it as a term id directly. None → None (caller defaults to current term).
+    """
+    if not semester:
+        return None
+    rows = table("terms").select(
+        "id", filters={"label": f"eq.{semester}"}, limit=1
     )
-    return bool(rows)
+    if rows:
+        return rows[0]["id"]
+    # Maybe the caller already passed a term id.
+    rows = table("terms").select("id", filters={"id": f"eq.{semester}"}, limit=1)
+    return rows[0]["id"] if rows else None
 
 
-def _user_owns_category(user_id: str, category_id: str) -> dict | None:
-    rows = table("course_categories").select(
-        "id,user_id,course_id,name,weight,sort_order",
-        filters={"id": f"eq.{category_id}", "user_id": f"eq.{user_id}"},
+def _resolve_enrollment(user_id: str, course_id: str, semester: str | None) -> dict | None:
+    """Resolve (user, abstract course, term) → the user's enrollment row.
+
+    Intersect the user's offerings of the course with the target term:
+    - if `semester` is given, pick the offering in that term;
+    - else default to the current term's offering, falling back to the only /
+      most-recent offering the user has for the course.
+    Returns the full enrollments row (curve_*, letter_scale, syllabus_doc_id,
+    offering_id) or None when the user has no matching enrollment.
+    """
+    offering_ids = academics.user_offering_ids_for_course(user_id, course_id)
+    if not offering_ids:
+        return None
+
+    target_term_id = _term_id_for_semester(semester)
+    if target_term_id is None and semester is None:
+        cur = academics.current_term()
+        target_term_id = cur["id"] if cur else None
+
+    chosen_offering: str | None = None
+    if target_term_id:
+        for oid in offering_ids:
+            t = academics.term_for_offering(oid)
+            if t and t.get("id") == target_term_id:
+                chosen_offering = oid
+                break
+    # No term match (or no term resolvable): fall back to the only offering, so
+    # single-section courses keep working without a semester param.
+    if chosen_offering is None and semester is None and len(offering_ids) == 1:
+        chosen_offering = offering_ids[0]
+    if chosen_offering is None:
+        return None
+
+    rows = table("enrollments").select(
+        "id,user_id,offering_id,letter_scale,syllabus_doc_id,"
+        "curve_mode,curve_avg_target,curve_sd_delta",
+        filters={"user_id": f"eq.{user_id}", "offering_id": f"eq.{chosen_offering}"},
         limit=1,
     )
     return rows[0] if rows else None
 
 
+def _course_meta(offering_id: str) -> dict:
+    """Abstract course code/name + credits + term label for an offering."""
+    course_id = academics.offering_course_id(offering_id)
+    course = {}
+    if course_id:
+        rows = table("courses").select(
+            "id,course_code,course_name,credits",
+            filters={"id": f"eq.{course_id}"},
+            limit=1,
+        )
+        course = rows[0] if rows else {}
+    term = academics.term_for_offering(offering_id) or {}
+    return {
+        "course_id": course_id,
+        "course_code": course.get("course_code"),
+        "course_name": course.get("course_name"),
+        "credits": course.get("credits"),
+        "semester": term.get("label"),
+    }
+
+
+def _load_categories(enrollment_id: str, order: str | None = None) -> list[dict]:
+    return table("gradebook_categories").select(
+        "id,enrollment_id,name,weight,sort_order,drop_lowest",
+        filters={"enrollment_id": f"eq.{enrollment_id}"},
+        order=order or "sort_order.asc",
+    )
+
+
+def _load_assignments(enrollment_id: str, *, order: str | None = None, decrypt: bool = True) -> list[dict]:
+    assigns = table("assignments").select(
+        "id,enrollment_id,category_id,title,due_date,assignment_type,"
+        "points_possible,points_earned,notes,source,"
+        "curve_class_mean,curve_class_sd",
+        filters={"enrollment_id": f"eq.{enrollment_id}"},
+        order=order or "due_date.asc",
+    )
+    if decrypt:
+        for a in assigns:
+            a["points_possible"] = decrypt_numeric(a.get("points_possible"))
+            a["points_earned"] = decrypt_numeric(a.get("points_earned"))
+            a["notes"] = decrypt_if_present(a.get("notes"))
+    return assigns
+
+
+def _enrollment_grade(enr: dict, cats: list[dict], assigns: list[dict]):
+    """Computed (percent, letter) for an enrollment, applying curve + drop-lowest."""
+    percent = gradebook_service.current_grade(
+        cats,
+        assigns,
+        curve_mode=enr.get("curve_mode") or "raw",
+        curve_avg_target=enr.get("curve_avg_target"),
+        curve_sd_delta=enr.get("curve_sd_delta"),
+    )
+    letter = gradebook_service.letter_for(percent, enr.get("letter_scale"))
+    return percent, letter
+
+
+def _owned_category(user_id: str, category_id: str) -> dict | None:
+    """A gradebook_category by id whose enrollment belongs to `user_id`."""
+    rows = table("gradebook_categories").select(
+        "id,enrollment_id,name,weight,sort_order,drop_lowest",
+        filters={"id": f"eq.{category_id}"},
+        limit=1,
+    )
+    if not rows:
+        return None
+    cat = rows[0]
+    enr = table("enrollments").select(
+        "id,user_id",
+        filters={"id": f"eq.{cat['enrollment_id']}", "user_id": f"eq.{user_id}"},
+        limit=1,
+    )
+    return cat if enr else None
+
+
+def _owned_assignment(user_id: str, assignment_id: str) -> dict | None:
+    rows = table("assignments").select(
+        "id,enrollment_id,category_id",
+        filters={"id": f"eq.{assignment_id}"},
+        limit=1,
+    )
+    if not rows:
+        return None
+    a = rows[0]
+    if not a.get("enrollment_id"):
+        return None
+    enr = table("enrollments").select(
+        "id,user_id",
+        filters={"id": f"eq.{a['enrollment_id']}", "user_id": f"eq.{user_id}"},
+        limit=1,
+    )
+    return a if enr else None
+
+
+# ── GET /summary ─────────────────────────────────────────────────────────────
+
 @router.get("/summary")
 def get_summary(request: Request, user_id: str = Query(...), semester: str = Query(...)):
-    """Return all enrolled courses for the given semester with computed
-    current grade + letter."""
+    """All of the user's enrolled courses for the given semester with computed
+    current grade + letter, plus the term GPA."""
     require_self(user_id, request)
 
-    enrollments = table("user_courses").select(
-        "course_id,letter_scale,courses!inner(id,course_code,course_name,semester)",
-        filters={
-            "user_id": f"eq.{user_id}",
-            "courses.semester": f"eq.{semester}",
-        },
-    )
-    if not enrollments:
-        return {"courses": []}
+    term_id = _term_id_for_semester(semester)
+    if not term_id:
+        return {"courses": [], "gpa": None, "semester": semester}
 
-    course_ids = [e["course_id"] for e in enrollments]
-    in_clause = "in.(" + ",".join(course_ids) + ")"
-
-    cats = table("course_categories").select(
-        "id,user_id,course_id,name,weight,sort_order",
-        filters={"user_id": f"eq.{user_id}", "course_id": in_clause},
-    )
-    assigns = table("assignments").select(
-        "id,course_id,category_id,points_possible,points_earned",
-        filters={"user_id": f"eq.{user_id}", "course_id": in_clause},
-    )
-
-    for a in assigns:
-        a["points_possible"] = decrypt_numeric(a.get("points_possible"))
-        a["points_earned"] = decrypt_numeric(a.get("points_earned"))
-
-    cats_by_course: dict[str, list] = {cid: [] for cid in course_ids}
-    for c in cats:
-        cats_by_course.setdefault(c["course_id"], []).append(c)
-    assigns_by_course: dict[str, list] = {cid: [] for cid in course_ids}
-    for a in assigns:
-        assigns_by_course.setdefault(a["course_id"], []).append(a)
+    enrollments = table("enrollments").select(
+        "id,user_id,offering_id,letter_scale,curve_mode,curve_avg_target,curve_sd_delta",
+        filters={"user_id": f"eq.{user_id}"},
+    ) or []
 
     out = []
-    for e in enrollments:
-        cid = e["course_id"]
-        course = e["courses"]
-        course_assigns = assigns_by_course[cid]
-        graded = [a for a in course_assigns
+    course_grades = []
+    for enr in enrollments:
+        offering_id = enr["offering_id"]
+        term = academics.term_for_offering(offering_id)
+        if not term or term.get("id") != term_id:
+            continue
+        meta = _course_meta(offering_id)
+        cats = _load_categories(enr["id"])
+        assigns = _load_assignments(enr["id"])
+        graded = [a for a in assigns
                   if a.get("points_possible") and a.get("points_earned") is not None]
-        percent = gradebook_service.current_grade(cats_by_course[cid], course_assigns)
-        letter = gradebook_service.letter_for(percent, e.get("letter_scale"))
+        percent, letter = _enrollment_grade(enr, cats, assigns)
         out.append({
-            "course_id": cid,
-            "course_code": course["course_code"],
-            "course_name": course["course_name"],
-            "semester": course["semester"],
+            "course_id": meta["course_id"],
+            "course_code": meta["course_code"],
+            "course_name": meta["course_name"],
+            "semester": meta["semester"],
             "percent": percent,
             "letter": letter,
             "graded_count": len(graded),
-            "total_count": len(course_assigns),
+            "total_count": len(assigns),
         })
-    return {"courses": out}
+        course_grades.append({
+            "grade_points": gradebook_service.gpa_points(percent, enr.get("letter_scale")),
+            "credits": meta.get("credits"),
+        })
 
+    return {
+        "courses": out,
+        "gpa": gradebook_service.weighted_gpa(course_grades),
+        "semester": semester,
+    }
+
+
+# ── GET /courses/{course_id} ─────────────────────────────────────────────────
 
 @router.get("/courses/{course_id}")
-def get_course(course_id: str, request: Request, user_id: str = Query(...)):
-    """Full gradebook for one course: categories, assignments, computed grade."""
+def get_course(
+    course_id: str,
+    request: Request,
+    user_id: str = Query(...),
+    semester: str | None = Query(None),
+):
+    """Full gradebook for one enrollment: categories, assignments, computed grade."""
     require_self(user_id, request)
 
-    enrollment = table("user_courses").select(
-        "course_id,letter_scale,courses!inner(id,course_code,course_name,semester)",
-        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
-        limit=1,
-    )
-    if not enrollment:
+    enr = _resolve_enrollment(user_id, course_id, semester)
+    if not enr:
         raise HTTPException(status_code=404, detail="Course not in your gradebook")
-    course = enrollment[0]["courses"]
-    letter_scale = enrollment[0].get("letter_scale")
 
-    cats = table("course_categories").select(
-        "id,user_id,course_id,name,weight,sort_order",
-        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
-        order="sort_order.asc",
-    )
-    assigns = table("assignments").select(
-        "id,user_id,course_id,category_id,title,due_date,assignment_type,points_possible,points_earned,notes,source",
-        filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
-        order="due_date.asc",
-    )
-    for a in assigns:
-        a["points_possible"] = decrypt_numeric(a.get("points_possible"))
-        a["points_earned"] = decrypt_numeric(a.get("points_earned"))
-        a["notes"] = decrypt_if_present(a.get("notes"))
+    meta = _course_meta(enr["offering_id"])
+    cats = _load_categories(enr["id"])
+    assigns = _load_assignments(enr["id"])
 
-    # Per-category grade for the UI.
+    # Per-category grade for the UI (respects drop_lowest, raw 0–100).
     by_cat: dict[str, list] = {c["id"]: [] for c in cats}
     for a in assigns:
         cid = a.get("category_id")
         if cid in by_cat:
             by_cat[cid].append(a)
     for c in cats:
-        c["category_grade"] = gradebook_service.category_grade(by_cat[c["id"]])
+        c["category_grade"] = gradebook_service.category_grade(
+            by_cat[c["id"]], int(c.get("drop_lowest") or 0)
+        )
 
-    percent = gradebook_service.current_grade(cats, assigns)
-    letter = gradebook_service.letter_for(percent, letter_scale)
+    percent, letter = _enrollment_grade(enr, cats, assigns)
 
     return {
-        "course_id": course["id"],
-        "course_code": course["course_code"],
-        "course_name": course["course_name"],
-        "semester": course["semester"],
+        "course_id": meta["course_id"],
+        "course_code": meta["course_code"],
+        "course_name": meta["course_name"],
+        "semester": meta["semester"],
         "percent": percent,
         "letter": letter,
-        "letter_scale": letter_scale,
+        "letter_scale": enr.get("letter_scale"),
+        "curve_mode": enr.get("curve_mode") or "raw",
+        "curve_avg_target": enr.get("curve_avg_target"),
+        "curve_sd_delta": enr.get("curve_sd_delta"),
         "categories": cats,
         "assignments": assigns,
     }
 
 
+# ── Categories CRUD ──────────────────────────────────────────────────────────
+
 @router.post("/courses/{course_id}/categories")
 def create_category(course_id: str, body: CreateCategoryBody, request: Request):
     require_self(body.user_id, request)
-    if not _user_owns_course(body.user_id, course_id):
+    enr = _resolve_enrollment(body.user_id, course_id, body.semester)
+    if not enr:
         raise HTTPException(status_code=404, detail="Course not in your gradebook")
     new_id = str(uuid.uuid4())
-    inserted = table("course_categories").insert({
+    inserted = table("gradebook_categories").insert({
         "id": new_id,
-        "user_id": body.user_id,
-        "course_id": course_id,
+        "enrollment_id": enr["id"],
         "name": body.name,
         "weight": body.weight,
         "sort_order": 0,
+        "drop_lowest": body.drop_lowest,
     })
     return {"category": inserted[0] if inserted else None}
 
@@ -180,7 +319,8 @@ def create_category(course_id: str, body: CreateCategoryBody, request: Request):
 @router.patch("/courses/{course_id}/categories")
 def bulk_update_categories(course_id: str, body: BulkUpdateCategoriesBody, request: Request):
     require_self(body.user_id, request)
-    if not _user_owns_course(body.user_id, course_id):
+    enr = _resolve_enrollment(body.user_id, course_id, body.semester)
+    if not enr:
         raise HTTPException(status_code=404, detail="Course not in your gradebook")
 
     total = sum(c.weight for c in body.categories)
@@ -193,19 +333,24 @@ def bulk_update_categories(course_id: str, body: BulkUpdateCategoriesBody, reque
     saved = []
     for c in body.categories:
         if c.id:
-            updated = table("course_categories").update(
-                {"name": c.name, "weight": c.weight, "sort_order": c.sort_order},
-                filters={"id": f"eq.{c.id}", "user_id": f"eq.{body.user_id}"},
+            updated = table("gradebook_categories").update(
+                {
+                    "name": c.name,
+                    "weight": c.weight,
+                    "sort_order": c.sort_order,
+                    "drop_lowest": c.drop_lowest,
+                },
+                filters={"id": f"eq.{c.id}", "enrollment_id": f"eq.{enr['id']}"},
             )
             saved.extend(updated)
         else:
-            new = table("course_categories").insert({
+            new = table("gradebook_categories").insert({
                 "id": str(uuid.uuid4()),
-                "user_id": body.user_id,
-                "course_id": course_id,
+                "enrollment_id": enr["id"],
                 "name": c.name,
                 "weight": c.weight,
                 "sort_order": c.sort_order,
+                "drop_lowest": c.drop_lowest,
             })
             saved.extend(new)
     return {"categories": saved}
@@ -214,35 +359,28 @@ def bulk_update_categories(course_id: str, body: BulkUpdateCategoriesBody, reque
 @router.delete("/categories/{category_id}")
 def delete_category(category_id: str, request: Request, user_id: str = Query(...)):
     require_self(user_id, request)
-    cat = _user_owns_category(user_id, category_id)
+    cat = _owned_category(user_id, category_id)
     if not cat:
         raise HTTPException(status_code=404, detail="Category not found")
-    table("course_categories").delete(filters={"id": f"eq.{category_id}"})
+    table("gradebook_categories").delete(filters={"id": f"eq.{category_id}"})
     return {"deleted": True}
 
 
-def _user_owns_assignment(user_id: str, assignment_id: str) -> dict | None:
-    rows = table("assignments").select(
-        "id,user_id,course_id,category_id",
-        filters={"id": f"eq.{assignment_id}", "user_id": f"eq.{user_id}"},
-        limit=1,
-    )
-    return rows[0] if rows else None
-
+# ── Assignments CRUD ─────────────────────────────────────────────────────────
 
 @router.post("/assignments")
 def create_assignment(body: CreateAssignmentBody, request: Request):
     require_self(body.user_id, request)
-    if not _user_owns_course(body.user_id, body.course_id):
+    enr = _resolve_enrollment(body.user_id, body.course_id, body.semester)
+    if not enr:
         raise HTTPException(status_code=404, detail="Course not in your gradebook")
-    if body.category_id and not _user_owns_category(body.user_id, body.category_id):
+    if body.category_id and not _owned_category(body.user_id, body.category_id):
         raise HTTPException(status_code=400, detail="Category not in your gradebook")
 
     new_id = str(uuid.uuid4())
     inserted = table("assignments").insert({
         "id": new_id,
-        "user_id": body.user_id,
-        "course_id": body.course_id,
+        "enrollment_id": enr["id"],
         "title": body.title,
         "category_id": body.category_id,
         "points_possible": encrypt_if_present(body.points_possible),
@@ -266,9 +404,9 @@ def create_assignment(body: CreateAssignmentBody, request: Request):
 @router.patch("/assignments/{assignment_id}")
 def update_assignment_route(assignment_id: str, body: UpdateAssignmentBody, request: Request):
     require_self(body.user_id, request)
-    if not _user_owns_assignment(body.user_id, assignment_id):
+    if not _owned_assignment(body.user_id, assignment_id):
         raise HTTPException(status_code=404, detail="Assignment not found")
-    if body.category_id and not _user_owns_category(body.user_id, body.category_id):
+    if body.category_id and not _owned_category(body.user_id, body.category_id):
         raise HTTPException(status_code=400, detail="Category not in your gradebook")
 
     incoming = body.model_dump(exclude_unset=True, exclude={"user_id"})
@@ -282,7 +420,7 @@ def update_assignment_route(assignment_id: str, body: UpdateAssignmentBody, requ
         return {"updated": False}
     table("assignments").update(
         patch_data,
-        filters={"id": f"eq.{assignment_id}", "user_id": f"eq.{body.user_id}"},
+        filters={"id": f"eq.{assignment_id}"},
     )
     return {"updated": True}
 
@@ -290,27 +428,28 @@ def update_assignment_route(assignment_id: str, body: UpdateAssignmentBody, requ
 @router.delete("/assignments/{assignment_id}")
 def delete_assignment_route(assignment_id: str, request: Request, user_id: str = Query(...)):
     require_self(user_id, request)
-    if not _user_owns_assignment(user_id, assignment_id):
+    if not _owned_assignment(user_id, assignment_id):
         raise HTTPException(status_code=404, detail="Assignment not found")
-    table("assignments").delete(
-        filters={"id": f"eq.{assignment_id}", "user_id": f"eq.{user_id}"},
-    )
+    table("assignments").delete(filters={"id": f"eq.{assignment_id}"})
     return {"deleted": True}
 
 
+# ── POST /syllabus/apply ─────────────────────────────────────────────────────
+
 @router.post("/syllabus/apply")
 def apply_syllabus(body: SyllabusApplyBody, request: Request):
-    """Apply user-confirmed extracted categories + assignments to a course.
+    """Apply user-confirmed extracted categories + assignments to an enrollment.
 
     - Validates weights sum to 100 (±0.5).
-    - Validates the user owns the course AND the document.
-    - Wipes existing categories for (user, course); inserts new ones.
-    - Inserts assignments with source='syllabus', dedupes by (course_id, title, due_date).
-    - Sets user_courses.syllabus_doc_id.
+    - Validates the user owns the enrollment AND the document.
+    - Wipes existing categories for the enrollment; inserts new ones.
+    - Inserts assignments with source='syllabus', dedupes by (title, due_date).
+    - Sets enrollments.syllabus_doc_id.
     - Returns the refreshed course detail.
     """
     require_self(body.user_id, request)
-    if not _user_owns_course(body.user_id, body.course_id):
+    enr = _resolve_enrollment(body.user_id, body.course_id, body.semester)
+    if not enr:
         raise HTTPException(status_code=404, detail="Course not in your gradebook")
 
     doc_rows = table("documents").select(
@@ -329,28 +468,25 @@ def apply_syllabus(body: SyllabusApplyBody, request: Request):
         )
 
     # Wipe + replace categories.
-    table("course_categories").delete(filters={
-        "user_id": f"eq.{body.user_id}",
-        "course_id": f"eq.{body.course_id}",
-    })
+    table("gradebook_categories").delete(filters={"enrollment_id": f"eq.{enr['id']}"})
     new_cats = [
         {
             "id": str(uuid.uuid4()),
-            "user_id": body.user_id,
-            "course_id": body.course_id,
+            "enrollment_id": enr["id"],
             "name": c.name,
             "weight": c.weight,
             "sort_order": c.sort_order,
+            "drop_lowest": c.drop_lowest,
         }
         for c in body.categories
     ]
     if new_cats:
-        table("course_categories").insert(new_cats)
+        table("gradebook_categories").insert(new_cats)
 
-    # Dedupe assignments by (course_id, title, due_date).
+    # Dedupe assignments by (title, due_date) within the enrollment.
     existing = table("assignments").select(
         "title,due_date",
-        filters={"user_id": f"eq.{body.user_id}", "course_id": f"eq.{body.course_id}"},
+        filters={"enrollment_id": f"eq.{enr['id']}"},
     )
     seen = {(e.get("title", ""), e.get("due_date") or "") for e in existing}
     new_assigns = []
@@ -362,8 +498,7 @@ def apply_syllabus(body: SyllabusApplyBody, request: Request):
         seen.add((title, due))
         new_assigns.append({
             "id": str(uuid.uuid4()),
-            "user_id": body.user_id,
-            "course_id": body.course_id,
+            "enrollment_id": enr["id"],
             "title": title,
             "due_date": a.get("due_date"),
             "assignment_type": a.get("assignment_type"),
@@ -377,20 +512,23 @@ def apply_syllabus(body: SyllabusApplyBody, request: Request):
         table("assignments").insert(new_assigns)
 
     # Stamp the doc id on the enrollment.
-    table("user_courses").update(
+    table("enrollments").update(
         {"syllabus_doc_id": body.doc_id},
-        filters={"user_id": f"eq.{body.user_id}", "course_id": f"eq.{body.course_id}"},
+        filters={"id": f"eq.{enr['id']}"},
     )
 
     # Return the refreshed course payload so the client can swap state in.
-    refreshed = get_course(body.course_id, request, user_id=body.user_id)
+    refreshed = get_course(body.course_id, request, user_id=body.user_id, semester=body.semester)
     return {"course": refreshed}
 
+
+# ── PATCH /courses/{course_id}/scale ─────────────────────────────────────────
 
 @router.patch("/courses/{course_id}/scale")
 def set_letter_scale(course_id: str, body: SetLetterScaleBody, request: Request):
     require_self(body.user_id, request)
-    if not _user_owns_course(body.user_id, course_id):
+    enr = _resolve_enrollment(body.user_id, course_id, body.semester)
+    if not enr:
         raise HTTPException(status_code=404, detail="Course not in your gradebook")
 
     scale_payload = None
@@ -405,8 +543,78 @@ def set_letter_scale(course_id: str, body: SetLetterScaleBody, request: Request)
             prev_min = tier.min
         scale_payload = [tier.model_dump() for tier in body.scale]
 
-    table("user_courses").update(
+    table("enrollments").update(
         {"letter_scale": scale_payload},
-        filters={"user_id": f"eq.{body.user_id}", "course_id": f"eq.{course_id}"},
+        filters={"id": f"eq.{enr['id']}"},
     )
     return {"updated": True, "letter_scale": scale_payload}
+
+
+# ── PATCH /courses/{course_id}/curve ─────────────────────────────────────────
+
+@router.patch("/courses/{course_id}/curve")
+def set_curve(course_id: str, body: SetCurveBody, request: Request):
+    """Set the per-enrollment bell-curve policy (enrollments.curve_*)."""
+    require_self(body.user_id, request)
+    enr = _resolve_enrollment(body.user_id, course_id, body.semester)
+    if not enr:
+        raise HTTPException(status_code=404, detail="Course not in your gradebook")
+
+    payload = {
+        "curve_mode": body.curve_mode,
+        "curve_avg_target": body.curve_avg_target,
+        "curve_sd_delta": body.curve_sd_delta,
+    }
+    table("enrollments").update(payload, filters={"id": f"eq.{enr['id']}"})
+    return {"updated": True, **payload}
+
+
+# ── GET /gpa ─────────────────────────────────────────────────────────────────
+
+@router.get("/gpa")
+def get_gpa(request: Request, user_id: str = Query(...), semester: str | None = Query(None)):
+    """Credit-weighted GPA.
+
+    Without `semester`: cumulative/transcript GPA across **all** the user's
+    offerings of all enrolled courses (all terms). With `semester`: the GPA for
+    that one term only. Returns per-course grade points + the overall GPA.
+    """
+    require_self(user_id, request)
+
+    term_id = _term_id_for_semester(semester) if semester else None
+
+    enrollments = table("enrollments").select(
+        "id,user_id,offering_id,letter_scale,curve_mode,curve_avg_target,curve_sd_delta",
+        filters={"user_id": f"eq.{user_id}"},
+    ) or []
+
+    courses = []
+    course_grades = []
+    for enr in enrollments:
+        offering_id = enr["offering_id"]
+        if term_id:
+            term = academics.term_for_offering(offering_id)
+            if not term or term.get("id") != term_id:
+                continue
+        meta = _course_meta(offering_id)
+        cats = _load_categories(enr["id"])
+        assigns = _load_assignments(enr["id"])
+        percent, letter = _enrollment_grade(enr, cats, assigns)
+        gp = gradebook_service.gpa_points(percent, enr.get("letter_scale"))
+        courses.append({
+            "course_id": meta["course_id"],
+            "course_code": meta["course_code"],
+            "semester": meta["semester"],
+            "credits": meta.get("credits"),
+            "percent": percent,
+            "letter": letter,
+            "grade_points": gp,
+        })
+        course_grades.append({"grade_points": gp, "credits": meta.get("credits")})
+
+    return {
+        "gpa": gradebook_service.weighted_gpa(course_grades),
+        "courses": courses,
+        "semester": semester,
+        "scope": "semester" if term_id else "cumulative",
+    }

--- a/backend/services/gradebook_service.py
+++ b/backend/services/gradebook_service.py
@@ -3,17 +3,22 @@ Pure functions for gradebook math.
 
 No Supabase or HTTP coupling — routes pass in plain rows/dicts and get back
 plain dicts. Keeps the calc logic trivially testable.
+
+This module is schema-agnostic: it never sees ``user_id`` / ``course_id`` /
+``enrollment_id``. The routes resolve the enrollment and hand the math layer
+plain category + assignment rows plus the enrollment's curve policy.
 """
 from __future__ import annotations
 
 from typing import Iterable, Optional, TypedDict
 
 
-class CategoryRow(TypedDict):
+class CategoryRow(TypedDict, total=False):
     id: str
     name: str
     weight: float
     sort_order: int
+    drop_lowest: int
 
 
 class AssignmentRow(TypedDict, total=False):
@@ -40,15 +45,40 @@ DEFAULT_LETTER_SCALE: list[tuple[float, str]] = [
     (0.0,  "F"),
 ]
 
+# Standard letter → 4.0-scale grade points (US GPA convention).
+LETTER_GRADE_POINTS: dict[str, float] = {
+    "A+": 4.0,
+    "A": 4.0,
+    "A-": 3.7,
+    "B+": 3.3,
+    "B": 3.0,
+    "B-": 2.7,
+    "C+": 2.3,
+    "C": 2.0,
+    "C-": 1.7,
+    "D+": 1.3,
+    "D": 1.0,
+    "D-": 0.7,
+    "F": 0.0,
+}
 
-def category_grade(items: Iterable[AssignmentRow]) -> Optional[float]:
+
+def category_grade(
+    items: Iterable[AssignmentRow],
+    drop_lowest: int = 0,
+) -> Optional[float]:
     """Return the 0–1 grade for one category, or None if no graded items.
 
     A graded item has both points_possible (> 0) and points_earned (not None).
     Sums earned / sums possible across graded items.
+
+    Drop-lowest policy (gradebook_categories.drop_lowest): if ``drop_lowest > 0``,
+    the N graded items with the lowest per-item ratio (earned/possible) are
+    discarded before summing. If ``drop_lowest`` is >= the number of graded
+    items the category has no contributing items and returns None (so it drops
+    out of the weighted average and its weight is renormalized away).
     """
-    total_possible = 0.0
-    total_earned = 0.0
+    graded = []
     for item in items:
         possible = item.get("points_possible")
         earned = item.get("points_earned")
@@ -56,24 +86,100 @@ def category_grade(items: Iterable[AssignmentRow]) -> Optional[float]:
             continue
         if possible <= 0:
             continue
-        total_possible += float(possible)
-        total_earned += float(earned)
+        graded.append((float(possible), float(earned)))
+
+    if not graded:
+        return None
+
+    if drop_lowest and drop_lowest > 0:
+        # Drop the N items with the lowest earned/possible ratio.
+        graded.sort(key=lambda pe: pe[1] / pe[0])
+        graded = graded[drop_lowest:]
+        if not graded:
+            return None
+
+    total_possible = sum(p for p, _ in graded)
+    total_earned = sum(e for _, e in graded)
     if total_possible == 0:
         return None
     return total_earned / total_possible
 
 
+def apply_curve(
+    raw_percent: Optional[float],
+    *,
+    class_mean: Optional[float],
+    class_sd: Optional[float],
+    avg_target: Optional[float],
+    sd_delta: Optional[float],
+) -> Optional[float]:
+    """Linear z-score bell-curve rescale of a 0–100 percent.
+
+    The curve recenters the class distribution on ``avg_target`` and optionally
+    re-scales its spread by ``sd_delta`` (a delta added to the class standard
+    deviation — negative tightens the spread, positive widens it)::
+
+        new_sd = class_sd + sd_delta
+        curved = avg_target + (raw - class_mean) * (new_sd / class_sd)
+        curved = clamp(curved, 0, 100)
+
+    The student keeps their position relative to the class mean but the whole
+    distribution slides so the class average lands on ``avg_target``.
+
+    Degenerate inputs fall back to ``raw_percent`` (no curve) so a missing or
+    zero class SD, or a missing target, can never blow up or zero out a grade.
+    """
+    if raw_percent is None:
+        return None
+    if avg_target is None or class_mean is None:
+        return raw_percent
+    if not class_sd:  # None or 0 — can't rescale spread; just return raw.
+        return raw_percent
+    new_sd = float(class_sd) + float(sd_delta or 0.0)
+    curved = float(avg_target) + (raw_percent - float(class_mean)) * (new_sd / float(class_sd))
+    return max(0.0, min(100.0, curved))
+
+
+def _class_stats_from_assignments(
+    assignments: Iterable[AssignmentRow],
+) -> tuple[Optional[float], Optional[float]]:
+    """Average the per-assignment class mean / class sd carried on assignment
+    rows (curve_class_mean / curve_class_sd, plaintext NUMERIC). Returns
+    (mean, sd) using the mean of the present values, or (None, None) when no
+    assignment carries stats. Lets an enrollment-level curve borrow class stats
+    that the (out-of-scope) gradescope sync stamps per assignment.
+    """
+    means = [float(a["curve_class_mean"]) for a in assignments
+             if a.get("curve_class_mean") is not None]
+    sds = [float(a["curve_class_sd"]) for a in assignments
+           if a.get("curve_class_sd") is not None]
+    mean = sum(means) / len(means) if means else None
+    sd = sum(sds) / len(sds) if sds else None
+    return mean, sd
+
+
 def current_grade(
     categories: list[CategoryRow],
     assignments: Iterable[AssignmentRow],
+    *,
+    curve_mode: str = "raw",
+    curve_avg_target: Optional[float] = None,
+    curve_sd_delta: Optional[float] = None,
 ) -> Optional[float]:
     """Return the 0–100 current grade across all categories, or None.
 
-    For each category with at least one graded item, computes the
-    category_grade and weights it by the category's weight. Categories
-    with no graded items drop out — total weight is renormalized so the
-    contributing weights sum to 100.
+    For each category with at least one graded item (after applying the
+    category's ``drop_lowest``), computes the category_grade and weights it by
+    the category's weight. Categories with no contributing graded items drop
+    out — total weight is renormalized so the contributing weights sum to 100.
+
+    When ``curve_mode == 'curved'`` the final weighted percent is run through
+    ``apply_curve`` using the enrollment-level ``curve_avg_target`` /
+    ``curve_sd_delta`` policy against the class mean/sd derived from the
+    assignments' per-assignment curve stats. If no class stats are available
+    the curve degenerates to a no-op (raw percent).
     """
+    assignments = list(assignments)
     by_cat: dict[str, list[AssignmentRow]] = {c["id"]: [] for c in categories}
     for a in assignments:
         cid = a.get("category_id")
@@ -83,7 +189,7 @@ def current_grade(
     total_weight = 0.0
     weighted_sum = 0.0
     for cat in categories:
-        grade = category_grade(by_cat[cat["id"]])
+        grade = category_grade(by_cat[cat["id"]], int(cat.get("drop_lowest") or 0))
         if grade is None:
             continue
         total_weight += float(cat["weight"])
@@ -91,7 +197,18 @@ def current_grade(
 
     if total_weight == 0:
         return None
-    return (weighted_sum / total_weight) * 100.0
+    raw = (weighted_sum / total_weight) * 100.0
+
+    if curve_mode == "curved":
+        class_mean, class_sd = _class_stats_from_assignments(assignments)
+        return apply_curve(
+            raw,
+            class_mean=class_mean,
+            class_sd=class_sd,
+            avg_target=curve_avg_target,
+            sd_delta=curve_sd_delta,
+        )
+    return raw
 
 
 def letter_for(percent: Optional[float], scale: Optional[list[dict]]) -> Optional[str]:
@@ -112,3 +229,46 @@ def letter_for(percent: Optional[float], scale: Optional[list[dict]]) -> Optiona
         if percent >= floor:
             return letter
     return None
+
+
+def gpa_points(
+    percent: Optional[float],
+    scale: Optional[list[dict]] = None,
+) -> Optional[float]:
+    """Map a 0–100 percentage to 4.0-scale grade points, or None.
+
+    Resolves the letter via ``letter_for`` (custom or default scale), then maps
+    the letter through the standard LETTER_GRADE_POINTS table. Unknown letters
+    (e.g. from an exotic custom scale) fall back to None so they don't silently
+    score 0.0 into a GPA.
+    """
+    letter = letter_for(percent, scale)
+    if letter is None:
+        return None
+    return LETTER_GRADE_POINTS.get(letter)
+
+
+def weighted_gpa(course_grades: Iterable[dict]) -> Optional[float]:
+    """Credit-weighted GPA across courses, or None when nothing contributes.
+
+    ``course_grades`` items: {"grade_points": float | None, "credits": number}.
+    Entries with ``grade_points is None`` (ungraded) are skipped. Credits
+    default to 1 when null/zero so a course always counts at least once::
+
+        gpa = Σ(grade_points_i * credits_i) / Σ credits_i
+    """
+    total_credits = 0.0
+    total_points = 0.0
+    for cg in course_grades:
+        gp = cg.get("grade_points")
+        if gp is None:
+            continue
+        credits = cg.get("credits")
+        c = float(credits) if credits else 1.0
+        if c <= 0:
+            c = 1.0
+        total_credits += c
+        total_points += float(gp) * c
+    if total_credits == 0:
+        return None
+    return total_points / total_credits

--- a/backend/tests/test_gradebook_routes.py
+++ b/backend/tests/test_gradebook_routes.py
@@ -1,6 +1,18 @@
-"""Route tests for /api/gradebook/* — exercise the real Pydantic + service code,
-mock only the Supabase `table()` boundary."""
-from unittest.mock import patch, MagicMock
+"""Route tests for /api/gradebook/* on the enrollment-keyed (academics-split)
+schema.
+
+The gradebook resolves the abstract ``course_id`` + an optional ``semester``
+(term label) to the user's **enrollment** via ``services.academics``, then keys
+``gradebook_categories`` / ``assignments`` on ``enrollment_id``.
+
+Both ``routes.gradebook.table`` and ``services.academics.table`` are patched with
+one shared, **filter-aware** fake so the resolver's multi-table queries (terms,
+course_offerings, enrollments) and the route's gradebook queries all resolve
+against the same canned dataset. Mocks live only at the ``table()`` boundary;
+the real Pydantic + service + resolver code runs.
+"""
+import copy
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -11,48 +23,122 @@ from main import app
 client = TestClient(app)
 
 
-def _mock_self():
-    """Bypass require_self auth in tests."""
-    return patch("routes.gradebook.require_self", return_value=None)
+# ── Filter-aware fake table() ────────────────────────────────────────────────
 
-
-def _mock_table_rows(rows_by_table):
-    """Return a side_effect for `db.connection.table` that returns canned rows.
-
-    rows_by_table: {"users": [...], "courses": [...], ...}
-    Each `select(...)` call returns the rows for that table; `insert`,
-    `update`, `delete` echo the data back.
+class _FakeTable:
+    """A `table(name)` stand-in that filters canned rows by the PostgREST
+    `eq.`/`in.()` filters the resolver + routes pass, so the same table can be
+    queried with different filters within one request and return the right rows.
+    Records insert/update/delete for assertions; echoes payloads back like the
+    real REST representation.
     """
-    def factory(name):
-        m = MagicMock()
-        m.select.return_value = rows_by_table.get(name, [])
-        m.insert.side_effect = lambda d: [d] if isinstance(d, dict) else d
-        m.update.side_effect = lambda d, filters: [d]
-        m.delete.return_value = []
-        return m
-    return factory
+
+    def __init__(self, name, rows, recorder):
+        self.name = name
+        self.rows = rows
+        self.recorder = recorder
+
+    def _match(self, row, filters):
+        for col, expr in (filters or {}).items():
+            if col in ("or",):  # unsupported here; treat as no-op pass
+                continue
+            if expr.startswith("eq."):
+                if str(row.get(col)) != expr[3:]:
+                    return False
+            elif expr.startswith("in."):
+                inner = expr[len("in.("):-1]
+                wanted = set(inner.split(",")) if inner else set()
+                if str(row.get(col)) not in wanted:
+                    return False
+        return True
+
+    def select(self, _cols="*", filters=None, order=None, limit=None):
+        out = [dict(r) for r in self.rows if self._match(r, filters)]
+        if limit is not None:
+            out = out[:limit]
+        return out
+
+    def insert(self, data):
+        # Snapshot the payload at write time — the route may mutate the returned
+        # row in place (e.g. decrypt points back for the client response), and we
+        # want the recorder to reflect what was actually stored (ciphertext).
+        self.recorder.append((self.name, "insert", copy.deepcopy(data)))
+        return [data] if isinstance(data, dict) else data
+
+    def update(self, data, filters=None):
+        self.recorder.append((self.name, "update", data))
+        return [data]
+
+    def delete(self, filters=None):
+        self.recorder.append((self.name, "delete", filters))
+        return []
+
+
+def _factory(rows_by_table, recorder):
+    def make(name):
+        return _FakeTable(name, rows_by_table.get(name, []), recorder)
+    return make
+
+
+def _patched(rows_by_table, recorder=None):
+    """Patch the table() boundary in both the route and the resolver."""
+    recorder = recorder if recorder is not None else []
+    f = _factory(rows_by_table, recorder)
+    return (
+        patch("routes.gradebook.require_self", return_value=None),
+        patch("routes.gradebook.table", side_effect=f),
+        patch("services.academics.table", side_effect=f),
+        recorder,
+    )
+
+
+# A canonical current-term dataset: user u1 enrolled in CS161 (offering off1,
+# term spring-2026 which contains today's seed date). Today (2026-06-24) sits in
+# summer-2026, but the resolver falls back to the single offering when no
+# semester is given, so off1 still resolves.
+def _base_rows():
+    return {
+        "terms": [
+            {"id": "spring-2026", "label": "Spring 2026", "start_date": "2026-01-05",
+             "end_date": "2026-05-17", "sort_key": 20261},
+            {"id": "fall-2026", "label": "Fall 2026", "start_date": "2026-08-24",
+             "end_date": "2027-01-03", "sort_key": 20263},
+        ],
+        "courses": [
+            {"id": "cs161", "course_code": "CS 161", "course_name": "Intro CS", "credits": 3},
+        ],
+        "course_offerings": [
+            {"id": "off1", "course_id": "cs161", "term_id": "spring-2026"},
+        ],
+        "enrollments": [
+            {"id": "enr1", "user_id": "u1", "offering_id": "off1", "letter_scale": None,
+             "curve_mode": "raw", "curve_avg_target": None, "curve_sd_delta": None,
+             "syllabus_doc_id": None},
+        ],
+    }
 
 
 # ── GET /summary ─────────────────────────────────────────────────────────────
 
 class TestSummary:
-    def test_returns_courses_with_computed_grades(self):
-        enrolled = [
-            {"course_id": "cs161", "letter_scale": None, "courses": {
-                "id": "cs161", "course_code": "CS 161", "course_name": "Intro CS",
-                "semester": "Spring 2026"}},
+    def test_returns_courses_with_computed_grades_and_gpa(self):
+        rows = _base_rows()
+        rows["gradebook_categories"] = [
+            {"id": "exams", "enrollment_id": "enr1", "name": "Exams", "weight": 100,
+             "sort_order": 0, "drop_lowest": 0},
         ]
-        cats = [{"id": "exams", "course_id": "cs161", "name": "Exams", "weight": 100, "sort_order": 0}]
-        assigns = [
-            {"id": "a1", "course_id": "cs161", "title": "Midterm", "category_id": "exams",
-             "points_possible": 100, "points_earned": 90},
+        rows["assignments"] = [
+            {"id": "a1", "enrollment_id": "enr1", "title": "Midterm", "category_id": "exams",
+             "points_possible": 90.0, "points_earned": None, "due_date": None,
+             "assignment_type": "exam", "notes": None, "source": "manual",
+             "curve_class_mean": None, "curve_class_sd": None},
+            {"id": "a2", "enrollment_id": "enr1", "title": "Final", "category_id": "exams",
+             "points_possible": 100.0, "points_earned": 90.0, "due_date": None,
+             "assignment_type": "exam", "notes": None, "source": "manual",
+             "curve_class_mean": None, "curve_class_sd": None},
         ]
-        rows = {
-            "user_courses": enrolled,
-            "course_categories": cats,
-            "assignments": assigns,
-        }
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
             r = client.get("/api/gradebook/summary",
                            params={"user_id": "u1", "semester": "Spring 2026"})
         assert r.status_code == 200
@@ -60,41 +146,46 @@ class TestSummary:
         assert len(body["courses"]) == 1
         c = body["courses"][0]
         assert c["course_code"] == "CS 161"
+        # decrypt_numeric passes plain floats through; 90/100 graded = 90%.
         assert c["percent"] == pytest.approx(90.0)
         assert c["letter"] == "A-"
         assert c["graded_count"] == 1
-        assert c["total_count"] == 1
+        assert c["total_count"] == 2
+        # term GPA: A- (3.7), single 3-credit course → 3.7
+        assert body["gpa"] == pytest.approx(3.7)
+
+    def test_unknown_semester_returns_empty(self):
+        rs, t1, t2, _ = _patched(_base_rows())
+        with rs, t1, t2:
+            r = client.get("/api/gradebook/summary",
+                           params={"user_id": "u1", "semester": "Winter 1999"})
+        assert r.status_code == 200
+        assert r.json()["courses"] == []
 
 
 # ── GET /courses/{course_id} ─────────────────────────────────────────────────
 
 class TestCourseDetail:
     def test_returns_categories_assignments_and_overall(self):
-        enrollment = [{"course_id": "cs161", "letter_scale": None,
-                       "courses": {"id": "cs161", "course_code": "CS 161",
-                                   "course_name": "Intro CS", "semester": "Spring 2026"}}]
-        cats = [
-            {"id": "exams", "course_id": "cs161", "user_id": "u1",
-             "name": "Exams", "weight": 60, "sort_order": 0},
-            {"id": "psets", "course_id": "cs161", "user_id": "u1",
-             "name": "P-Sets", "weight": 40, "sort_order": 1},
+        rows = _base_rows()
+        rows["gradebook_categories"] = [
+            {"id": "exams", "enrollment_id": "enr1", "name": "Exams", "weight": 60,
+             "sort_order": 0, "drop_lowest": 0},
+            {"id": "psets", "enrollment_id": "enr1", "name": "P-Sets", "weight": 40,
+             "sort_order": 1, "drop_lowest": 0},
         ]
-        assigns = [
-            {"id": "a1", "user_id": "u1", "course_id": "cs161", "title": "Midterm",
-             "category_id": "exams", "points_possible": 100, "points_earned": 80,
-             "due_date": "2026-03-10", "assignment_type": "exam", "notes": None,
-             "source": "manual"},
-            {"id": "a2", "user_id": "u1", "course_id": "cs161", "title": "P-Set 1",
-             "category_id": "psets", "points_possible": 100, "points_earned": 100,
-             "due_date": "2026-02-01", "assignment_type": "homework", "notes": None,
-             "source": "manual"},
+        rows["assignments"] = [
+            {"id": "a1", "enrollment_id": "enr1", "title": "Midterm", "category_id": "exams",
+             "points_possible": 100.0, "points_earned": 80.0, "due_date": "2026-03-10",
+             "assignment_type": "exam", "notes": None, "source": "manual",
+             "curve_class_mean": None, "curve_class_sd": None},
+            {"id": "a2", "enrollment_id": "enr1", "title": "P-Set 1", "category_id": "psets",
+             "points_possible": 100.0, "points_earned": 100.0, "due_date": "2026-02-01",
+             "assignment_type": "homework", "notes": None, "source": "manual",
+             "curve_class_mean": None, "curve_class_sd": None},
         ]
-        rows = {
-            "user_courses": enrollment,
-            "course_categories": cats,
-            "assignments": assigns,
-        }
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
             r = client.get("/api/gradebook/courses/cs161", params={"user_id": "u1"})
         assert r.status_code == 200
         body = r.json()
@@ -104,10 +195,37 @@ class TestCourseDetail:
         assert body["letter"] == "B+"
         assert {c["name"] for c in body["categories"]} == {"Exams", "P-Sets"}
         assert len(body["assignments"]) == 2
+        assert body["curve_mode"] == "raw"
+
+    def test_curved_course_applies_bell_curve(self):
+        rows = _base_rows()
+        rows["enrollments"] = [
+            {"id": "enr1", "user_id": "u1", "offering_id": "off1", "letter_scale": None,
+             "curve_mode": "curved", "curve_avg_target": 80.0, "curve_sd_delta": 0.0,
+             "syllabus_doc_id": None},
+        ]
+        rows["gradebook_categories"] = [
+            {"id": "exams", "enrollment_id": "enr1", "name": "Exams", "weight": 100,
+             "sort_order": 0, "drop_lowest": 0},
+        ]
+        rows["assignments"] = [
+            {"id": "a1", "enrollment_id": "enr1", "title": "Exam", "category_id": "exams",
+             "points_possible": 100.0, "points_earned": 70.0, "due_date": None,
+             "assignment_type": "exam", "notes": None, "source": "manual",
+             "curve_class_mean": 60.0, "curve_class_sd": 10.0},
+        ]
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
+            r = client.get("/api/gradebook/courses/cs161", params={"user_id": "u1"})
+        assert r.status_code == 200
+        # raw 70 → curved 80 + (70-60)*(10/10) = 90
+        assert r.json()["percent"] == pytest.approx(90.0)
 
     def test_404_when_user_not_enrolled(self):
-        rows = {"user_courses": []}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rows = _base_rows()
+        rows["enrollments"] = []
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
             r = client.get("/api/gradebook/courses/nope", params={"user_id": "u1"})
         assert r.status_code == 404
 
@@ -116,18 +234,23 @@ class TestCourseDetail:
 
 class TestCategories:
     def test_create_one_category(self):
-        rows = {"user_courses": [{"id": "uc1"}]}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, rec = _patched(_base_rows())
+        with rs, t1, t2:
             r = client.post(
                 "/api/gradebook/courses/cs161/categories",
-                json={"user_id": "u1", "name": "Exams", "weight": 40},
+                json={"user_id": "u1", "name": "Exams", "weight": 40, "drop_lowest": 1},
             )
         assert r.status_code == 200
-        assert r.json()["category"]["name"] == "Exams"
+        cat = r.json()["category"]
+        assert cat["name"] == "Exams"
+        assert cat["enrollment_id"] == "enr1"
+        assert cat["drop_lowest"] == 1
 
     def test_create_rejects_unknown_course(self):
-        rows = {"user_courses": []}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rows = _base_rows()
+        rows["enrollments"] = []
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
             r = client.post(
                 "/api/gradebook/courses/cs999/categories",
                 json={"user_id": "u1", "name": "Exams", "weight": 40},
@@ -135,7 +258,6 @@ class TestCategories:
         assert r.status_code == 404
 
     def test_bulk_update_validates_weight_total(self):
-        rows = {"user_courses": [{"id": "uc1"}]}
         body = {
             "user_id": "u1",
             "categories": [
@@ -143,77 +265,133 @@ class TestCategories:
                 {"id": "psets", "name": "P-Sets", "weight": 30, "sort_order": 1},
             ],
         }
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, _ = _patched(_base_rows())
+        with rs, t1, t2:
             r = client.patch("/api/gradebook/courses/cs161/categories", json=body)
         assert r.status_code == 400
         assert "100" in r.json()["detail"].lower() or "weight" in r.json()["detail"].lower()
 
     def test_bulk_update_accepts_total_100(self):
-        rows = {"user_courses": [{"id": "uc1"}]}
         body = {
             "user_id": "u1",
             "categories": [
-                {"id": "exams", "name": "Exams", "weight": 60, "sort_order": 0},
+                {"id": "exams", "name": "Exams", "weight": 60, "sort_order": 0, "drop_lowest": 2},
                 {"id": "psets", "name": "P-Sets", "weight": 40, "sort_order": 1},
             ],
         }
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, rec = _patched(_base_rows())
+        with rs, t1, t2:
             r = client.patch("/api/gradebook/courses/cs161/categories", json=body)
         assert r.status_code == 200
         assert len(r.json()["categories"]) == 2
+        # drop_lowest carried through the update payload
+        updates = [d for (n, op, d) in rec if n == "gradebook_categories" and op == "update"]
+        assert any(u.get("drop_lowest") == 2 for u in updates)
 
-    def test_delete_orphans_assignments(self):
-        rows = {"course_categories": [{"id": "exams", "user_id": "u1", "course_id": "cs161"}]}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+    def test_delete_category(self):
+        rows = _base_rows()
+        rows["gradebook_categories"] = [
+            {"id": "exams", "enrollment_id": "enr1", "name": "Exams", "weight": 100,
+             "sort_order": 0, "drop_lowest": 0},
+        ]
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
             r = client.delete("/api/gradebook/categories/exams", params={"user_id": "u1"})
         assert r.status_code == 200
+
+    def test_delete_404_when_not_owner(self):
+        rows = _base_rows()
+        rows["gradebook_categories"] = [
+            {"id": "exams", "enrollment_id": "other-enr", "name": "Exams", "weight": 100,
+             "sort_order": 0, "drop_lowest": 0},
+        ]
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
+            r = client.delete("/api/gradebook/categories/exams", params={"user_id": "u1"})
+        assert r.status_code == 404
 
 
 # ── Assignments CRUD ─────────────────────────────────────────────────────────
 
 class TestAssignments:
     def test_create_assignment_minimal(self):
-        rows = {"user_courses": [{"id": "uc1"}]}
-        body = {"user_id": "u1", "course_id": "cs161", "title": "Midterm 1"}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
-            r = client.post("/api/gradebook/assignments", json=body)
+        rs, t1, t2, rec = _patched(_base_rows())
+        with rs, t1, t2:
+            r = client.post("/api/gradebook/assignments",
+                            json={"user_id": "u1", "course_id": "cs161", "title": "Midterm 1"})
         assert r.status_code == 200
         a = r.json()["assignment"]
         assert a["title"] == "Midterm 1"
         assert a["source"] == "manual"
+        assert a["enrollment_id"] == "enr1"
+
+    def test_create_encrypts_points_and_returns_plaintext(self):
+        rs, t1, t2, rec = _patched(_base_rows())
+        with rs, t1, t2:
+            r = client.post("/api/gradebook/assignments",
+                            json={"user_id": "u1", "course_id": "cs161", "title": "Q",
+                                  "points_possible": 100, "points_earned": 88})
+        assert r.status_code == 200
+        a = r.json()["assignment"]
+        # Returned plaintext to the client...
+        assert a["points_earned"] == pytest.approx(88.0)
+        # ...but the stored insert payload was ciphertext (not the raw float).
+        inserts = [d for (n, op, d) in rec if n == "assignments" and op == "insert"]
+        assert inserts and inserts[0]["points_earned"] != 88
+        assert isinstance(inserts[0]["points_earned"], str)
 
     def test_create_rejects_unknown_course(self):
-        rows = {"user_courses": []}
-        body = {"user_id": "u1", "course_id": "cs999", "title": "X"}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
-            r = client.post("/api/gradebook/assignments", json=body)
+        rows = _base_rows()
+        rows["enrollments"] = []
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
+            r = client.post("/api/gradebook/assignments",
+                            json={"user_id": "u1", "course_id": "cs999", "title": "X"})
         assert r.status_code == 404
 
     def test_create_rejects_zero_points_possible(self):
-        rows = {"user_courses": [{"id": "uc1"}]}
-        body = {"user_id": "u1", "course_id": "cs161", "title": "X",
-                "points_possible": 0}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
-            r = client.post("/api/gradebook/assignments", json=body)
-        assert r.status_code == 422  # Pydantic gt=0 validation
+        rs, t1, t2, _ = _patched(_base_rows())
+        with rs, t1, t2:
+            r = client.post("/api/gradebook/assignments",
+                            json={"user_id": "u1", "course_id": "cs161", "title": "X",
+                                  "points_possible": 0})
+        assert r.status_code == 422  # Pydantic gt=0
+
+    def test_create_rejects_bad_assignment_type(self):
+        rs, t1, t2, _ = _patched(_base_rows())
+        with rs, t1, t2:
+            r = client.post("/api/gradebook/assignments",
+                            json={"user_id": "u1", "course_id": "cs161", "title": "X",
+                                  "assignment_type": "midterm"})  # not in enum
+        assert r.status_code == 422
 
     def test_update_grade_inline(self):
-        rows = {"assignments": [{"id": "a1", "user_id": "u1", "course_id": "cs161"}]}
-        body = {"user_id": "u1", "points_earned": 87}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
-            r = client.patch("/api/gradebook/assignments/a1", json=body)
+        rows = _base_rows()
+        rows["assignments"] = [
+            {"id": "a1", "enrollment_id": "enr1", "category_id": None},
+        ]
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
+            r = client.patch("/api/gradebook/assignments/a1",
+                             json={"user_id": "u1", "points_earned": 87})
         assert r.status_code == 200
 
     def test_update_404_when_not_owner(self):
-        rows = {"assignments": []}
-        body = {"user_id": "u1", "points_earned": 87}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
-            r = client.patch("/api/gradebook/assignments/a1", json=body)
+        rows = _base_rows()
+        rows["assignments"] = [
+            {"id": "a1", "enrollment_id": "other-enr", "category_id": None},
+        ]
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
+            r = client.patch("/api/gradebook/assignments/a1",
+                             json={"user_id": "u1", "points_earned": 87})
         assert r.status_code == 404
 
     def test_delete_assignment(self):
-        rows = {"assignments": [{"id": "a1", "user_id": "u1"}]}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rows = _base_rows()
+        rows["assignments"] = [{"id": "a1", "enrollment_id": "enr1", "category_id": None}]
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
             r = client.delete("/api/gradebook/assignments/a1", params={"user_id": "u1"})
         assert r.status_code == 200
 
@@ -222,50 +400,142 @@ class TestAssignments:
 
 class TestLetterScale:
     def test_set_custom_scale(self):
-        rows = {"user_courses": [{"id": "uc1"}]}
         body = {"user_id": "u1", "scale": [
-            {"min": 90, "letter": "A"},
-            {"min": 80, "letter": "B"},
-            {"min": 0,  "letter": "F"},
+            {"min": 90, "letter": "A"}, {"min": 80, "letter": "B"}, {"min": 0, "letter": "F"},
         ]}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, rec = _patched(_base_rows())
+        with rs, t1, t2:
             r = client.patch("/api/gradebook/courses/cs161/scale", json=body)
         assert r.status_code == 200
+        updates = [d for (n, op, d) in rec if n == "enrollments" and op == "update"]
+        assert updates and updates[0]["letter_scale"][0]["letter"] == "A"
 
     def test_clear_scale_with_null(self):
-        rows = {"user_courses": [{"id": "uc1"}]}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, _ = _patched(_base_rows())
+        with rs, t1, t2:
             r = client.patch("/api/gradebook/courses/cs161/scale",
                              json={"user_id": "u1", "scale": None})
         assert r.status_code == 200
 
     def test_rejects_non_monotonic_scale(self):
-        rows = {"user_courses": [{"id": "uc1"}]}
         body = {"user_id": "u1", "scale": [
-            {"min": 80, "letter": "A"},
-            {"min": 90, "letter": "B"},  # B requires higher than A — invalid
+            {"min": 80, "letter": "A"}, {"min": 90, "letter": "B"},
         ]}
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, _ = _patched(_base_rows())
+        with rs, t1, t2:
             r = client.patch("/api/gradebook/courses/cs161/scale", json=body)
         assert r.status_code == 400
+
+
+# ── PATCH /courses/{course_id}/curve ─────────────────────────────────────────
+
+class TestCurve:
+    def test_set_curve_writes_enrollment_fields(self):
+        body = {"user_id": "u1", "curve_mode": "curved",
+                "curve_avg_target": 82.5, "curve_sd_delta": -3.0}
+        rs, t1, t2, rec = _patched(_base_rows())
+        with rs, t1, t2:
+            r = client.patch("/api/gradebook/courses/cs161/curve", json=body)
+        assert r.status_code == 200
+        updates = [d for (n, op, d) in rec if n == "enrollments" and op == "update"]
+        assert updates and updates[0]["curve_mode"] == "curved"
+        assert updates[0]["curve_avg_target"] == 82.5
+        assert updates[0]["curve_sd_delta"] == -3.0
+
+    def test_set_curve_404_when_not_enrolled(self):
+        rows = _base_rows()
+        rows["enrollments"] = []
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
+            r = client.patch("/api/gradebook/courses/cs161/curve",
+                             json={"user_id": "u1", "curve_mode": "raw"})
+        assert r.status_code == 404
+
+    def test_rejects_bad_curve_mode(self):
+        rs, t1, t2, _ = _patched(_base_rows())
+        with rs, t1, t2:
+            r = client.patch("/api/gradebook/courses/cs161/curve",
+                             json={"user_id": "u1", "curve_mode": "wild"})
+        assert r.status_code == 422
+
+
+# ── GET /gpa (cumulative, credit-weighted) ───────────────────────────────────
+
+class TestGpa:
+    def _two_course_rows(self):
+        """u1 in CS161 (3cr, 90% → A- → 3.7) and MATH200 (4cr, 80% → B- → 2.7)."""
+        rows = {
+            "terms": [
+                {"id": "spring-2026", "label": "Spring 2026", "start_date": "2026-01-05",
+                 "end_date": "2026-05-17", "sort_key": 20261},
+            ],
+            "courses": [
+                {"id": "cs161", "course_code": "CS 161", "course_name": "Intro CS", "credits": 3},
+                {"id": "math200", "course_code": "MATH 200", "course_name": "Calc", "credits": 4},
+            ],
+            "course_offerings": [
+                {"id": "off1", "course_id": "cs161", "term_id": "spring-2026"},
+                {"id": "off2", "course_id": "math200", "term_id": "spring-2026"},
+            ],
+            "enrollments": [
+                {"id": "enr1", "user_id": "u1", "offering_id": "off1", "letter_scale": None,
+                 "curve_mode": "raw", "curve_avg_target": None, "curve_sd_delta": None,
+                 "syllabus_doc_id": None},
+                {"id": "enr2", "user_id": "u1", "offering_id": "off2", "letter_scale": None,
+                 "curve_mode": "raw", "curve_avg_target": None, "curve_sd_delta": None,
+                 "syllabus_doc_id": None},
+            ],
+            "gradebook_categories": [
+                {"id": "c1", "enrollment_id": "enr1", "name": "All", "weight": 100,
+                 "sort_order": 0, "drop_lowest": 0},
+                {"id": "c2", "enrollment_id": "enr2", "name": "All", "weight": 100,
+                 "sort_order": 0, "drop_lowest": 0},
+            ],
+            "assignments": [
+                {"id": "a1", "enrollment_id": "enr1", "title": "X", "category_id": "c1",
+                 "points_possible": 100.0, "points_earned": 90.0, "due_date": None,
+                 "assignment_type": "exam", "notes": None, "source": "manual",
+                 "curve_class_mean": None, "curve_class_sd": None},
+                {"id": "a2", "enrollment_id": "enr2", "title": "Y", "category_id": "c2",
+                 "points_possible": 100.0, "points_earned": 80.0, "due_date": None,
+                 "assignment_type": "exam", "notes": None, "source": "manual",
+                 "curve_class_mean": None, "curve_class_sd": None},
+            ],
+        }
+        return rows
+
+    def test_cumulative_gpa_is_credit_weighted(self):
+        rs, t1, t2, _ = _patched(self._two_course_rows())
+        with rs, t1, t2:
+            r = client.get("/api/gradebook/gpa", params={"user_id": "u1"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["scope"] == "cumulative"
+        # (3.7*3 + 2.7*4) / 7 = 3.1285714...
+        assert body["gpa"] == pytest.approx(3.1285714, rel=1e-4)
+        assert len(body["courses"]) == 2
+
+    def test_semester_gpa_scopes_to_term(self):
+        rs, t1, t2, _ = _patched(self._two_course_rows())
+        with rs, t1, t2:
+            r = client.get("/api/gradebook/gpa",
+                           params={"user_id": "u1", "semester": "Spring 2026"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["scope"] == "semester"
+        assert body["gpa"] == pytest.approx(3.1285714, rel=1e-4)
 
 
 # ── POST /syllabus/apply ─────────────────────────────────────────────────────
 
 class TestSyllabusApply:
     def test_replaces_categories_and_inserts_assignments(self):
-        rows = {
-            "user_courses": [{"id": "uc1", "course_id": "cs161", "letter_scale": None,
-                               "courses": {"id": "cs161", "course_code": "CS 161",
-                                           "course_name": "Intro CS", "semester": "Spring 2026"}}],
-            "documents": [{"id": "doc1", "user_id": "u1"}],
-            "course_categories": [],
-            "assignments": [],
-        }
+        rows = _base_rows()
+        rows["documents"] = [{"id": "doc1", "user_id": "u1"}]
+        rows["gradebook_categories"] = []
+        rows["assignments"] = []
         body = {
-            "user_id": "u1",
-            "course_id": "cs161",
-            "doc_id": "doc1",
+            "user_id": "u1", "course_id": "cs161", "doc_id": "doc1",
             "categories": [
                 {"name": "Exams", "weight": 60, "sort_order": 0},
                 {"name": "P-Sets", "weight": 40, "sort_order": 1},
@@ -277,50 +547,57 @@ class TestSyllabusApply:
                  "assignment_type": "homework", "notes": None},
             ],
         }
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, rec = _patched(rows)
+        with rs, t1, t2:
             r = client.post("/api/gradebook/syllabus/apply", json=body)
         assert r.status_code == 200
-        out = r.json()
-        assert "course" in out
+        assert "course" in r.json()
+        # categories wiped + reinserted keyed on enrollment_id
+        cat_inserts = [d for (n, op, d) in rec if n == "gradebook_categories" and op == "insert"]
+        assert cat_inserts and all(c["enrollment_id"] == "enr1" for c in cat_inserts[0])
+        # syllabus_doc_id stamped on the enrollment
+        enr_updates = [d for (n, op, d) in rec if n == "enrollments" and op == "update"]
+        assert any(u.get("syllabus_doc_id") == "doc1" for u in enr_updates)
 
     def test_rejects_when_weights_dont_sum_to_100(self):
-        rows = {"user_courses": [{"id": "uc1"}], "documents": [{"id": "doc1", "user_id": "u1"}]}
+        rows = _base_rows()
+        rows["documents"] = [{"id": "doc1", "user_id": "u1"}]
         body = {
-            "user_id": "u1",
-            "course_id": "cs161",
-            "doc_id": "doc1",
+            "user_id": "u1", "course_id": "cs161", "doc_id": "doc1",
             "categories": [
                 {"name": "Exams", "weight": 60, "sort_order": 0},
                 {"name": "P-Sets", "weight": 30, "sort_order": 1},
             ],
             "assignments": [],
         }
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
             r = client.post("/api/gradebook/syllabus/apply", json=body)
         assert r.status_code == 400
 
     def test_rejects_unknown_course(self):
-        rows = {"user_courses": [], "documents": [{"id": "doc1", "user_id": "u1"}]}
+        rows = _base_rows()
+        rows["enrollments"] = []
+        rows["documents"] = [{"id": "doc1", "user_id": "u1"}]
         body = {
-            "user_id": "u1",
-            "course_id": "cs999",
-            "doc_id": "doc1",
+            "user_id": "u1", "course_id": "cs999", "doc_id": "doc1",
             "categories": [{"name": "X", "weight": 100, "sort_order": 0}],
             "assignments": [],
         }
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
             r = client.post("/api/gradebook/syllabus/apply", json=body)
         assert r.status_code == 404
 
     def test_rejects_doc_owned_by_other_user(self):
-        rows = {"user_courses": [{"id": "uc1"}], "documents": [{"id": "doc1", "user_id": "other"}]}
+        rows = _base_rows()
+        rows["documents"] = [{"id": "doc1", "user_id": "other"}]
         body = {
-            "user_id": "u1",
-            "course_id": "cs161",
-            "doc_id": "doc1",
+            "user_id": "u1", "course_id": "cs161", "doc_id": "doc1",
             "categories": [{"name": "X", "weight": 100, "sort_order": 0}],
             "assignments": [],
         }
-        with _mock_self(), patch("routes.gradebook.table", side_effect=_mock_table_rows(rows)):
+        rs, t1, t2, _ = _patched(rows)
+        with rs, t1, t2:
             r = client.post("/api/gradebook/syllabus/apply", json=body)
         assert r.status_code == 403

--- a/backend/tests/test_gradebook_service.py
+++ b/backend/tests/test_gradebook_service.py
@@ -99,3 +99,146 @@ class TestLetterFor:
     def test_handles_boundary_exactly(self):
         assert svc.letter_for(93.0, None) == "A"
         assert svc.letter_for(92.999, None) == "A-"
+
+
+# ── drop-lowest ──────────────────────────────────────────────────────────────
+
+class TestDropLowest:
+    def test_drops_single_lowest_ratio_item(self):
+        items = [
+            {"points_possible": 100, "points_earned": 100},  # ratio 1.0
+            {"points_possible": 100, "points_earned": 50},   # ratio 0.5 (dropped)
+            {"points_possible": 100, "points_earned": 90},   # ratio 0.9
+        ]
+        # Keep 100/100 and 90/100 → 190/200 = 0.95
+        assert svc.category_grade(items, drop_lowest=1) == pytest.approx(0.95)
+
+    def test_drop_lowest_uses_ratio_not_absolute_points(self):
+        items = [
+            {"points_possible": 10,  "points_earned": 1},    # ratio 0.10 (worst, dropped)
+            {"points_possible": 100, "points_earned": 60},   # ratio 0.60
+        ]
+        # Drop the 1/10 (ratio 0.1) even though it's fewer absolute points.
+        assert svc.category_grade(items, drop_lowest=1) == pytest.approx(0.60)
+
+    def test_drop_lowest_ge_count_returns_none(self):
+        items = [{"points_possible": 100, "points_earned": 80}]
+        assert svc.category_grade(items, drop_lowest=1) is None
+        assert svc.category_grade(items, drop_lowest=5) is None
+
+    def test_drop_lowest_via_current_grade(self):
+        cats = [{"id": "hw", "name": "HW", "weight": 100, "sort_order": 0, "drop_lowest": 1}]
+        assignments = [
+            {"category_id": "hw", "points_possible": 100, "points_earned": 100},
+            {"category_id": "hw", "points_possible": 100, "points_earned": 60},
+            {"category_id": "hw", "points_possible": 100, "points_earned": 80},
+        ]
+        # Drop the 60 → (100+80)/(200) = 0.9 → 90.0
+        assert svc.current_grade(cats, assignments) == pytest.approx(90.0)
+
+
+# ── apply_curve ──────────────────────────────────────────────────────────────
+
+class TestApplyCurve:
+    def test_recenters_on_target_keeping_relative_position(self):
+        # raw 70, class mean 60 sd 10, target 75, sd_delta 0 → new_sd=10
+        # curved = 75 + (70-60) * (10/10) = 85
+        out = svc.apply_curve(70.0, class_mean=60.0, class_sd=10.0,
+                              avg_target=75.0, sd_delta=0.0)
+        assert out == pytest.approx(85.0)
+
+    def test_sd_delta_tightens_spread(self):
+        # new_sd = 10 + (-5) = 5; curved = 75 + (70-60)*(5/10) = 80
+        out = svc.apply_curve(70.0, class_mean=60.0, class_sd=10.0,
+                              avg_target=75.0, sd_delta=-5.0)
+        assert out == pytest.approx(80.0)
+
+    def test_clamps_to_0_100(self):
+        out = svc.apply_curve(100.0, class_mean=50.0, class_sd=5.0,
+                              avg_target=90.0, sd_delta=0.0)
+        assert out == 100.0
+        low = svc.apply_curve(10.0, class_mean=80.0, class_sd=5.0,
+                              avg_target=70.0, sd_delta=0.0)
+        assert low == 0.0
+
+    def test_falls_back_to_raw_when_sd_missing_or_zero(self):
+        assert svc.apply_curve(70.0, class_mean=60.0, class_sd=0.0,
+                               avg_target=75.0, sd_delta=0.0) == 70.0
+        assert svc.apply_curve(70.0, class_mean=60.0, class_sd=None,
+                               avg_target=75.0, sd_delta=0.0) == 70.0
+
+    def test_falls_back_to_raw_when_target_or_mean_missing(self):
+        assert svc.apply_curve(70.0, class_mean=60.0, class_sd=10.0,
+                               avg_target=None, sd_delta=0.0) == 70.0
+        assert svc.apply_curve(70.0, class_mean=None, class_sd=10.0,
+                               avg_target=75.0, sd_delta=0.0) == 70.0
+
+    def test_none_percent_returns_none(self):
+        assert svc.apply_curve(None, class_mean=60.0, class_sd=10.0,
+                               avg_target=75.0, sd_delta=0.0) is None
+
+
+class TestCurrentGradeCurved:
+    def test_curved_mode_uses_assignment_class_stats(self):
+        cats = [{"id": "exams", "name": "Exams", "weight": 100, "sort_order": 0,
+                 "drop_lowest": 0}]
+        assignments = [
+            {"category_id": "exams", "points_possible": 100, "points_earned": 70,
+             "curve_class_mean": 60.0, "curve_class_sd": 10.0},
+        ]
+        # raw = 70; curved = 80 + (70-60)*(10/10) = 90
+        out = svc.current_grade(cats, assignments, curve_mode="curved",
+                                curve_avg_target=80.0, curve_sd_delta=0.0)
+        assert out == pytest.approx(90.0)
+
+    def test_raw_mode_ignores_curve_targets(self):
+        cats = [{"id": "exams", "name": "Exams", "weight": 100, "sort_order": 0}]
+        assignments = [
+            {"category_id": "exams", "points_possible": 100, "points_earned": 70,
+             "curve_class_mean": 60.0, "curve_class_sd": 10.0},
+        ]
+        out = svc.current_grade(cats, assignments, curve_mode="raw",
+                                curve_avg_target=80.0, curve_sd_delta=0.0)
+        assert out == pytest.approx(70.0)
+
+
+# ── GPA ──────────────────────────────────────────────────────────────────────
+
+class TestGpa:
+    def test_gpa_points_default_scale(self):
+        assert svc.gpa_points(95.0) == pytest.approx(4.0)
+        assert svc.gpa_points(91.0) == pytest.approx(3.7)   # A-
+        assert svc.gpa_points(80.0) == pytest.approx(2.7)   # B-
+        assert svc.gpa_points(40.0) == pytest.approx(0.0)   # F
+
+    def test_gpa_points_none_when_no_grade(self):
+        assert svc.gpa_points(None) is None
+
+    def test_weighted_gpa_credit_weighted(self):
+        # Hand-computed transcript fixture:
+        #   CS161   3 credits, 90% → A- → 3.7
+        #   MATH200 4 credits, 80% → B- → 2.7
+        #   GPA = (3.7*3 + 2.7*4) / (3+4) = 21.9 / 7 = 3.1285714...
+        grades = [
+            {"grade_points": svc.gpa_points(90.0), "credits": 3},
+            {"grade_points": svc.gpa_points(80.0), "credits": 4},
+        ]
+        assert svc.weighted_gpa(grades) == pytest.approx(3.1285714, rel=1e-4)
+
+    def test_weighted_gpa_skips_ungraded(self):
+        grades = [
+            {"grade_points": 4.0, "credits": 3},
+            {"grade_points": None, "credits": 4},   # ungraded — skipped
+        ]
+        assert svc.weighted_gpa(grades) == pytest.approx(4.0)
+
+    def test_weighted_gpa_none_when_nothing_graded(self):
+        assert svc.weighted_gpa([{"grade_points": None, "credits": 3}]) is None
+
+    def test_weighted_gpa_defaults_credits_to_one(self):
+        # 4.0 (1 credit default) and 2.0 (1 credit default) → 3.0
+        grades = [
+            {"grade_points": 4.0, "credits": None},
+            {"grade_points": 2.0, "credits": 0},
+        ]
+        assert svc.weighted_gpa(grades) == pytest.approx(3.0)

--- a/backend/tests/test_response_decrypt_boundary.py
+++ b/backend/tests/test_response_decrypt_boundary.py
@@ -24,8 +24,7 @@ class TestGradebookCreateAssignmentResponse:
     def test_response_is_decrypted_not_ciphertext(self):
         stored = {
             "id": "a1",
-            "user_id": "user_andres",
-            "course_id": "c1",
+            "enrollment_id": "enr1",
             "category_id": None,
             "title": "HW1",
             "due_date": "2026-03-01",
@@ -35,7 +34,9 @@ class TestGradebookCreateAssignmentResponse:
             "notes": encrypt_if_present("Study chapters 1-3"),
             "source": "manual",
         }
-        with patch("routes.gradebook._user_owns_course", return_value=True), \
+        # Resolve to an enrollment (academics-split shape) and capture the insert.
+        enr = {"id": "enr1", "user_id": "user_andres", "offering_id": "off1"}
+        with patch("routes.gradebook._resolve_enrollment", return_value=enr), \
              patch("routes.gradebook.table") as t:
             t.return_value.insert.return_value = [dict(stored)]
             r = client.post(

--- a/docs/superpowers/plans/2026-06-24-db-gradebook-code.md
+++ b/docs/superpowers/plans/2026-06-24-db-gradebook-code.md
@@ -1,0 +1,197 @@
+# `db/gradebook-code` Implementation Plan (epic slice — gradebook)
+
+> **For agentic workers:** code-only slice. The schema already landed (migrations 0019–0027,
+> incl. `0021_gradebook.sql`). This slice rewires the gradebook application code onto the new
+> enrollment-keyed shape and adds bell-curve + drop-lowest + GPA. Branch: `db/gradebook-code`
+> based on `db/academics-code` (carries the academics spine + `services/academics.py`).
+
+**Goal:** Make the gradebook semester-aware on the new schema. Categories and assignments key on
+`enrollment_id` (not `user_id`+`course_id`). The public API keeps the abstract `course_id` plus
+the existing `semester` query param. Add bell-curve (raw vs curved) and drop-lowest to the
+weighted-score computation, and add per-semester + cumulative (credit-weighted) GPA.
+
+## Locked product contract
+
+- **API boundary keeps the abstract `course_id`.** Routes still receive `course_id`; the
+  `GET /summary` route still receives `semester`. Per-course routes accept an optional
+  `semester` query param (default = current term).
+- **Term/semester is a real second axis.** `terms` is the source of truth (`GET /api/semesters`
+  exists). A `semester` value is a term **label** (e.g. `"Spring 2026"`); we map it to a
+  `term_id` via `terms.label`, falling back to treating the value as a `term_id` directly.
+- **Resolution:** `(course_id, term)` → the user's **enrollment** = intersect
+  `services.academics.user_offering_ids_for_course(user_id, course_id)` with the offerings in
+  that term. The gradebook keys `gradebook_categories.enrollment_id` /
+  `assignments.enrollment_id` on that enrollment. The knowledge graph stays on the abstract
+  `course_id` (out of this slice).
+- **Encryption:** `points_possible` / `points_earned` stay 🔒 **TEXT** (numeric semantics);
+  `notes` stays 🔒 TEXT. `encrypt_if_present` at write, `decrypt_numeric` / `decrypt_if_present`
+  at read.
+- **Gradescope is out of scope** — just don't break the `gradescope_assignment_id` column.
+
+## Schema facts (read off `db/migrations/0021_gradebook.sql`)
+
+- **`enrollments`** gained: `curve_mode TEXT NOT NULL DEFAULT 'raw' CHECK IN ('raw','curved')`,
+  `curve_avg_target NUMERIC`, `curve_sd_delta NUMERIC`. Keeps `id, user_id, offering_id, color,
+  nickname, enrolled_at, letter_scale (JSONB), syllabus_doc_id`.
+- **`gradebook_categories`** (was `course_categories`): `id, enrollment_id→enrollments (CASCADE),
+  name, weight NUMERIC, sort_order INTEGER DEFAULT 0, drop_lowest INTEGER NOT NULL DEFAULT 0
+  CHECK (>=0), created_at, updated_at`. **No `user_id`/`course_id` columns.**
+- **`assignments`** (recreated): `id, enrollment_id→enrollments (nullable; CASCADE),
+  category_id→gradebook_categories (SET NULL), title, due_date DATE,
+  assignment_type TEXT CHECK IN ('homework','exam','reading','project','quiz','other'),
+  notes 🔒, points_possible 🔒 TEXT, points_earned 🔒 TEXT,
+  source TEXT NOT NULL DEFAULT 'manual' CHECK IN ('manual','syllabus'), google_event_id,
+  gradescope_assignment_id, curve_class_mean NUMERIC, curve_class_sd NUMERIC,
+  curve_avg_target NUMERIC, curve_sd_delta NUMERIC, created_at, updated_at`.
+  **No `user_id`/`course_id` columns.** Curve stats are plaintext NUMERIC (class stats, not
+  student-identifying).
+- **`courses`** (abstract catalog) carries `credits INTEGER` — the GPA credit weight.
+
+### Exact CHECK enum value sets (read off 0021)
+
+- `enrollments.curve_mode ∈ {'raw','curved'}`
+- `assignments.assignment_type ∈ {'homework','exam','reading','project','quiz','other'}`
+- `assignments.source ∈ {'manual','syllabus'}`
+- `gradebook_categories.drop_lowest >= 0`
+
+## Resolver (use `services.academics`, do not edit it)
+
+- `current_term()` → current term row (date-derived).
+- `list_terms()` → all terms.
+- `user_offering_ids_for_course(user_id, course_id)` → offerings of the abstract course the user
+  is enrolled in.
+- `term_for_offering(offering_id)` → term row (for the semester label in responses).
+- `resolve_offering(course_id, term_id=None, *, create=False)` — not needed for reads here.
+
+New local helper in `routes/gradebook.py`:
+`_resolve_enrollment(user_id, course_id, semester=None) -> dict | None` — maps `semester`→term_id
+(via `terms.label`), lists the user's offerings of the course, picks the offering whose
+`term_id` matches the resolved term (or the only/most-recent offering when no term given),
+then loads the matching `enrollments` row. Returns the enrollment dict (with `curve_*`,
+`letter_scale`, `offering_id`) or `None`.
+
+## File-by-file change map (current → new)
+
+### `services/gradebook_service.py`
+Pure math, no DB. Current: `category_grade`, `current_grade`, `letter_for`,
+`DEFAULT_LETTER_SCALE`. Changes:
+- **`category_grade(items, drop_lowest=0)`** — when `drop_lowest > 0`, drop the N graded items
+  with the lowest per-item ratio (`earned/possible`) before summing. Items with
+  `possible <= 0` or missing earned still skip. Document the formula.
+- **`apply_curve(raw_percent, *, class_mean, class_sd, avg_target, sd_delta)`** — new pure fn.
+  Linear z-score rescale: `curved = avg_target + (raw - class_mean) * (new_sd / class_sd)` where
+  `new_sd = class_sd + sd_delta`. Falls back to `raw_percent` when `class_sd` is missing/0 or
+  `avg_target` is None. Clamp to `[0, 100]`. Document the formula.
+- **`current_grade(categories, assignments, *, curve_mode='raw', curve_avg_target=None,
+  curve_sd_delta=None)`** — pass each category's `drop_lowest` into `category_grade`; when
+  `curve_mode == 'curved'`, apply `apply_curve` to the final weighted percent using the
+  enrollment-level avg target/sd delta against the **class mean/sd derived from the assignments'
+  per-assignment `curve_class_mean`/`curve_class_sd`** when present, else enrollment targets only.
+  (Enrollment-level curve is the primary path; per-assignment curve stats are carried but the
+  weighted-percent curve uses the enrollment policy. Documented as an assumption.)
+- **`gpa_points(percent, scale=None)`** — new: map a percent → 4.0-scale grade points using a
+  standard letter→points table (A=4.0, A-=3.7, B+=3.3, …, F=0.0), reusing `letter_for`.
+- **`weighted_gpa(course_grades)`** — new: credit-weighted mean of grade points across a list of
+  `{"grade_points": x, "credits": c}`; ignores entries with `grade_points is None`. Returns the
+  cumulative/transcript GPA.
+
+### `routes/gradebook.py`
+Replace **all** `user_courses` / `course_categories` references and the `user_id`+`course_id`
+keying with enrollment keying.
+- `_user_owns_course` → `_resolve_enrollment(user_id, course_id, semester)` returning the
+  enrollment row (or None). Ownership = a resolvable enrollment.
+- `_user_owns_category(user_id, category_id)` → look up `gradebook_categories` by id, then verify
+  its `enrollment_id` belongs to the user (load enrollment, check `user_id`).
+- `_user_owns_assignment(user_id, assignment_id)` → look up `assignments` by id, verify its
+  `enrollment_id` belongs to the user.
+- **`GET /summary`** — list the user's enrollments (optionally filtered to the `semester` term),
+  join `course_offerings` → `courses` for code/name + `terms` for the label, load
+  `gradebook_categories`/`assignments` by `enrollment_id`, compute curved/dropped grade + letter,
+  return per-course rows **plus** a `gpa` field (term GPA across the listed courses).
+- **`GET /courses/{course_id}`** — accept optional `semester`; resolve enrollment; load cats +
+  assigns by `enrollment_id`; apply drop-lowest + curve; return categories (with `drop_lowest`
+  and per-category grade), assignments, percent, letter, `letter_scale`, `curve_mode`, semester
+  label.
+- **categories CRUD** — insert/update/delete on `gradebook_categories` keyed on `enrollment_id`
+  (resolved from `course_id`+`semester`). Carry `drop_lowest` through create/bulk-update.
+- **assignments CRUD** — `CreateAssignmentBody`/`UpdateAssignmentBody` resolve to an enrollment;
+  insert/update `assignments` with `enrollment_id` (no `user_id`/`course_id`). Keep
+  decrypt-on-return.
+- **`POST /syllabus/apply`** — resolve enrollment; wipe + replace `gradebook_categories` by
+  `enrollment_id`; insert assignments keyed on `enrollment_id`; stamp `enrollments.syllabus_doc_id`.
+- **`PATCH /courses/{course_id}/scale`** — update `enrollments.letter_scale` for the resolved
+  enrollment.
+- **NEW curve route** `PATCH /courses/{course_id}/curve` — set
+  `enrollments.curve_mode`/`curve_avg_target`/`curve_sd_delta`.
+- **NEW GPA route** `GET /gpa` — cumulative/transcript GPA: across all the user's offerings of
+  all enrolled courses, credit-weighted (`courses.credits`), with per-course and overall numbers.
+
+### `models/__init__.py` (gradebook section)
+- `CreateCategoryBody`: add optional `course_id`-less? No — `course_id` stays in the path; add
+  `semester: Optional[str]` and `drop_lowest: int = Field(default=0, ge=0)`.
+- `CategoryItem`: add `drop_lowest: int = Field(default=0, ge=0)`.
+- `BulkUpdateCategoriesBody`: add `semester: Optional[str]`.
+- `CreateAssignmentBody` / `UpdateAssignmentBody`: add `semester: Optional[str]`; constrain
+  `assignment_type: Optional[Literal['homework','exam','reading','project','quiz','other']]`.
+- `SetLetterScaleBody` / `SyllabusApplyBody`: add `semester: Optional[str]`.
+- New `SetCurveBody`: `user_id, semester: Optional[str], curve_mode: Literal['raw','curved'],
+  curve_avg_target: Optional[float], curve_sd_delta: Optional[float]`.
+
+### `tests/test_gradebook_routes.py`
+Rewrite the mocked rows to the enrollment-keyed shape (`enrollments` rows with `offering_id`,
+`course_offerings`/`courses`/`terms` rows, `gradebook_categories`/`assignments` keyed on
+`enrollment_id`). Keep coverage of: summary, course detail, 404 when not enrolled, categories
+CRUD + weight validation, assignments CRUD + `gt=0` 422, letter scale set/clear/non-monotonic,
+syllabus apply (replace, weight reject, unknown course, foreign doc). Add:
+- curve route sets enrollment curve fields,
+- GET /gpa returns credit-weighted cumulative GPA.
+
+## Formulas
+
+**Drop-lowest** (per category): given graded items with ratio `r_i = earned_i / possible_i`
+(`possible_i > 0`), drop the `drop_lowest` items with the smallest `r_i`, then
+`category_grade = Σ earned_kept / Σ possible_kept`. If `drop_lowest >=` graded count, the
+category has no contributing items → grade `None` (drops out of the weighted sum, weight
+renormalized — same as today).
+
+**Bell curve** (linear z-rescale, applied to the final weighted percent when
+`curve_mode='curved'`):
+```
+new_sd = class_sd + sd_delta          # sd_delta shifts spread (e.g. -5 tightens)
+curved = avg_target + (raw - class_mean) * (new_sd / class_sd)
+curved = clamp(curved, 0, 100)
+```
+Falls back to `raw` when `class_sd` is falsy/0 or `avg_target` is None. `class_mean`/`class_sd`
+default from per-assignment `curve_class_mean`/`curve_class_sd` averages when present; otherwise
+the curve degenerates to a recenter on `avg_target` is skipped (returns raw). Assumption
+documented: enrollment-level `curve_avg_target`/`curve_sd_delta` are the policy; class stats come
+from assignment rows.
+
+**GPA:**
+- Letter→points: A=4.0, A-=3.7, B+=3.3, B=3.0, B-=2.7, C+=2.3, C=2.0, C-=1.7, D+=1.3, D=1.0,
+  D-=0.7, F=0.0 (default scale; custom letter_scale maps by letter).
+- Per-course grade points = `gpa_points(curved_percent, letter_scale)`.
+- **Per-semester GPA** = credit-weighted mean across the one term's courses:
+  `Σ(points_i * credits_i) / Σ credits_i` (courses with no grade omitted; credits default 1 when
+  null).
+- **Cumulative/transcript GPA** = same credit-weighted mean across **all** the user's offerings
+  of all enrolled courses, across terms.
+
+## Hand-computed GPA fixture (asserted exactly)
+Two courses, current term:
+- **CS161** (credits 3): one category Exams weight 100, one graded assignment 90/100 → 90% →
+  letter `A-` → 3.7 points.
+- **MATH200** (credits 4): one category HW weight 100, one graded assignment 80/100 → 80% →
+  letter `B-` → 2.7 points.
+
+Term GPA = `(3.7*3 + 2.7*4) / (3+4) = (11.1 + 10.8) / 7 = 21.9 / 7 = 3.12857… ≈ 3.13`.
+The fixture asserts `pytest.approx(3.1285714, rel=1e-4)`.
+
+A second fixture exercises drop-lowest + curve to assert the weighted-percent path
+(hand-computed in the test).
+
+## Out of scope
+- Gradescope sync (no gradescope code on this branch). Don't break `gradescope_assignment_id` /
+  `gradescope_course_links`.
+- `services/academics.py`, `graph_service.py`, `course_context_service.py` (do not edit).
+- Graph / analytics / study / identity files.


### PR DESCRIPTION
Gradebook slice (migration 0021, + curve/drop-lowest #266). Enrollment-keyed gradebook; per-semester + cumulative GPA; bell-curve (raw vs curved) + drop-lowest; `decrypt_numeric` on 🔒 points; new `PATCH /courses/{id}/curve` + `GET /gpa`; hand-computed GPA fixture. Green; ruff clean.

Plan: `docs/superpowers/plans/2026-06-24-db-gradebook-code.md`.

**Integration note:** touches `models/__init__.py` + `tests/test_response_decrypt_boundary.py` (also edited by db/identity-code — small additive conflict). Largest slice — suggest merging last.