### PR TITLE
fix(db): drop vestigial course_code NOT NULL on course_offerings (0028)

### DIFF
--- a/backend/db/migrations/0028_drop_offering_course_code.sql
+++ b/backend/db/migrations/0028_drop_offering_course_code.sql
@@ -1,0 +1,12 @@
+-- 0028: drop the vestigial `course_code` column left on `course_offerings`.
+--
+-- 0020 renamed `courses` -> `course_offerings` and dropped the now-abstract columns
+-- (course_name/department/credits/description/semester/school) but MISSED `course_code`,
+-- which stayed behind as `NOT NULL` (inherited from the original 0001 `courses` table).
+-- The abstract `course_code` now lives on the `courses` table, reached via
+-- `course_offerings.course_id`. The leftover NOT NULL column silently broke every INSERT
+-- of a NEW offering — the app's `resolve_offering(create=True)` / `add_course` and
+-- `seed_staging.py` insert `{id, course_id, term_id, ...}` with no `course_code`, so the
+-- row's `course_code` is NULL and trips the not-null constraint (Postgres 23502).
+-- Existing rows merely lose a redundant column.
+ALTER TABLE course_offerings DROP COLUMN IF EXISTS course_code;


### PR DESCRIPTION
**Real-DB bug surfaced by seeding staging.** `0020` renamed `courses → course_offerings` and dropped the abstract columns (course_name/department/credits/description/semester/school) but **missed `course_code`**, which stayed behind `NOT NULL` (from the 0001 baseline).

The 8192 migrated rows have it populated so it went unnoticed — but **every new offering insert fails** with Postgres `23502`, because neither `seed_staging.py` nor the app supplies `course_code`. This means the app's `resolve_offering(create=True)` / `add_course` would hit the **same** error against the real DB (mocked tests couldn't catch it).

`0028` drops the redundant column (abstract `course_code` lives on `courses`, reached via `course_offerings.course_id`). `DROP COLUMN IF EXISTS` → idempotent. Existing rows lose only a redundant column.

Apply to staging: `dotenv -f .env.staging run -- python -m db.migrate`, then re-run the seed.