### PR TITLE
db/identity-reconcile: route users.name readers through user_profiles + flashcard column (epic follow-up)

### DIFF
--- a/backend/docs/superpowers/plans/2026-06-24-db-identity-reconcile.md
+++ b/backend/docs/superpowers/plans/2026-06-24-db-identity-reconcile.md
@@ -1,0 +1,114 @@
+# DB Identity Reconcile — fix cross-domain `users.name` breakages from the 0024 split
+
+Branch: `db/identity-reconcile` off `epic/db-modular-redesign`.
+
+## Problem
+
+Migration 0024 (identity split) moved the public-profile fields **out of `users`**
+into a new 1:1 `user_profiles` table (PK/FK `user_id`). `name` (and
+`first_name`/`last_name`/`bio`/`location`) are 🔒 column-encrypted on
+`user_profiles`. Migration 0024 also **renamed `users.room_id` → `users.current_room_id`**.
+
+The identity slice updated identity-owned files (`routes/profile.py`) but left
+cross-domain readers/writers of `users.name` untouched. Mocked tests didn't catch
+these because they stub `table()`; against the real DB these raise (writes) or
+return NULL → blank names (reads).
+
+Separately: migration 0025 rebuilt `flashcards` with the link column named
+`offering_id` (was `course_id`); `flashcard_import_service.dedup_against_existing`
+still filters on `course_id`.
+
+## The `user_profiles` pattern (established in `routes/profile.py`)
+
+- 1:1 with `users` on `user_id`.
+- Encrypted columns: `name, first_name, last_name, bio, location`.
+- Write via `encrypt_if_present`; read via `decrypt_if_present`
+  (both from `services/encryption.py`).
+- A row may not exist yet for a freshly FK-stubbed user (it's created at
+  onboarding/oauth). Display-name reads must tolerate a missing row → "" / fallback.
+
+## New helper: `services/profiles.py`
+
+```
+get_display_name(user_id: str) -> str
+    Read user_profiles.name by user_id, decrypt_if_present, return "" if absent.
+
+get_display_names(user_ids: list[str]) -> dict[str, str]
+    Bulk: one `in.(...)` select on user_profiles, returns {user_id: decrypted_name}.
+    Missing rows simply absent from the dict (callers default per their old shape).
+```
+
+All DB access through `db.connection.table("user_profiles")`. Decrypt via
+`services.encryption.decrypt_if_present`.
+
+## Site list (current → new)
+
+### HARD WRITE BREAK
+- `services/graph_service.py` `ensure_user_exists` (~L72):
+  `insert({"id": user_id, "name": name, "streak_count": 0})`
+  → `insert({"id": user_id, "streak_count": 0})`. Drop the derived `name` and the
+  derivation line. Do **not** create a `user_profiles` row here (onboarding/oauth own it).
+
+### READ sites (NULL → blank name)
+- `main.py:191` `list_users`: `select("id,name,room_id")` on `users`.
+  - `name` no longer on `users` → use `get_display_names([...])`.
+  - `room_id` renamed → select `current_room_id`, still return it under key `"room_id"`.
+  - Response shape unchanged: `{"users": [{"id","name","room_id"}]}` sorted by name.
+- `routes/social.py:159` (room activity): bulk `select("id,name")` →
+  `get_display_names(user_ids)`; `user_name` falls back to `user_id` when absent.
+- `routes/social.py:184` (`match_partners`): per-member name →
+  `get_display_names(member_ids)`; name falls back to "".
+- `routes/social.py:225/229` (`school_match`): bulk member names + requester name →
+  `get_display_names(...)` for members, `get_display_name(body.user_id)` for requester
+  (fallback to `body.user_id` to match old behavior).
+- `routes/social.py:469` (`get_students`): `select("id,name,streak_count")` →
+  select `id,streak_count` and resolve names via `get_display_names([u["id"]...])`.
+  Response keys unchanged: `user_id,name,streak,courses,stats,top_concepts`.
+- `routes/quiz.py:461`: `table("users").select("name")` → `get_display_name(user_id)`
+  with "Student" fallback (matches old `if user_rows else "Student"`).
+- `routes/learn.py:382` `get_user_name`: `table("users").select("name")` →
+  `get_display_name(user_id)` with "Student" fallback.
+
+### flashcards column rename
+- `services/flashcard_import_service.py:51,57,59-60` `dedup_against_existing`:
+  rename param `course_id` → `offering_id`; filter key `course_id` → `offering_id`.
+  Caller `routes/flashcards.py:335` already passes the resolved `offering_id`
+  positionally, so update the keyword/positional binding accordingly (positional —
+  no call-site change needed beyond clarity). Behavior identical.
+
+## users_search decision
+
+`services/users_search.py::paginate_users` reads `table("users").select("id,name,email,...")`
+directly — **not** a DB view (grepped: no `search_users_decrypted` / decrypted view
+exists in `db/migrations/`). After 0024, `users.name` is gone, so `name` must come
+from `user_profiles`.
+
+**Decision: CODE-ONLY fix, no migration.** Select identity columns from `users`
+(`id,email,is_approved,created_at,last_sign_in_at`), then enrich each page's rows
+with decrypted names from `user_profiles` via `get_display_names`. For the search
+path we still need names for every user to filter — fetch all profile names in bulk
+(admin scale, behind `require_admin`, matches the existing "decrypt the whole table"
+rationale). No `0028` migration required.
+
+## Tests (TDD)
+
+- `tests/test_profiles_service.py` (new):
+  - `get_display_name` decrypts a present row; returns "" when absent.
+  - `get_display_names` bulk-maps decrypted names; missing rows omitted; empty input.
+- `tests/test_graph_service.py` or a new focused test: assert `ensure_user_exists`
+  insert payload does **not** contain `"name"` (and contains `id`/`streak_count`).
+- Update `tests/test_users_roster_auth.py`: mock now returns `current_room_id` on
+  users + a `user_profiles` lookup for names.
+- Update `tests/test_social_students.py`: users rows no longer carry `name`; add a
+  `user_profiles` lookup in the table factory.
+- Update `tests/test_users_search.py`: users rows carry no `name`; add a
+  `user_profiles` lookup.
+- Update `tests/test_flashcard_import*`/`test_flashcards*` if they assert the
+  `course_id` filter key → `offering_id`.
+
+## Gate
+
+- `cd backend && $PY -m pytest tests/ -q` — zero NEW failures beyond the 2 known
+  env-only `test_storage_service.py` failures.
+- `$RUFF check .` — clean.
+- Commit on `db/identity-reconcile`, push `-u origin db/identity-reconcile`. No PR.

--- a/backend/main.py
+++ b/backend/main.py
@@ -177,9 +177,10 @@ def health():
 def list_users(request: Request):
     """List users with decrypted display names.
 
-    The `users.name` column is encrypted at rest (see
-    services.encryption); decrypt before returning so clients render the
-    human-readable name, not ciphertext. Sort by the decrypted value.
+    The display name now lives on `user_profiles` (migration 0024 moved it out of
+    `users`); it is 🔒 encrypted there. Resolve it via services.profiles, which
+    decrypts. `users.room_id` was likewise renamed to `current_room_id` by 0024 —
+    select the new column but keep the legacy `room_id` response key.
 
     Requires an authenticated session: this returns decrypted legal names,
     so an unauthenticated caller must never reach the roster (401).
@@ -187,13 +188,14 @@ def list_users(request: Request):
     from services.auth_guard import get_session_user_id
     get_session_user_id(request)  # 401 if unauthenticated
     from db.connection import table
-    from services.encryption import decrypt_if_present
-    rows = table("users").select("id,name,room_id")
+    from services.profiles import get_display_names
+    rows = table("users").select("id,current_room_id")
+    names = get_display_names([r.get("id") for r in rows if r.get("id")])
     users = [
         {
             "id": r.get("id"),
-            "name": decrypt_if_present(r.get("name")) or "",
-            "room_id": r.get("room_id"),
+            "name": names.get(r.get("id"), ""),
+            "room_id": r.get("current_room_id"),
         }
         for r in rows
     ]

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -18,6 +18,7 @@ from services.academics import offering_course_id, resolve_offering
 from models import StartSessionBody, ChatBody, EndSessionBody, ActionBody, ModeSwitchBody, RenameSessionBody
 from services.auth_guard import require_self, get_session_user_id
 from services.encryption import encrypt_if_present, encrypt_json, decrypt_if_present, decrypt_json
+from services.profiles import get_display_name
 from services.gemini_service import (
     MODEL_LITE,
     MODEL_SMART,
@@ -379,10 +380,8 @@ def save_message(session_id: str, role: str, content: str, graph_update: dict = 
 
 
 def get_user_name(user_id: str) -> str:
-    rows = table("users").select("name", filters={"id": f"eq.{user_id}"})
-    if not rows:
-        return "Student"
-    return decrypt_if_present(rows[0]["name"]) or "Student"
+    # Display name lives on user_profiles (0024); resolve + decrypt via helper.
+    return get_display_name(user_id) or "Student"
 
 
 def _consume_pending(session_id: str, user_id: str) -> None:

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -13,7 +13,7 @@ from agents.deps import SaplingDeps
 from db.connection import table
 from models import GenerateQuizBody, SubmitQuizBody
 from services.auth_guard import require_self
-from services.encryption import decrypt_if_present
+from services.profiles import get_display_name
 from services.gemini_service import MODEL_LITE, MODEL_SMART, call_gemini_json
 from services.graph_service import apply_graph_update, get_graph
 from services.quiz_context_service import get_quiz_context, save_quiz_context
@@ -458,9 +458,9 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
         "concept_name",
         filters={"id": f"eq.{concept_node_id}", "user_id": f"eq.{user_id}"},
     )
-    user_rows = table("users").select("name", filters={"id": f"eq.{user_id}"})
     concept_name = node2_rows[0]["concept_name"] if node2_rows else "Unknown"
-    student_name = decrypt_if_present(user_rows[0]["name"]) if user_rows else "Student"
+    # Display name lives on user_profiles (0024); resolve + decrypt via helper.
+    student_name = get_display_name(user_id) or "Student"
 
     existing_ctx = get_quiz_context(user_id, concept_node_id)
     ctx_prompt = (

--- a/backend/routes/social.py
+++ b/backend/routes/social.py
@@ -9,6 +9,7 @@ from db.connection import table
 from models import CreateRoomBody, JoinRoomBody, MatchBody, SendMessageBody, EditMessageBody, ToggleReactionBody, LeaveRoomBody
 from services.auth_guard import require_self, get_session_user_id
 from services.encryption import encrypt_if_present, decrypt_if_present
+from services.profiles import get_display_name, get_display_names
 from services.graph_service import get_graph
 from services.matching_service import find_study_matches
 from services.gemini_service import call_gemini
@@ -104,14 +105,13 @@ def room_overview(room_id: str, request: Request):
 
     members = []
     if member_ids:
-        user_rows = table("users").select(
-            "id,name", filters={"id": f"in.({','.join(member_ids)})"}
-        )
-        for u in user_rows:
+        # Names live on user_profiles (0024); resolve in bulk and decrypt.
+        name_map = get_display_names(member_ids)
+        for uid in member_ids:
             members.append({
-                "user_id": u["id"],
-                "name": decrypt_if_present(u["name"]),
-                "graph": get_graph(u["id"]),
+                "user_id": uid,
+                "name": name_map.get(uid, ""),
+                "graph": get_graph(uid),
             })
 
     member_summaries = []
@@ -154,10 +154,7 @@ def room_activity(room_id: str, request: Request):
     )
 
     user_ids = list(set(a["user_id"] for a in activity_rows))
-    user_name_map = {}
-    if user_ids:
-        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(user_ids)})"})
-        user_name_map = {u["id"]: decrypt_if_present(u["name"]) for u in user_rows}
+    user_name_map = get_display_names(user_ids) if user_ids else {}
 
     activities = [
         {
@@ -181,10 +178,11 @@ def match_partners(room_id: str, body: MatchBody, request: Request):
 
     members_with_graphs = []
     if member_ids:
-        user_rows = table("users").select("id,name", filters={"id": f"in.({','.join(member_ids)})"})
+        # Names live on user_profiles (0024); resolve in bulk and decrypt.
+        name_map = get_display_names(member_ids)
         members_with_graphs = [
-            {"user_id": u["id"], "name": decrypt_if_present(u["name"]), "graph": get_graph(u["id"])}
-            for u in user_rows
+            {"user_id": uid, "name": name_map.get(uid, ""), "graph": get_graph(uid)}
+            for uid in member_ids
         ]
 
     try:
@@ -216,18 +214,20 @@ def school_match(body: MatchBody, request: Request):
     excl_list = list(excluded_ids)
 
     school_users = table("users").select(
-        "id,name",
+        "id",
         filters={"id": f"not.in.({','.join(excl_list)})"},
     )
 
+    # Names live on user_profiles (0024); resolve in bulk and decrypt.
+    school_ids = [u["id"] for u in school_users]
+    name_map = get_display_names(school_ids)
     members_with_graphs = [
-        {"user_id": u["id"], "name": decrypt_if_present(u["name"]), "graph": get_graph(u["id"])}
-        for u in school_users
+        {"user_id": uid, "name": name_map.get(uid, ""), "graph": get_graph(uid)}
+        for uid in school_ids
     ]
 
     requester_graph = get_graph(body.user_id)
-    requester_rows = table("users").select("name", filters={"id": f"eq.{body.user_id}"})
-    requester_name = decrypt_if_present(requester_rows[0]["name"]) if requester_rows else body.user_id
+    requester_name = get_display_name(body.user_id) or body.user_id
 
     all_members = [
         {"user_id": body.user_id, "name": requester_name, "graph": requester_graph}
@@ -426,7 +426,9 @@ def toggle_reaction(room_id: str, message_id: str, body: ToggleReactionBody, req
 def get_students(request: Request):
     """Return a lightweight profile for every user in the DB."""
     user_id = get_session_user_id(request)
-    users = table("users").select("id,name,streak_count")
+    users = table("users").select("id,streak_count")
+    # Display names live on user_profiles (0024); resolve in bulk and decrypt.
+    name_map = get_display_names([u["id"] for u in users])
     # A user's courses now resolve through the enrollment chain
     # (enrollments → course_offerings → courses); the abstract `courses` catalog
     # no longer carries a per-user row. Read the offering's abstract course name
@@ -467,7 +469,7 @@ def get_students(request: Request):
     students = [
         {
             "user_id": u["id"],
-            "name": decrypt_if_present(u["name"]),
+            "name": name_map.get(u["id"], ""),
             "streak": u.get("streak_count") or 0,
             "courses": sorted(courses_by_user[u["id"]]),
             "stats": dict(mastery_by_user[u["id"]]),

--- a/backend/services/flashcard_import_service.py
+++ b/backend/services/flashcard_import_service.py
@@ -48,16 +48,19 @@ def _normalize(text: str) -> str:
 
 def dedup_against_existing(
     user_id: str,
-    course_id: str | None,
+    offering_id: str | None,
     cards: list[Card],
     topic: str | None = None,
 ) -> tuple[list[Card], list[Card]]:
     """Return (keep, skipped) where skipped have a near-duplicate front
     (Levenshtein <= 3 on normalized front) among the user's existing cards
-    in the same course (or topic when course_id is None)."""
+    in the same offering (or topic when offering_id is None).
+
+    Flashcards key on the course offering after migration 0025 (the link column
+    was renamed course_id -> offering_id)."""
     filters = {"user_id": f"eq.{user_id}"}
-    if course_id:
-        filters["course_id"] = f"eq.{course_id}"
+    if offering_id:
+        filters["offering_id"] = f"eq.{offering_id}"
     elif topic:
         filters["topic"] = f"eq.{topic}"
 

--- a/backend/services/graph_service.py
+++ b/backend/services/graph_service.py
@@ -68,12 +68,17 @@ def _get_course_nodes(user_id: str, course_id: str) -> list:
 
 
 def ensure_user_exists(user_id: str) -> None:
-    """Create a user row if one doesn't exist yet (prevents FK violations)."""
+    """Create a user row if one doesn't exist yet (prevents FK violations).
+
+    Insert only columns that still live on `users` after the 0024 identity split
+    — the public profile (incl. `name`) moved to `user_profiles`. A stub user has
+    no display name yet; onboarding/oauth populate `user_profiles` separately, so
+    we deliberately do NOT create a profile row here.
+    """
     existing = table("users").select("id", filters={"id": f"eq.{user_id}"})
     if not existing:
-        name = user_id.replace("user_", "").replace("_", " ").title()
         try:
-            table("users").insert({"id": user_id, "name": name, "streak_count": 0})
+            table("users").insert({"id": user_id, "streak_count": 0})
         except Exception:
             pass  # already exists (race condition) — safe to ignore
 

--- a/backend/services/profiles.py
+++ b/backend/services/profiles.py
@@ -1,0 +1,42 @@
+"""Display-name reads off `user_profiles`.
+
+Migration 0024 split the public profile out of `users` into a 1:1
+`user_profiles` table (PK/FK `user_id`). The display `name` column lives there
+and is 🔒 column-encrypted. Cross-domain callers that used to read
+`users.name` use these helpers to resolve a human-readable name again.
+
+A freshly FK-stubbed user (see graph_service.ensure_user_exists) has no
+`user_profiles` row yet — onboarding/oauth create it — so reads tolerate a
+missing row and return "" (single) / omit the id (bulk).
+"""
+
+from db.connection import table
+from services.encryption import decrypt_if_present
+
+
+def get_display_name(user_id: str) -> str:
+    """Return the decrypted display name for a single user, or "" if unset."""
+    rows = table("user_profiles").select("name", filters={"user_id": f"eq.{user_id}"})
+    if not rows:
+        return ""
+    return decrypt_if_present(rows[0].get("name")) or ""
+
+
+def get_display_names(user_ids: list[str]) -> dict[str, str]:
+    """Bulk-resolve decrypted display names keyed by user_id.
+
+    Ids with no `user_profiles` row (or a null name) are simply omitted from the
+    returned mapping; callers default per their own response shape.
+    """
+    ids = list(dict.fromkeys(user_ids))  # dedup, preserve order
+    if not ids:
+        return {}
+    rows = table("user_profiles").select(
+        "user_id,name", filters={"user_id": f"in.({','.join(ids)})"}
+    )
+    out: dict[str, str] = {}
+    for r in rows or []:
+        name = decrypt_if_present(r.get("name"))
+        if name:
+            out[r["user_id"]] = name
+    return out

--- a/backend/services/users_search.py
+++ b/backend/services/users_search.py
@@ -12,9 +12,13 @@ from typing import Optional
 
 from db.connection import table
 from services.encryption import decrypt_if_present
+from services.profiles import get_display_names
 
 _DEFAULT_PAGE_SIZE = 50
 _MAX_PAGE_SIZE = 200
+
+# After migration 0024 the display `name` lives on user_profiles, not users.
+_USERS_COLS = "id,email,is_approved,created_at,last_sign_in_at"
 
 
 def _attach_roles(users: list[dict]) -> None:
@@ -26,10 +30,11 @@ def _attach_roles(users: list[dict]) -> None:
         user["roles"] = [r["roles"] for r in (rows or []) if r.get("roles")]
 
 
-def _decrypt(user: dict) -> dict:
-    user["name"] = decrypt_if_present(user.get("name"))
-    user["email"] = decrypt_if_present(user.get("email"))
-    return user
+def _attach_names(users: list[dict]) -> None:
+    """Resolve each user's display name off user_profiles (🔒, decrypted)."""
+    names = get_display_names([u["id"] for u in users if u.get("id")])
+    for user in users:
+        user["name"] = names.get(user["id"], "")
 
 
 def paginate_users(
@@ -40,24 +45,27 @@ def paginate_users(
     page = max(1, int(page))
     page_size = max(1, min(_MAX_PAGE_SIZE, int(page_size)))
     offset = (page - 1) * page_size
-    columns = "id,name,email,is_approved,created_at,last_sign_in_at"
 
     if not q:
         rows, total = table("users").select_with_count(
-            columns=columns,
+            columns=_USERS_COLS,
             order="created_at.desc",
             limit=page_size,
             offset=offset,
         )
         for u in rows:
-            _decrypt(u)
+            u["email"] = decrypt_if_present(u.get("email"))
+        _attach_names(rows)
         _attach_roles(rows)
         return {"users": rows, "total": total, "page": page, "page_size": page_size}
 
-    # Search path: decrypt everything, then filter and paginate in Python.
-    all_rows = table("users").select(columns=columns, order="created_at.desc")
+    # Search path: name moved to user_profiles, so PostgREST can't filter it
+    # (AEAD nonces aren't searchable anyway). Decrypt emails + resolve every
+    # name, then filter and paginate in Python. Admin-scale, behind require_admin.
+    all_rows = table("users").select(columns=_USERS_COLS, order="created_at.desc")
     for u in all_rows:
-        _decrypt(u)
+        u["email"] = decrypt_if_present(u.get("email"))
+    _attach_names(all_rows)
     needle = q.lower()
     filtered = [
         u for u in all_rows

--- a/backend/tests/test_flashcard_import_service.py
+++ b/backend/tests/test_flashcard_import_service.py
@@ -42,12 +42,21 @@ class TestDedup:
         assert keep == new
         assert skipped == []
 
-    def test_filters_by_topic_when_course_id_is_none(self):
+    def test_filters_by_offering_id(self):
+        # Migration 0025 renamed the flashcards link column course_id -> offering_id.
+        with patch("services.flashcard_import_service.table") as t:
+            t.return_value.select.return_value = []
+            svc.dedup_against_existing("u1", "off1", [])
+            _, kwargs = t.return_value.select.call_args
+            assert kwargs["filters"] == {"user_id": "eq.u1", "offering_id": "eq.off1"}
+
+    def test_filters_by_topic_when_offering_id_is_none(self):
         with patch("services.flashcard_import_service.table") as t:
             t.return_value.select.return_value = []
             svc.dedup_against_existing("u1", None, [], topic="Bio")
             call_kwargs = t.return_value.select.call_args
             assert "Bio" in str(call_kwargs)
+            assert "offering_id" not in str(call_kwargs)
             assert "course_id" not in str(call_kwargs)
 
 

--- a/backend/tests/test_graph_service.py
+++ b/backend/tests/test_graph_service.py
@@ -15,6 +15,7 @@ from services.graph_service import (
     delete_course,
     apply_graph_update,
     get_recommendations,
+    ensure_user_exists,
 )
 
 
@@ -81,6 +82,36 @@ def _enrollment_row(course_id: str, code: str = "", name: str = "Course",
             "terms": {"label": term},
         },
     }
+
+
+# ── ensure_user_exists ────────────────────────────────────────────────────────
+
+class TestEnsureUserExists:
+    def test_insert_payload_omits_name_after_identity_split(self):
+        """`name` moved to user_profiles (migration 0024); the users insert must
+        not reference it or the real-DB write raises."""
+        factory, mocks = _cached_mock_table({"users": []})  # no existing row
+        with patch("services.graph_service.table", side_effect=factory):
+            ensure_user_exists("u1")
+
+        users = mocks["users"]
+        users.insert.assert_called_once()
+        payload = users.insert.call_args[0][0]
+        assert "name" not in payload
+        assert payload == {"id": "u1", "streak_count": 0}
+
+    def test_does_not_create_profile_row(self):
+        """A stub user has no display name yet; onboarding/oauth own user_profiles."""
+        factory, mocks = _cached_mock_table({"users": []})
+        with patch("services.graph_service.table", side_effect=factory):
+            ensure_user_exists("u1")
+        assert "user_profiles" not in mocks
+
+    def test_skips_insert_when_user_exists(self):
+        factory, mocks = _cached_mock_table({"users": [{"id": "u1"}]})
+        with patch("services.graph_service.table", side_effect=factory):
+            ensure_user_exists("u1")
+        mocks["users"].insert.assert_not_called()
 
 
 # ── get_graph ─────────────────────────────────────────────────────────────────

--- a/backend/tests/test_learn_routes.py
+++ b/backend/tests/test_learn_routes.py
@@ -208,22 +208,32 @@ class TestResumeSession:
 # ── POST /api/learn/mode-switch ───────────────────────────────────────────────
 
 class TestModeSwitch:
-    def _make_table_factory(self, user_name: str, topic: str):
-        """Return a table() side-effect that answers users and sessions queries."""
+    def _make_table_factory(self, topic: str):
+        """Return a table() side-effect that answers sessions queries.
+
+        The display name no longer lives on `users` (migration 0024 moved it to
+        user_profiles); get_user_name resolves it via services.profiles, which
+        these tests patch through `routes.learn.get_display_name`.
+        """
         def factory(name):
             mock = MagicMock()
-            if name == "users":
-                mock.select.return_value = [{"name": user_name}]
-            elif name == "sessions":
+            if name == "sessions":
                 mock.select.return_value = [{"topic": topic}]
             else:
                 mock.select.return_value = []
             return mock
         return factory
 
+    def _patches(self, user_name: str, topic: str):
+        """table factory + display-name patch for the mode-switch greeting."""
+        return (
+            patch("routes.learn.table", side_effect=self._make_table_factory(topic)),
+            patch("routes.learn.get_display_name", return_value=user_name),
+        )
+
     def test_returns_200_with_reply(self):
-        factory = self._make_table_factory("Andres Garcia", "Recursion")
-        with patch("routes.learn.table", side_effect=factory):
+        tbl, name = self._patches("Andres Garcia", "Recursion")
+        with tbl, name:
             r = client.post(
                 "/api/learn/mode-switch",
                 json={"session_id": "s1", "user_id": "u1", "new_mode": "expository"},
@@ -233,8 +243,8 @@ class TestModeSwitch:
 
     def test_reply_uses_first_name_only(self):
         """Message must greet with first name only, not full name."""
-        factory = self._make_table_factory("Andres Garcia", "Recursion")
-        with patch("routes.learn.table", side_effect=factory):
+        tbl, name = self._patches("Andres Garcia", "Recursion")
+        with tbl, name:
             r = client.post(
                 "/api/learn/mode-switch",
                 json={"session_id": "s1", "user_id": "u1", "new_mode": "socratic"},
@@ -244,8 +254,8 @@ class TestModeSwitch:
         assert "Garcia" not in reply
 
     def test_reply_contains_mode_display_name(self):
-        factory = self._make_table_factory("Maria", "Sorting algorithms")
-        with patch("routes.learn.table", side_effect=factory):
+        tbl, name = self._patches("Maria", "Sorting algorithms")
+        with tbl, name:
             r = client.post(
                 "/api/learn/mode-switch",
                 json={"session_id": "s1", "user_id": "u1", "new_mode": "expository"},
@@ -254,8 +264,8 @@ class TestModeSwitch:
         assert "Expository" in reply
 
     def test_reply_contains_current_topic(self):
-        factory = self._make_table_factory("Jake", "Binary Search Trees")
-        with patch("routes.learn.table", side_effect=factory):
+        tbl, name = self._patches("Jake", "Binary Search Trees")
+        with tbl, name:
             r = client.post(
                 "/api/learn/mode-switch",
                 json={"session_id": "s1", "user_id": "u1", "new_mode": "teachback"},
@@ -264,8 +274,8 @@ class TestModeSwitch:
         assert "Binary Search Trees" in reply
 
     def test_reply_has_no_em_dash(self):
-        factory = self._make_table_factory("Sam", "Graphs")
-        with patch("routes.learn.table", side_effect=factory):
+        tbl, name = self._patches("Sam", "Graphs")
+        with tbl, name:
             r = client.post(
                 "/api/learn/mode-switch",
                 json={"session_id": "s1", "user_id": "u1", "new_mode": "socratic"},
@@ -275,8 +285,8 @@ class TestModeSwitch:
         assert "\u2013" not in reply  # en-dash (extra guard)
 
     def test_reply_has_no_markdown_bold(self):
-        factory = self._make_table_factory("Sam", "Graphs")
-        with patch("routes.learn.table", side_effect=factory):
+        tbl, name = self._patches("Sam", "Graphs")
+        with tbl, name:
             r = client.post(
                 "/api/learn/mode-switch",
                 json={"session_id": "s1", "user_id": "u1", "new_mode": "socratic"},
@@ -285,8 +295,8 @@ class TestModeSwitch:
         assert "**" not in reply
 
     def test_message_is_saved_to_db(self):
-        factory = self._make_table_factory("Lea", "Linked Lists")
-        with patch("routes.learn.table", side_effect=factory) as t:
+        tbl, name = self._patches("Lea", "Linked Lists")
+        with tbl as t, name:
             client.post(
                 "/api/learn/mode-switch",
                 json={"session_id": "s1", "user_id": "u1", "new_mode": "teachback"},

--- a/backend/tests/test_profiles_service.py
+++ b/backend/tests/test_profiles_service.py
@@ -1,0 +1,82 @@
+"""Unit tests for services.profiles — display-name reads off user_profiles.
+
+After migration 0024 the public display `name` lives on `user_profiles`
+(1:1 with users, PK/FK user_id) and is 🔒 encrypted. These helpers read it
+back and decrypt it for cross-domain callers that used to read users.name.
+"""
+from unittest.mock import patch
+
+from services import profiles
+
+
+class TestGetDisplayName:
+    def test_decrypts_present_row(self):
+        with patch("services.profiles.table") as t, patch(
+            "services.profiles.decrypt_if_present",
+            side_effect=lambda v: f"d:{v}" if v else v,
+        ):
+            t.return_value.select.return_value = [{"name": "ENC"}]
+            assert profiles.get_display_name("u1") == "d:ENC"
+
+    def test_returns_empty_when_row_absent(self):
+        with patch("services.profiles.table") as t:
+            t.return_value.select.return_value = []
+            assert profiles.get_display_name("u1") == ""
+
+    def test_returns_empty_when_name_is_none(self):
+        with patch("services.profiles.table") as t, patch(
+            "services.profiles.decrypt_if_present", side_effect=lambda v: v
+        ):
+            t.return_value.select.return_value = [{"name": None}]
+            assert profiles.get_display_name("u1") == ""
+
+    def test_filters_by_user_id(self):
+        with patch("services.profiles.table") as t, patch(
+            "services.profiles.decrypt_if_present", side_effect=lambda v: v
+        ):
+            t.return_value.select.return_value = [{"name": "X"}]
+            profiles.get_display_name("u42")
+            _, kwargs = t.return_value.select.call_args
+            assert kwargs["filters"] == {"user_id": "eq.u42"}
+
+
+class TestGetDisplayNames:
+    def test_bulk_maps_decrypted_names(self):
+        rows = [{"user_id": "u1", "name": "AENC"}, {"user_id": "u2", "name": "BENC"}]
+        decrypt_map = {"AENC": "Alice", "BENC": "Bob"}
+        with patch("services.profiles.table") as t, patch(
+            "services.profiles.decrypt_if_present",
+            side_effect=lambda v: decrypt_map.get(v, v),
+        ):
+            t.return_value.select.return_value = rows
+            out = profiles.get_display_names(["u1", "u2"])
+        assert out == {"u1": "Alice", "u2": "Bob"}
+
+    def test_missing_rows_omitted(self):
+        rows = [{"user_id": "u1", "name": "AENC"}]
+        with patch("services.profiles.table") as t, patch(
+            "services.profiles.decrypt_if_present", side_effect=lambda v: v
+        ):
+            t.return_value.select.return_value = rows
+            out = profiles.get_display_names(["u1", "u2"])
+        assert out == {"u1": "AENC"}
+        assert "u2" not in out
+
+    def test_empty_input_skips_query(self):
+        with patch("services.profiles.table") as t:
+            out = profiles.get_display_names([])
+        assert out == {}
+        t.assert_not_called()
+
+    def test_dedups_ids_in_query(self):
+        with patch("services.profiles.table") as t, patch(
+            "services.profiles.decrypt_if_present", side_effect=lambda v: v
+        ):
+            t.return_value.select.return_value = []
+            profiles.get_display_names(["u1", "u1", "u2"])
+            _, kwargs = t.return_value.select.call_args
+            flt = kwargs["filters"]["user_id"]
+            # in.(...) with each id once
+            assert flt.startswith("in.(")
+            ids = flt[len("in.(") : -1].split(",")
+            assert sorted(ids) == ["u1", "u2"]

--- a/backend/tests/test_social_students.py
+++ b/backend/tests/test_social_students.py
@@ -43,6 +43,13 @@ def _table_factory(users, enrollment_rows, node_rows):
     return table_side_effect
 
 
+def _names_for(users):
+    """Display names now live on user_profiles; the route resolves them via
+    services.profiles.get_display_names (patched here). Each fixture user's
+    `name` key stands in for that user's decrypted profile name."""
+    return {u["id"]: u["name"] for u in users}
+
+
 class TestGetStudents:
     def test_courses_resolved_via_enrollments(self):
         users = [{"id": "u1", "name": "Alice", "streak_count": 3}]
@@ -53,7 +60,7 @@ class TestGetStudents:
         with patch(
             "routes.social.table",
             side_effect=_table_factory(users, enrollments, []),
-        ):
+        ), patch("routes.social.get_display_names", return_value=_names_for(users)):
             r = client.get("/api/social/students")
 
         assert r.status_code == 200
@@ -73,7 +80,7 @@ class TestGetStudents:
         with patch(
             "routes.social.table",
             side_effect=_table_factory(users, enrollments, []),
-        ):
+        ), patch("routes.social.get_display_names", return_value=_names_for(users)):
             r = client.get("/api/social/students")
 
         assert r.status_code == 200
@@ -92,7 +99,7 @@ class TestGetStudents:
         with patch(
             "routes.social.table",
             side_effect=_table_factory(users, enrollments, []),
-        ):
+        ), patch("routes.social.get_display_names", return_value=_names_for(users)):
             r = client.get("/api/social/students")
 
         assert r.status_code == 200
@@ -105,7 +112,7 @@ class TestGetStudents:
         with patch(
             "routes.social.table",
             side_effect=_table_factory(users, [], []),
-        ):
+        ), patch("routes.social.get_display_names", return_value=_names_for(users)):
             r = client.get("/api/social/students")
 
         assert r.status_code == 200
@@ -125,7 +132,7 @@ class TestGetStudents:
         with patch(
             "routes.social.table",
             side_effect=_table_factory(users, enrollments, node_rows),
-        ):
+        ), patch("routes.social.get_display_names", return_value=_names_for(users)):
             r = client.get("/api/social/students")
 
         assert r.status_code == 200

--- a/backend/tests/test_users_roster_auth.py
+++ b/backend/tests/test_users_roster_auth.py
@@ -9,7 +9,7 @@ The autouse `_bypass_session_auth` fixture in conftest.py stubs the auth
 guard so authenticated-path tests don't need real tokens; the
 unauthenticated test restores the real guard to assert the 401.
 """
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -36,20 +36,32 @@ class TestListUsersAuth:
         assert r.status_code == 401
 
     def test_authenticated_returns_200_with_decrypted_names(self):
-        rows = [
-            {"id": "u1", "name": "ENC_BOB", "room_id": "r1"},
-            {"id": "u2", "name": "ENC_ALICE", "room_id": "r2"},
+        # users now carries id + current_room_id (0024 dropped name, renamed
+        # room_id); the display name resolves off user_profiles via
+        # services.profiles.get_display_names, which decrypts. The route imports
+        # both names locally from their modules, so patch at the source modules.
+        users_rows = [
+            {"id": "u1", "current_room_id": "r1"},
+            {"id": "u2", "current_room_id": "r2"},
         ]
-        decrypt_map = {"ENC_BOB": "Bob", "ENC_ALICE": "Alice"}
+        names_map = {"u1": "Bob", "u2": "Alice"}
 
-        with patch("db.connection.table") as t, patch(
-            "services.encryption.decrypt_if_present",
-            side_effect=lambda v: decrypt_map.get(v, v),
+        def by_name(name):
+            m = MagicMock()
+            m.select.return_value = users_rows if name == "users" else []
+            return m
+
+        with patch("db.connection.table", side_effect=by_name), patch(
+            "services.profiles.get_display_names", return_value=names_map
         ):
-            t.return_value.select.return_value = rows
             r = client.get("/api/users")
 
         assert r.status_code == 200
-        names = [u["name"] for u in r.json()["users"]]
+        result = r.json()["users"]
+        names = [u["name"] for u in result]
         # Sorted by decrypted name, lowercased.
         assert names == ["Alice", "Bob"]
+        # Legacy room_id response key preserved, sourced from current_room_id.
+        by_id = {u["name"]: u for u in result}
+        assert by_id["Bob"]["room_id"] == "r1"
+        assert by_id["Alice"]["room_id"] == "r2"

--- a/backend/tests/test_users_search.py
+++ b/backend/tests/test_users_search.py
@@ -4,12 +4,16 @@ from services.users_search import paginate_users
 
 class TestPaginateUsers:
     def test_no_query_uses_select_with_count(self):
+        # `name` now lives on user_profiles (0024); users carries only email + auth.
         users_rows = [
-            {"id": "u1", "name": "enc1", "email": "enc2", "is_approved": True,
+            {"id": "u1", "email": "enc2", "is_approved": True,
              "created_at": "2026-01-01T00:00:00Z", "last_sign_in_at": None},
         ]
         with patch("services.users_search.table") as t, \
-             patch("services.users_search.decrypt_if_present", side_effect=lambda v: f"d:{v}" if v else v):
+             patch("services.users_search.get_display_names",
+                   return_value={"u1": "Decrypted Name"}), \
+             patch("services.users_search.decrypt_if_present",
+                   side_effect=lambda v: f"d:{v}" if v else v):
             users_tbl = MagicMock()
             users_tbl.select_with_count.return_value = (users_rows, 137)
             roles_tbl = MagicMock()
@@ -25,20 +29,24 @@ class TestPaginateUsers:
         assert result["total"] == 137
         assert result["page"] == 1
         assert result["page_size"] == 50
-        assert result["users"][0]["name"] == "d:enc1"
+        # name resolved off user_profiles; email decrypted off the users row.
+        assert result["users"][0]["name"] == "Decrypted Name"
+        assert result["users"][0]["email"] == "d:enc2"
         users_tbl.select_with_count.assert_called_once()
 
     def test_query_filters_after_decrypt(self):
         rows = [
-            {"id": "u1", "name": "ALICE_ENC", "email": "AE", "is_approved": True,
+            {"id": "u1", "email": "AE", "is_approved": True,
              "created_at": "x", "last_sign_in_at": None},
-            {"id": "u2", "name": "BOB_ENC", "email": "BE", "is_approved": False,
+            {"id": "u2", "email": "BE", "is_approved": False,
              "created_at": "x", "last_sign_in_at": None},
         ]
-        decrypt_map = {"ALICE_ENC": "Alice Smith", "AE": "alice@bu.edu",
-                       "BOB_ENC": "Bob Jones", "BE": "bob@bu.edu"}
+        email_map = {"AE": "alice@bu.edu", "BE": "bob@bu.edu"}
+        name_map = {"u1": "Alice Smith", "u2": "Bob Jones"}
         with patch("services.users_search.table") as t, \
-             patch("services.users_search.decrypt_if_present", side_effect=lambda v: decrypt_map.get(v, v)):
+             patch("services.users_search.get_display_names", return_value=name_map), \
+             patch("services.users_search.decrypt_if_present",
+                   side_effect=lambda v: email_map.get(v, v)):
             users_tbl = MagicMock()
             users_tbl.select.return_value = rows
             roles_tbl = MagicMock()
@@ -51,12 +59,15 @@ class TestPaginateUsers:
 
             result = paginate_users(q="alice", page=1, page_size=10)
 
+        # Matches on the user_profiles-sourced name.
         assert result["total"] == 1
         assert len(result["users"]) == 1
+        assert result["users"][0]["name"] == "Alice Smith"
         assert result["users"][0]["email"] == "alice@bu.edu"
 
     def test_caps_page_size(self):
-        with patch("services.users_search.table") as t:
+        with patch("services.users_search.table") as t, \
+             patch("services.users_search.get_display_names", return_value={}):
             users_tbl = MagicMock()
             users_tbl.select_with_count.return_value = ([], 0)
             t.return_value = users_tbl
@@ -64,7 +75,7 @@ class TestPaginateUsers:
         assert result["page_size"] == 200  # hard cap
 
     def test_attaches_roles_and_drops_orphan_joins(self):
-        rows = [{"id": "u1", "name": "ENC", "email": "ENC", "is_approved": True,
+        rows = [{"id": "u1", "email": "ENC", "is_approved": True,
                  "created_at": "x", "last_sign_in_at": None}]
         # PostgREST returns an embedded `roles` value that is None when the join
         # target was deleted but the user_roles row remained.
@@ -77,6 +88,7 @@ class TestPaginateUsers:
         ]
 
         with patch("services.users_search.table") as t, \
+             patch("services.users_search.get_display_names", return_value={"u1": "Admin User"}), \
              patch("services.users_search.decrypt_if_present", side_effect=lambda v: v):
             users_tbl = MagicMock()
             users_tbl.select_with_count.return_value = (rows, 1)


### PR DESCRIPTION
Real-DB reconciliation the per-domain slices left behind (mocked tests didn't catch these — they only surface against the migrated schema).

**Fixes:**
- `graph_service.ensure_user_exists` no longer INSERTs the dropped `users.name` (inserts `{id, streak_count}` only).
- New `services/profiles.py`: `get_display_name` / `get_display_names` read `user_profiles` (decrypted); repointed `main.py`, `social.py` (6 name reads), `quiz.py`, `learn.py`, `users_search.py`. Bonus: fixed `main.py` `room_id → current_room_id` (another 0024 rename).
- `flashcard_import_service.dedup_against_existing`: `course_id → offering_id` (0025 rename).
- `users_search`: code-only (no decrypted DB view exists) — enriches rows from `user_profiles`; **no migration needed.**

**Tests:** new `test_profiles_service.py` (8) + `TestEnsureUserExists` (asserts no `name` in the users insert); updated roster/social/search/flashcard/learn suites. **779 passed, zero new failures** (only the 2 env-only `test_storage_service.py`); ruff clean.

Plan: `docs/superpowers/plans/2026-06-24-db-identity-reconcile.md`. After this, the epic is real-DB-safe → ready for `db/seed-staging` (#258) and the `epic → main` cutover.