### PR TITLE
fix(onboarding): persist completion so users aren't trapped in the Get Started loop

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,6 +8,7 @@ import OnboardingFlow from '@/components/OnboardingFlow';
 import HowItWorks from '@/components/HowItWorks';
 import SignInModal from '@/components/SignInModal';
 import { BRAND_FOREST } from '@/lib/brand';
+import { submitOnboardingProfile, type OnboardingProfilePayload } from '@/lib/api';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5000';
 
@@ -614,21 +615,22 @@ export default function LandingPage() {
   }
 
   async function handleOnboardingComplete(formData: { firstName: string; lastName: string; school: string; year: string; majors: string[]; minors: string[]; course_ids: string[]; style: string }) {
-    // Persist onboarding data to Supabase
+    // Persist onboarding data via the shared same-origin helper. The previous
+    // raw fetch hit NEXT_PUBLIC_API_URL (a cross-origin subdomain) without
+    // `credentials: 'include'`, so the sapling_session cookie was dropped and
+    // require_self 401'd — onboarding_completed never flipped to True, trapping
+    // the user in the "Get Started" flow on every sign-in. submitOnboardingProfile
+    // goes through fetchJSON (same-origin proxy + credentials + res.ok check).
     try {
-      await fetch(`${API_URL}/api/onboarding/profile`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          user_id: userId,
-          first_name: formData.firstName,
-          last_name: formData.lastName,
-          year: formData.year,
-          majors: formData.majors,
-          minors: formData.minors,
-          course_ids: formData.course_ids,
-          learning_style: formData.style,
-        }),
+      await submitOnboardingProfile({
+        user_id: userId,
+        first_name: formData.firstName,
+        last_name: formData.lastName,
+        year: formData.year,
+        majors: formData.majors,
+        minors: formData.minors,
+        course_ids: formData.course_ids,
+        learning_style: formData.style as OnboardingProfilePayload['learning_style'],
       });
     } catch (e) {
       console.error('Failed to save onboarding profile:', e);


### PR DESCRIPTION
## Problem

On staging, signing in repeatedly re-shows the **"Get Started" / onboarding flow** every time, even for an already-onboarded, approved user. Investigation (against the staging DB) showed the user row persists fine — the only thing stuck is the `onboarding_completed` boolean, which had been `False` since the account was created despite many sign-ins.

## Root cause

`page.tsx:handleOnboardingComplete` posted to `/api/onboarding/profile` using the component-local `API_URL = process.env.NEXT_PUBLIC_API_URL` — a **cross-origin** subdomain (`https://api.staging.saplinglearn.com`) — **without `credentials: 'include'`**. The browser therefore dropped the `sapling_session` cookie, so the backend's `require_self` returned **401** and the `onboarding_completed = True` write (`backend/routes/onboarding.py:42`) never ran.

The failure was invisible because the call used `await fetch(...)` with **no `res.ok` check** inside a `try/catch` that only catches network errors — so the 401 was swallowed and the user was routed to `/dashboard` as if it succeeded, then bounced back to onboarding on the next load.

Reproduced live: `POST https://api.staging.saplinglearn.com/api/onboarding/profile` with no cookie → `401 {"detail":"Not authenticated"}`.

## Fix

Use the existing `submitOnboardingProfile()` helper from `lib/api.ts`, which goes through `fetchJSON`:
- same-origin relative path (`API_URL = ''`, proxied to the backend via the `/api/*` rewrite) → the `sapling_session` cookie is sent
- `credentials: 'include'`
- checks `res.ok` and throws on failure, so errors surface instead of being hidden

## Blast radius

Audited all other direct `NEXT_PUBLIC_API_URL` usages — this was the **only authenticated cross-origin fetch**. The rest are non-authed (`/api/onboarding/courses` search) or top-level OAuth popup navigations (`/api/auth/google`), and `middleware.ts` sends the `Cookie` header explicitly server-side.

## Verification

- `npm run typecheck` (`tsc --noEmit`) passes with 0 errors.
- Affected staging user's `onboarding_completed` was manually set to `True` to unblock immediately; this PR fixes the persistence path so it no longer recurs.

> Note: main's Frontend CI check is independently red repo-wide (lockfile + eslint baseline), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding completion so profile details are saved more reliably.
  * Reduced issues caused by browser cookie and login-session handling during onboarding.
  * Kept the rest of the onboarding flow unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->