### PR TITLE
fix(db): seed _exists_by uses a real column, not hardcoded id

### DIFF
--- a/backend/db/seed_staging.py
+++ b/backend/db/seed_staging.py
@@ -101,7 +101,11 @@ def _insert_if_absent(table_name: str, row_id: str, row: dict) -> None:
 
 def _exists_by(table_name: str, eq_filters: dict) -> bool:
     filters = {col: f"eq.{val}" for col, val in eq_filters.items()}
-    rows = table(table_name).select("id", filters=filters, limit=1) or []
+    # Select a column we're already filtering on (always present) rather than a
+    # hardcoded "id": user_profiles is keyed on user_id and has no `id` column,
+    # so `select=id` 400s there. The filter keys are the natural/PK columns.
+    select_col = next(iter(eq_filters))
+    rows = table(table_name).select(select_col, filters=filters, limit=1) or []
     return len(rows) > 0
 
 


### PR DESCRIPTION
Second issue surfaced by seeding staging. The seed's idempotency pre-check `_exists_by` did `select("id")`, but `user_profiles` is keyed on `user_id` with **no `id` column** (0024 identity split) → PostgREST `400` on the select. Now it selects a column from the filter (the natural/PK key), which always exists. Audited the rest of the seed against the real schemas — `node_mastery_events`/`graph_nodes`/`graph_edges`/`documents`/`notes` all have `id` and matching conflict-keys, so this is the only such spot. Seed unit tests green (9), ruff clean.