### PR TITLE
db/seed-staging: idempotent demo seed for the new schema (#258)

### DIFF
--- a/backend/db/seed_staging.py
+++ b/backend/db/seed_staging.py
@@ -1,0 +1,438 @@
+"""Idempotent STAGING demo seed for the DB modular redesign (#258).
+
+⚠️  STAGING ONLY — FAKE DATA. Never run against production.
+
+This lays a small, self-contained demo dataset on top of the *new*
+(post-0019–0027) schema so the live staging app renders the knowledge graph,
+gradebook, and courses-with-term against a real database. Migrations 0019–0027
+must already be applied and the canonical ``terms`` (fall-2025 / spring-2026 /
+summer-2026 / fall-2026) already seeded (0019); this seed only *reads* those
+terms and adds demo rows around them. It never touches, duplicates, or depends
+on the real course catalog.
+
+Idempotent: every row uses a deterministic ``seed-…`` id and is written via
+upsert-on-UNIQUE or insert-if-absent, so re-running adds nothing and never errors.
+
+Safety: all DB access goes through ``db/connection.py::table()`` (configured via
+env only — no hardcoded URLs/keys, no secrets printed). 🔒 columns are written
+through ``services.encryption.encrypt_if_present`` so they land encrypted with
+whatever ``ENCRYPTION_KEY`` the staging env provides.
+
+Run (from ``backend/`` with staging env loaded):
+
+    python -m db.seed_staging
+"""
+from __future__ import annotations
+
+import os
+import sys
+from collections import defaultdict
+
+# Allow ``python db/seed_staging.py`` as well as ``python -m db.seed_staging``.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from config import get_mastery_tier  # noqa: E402  (tier ↔ score stay consistent)
+from db.connection import table  # noqa: E402  (module-level; patched in tests)
+from services.encryption import encrypt_if_present  # noqa: E402
+
+# ─── Deterministic ids (everything namespaced `seed-…`) ──────────────────────
+
+SCHOOL_ID = "seed-school-demo"
+
+# Abstract courses (catalog) keyed on the demo school.
+COURSE_CS = "seed-course-cs101"
+COURSE_MATH = "seed-course-math210"
+COURSE_BIO = "seed-course-bio110"
+
+# Canonical terms seeded by 0019 — referenced by id, never written here.
+TERM_FALL_2025 = "fall-2025"
+TERM_SPRING_2026 = "spring-2026"
+
+# Offerings (course taught in a term). CS101 is offered in BOTH terms so that
+# graph mastery (keyed on the abstract course) is cumulative across terms.
+OFF_CS_FALL = "seed-off-cs101-fall2025"
+OFF_CS_SPRING = "seed-off-cs101-spring2026"
+OFF_MATH = "seed-off-math210-spring2026"
+OFF_BIO = "seed-off-bio110-fall2025"
+
+USER_ID = "seed-user-demo"
+
+# Enrollments (demo user → offering). CS101 in both terms.
+ENR_CS_FALL = "seed-enr-cs101-fall2025"
+ENR_CS_SPRING = "seed-enr-cs101-spring2026"
+ENR_MATH = "seed-enr-math210-spring2026"
+ENR_BIO = "seed-enr-bio110-fall2025"
+
+
+# ─── Idempotency helpers ─────────────────────────────────────────────────────
+
+_counts: dict[str, dict[str, int]] = defaultdict(lambda: {"created": 0, "skipped": 0})
+
+
+def _record(table_name: str, created: bool) -> None:
+    _counts[table_name]["created" if created else "skipped"] += 1
+
+
+def _upsert(table_name: str, row: dict, on_conflict: str) -> None:
+    """Upsert a single row on its natural UNIQUE key.
+
+    merge-duplicates makes a re-run a no-op (same content, same key). We still
+    track created-vs-skipped via a pre-check on the conflict key for an honest
+    summary, but the write itself is the source of truth for idempotency.
+    """
+    exists = _exists_by(table_name, {k: row[k] for k in on_conflict.split(",")})
+    table(table_name).upsert(row, on_conflict=on_conflict)
+    _record(table_name, created=not exists)
+
+
+def _insert_if_absent(table_name: str, row_id: str, row: dict) -> None:
+    """Insert a row keyed on a deterministic id, only if that id is absent.
+
+    For tables with no natural UNIQUE (enrollments, gradebook_categories,
+    assignments, documents, notes, node_mastery_events) this is what keeps a
+    re-run from duplicating — especially the append-only node_mastery_events.
+    """
+    if _exists_by(table_name, {"id": row_id}):
+        _record(table_name, created=False)
+        return
+    table(table_name).insert({"id": row_id, **row})
+    _record(table_name, created=True)
+
+
+def _exists_by(table_name: str, eq_filters: dict) -> bool:
+    filters = {col: f"eq.{val}" for col, val in eq_filters.items()}
+    rows = table(table_name).select("id", filters=filters, limit=1) or []
+    return len(rows) > 0
+
+
+# ─── Seed steps ──────────────────────────────────────────────────────────────
+
+
+def seed_school() -> None:
+    _upsert(
+        "schools",
+        {"id": SCHOOL_ID, "name": "Sapling Demo University", "slug": "sapling-demo"},
+        on_conflict="slug",
+    )
+
+
+def seed_courses() -> None:
+    courses = [
+        (COURSE_CS, "CS101", "Intro to Computer Science", "Computer Science", 3,
+         "Foundations of programming and computational thinking."),
+        (COURSE_MATH, "MATH210", "Linear Algebra", "Mathematics", 4,
+         "Vectors, matrices, and linear transformations."),
+        (COURSE_BIO, "BIO110", "Cell Biology", "Biology", 3,
+         "Structure and function of the living cell."),
+    ]
+    for cid, code, name, dept, credits, desc in courses:
+        _upsert(
+            "courses",
+            {
+                "id": cid,
+                "school_id": SCHOOL_ID,
+                "course_code": code,
+                "course_name": name,
+                "department": dept,
+                "credits": credits,
+                "description": desc,
+            },
+            on_conflict="school_id,course_code",
+        )
+
+
+def seed_offerings() -> None:
+    # CS101 in TWO terms (multi-term), MATH210 + BIO110 once each.
+    # section is "" (not NULL) so the (course_id, term_id, section) UNIQUE is a
+    # stable conflict target for upsert idempotency.
+    offerings = [
+        (OFF_CS_FALL, COURSE_CS, TERM_FALL_2025, "Dr. Ada Lovelace", "MWF 09:00", "Hall A"),
+        (OFF_CS_SPRING, COURSE_CS, TERM_SPRING_2026, "Dr. Ada Lovelace", "MWF 11:00", "Hall A"),
+        (OFF_MATH, COURSE_MATH, TERM_SPRING_2026, "Dr. Emmy Noether", "TTh 10:00", "Hall B"),
+        (OFF_BIO, COURSE_BIO, TERM_FALL_2025, "Dr. Rosalind Franklin", "TTh 13:00", "Lab 2"),
+    ]
+    for oid, cid, term_id, instructor, meeting, location in offerings:
+        _upsert(
+            "course_offerings",
+            {
+                "id": oid,
+                "course_id": cid,
+                "term_id": term_id,
+                "section": "",
+                "instructor_name": instructor,
+                "meeting_times": meeting,
+                "location": location,
+            },
+            on_conflict="course_id,term_id,section",
+        )
+
+
+def seed_user() -> None:
+    # Slim users row (profile fields live in user_profiles after the 0024 split).
+    # email is encrypted on staging.
+    _upsert(
+        "users",
+        {
+            "id": USER_ID,
+            "email": encrypt_if_present("demo.student@staging.saplinglearn.com"),
+            "onboarding_completed": True,
+            "streak_count": 4,
+            "is_approved": True,
+            "auth_provider": "google",
+        },
+        on_conflict="id",
+    )
+    # 🔒 name fields via encrypt_if_present.
+    _upsert(
+        "user_profiles",
+        {
+            "user_id": USER_ID,
+            "name": encrypt_if_present("Demo Student"),
+            "first_name": encrypt_if_present("Demo"),
+            "last_name": encrypt_if_present("Student"),
+            "username": "demo-student",
+            "year": "Sophomore",
+            "majors": ["Computer Science"],
+            "minors": ["Mathematics"],
+            "learning_style": "visual",
+        },
+        on_conflict="user_id",
+    )
+
+
+def seed_enrollments() -> None:
+    # Demo user enrolled in all 4 offerings, incl. CS101 in BOTH terms.
+    # curve_mode ∈ {raw, curved} (0021); one curved to exercise the policy.
+    enrollments = [
+        (ENR_CS_FALL, OFF_CS_FALL, "#4f86f7", "Intro CS", "raw"),
+        (ENR_CS_SPRING, OFF_CS_SPRING, "#4f86f7", "Intro CS (S26)", "raw"),
+        (ENR_MATH, OFF_MATH, "#f7724f", "Lin Alg", "curved"),
+        (ENR_BIO, OFF_BIO, "#5fbf6b", "Cell Bio", "raw"),
+    ]
+    for eid, off_id, color, nickname, curve_mode in enrollments:
+        row = {
+            "user_id": USER_ID,
+            "offering_id": off_id,
+            "color": color,
+            "nickname": nickname,
+            "curve_mode": curve_mode,
+        }
+        if curve_mode == "curved":
+            row["curve_avg_target"] = 0.85
+            row["curve_sd_delta"] = 0.05
+        _insert_if_absent("enrollments", eid, row)
+
+
+# Graph: keyed on the ABSTRACT course_id (mastery is cumulative across terms).
+# (course_id, concept_name, mastery_score) — tier derived from score.
+_GRAPH_NODES = {
+    COURSE_CS: [
+        ("seed-node-cs-variables", "Variables and Types", 0.9),     # mastered
+        ("seed-node-cs-functions", "Functions", 0.6),               # learning
+        ("seed-node-cs-recursion", "Recursion", 0.2),               # struggling
+    ],
+    COURSE_MATH: [
+        ("seed-node-math-vectors", "Vectors", 0.8),                 # mastered
+        ("seed-node-math-matrices", "Matrices", 0.5),               # learning
+        ("seed-node-math-eigen", "Eigenvalues", 0.0),               # unexplored
+    ],
+    COURSE_BIO: [
+        ("seed-node-bio-membrane", "Cell Membrane", 0.7),           # learning
+        ("seed-node-bio-mitochondria", "Mitochondria", 0.55),       # learning
+        ("seed-node-bio-dna", "DNA Replication", 0.15),             # struggling
+    ],
+}
+
+# Within-course edges. relationship_type ∈
+# {related, prerequisite, builds_on, part_of} (0023).
+_GRAPH_EDGES = [
+    ("seed-node-cs-variables", "seed-node-cs-functions", "prerequisite", 0.9),
+    ("seed-node-cs-functions", "seed-node-cs-recursion", "builds_on", 0.8),
+    ("seed-node-math-vectors", "seed-node-math-matrices", "builds_on", 0.7),
+    ("seed-node-bio-membrane", "seed-node-bio-mitochondria", "related", 0.5),
+]
+
+# Append-only mastery events (0023). (node_id, event_id, delta, reason).
+_MASTERY_EVENTS = [
+    ("seed-node-cs-variables", "seed-evt-cs-variables-1", 0.4, "quiz: intro types"),
+    ("seed-node-cs-variables", "seed-evt-cs-variables-2", 0.5, "lecture review"),
+    ("seed-node-cs-functions", "seed-evt-cs-functions-1", 0.3, "homework 2"),
+    ("seed-node-math-vectors", "seed-evt-math-vectors-1", 0.4, "problem set 1"),
+    ("seed-node-bio-membrane", "seed-evt-bio-membrane-1", 0.35, "reading quiz"),
+    ("seed-node-bio-dna", "seed-evt-bio-dna-1", 0.15, "first pass"),
+]
+
+
+def seed_graph() -> None:
+    for course_id, nodes in _GRAPH_NODES.items():
+        for node_id, concept, score in nodes:
+            subject = concept.split()[0]
+            _upsert(
+                "graph_nodes",
+                {
+                    "id": node_id,
+                    "user_id": USER_ID,
+                    "course_id": course_id,
+                    "concept_name": concept,
+                    "subject": subject,
+                    "mastery_score": score,
+                    "mastery_tier": get_mastery_tier(score),
+                },
+                on_conflict="user_id,course_id,concept_name",
+            )
+
+    for src_id, tgt_id, rel_type, strength in _GRAPH_EDGES:
+        edge_id = f"seed-edge-{src_id.removeprefix('seed-node-')}-{tgt_id.removeprefix('seed-node-')}"
+        _upsert(
+            "graph_edges",
+            {
+                "id": edge_id,
+                "user_id": USER_ID,
+                "source_node_id": src_id,
+                "target_node_id": tgt_id,
+                "relationship_type": rel_type,
+                "strength": strength,
+            },
+            on_conflict="user_id,source_node_id,target_node_id,relationship_type",
+        )
+
+    for node_id, event_id, delta, reason in _MASTERY_EVENTS:
+        _insert_if_absent(
+            "node_mastery_events",
+            event_id,
+            {"node_id": node_id, "delta": delta, "reason": reason},
+        )
+
+
+# Gradebook: one category per enrollment; one drops its lowest.
+# (enrollment_id, category_id, name, weight, drop_lowest)
+_CATEGORIES = [
+    (ENR_CS_FALL, "seed-cat-cs-fall-hw", "Homework", 0.4, 1),
+    (ENR_CS_SPRING, "seed-cat-cs-spring-hw", "Homework", 0.4, 0),
+    (ENR_MATH, "seed-cat-math-exams", "Exams", 0.6, 0),
+    (ENR_BIO, "seed-cat-bio-labs", "Labs", 0.5, 0),
+]
+
+# Assignments: on enrollment + category. source ∈ {manual, syllabus};
+# assignment_type ∈ {homework, exam, reading, project, quiz, other}.
+# (assignment_id, enrollment_id, category_id, title, due_date, type, source, possible, earned)
+_ASSIGNMENTS = [
+    ("seed-asg-cs-fall-hw1", ENR_CS_FALL, "seed-cat-cs-fall-hw",
+     "Homework 1: Variables", "2025-09-08", "homework", "syllabus", "100", "92"),
+    ("seed-asg-cs-fall-hw2", ENR_CS_FALL, "seed-cat-cs-fall-hw",
+     "Homework 2: Functions", "2025-09-22", "homework", "manual", "100", "78"),
+    ("seed-asg-cs-spring-hw1", ENR_CS_SPRING, "seed-cat-cs-spring-hw",
+     "Homework 1: Recursion", "2026-01-26", "homework", "manual", "100", None),
+    ("seed-asg-math-mid", ENR_MATH, "seed-cat-math-exams",
+     "Midterm Exam", "2026-03-02", "exam", "syllabus", "100", "88"),
+    ("seed-asg-bio-lab1", ENR_BIO, "seed-cat-bio-labs",
+     "Lab 1: Microscopy", "2025-09-15", "project", "manual", "50", "47"),
+    ("seed-asg-bio-reading", ENR_BIO, "seed-cat-bio-labs",
+     "Chapter 3 Reading Quiz", "2025-09-19", "reading", "manual", "20", "16"),
+]
+
+
+def seed_gradebook() -> None:
+    for enr_id, cat_id, name, weight, drop_lowest in _CATEGORIES:
+        _insert_if_absent(
+            "gradebook_categories",
+            cat_id,
+            {
+                "enrollment_id": enr_id,
+                "name": name,
+                "weight": weight,
+                "drop_lowest": drop_lowest,
+            },
+        )
+
+    for asg_id, enr_id, cat_id, title, due, atype, source, possible, earned in _ASSIGNMENTS:
+        _insert_if_absent(
+            "assignments",
+            asg_id,
+            {
+                "enrollment_id": enr_id,
+                "category_id": cat_id,
+                "title": title,
+                "due_date": due,
+                "assignment_type": atype,
+                "source": source,
+                # 🔒 points (numeric semantics; decrypt_numeric at read).
+                "points_possible": encrypt_if_present(possible),
+                "points_earned": encrypt_if_present(earned),
+            },
+        )
+
+
+def seed_study() -> None:
+    # A document + a note on the CS101 fall-2025 offering so study endpoints
+    # have data. category ∈ {syllabus, lecture_notes, slides, reading,
+    # assignment, study_guide, other} (0025).
+    _insert_if_absent(
+        "documents",
+        "seed-doc-cs-fall-syllabus",
+        {
+            "user_id": USER_ID,
+            "offering_id": OFF_CS_FALL,
+            "file_name": "cs101-syllabus.pdf",
+            "category": "syllabus",
+            # 🔒 summary / concept_notes.
+            "summary": encrypt_if_present(
+                "CS101 syllabus: weekly homework, one midterm, final project."
+            ),
+            "concept_notes": encrypt_if_present(
+                "Covers variables, functions, recursion."
+            ),
+        },
+    )
+    _insert_if_absent(
+        "notes",
+        "seed-note-cs-fall-week1",
+        {
+            "user_id": USER_ID,
+            "offering_id": OFF_CS_FALL,
+            # 🔒 title / body.
+            "title": encrypt_if_present("Week 1 — Variables"),
+            "body": encrypt_if_present(
+                "A variable binds a name to a value. Types: int, str, bool, float."
+            ),
+            "tags": ["week1", "basics"],
+        },
+    )
+
+
+# ─── Entry point ─────────────────────────────────────────────────────────────
+
+
+def _print_summary() -> None:
+    print("\nSeed summary (staging demo data):")
+    order = [
+        "schools", "courses", "course_offerings", "users", "user_profiles",
+        "enrollments", "graph_nodes", "graph_edges", "node_mastery_events",
+        "gradebook_categories", "assignments", "documents", "notes",
+    ]
+    total_created = 0
+    for name in order:
+        c = _counts.get(name, {"created": 0, "skipped": 0})
+        total_created += c["created"]
+        print(f"  {name:22s} created={c['created']:<3d} skipped(exists)={c['skipped']}")
+    print(f"  {'TOTAL created':22s} {total_created}")
+    if total_created == 0:
+        print("  (all rows already present — re-run was a no-op)")
+
+
+def main() -> None:
+    """Seed the staging demo dataset. Idempotent; safe to re-run."""
+    _counts.clear()  # fresh per-run summary (also keeps re-runs in one process honest)
+    seed_school()
+    seed_courses()
+    seed_offerings()
+    seed_user()
+    seed_enrollments()
+    seed_graph()
+    seed_gradebook()
+    seed_study()
+    _print_summary()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -1,0 +1,301 @@
+"""Hermetic tests for db/seed_staging.py (#258).
+
+No real DB: `db.seed_staging.table` is patched to a recording FakeTable backed by
+an in-memory per-table store that mimics PostgREST's eq-filter select, insert,
+and upsert(merge-duplicates) semantics closely enough to exercise the seed's
+idempotency, FK consistency, enum validity, multi-term, and encryption boundaries.
+"""
+from unittest.mock import patch
+
+import pytest
+
+import db.seed_staging as seed
+from services.encryption import decrypt
+
+# CHECK-enum sets read off migrations 0019–0027 (the seed must stay within these).
+MASTERY_TIERS = {"unexplored", "struggling", "learning", "mastered", "subject_root"}
+RELATIONSHIP_TYPES = {"related", "prerequisite", "builds_on", "part_of"}
+ASSIGNMENT_TYPES = {"homework", "exam", "reading", "project", "quiz", "other"}
+ASSIGNMENT_SOURCES = {"manual", "syllabus"}
+DOC_CATEGORIES = {
+    "syllabus", "lecture_notes", "slides", "reading", "assignment",
+    "study_guide", "other",
+}
+CURVE_MODES = {"raw", "curved"}
+
+# Terms pre-seeded by 0019 — the seed references these but never writes them.
+PRESEEDED_TERMS = {"fall-2025", "spring-2026", "summer-2026", "fall-2026"}
+
+
+# Primary key column per table (user_profiles is keyed on user_id, not id).
+_PK = {"user_profiles": "user_id"}
+
+
+def _pk(name: str) -> str:
+    return _PK.get(name, "id")
+
+
+class _FakeStore:
+    """Shared in-memory DB: {table_name: {pk_value: row}}.
+
+    Pre-populated with the canonical terms (which 0019 seeds and the seed only
+    reads), so any term FK the seed uses resolves.
+    """
+
+    def __init__(self):
+        self.tables: dict[str, dict] = {
+            "terms": {t: {"id": t} for t in PRESEEDED_TERMS},
+        }
+
+    def rows(self, name: str) -> list[dict]:
+        return list(self.tables.get(name, {}).items())
+
+
+class _FakeTable:
+    def __init__(self, name: str, store: _FakeStore):
+        self.name = name
+        self.store = store
+        self.store.tables.setdefault(name, {})
+
+    @property
+    def _t(self) -> dict:
+        return self.store.tables[self.name]
+
+    def select(self, columns="*", filters=None, order=None, limit=None):
+        rows = list(self._t.values())
+        if filters:
+            for col, expr in filters.items():
+                # Only the eq.<val> form is used by the seed's presence checks.
+                assert expr.startswith("eq."), f"unexpected filter {expr!r}"
+                val = expr[len("eq."):]
+                rows = [r for r in rows if str(r.get(col)) == val]
+        if limit is not None:
+            rows = rows[:limit]
+        return rows
+
+    def insert(self, data):
+        pk = _pk(self.name)
+        rows = data if isinstance(data, list) else [data]
+        for row in rows:
+            rid = row[pk]
+            assert rid not in self._t, (
+                f"duplicate insert into {self.name} {pk}={rid} (not idempotent)"
+            )
+            self._t[rid] = dict(row)
+        return rows
+
+    def upsert(self, data, on_conflict="id"):
+        pk = _pk(self.name)
+        rows = data if isinstance(data, list) else [data]
+        keys = on_conflict.split(",")
+        for row in rows:
+            # merge-duplicates: find any existing row matching the conflict key.
+            match_id = None
+            for existing_id, existing in self._t.items():
+                if all(str(existing.get(k)) == str(row.get(k)) for k in keys):
+                    match_id = existing_id
+                    break
+            rid = match_id if match_id is not None else row[pk]
+            merged = dict(self._t.get(rid, {}))
+            merged.update(row)
+            self._t[rid] = merged
+        return rows
+
+
+@pytest.fixture
+def store():
+    s = _FakeStore()
+
+    def _factory(name: str):
+        return _FakeTable(name, s)
+
+    with patch.object(seed, "table", side_effect=_factory):
+        yield s
+
+
+def _run(store):
+    seed.main()
+    return store
+
+
+# ─── Insertion coverage ──────────────────────────────────────────────────────
+
+
+def test_seeds_all_expected_tables(store):
+    _run(store)
+    expected = {
+        "schools", "courses", "course_offerings", "users", "user_profiles",
+        "enrollments", "graph_nodes", "graph_edges", "node_mastery_events",
+        "gradebook_categories", "assignments", "documents", "notes",
+    }
+    for name in expected:
+        assert store.tables.get(name), f"{name} got no rows"
+
+
+def test_terms_are_never_written(store):
+    before = dict(store.tables["terms"])
+    _run(store)
+    assert store.tables["terms"] == before, "seed must not write canonical terms"
+
+
+def test_expected_counts(store):
+    _run(store)
+    n = lambda t: len(store.tables[t])  # noqa: E731
+    assert n("schools") == 1
+    assert n("courses") == 3
+    assert n("course_offerings") == 4
+    assert n("users") == 1
+    assert n("user_profiles") == 1
+    assert n("enrollments") == 4
+    assert n("graph_nodes") == 9
+    assert n("graph_edges") == 4
+    assert n("node_mastery_events") == 6
+    assert n("gradebook_categories") == 4
+    assert n("assignments") == 6
+    assert n("documents") == 1
+    assert n("notes") == 1
+
+
+# ─── FK consistency ──────────────────────────────────────────────────────────
+
+
+def test_fk_consistency(store):
+    _run(store)
+    course_ids = set(store.tables["courses"])
+    offering_ids = set(store.tables["course_offerings"])
+    user_ids = set(store.tables["users"])
+    node_ids = set(store.tables["graph_nodes"])
+    enrollment_ids = set(store.tables["enrollments"])
+    category_ids = set(store.tables["gradebook_categories"])
+
+    for off in store.tables["course_offerings"].values():
+        assert off["course_id"] in course_ids
+        assert off["term_id"] in PRESEEDED_TERMS
+
+    assert set(store.tables["user_profiles"]) <= user_ids
+
+    for enr in store.tables["enrollments"].values():
+        assert enr["user_id"] in user_ids
+        assert enr["offering_id"] in offering_ids
+
+    for node in store.tables["graph_nodes"].values():
+        assert node["user_id"] in user_ids
+        assert node["course_id"] in course_ids  # graph keyed on ABSTRACT course
+
+    for edge in store.tables["graph_edges"].values():
+        assert edge["source_node_id"] in node_ids
+        assert edge["target_node_id"] in node_ids
+
+    for evt in store.tables["node_mastery_events"].values():
+        assert evt["node_id"] in node_ids
+
+    for cat in store.tables["gradebook_categories"].values():
+        assert cat["enrollment_id"] in enrollment_ids
+
+    for asg in store.tables["assignments"].values():
+        assert asg["enrollment_id"] in enrollment_ids
+        assert asg["category_id"] in category_ids
+
+    for doc in store.tables["documents"].values():
+        assert doc["user_id"] in user_ids
+        assert doc["offering_id"] in offering_ids
+
+    for note in store.tables["notes"].values():
+        assert note["user_id"] in user_ids
+        assert note["offering_id"] in offering_ids
+
+
+# ─── Enum validity ───────────────────────────────────────────────────────────
+
+
+def test_enum_values_within_check_sets(store):
+    _run(store)
+    for node in store.tables["graph_nodes"].values():
+        assert node["mastery_tier"] in MASTERY_TIERS
+    for edge in store.tables["graph_edges"].values():
+        assert edge["relationship_type"] in RELATIONSHIP_TYPES
+    for enr in store.tables["enrollments"].values():
+        assert enr["curve_mode"] in CURVE_MODES
+    for asg in store.tables["assignments"].values():
+        assert asg["assignment_type"] in ASSIGNMENT_TYPES
+        assert asg["source"] in ASSIGNMENT_SOURCES
+    for doc in store.tables["documents"].values():
+        assert doc["category"] in DOC_CATEGORIES
+
+
+def test_mastery_tier_matches_score(store):
+    from config import get_mastery_tier
+    _run(store)
+    for node in store.tables["graph_nodes"].values():
+        assert node["mastery_tier"] == get_mastery_tier(node["mastery_score"])
+
+
+# ─── Multi-term ──────────────────────────────────────────────────────────────
+
+
+def test_multi_term_same_course_two_terms(store):
+    _run(store)
+    cs_course = "seed-course-cs101"
+    cs_offerings = [
+        o for o in store.tables["course_offerings"].values()
+        if o["course_id"] == cs_course
+    ]
+    terms = {o["term_id"] for o in cs_offerings}
+    assert len(terms) >= 2, "CS101 must be offered in >=2 terms"
+    assert {"fall-2025", "spring-2026"} <= terms
+
+    # Demo user enrolled in both CS101 offerings.
+    cs_off_ids = {o["id"] for o in cs_offerings}
+    enrolled_offs = {
+        e["offering_id"] for e in store.tables["enrollments"].values()
+    }
+    assert cs_off_ids <= enrolled_offs, "user must be enrolled in both CS101 terms"
+
+
+# ─── Encryption boundary ─────────────────────────────────────────────────────
+
+
+def test_sensitive_columns_encrypted_at_rest(store):
+    _run(store)
+    profile = next(iter(store.tables["user_profiles"].values()))
+    assert profile["name"] != "Demo Student"
+    assert decrypt(profile["name"]) == "Demo Student"
+    assert decrypt(profile["first_name"]) == "Demo"
+
+    note = next(iter(store.tables["notes"].values()))
+    assert note["title"] != "Week 1 — Variables"
+    assert decrypt(note["title"]) == "Week 1 — Variables"
+
+    doc = next(iter(store.tables["documents"].values()))
+    assert decrypt(doc["summary"]).startswith("CS101 syllabus")
+
+    asg = store.tables["assignments"]["seed-asg-cs-fall-hw1"]
+    assert asg["points_possible"] != "100"
+    assert decrypt(asg["points_possible"]) == "100"
+    assert decrypt(asg["points_earned"]) == "92"
+
+    # None points stay None (encrypt_if_present is a no-op on None).
+    unsubmitted = store.tables["assignments"]["seed-asg-cs-spring-hw1"]
+    assert unsubmitted["points_earned"] is None
+
+    # users.email is encrypted too.
+    user = next(iter(store.tables["users"].values()))
+    assert user["email"] != "demo.student@staging.saplinglearn.com"
+    assert decrypt(user["email"]) == "demo.student@staging.saplinglearn.com"
+
+
+# ─── Idempotency ─────────────────────────────────────────────────────────────
+
+
+def test_second_run_adds_no_rows(store):
+    _run(store)
+    counts_after_first = {name: len(rows) for name, rows in store.tables.items()}
+
+    # A 2nd run must not insert duplicates. _FakeTable.insert asserts on a
+    # duplicate id, so this also fails loudly if insert-if-absent regresses.
+    seed.main()
+
+    counts_after_second = {name: len(rows) for name, rows in store.tables.items()}
+    assert counts_after_second == counts_after_first, (
+        "second run changed row counts — seed is not idempotent"
+    )

--- a/docs/staging/setup-checklist.md
+++ b/docs/staging/setup-checklist.md
@@ -51,7 +51,7 @@ variables, Cloudflare worker secrets, or a local gitignored `backend/.env.stagin
 
 ### Step 6 — Local tooling + smoke test
 - [ ] `cp backend/.env.staging.example backend/.env.staging` and fill real values (gitignored — for running migrate/seed against staging from your machine).
-- [ ] Apply schema + seed (once `seed_staging.py` lands): `python -m db.migrate`, then the seed.
+- [ ] Apply schema, then seed demo data: `python -m db.migrate`, then `python -m db.seed_staging` (idempotent fake demo dataset — graph + gradebook + courses-with-term; safe to re-run).
 - [ ] Visit `https://staging.saplinglearn.com`: Access wall → Google login → upload a doc → graph renders.
 
 ---

--- a/docs/superpowers/plans/2026-06-24-db-seed-staging.md
+++ b/docs/superpowers/plans/2026-06-24-db-seed-staging.md
@@ -1,0 +1,130 @@
+# Plan — `db/seed_staging.py` (DB modular redesign, #258)
+
+A self-contained, idempotent seed that lays a small **fake** demo dataset on top
+of the **new** (post-0019–0027) schema so the live staging app renders the graph,
+gradebook, and courses-with-term against a real DB.
+
+It is **staging-only** (fake data), never prod. It only ever talks to whatever
+`db/connection.py::table()` is configured for via env — no hardcoded URLs/keys.
+
+## Preconditions (already true on staging)
+
+- Migrations **0019–0027 applied**. The 4 canonical `terms`
+  (`fall-2025` / `spring-2026` / `summer-2026` / `fall-2026`) are seeded by 0019.
+- The real ~8192-row course catalog already exists. **The seed does not touch,
+  duplicate, or depend on it** — all demo rows are namespaced under a demo school
+  with deterministic `seed-…` ids.
+
+## Entities seeded + counts
+
+| Table | Count | Notes |
+|---|---|---|
+| `schools` | 1 | `seed-school-demo` (demo namespace; upsert on `slug`) |
+| `courses` (abstract) | 3 | CS101, MATH210, BIO110 under the demo school |
+| `terms` | 0 (reused) | query existing `fall-2025` + `spring-2026` by id; never inserted |
+| `course_offerings` | 4 | CS101 offered in **2 terms** (fall-2025 + spring-2026); MATH210 + BIO110 once each |
+| `users` (slim) | 1 | `seed-user-demo` (id/email/onboarding/streak/is_approved) |
+| `user_profiles` | 1 | 🔒 name/first_name/last_name |
+| `enrollments` | 4 | demo user → all 4 offerings (incl. **CS101 in both terms**); `curve_mode`, `drop_lowest` via category |
+| `graph_nodes` | 9 | per **abstract** `course_id` (3 per course); valid `mastery_tier` |
+| `graph_edges` | 4 | within-course `prerequisite` / `builds_on` / `related` |
+| `node_mastery_events` | 6 | append-only (0023): a couple per "studied" node |
+| `gradebook_categories` | 4 | one per enrollment; one with `drop_lowest=1` |
+| `assignments` | 6 | on enrollment+category; 🔒 points; valid `source`/`assignment_type` |
+| `documents` | 1 | on the CS101 fall-2025 offering; 🔒 `summary`/`concept_notes`; valid `category` |
+| `notes` | 1 | on the same offering; 🔒 `title`/`body` |
+
+All ids deterministic, prefixed `seed-`. All FKs point at other `seed-` rows or
+the pre-seeded canonical `terms`.
+
+## Idempotency strategy
+
+Safe to run repeatedly; a re-run inserts nothing new and never errors.
+
+- **Deterministic ids** everywhere (`seed-school-demo`, `seed-course-cs101`,
+  `seed-off-cs101-fall2025`, `seed-user-demo`, `seed-node-cs101-variables`, …).
+- Two mechanics, both check-then-act:
+  - `_upsert(table, rows, on_conflict=…)` for tables with a natural UNIQUE
+    (`schools.slug`, `courses(school_id,course_code)`, `users.id`,
+    `user_profiles.user_id`, `graph_nodes(user_id,course_id,concept_name)`,
+    `graph_edges(user_id,source,target,rel_type)`,
+    `course_offerings(course_id,term_id,section)`). Re-runs merge-duplicate → no dupes.
+  - `_insert_if_absent(table, id, row)` for tables with no natural key
+    (`enrollments`, `gradebook_categories`, `assignments`, `documents`, `notes`,
+    `node_mastery_events`): `select id` by deterministic id first; insert only if
+    missing. (`node_mastery_events` is append-only with no UNIQUE, so the explicit
+    presence check is what keeps it from growing on every run.)
+- `terms` are only **read** (by id), never written → cannot collide with 0019.
+- A per-table counter distinguishes `created` vs `skipped (exists)` and is printed
+  in the summary, so a 2nd run visibly shows all-skips.
+
+## Encryption boundary (🔒)
+
+Every encrypted column is passed through `services.encryption.encrypt_if_present`
+at the write boundary (the helper is a no-op on `None`). Columns covered:
+
+- `user_profiles.name` / `first_name` / `last_name`
+- `notes.title` / `body` / `last_summary`
+- `documents.summary` / `concept_notes`
+- `assignments.points_possible` / `points_earned` / `notes`
+
+`users.email` is also encrypted (staging encrypts it). The script calls the helper
+only; when run with staging env the helper uses staging's `ENCRYPTION_KEY`. Upserts
+re-encrypt with a fresh nonce each run — the row content is unchanged and the unique
+key (id / natural key) is plaintext, so idempotency holds regardless of nonce churn.
+
+## Enum values (read off migrations — no guesses)
+
+- `enrollments.curve_mode` ∈ {`raw`,`curved`} (0021) — demo uses `raw` and one `curved`.
+- `graph_nodes.mastery_tier` ∈ {`unexplored`,`struggling`,`learning`,`mastered`,`subject_root`} (0023);
+  derived from score via `config.get_mastery_tier` so tier ↔ score stay consistent.
+- `graph_edges.relationship_type` ∈ {`related`,`prerequisite`,`builds_on`,`part_of`} (0023).
+- `assignments.source` ∈ {`manual`,`syllabus`}; `assignment_type` ∈
+  {`homework`,`exam`,`reading`,`project`,`quiz`,`other`} (0021).
+- `documents.category` ∈ {`syllabus`,`lecture_notes`,`slides`,`reading`,`assignment`,`study_guide`,`other`} (0025).
+- `sessions.mode` ∈ {`socratic`,`expository`,`teachback`} (0025) — not seeded but documented for completeness.
+- `terms.term` ∈ {`Fall`,`Spring`,`Summer`,`Winter`} (0019) — reused, not written.
+
+## How multi-term is exercised
+
+- The **same abstract course** `seed-course-cs101` gets **two offerings**:
+  `seed-off-cs101-fall2025` (term `fall-2025`) and `seed-off-cs101-spring2026`
+  (term `spring-2026`).
+- The demo user is **enrolled in both**. Because the knowledge graph is keyed on
+  the **abstract** `course_id` (not the offering), the CS101 graph nodes/mastery
+  accumulate **across both terms** — exactly the cumulative-across-terms behaviour
+  the redesign targets. Gradebook/analytics stay offering-scoped (separate
+  enrollments, categories, assignments per term), demonstrating both halves of the
+  bridge in `services/academics.py`.
+
+## Run command (against staging)
+
+From `backend/`, with staging env loaded (`SUPABASE_URL`, `SUPABASE_SERVICE_KEY`,
+`ENCRYPTION_KEY` from `backend/.env.staging`):
+
+```
+python -m db.seed_staging
+```
+
+Prints a per-table created/skipped summary at the end. Re-running is a no-op.
+
+## Tests (`tests/test_seed_staging.py`, hermetic — no real DB)
+
+`db.seed_staging.table` is patched to a recording mock (FakeTable) backed by an
+in-memory store keyed per table. Assertions:
+
+1. `main()` inserts/upserts into every expected table.
+2. FK consistency: every `course_offerings.course_id` exists in `courses`; every
+   `enrollments.offering_id` exists in `course_offerings`; `enrollments.user_id`
+   exists in `users`; `user_profiles.user_id` exists in `users`;
+   `graph_edges` source/target ids exist in `graph_nodes`; `node_mastery_events.node_id`
+   exists in `graph_nodes`; gradebook/assignments/notes/documents FKs resolve.
+3. Enum validity: collected `mastery_tier` / `relationship_type` / `assignment_type` /
+   `source` / `category` / `curve_mode` values are all within the migration CHECK sets.
+4. Multi-term: ≥2 distinct `term_id` across CS101 offerings; demo user enrolled in both.
+5. Encryption: `user_profiles.name`, `notes.title`, `documents.summary`,
+   `assignments.points_possible` are ciphertext that `decrypt()`s back to the plaintext.
+6. Idempotency: a 2nd `main()` over the same store adds **no** new rows.
+
+Gate: zero NEW failures vs the 2 pre-existing env-only `test_storage_service.py`
+failures; the new test file passes; `ruff check .` clean.


### PR DESCRIPTION
Self-contained, idempotent `seed_staging.py` so the live app renders graph + gradebook + courses-with-term against the migrated staging DB. **Code only — does not run against any DB**; a human runs it with staging env.

**Seeds (all FK-valid, `seed-…` ids):** 1 school · 3 abstract courses · 4 offerings (CS101 in *two* terms) · 1 user + profile · 4 enrollments · 9 graph_nodes + 4 edges + 6 node_mastery_events · 4 gradebook_categories (one `drop_lowest=1`) + 6 assignments · 1 document + 1 note.

- **Idempotent:** deterministic ids + upsert-on-UNIQUE / insert-if-absent; `terms` read-only (no collision with 0019, no dependency on the real 8192-row catalog).
- **Encryption:** every 🔒 column via `encrypt_if_present` (uses staging's `ENCRYPTION_KEY` at run time).
- **Enums** read straight off 0019–0027 (no guesses).
- **Multi-term:** CS101 has two offerings + the user enrolled in both → cumulative graph mastery vs offering-scoped gradebook, exercising both halves of `services/academics.py`.
- **Tests:** `tests/test_seed_staging.py` (hermetic, recording mock) — coverage, FK consistency, enum validity, encryption round-trip, 2nd-run idempotency. **788 passed**, zero new failures; ruff clean.

Run (from `backend/`, staging env): `python -m db.seed_staging`. Checklist Step 6 updated.

Plan: `docs/superpowers/plans/2026-06-24-db-seed-staging.md`. Closes #258.