### PR TITLE
refactor(frontend): shared UI primitives + green consolidation (Phase 2)

### DIFF
--- a/docs/button-shape-comparison.html
+++ b/docs/button-shape-comparison.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sapling — Primary Button Shape: Sharp vs Pill</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Playfair+Display:ital,wght@0,500;0,600;0,700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#faf8f3; --bg-panel:#fdfcf9; --bg-soft:#ebe6dc; --bg-inset:#f7f3eb; --bg-subtle:#f4f1ea;
+    --border:rgba(42,39,31,.12); --border-strong:rgba(42,39,31,.20);
+    --text:#1a1814; --text-dim:#3f3b31; --text-muted:#6f6857;
+    /* unified green family (sage retired → forest) */
+    --forest:#1B6C42; --forest-bright:#2D8F5C; --forest-soft:#f1f6ee; --forest-border:#c3d8b3;
+    --positive:#3a7d4e; /* single status green (merges grade-a + mastery) */
+    --amber:#c89b5e; --rust:#b4562c; --err:#a83a3a;
+    --r-sm:6px; --r-md:10px; --r-full:999px;
+    --shadow-sm:0 1px 2px rgba(19,38,16,.05),0 1px 1px rgba(19,38,16,.04);
+    --shadow-md:0 4px 14px rgba(19,38,16,.07);
+    --mono:'JetBrains Mono',ui-monospace,monospace;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--text);font-family:'DM Sans',system-ui,sans-serif;font-size:14px;line-height:1.55;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1180px;margin:0 auto;padding:48px 32px 100px}
+  .serif{font-family:'Playfair Display',Georgia,serif;letter-spacing:-.015em}
+  .micro{font-family:var(--mono);font-size:10.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--text-muted)}
+  code{font-family:var(--mono);font-size:.85em;background:var(--bg-soft);padding:1px 5px;border-radius:4px;color:var(--text-dim)}
+
+  header{margin-bottom:14px}
+  h1{font-family:'Playfair Display',serif;font-weight:700;font-size:clamp(30px,4vw,46px);letter-spacing:-.02em;margin:10px 0 10px}
+  h1 em{font-style:italic;color:var(--forest)}
+  .lede{font-size:17px;color:var(--text-dim);max-width:70ch;margin:0}
+  .note{margin:18px 0 34px;font-size:13.5px;color:var(--text-muted);background:var(--bg-inset);border:1px solid var(--border);border-radius:var(--r-md);padding:12px 16px;max-width:80ch}
+
+  .cols{display:grid;grid-template-columns:1fr 1fr;gap:28px}
+  @media(max-width:860px){.cols{grid-template-columns:1fr}}
+  .col-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px}
+  .col-head h2{font-family:'Playfair Display',serif;font-weight:600;font-size:22px;margin:0}
+  .tag{font-family:var(--mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;padding:4px 10px;border-radius:var(--r-full)}
+  .tag-a{background:var(--forest-soft);color:#2b5221;border:1px solid var(--forest-border)}
+  .tag-b{background:var(--bg-soft);color:var(--text-muted)}
+
+  /* the demo surface — a realistic app fragment */
+  .surface{background:var(--bg-panel);border:1px solid var(--border);border-radius:16px;box-shadow:var(--shadow-sm);overflow:hidden}
+  .topbar{display:flex;align-items:center;justify-content:space-between;padding:14px 18px;border-bottom:1px solid var(--border);background:var(--bg-subtle)}
+  .topbar .title{font-family:'Playfair Display',serif;font-size:18px;font-weight:600}
+  .body{padding:18px}
+  .row{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:16px}
+  .label{font-size:12px;color:var(--text-muted);width:100%;margin-bottom:-4px}
+
+  /* buttons — .pri radius is what differs per column */
+  button{font-family:inherit;cursor:pointer;border:1px solid transparent;font-weight:500;transition:filter .14s,background .14s,border-color .14s}
+  .btn{display:inline-flex;align-items:center;gap:7px;padding:8px 14px;font-size:13px;border:1px solid var(--border);background:var(--bg-panel);color:var(--text)}
+  .btn:hover{border-color:var(--border-strong);background:var(--bg-subtle)}
+  .pri{background:var(--forest);color:#fff;border-color:transparent}
+  .pri:hover{filter:brightness(1.07);background:var(--forest)}
+  .ghost{background:transparent;border-color:transparent;color:var(--text-dim)}
+  .ghost:hover{background:var(--bg-soft)}
+  .danger{color:var(--err);border-color:rgba(168,58,58,.3);background:transparent}
+  .big{padding:13px 28px;font-size:15px}
+
+  /* per-column radius */
+  .sharp .btn,.sharp .pri,.sharp .ghost,.sharp .danger{border-radius:var(--r-sm)}
+  .pill  .btn,.pill  .pri,.pill  .ghost,.pill  .danger{border-radius:var(--r-full)}
+
+  /* toggles stay pill in BOTH (true segmented control) */
+  .seg{display:inline-flex;background:var(--bg-soft);border-radius:var(--r-full);padding:3px;gap:2px}
+  .seg button{border-radius:var(--r-full);padding:6px 14px;font-size:12.5px;background:transparent;color:var(--text-dim);border:0}
+  .seg button.on{background:var(--forest);color:#fff}
+
+  /* chips/pills (the unified Chip) — same in both */
+  .chip{display:inline-flex;align-items:center;gap:5px;padding:3px 9px;border-radius:var(--r-full);font-family:var(--mono);font-size:10.5px;letter-spacing:.04em;text-transform:uppercase;background:var(--bg-soft);color:var(--text-dim);border:1px solid var(--border)}
+  .chip-accent{background:var(--forest-soft);color:#2b5221;border-color:var(--forest-border)}
+  .chip-amber{background:#f7efe0;color:#8a6d2c;border-color:transparent}
+
+  /* a gradebook-style mini card */
+  .gcard{border:1px solid var(--border);border-radius:12px;overflow:hidden;margin-bottom:16px}
+  .gcard .hd{padding:14px 16px 12px;background:linear-gradient(135deg,var(--positive),#2f6b41);color:#fff}
+  .gcard .hd .micro{color:rgba(255,255,255,.75)}
+  .gcard .hd .grade{font-family:'Playfair Display',serif;font-size:34px;font-weight:600;line-height:1}
+  .gcard .ft{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;font-size:13px}
+  .gcard .pct{font-family:var(--mono);font-weight:600;color:var(--positive)}
+
+  .divider{height:1px;background:var(--border);margin:16px 0}
+  .caption{font-size:12px;color:var(--text-muted);margin-top:10px}
+  .footer{margin-top:46px;padding-top:22px;border-top:1px solid var(--border);font-size:13px;color:var(--text-dim);max-width:80ch}
+  .footer b{color:var(--text)}
+  .legend{display:flex;gap:18px;flex-wrap:wrap;margin-top:8px}
+  .sw{display:inline-flex;align-items:center;gap:7px;font-size:12px;color:var(--text-muted)}
+  .dot{width:14px;height:14px;border-radius:4px;border:1px solid rgba(0,0,0,.1)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <span class="micro">Sapling · Button-shape decision · 2026-06-30</span>
+    <h1>Same screen, <em>two</em> primary-button shapes</h1>
+    <p class="lede">Identical UI on both sides. The only difference is the <strong>primary action button</strong> radius: <code>6px</code> (sharp, the app's current identity) vs <code>999px</code> (pill, the landing's). Greens are already unified to forest (sage retired) so you're judging shape, not color.</p>
+  </header>
+  <div class="note">
+    <strong>What stays the same in both columns:</strong> segmented toggles are always pills (that's a true toggle, not a button) · chips/badges are always pills · the grade card, secondary &amp; ghost buttons, and layout are identical. Only the filled/outlined <em>action</em> buttons change radius.
+    <div class="legend">
+      <span class="sw"><span class="dot" style="background:#1B6C42"></span>--forest (brand/action)</span>
+      <span class="sw"><span class="dot" style="background:#3a7d4e"></span>--positive (status: grade/mastery)</span>
+      <span class="sw"><span class="dot" style="background:#c89b5e"></span>--amber (in-progress)</span>
+    </div>
+  </div>
+
+  <div class="cols">
+    <!-- ───────── SHARP ───────── -->
+    <div>
+      <div class="col-head"><h2>Sharp · 6px</h2><span class="tag tag-a">app identity · recommended</span></div>
+      <div class="surface sharp">
+        <div class="topbar"><span class="title">Grades</span><button class="btn pri">Upload syllabus</button></div>
+        <div class="body">
+          <div class="row"><span class="chip chip-accent">● Spring 2026</span><span class="chip">Fall 2025</span></div>
+          <div class="gcard">
+            <div class="hd"><div class="micro">Data Structures</div><div class="grade">A−</div></div>
+            <div class="ft"><span class="pct">92.1%</span><span class="chip chip-accent">on track</span></div>
+          </div>
+          <div class="label">Primary / secondary / ghost</div>
+          <div class="row"><button class="btn pri">Start learning</button><button class="btn">Edit weights</button><button class="btn ghost">Cancel</button><button class="btn danger">Delete</button></div>
+          <div class="divider"></div>
+          <div class="label">Hero CTA (landing)</div>
+          <div class="row"><button class="btn pri big">Sign up for Beta Testing</button></div>
+          <div class="divider"></div>
+          <div class="label">Segmented toggle — pill in BOTH columns</div>
+          <div class="row"><div class="seg"><button class="on">Chat</button><button>Graph</button><button>Quiz</button></div></div>
+        </div>
+      </div>
+      <p class="caption">Buttons echo the editorial app: crisp corners, calm. Pills are reserved for toggles &amp; chips, so a pill always means “segmented choice,” never “action.”</p>
+    </div>
+
+    <!-- ───────── PILL ───────── -->
+    <div>
+      <div class="col-head"><h2>Pill · fully rounded</h2><span class="tag tag-b">landing identity</span></div>
+      <div class="surface pill">
+        <div class="topbar"><span class="title">Grades</span><button class="btn pri">Upload syllabus</button></div>
+        <div class="body">
+          <div class="row"><span class="chip chip-accent">● Spring 2026</span><span class="chip">Fall 2025</span></div>
+          <div class="gcard">
+            <div class="hd"><div class="micro">Data Structures</div><div class="grade">A−</div></div>
+            <div class="ft"><span class="pct">92.1%</span><span class="chip chip-accent">on track</span></div>
+          </div>
+          <div class="label">Primary / secondary / ghost</div>
+          <div class="row"><button class="btn pri">Start learning</button><button class="btn">Edit weights</button><button class="btn ghost">Cancel</button><button class="btn danger">Delete</button></div>
+          <div class="divider"></div>
+          <div class="label">Hero CTA (landing)</div>
+          <div class="row"><button class="btn pri big">Sign up for Beta Testing</button></div>
+          <div class="divider"></div>
+          <div class="label">Segmented toggle — pill in BOTH columns</div>
+          <div class="row"><div class="seg"><button class="on">Chat</button><button>Graph</button><button>Quiz</button></div></div>
+        </div>
+      </div>
+      <p class="caption">Softer, more “consumer/marketing.” Risk: a pill button and a pill toggle look alike, so “action” vs “choice” gets ambiguous — and it changes the look of ~211 in-app buttons + the dashboard.</p>
+    </div>
+  </div>
+
+  <div class="footer">
+    <b>My read:</b> go <b>sharp 6px</b>. The app is already 95% there (211 buttons), it keeps a clear “pill = toggle/chip, rectangle = action” rule, and it only requires changing the handful of landing CTAs + the 5 gradebook modal buttons + the Study ratings — not the whole app. The pill option is the bigger, riskier change for a softer feel. Either way, the fix is the same shared <code>&lt;Button&gt;</code> primitive; this only decides its default radius.
+  </div>
+</div>
+</body>
+</html>

--- a/docs/changes-tour.html
+++ b/docs/changes-tour.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sapling — What changed · guided tour</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Playfair+Display:ital,wght@0,500;0,600;0,700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#faf8f3; --bg-panel:#fdfcf9; --bg-soft:#ebe6dc; --bg-inset:#f7f3eb;
+    --border:rgba(42,39,31,.12); --border-strong:rgba(42,39,31,.20);
+    --text:#1a1814; --text-dim:#3f3b31; --text-muted:#6f6857;
+    --forest:#1B6C42; --forest-bright:#2D8F5C; --positive:#3a7d4e; --forest-soft:#f1f6ee; --forest-border:#c3d8b3;
+    --amber:#c89b5e;
+    --r-sm:6px; --r-md:10px; --r-lg:16px; --r-full:999px;
+    --shadow-sm:0 1px 2px rgba(19,38,16,.05),0 1px 1px rgba(19,38,16,.04);
+    --mono:'JetBrains Mono',ui-monospace,monospace;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--text);font-family:'DM Sans',system-ui,sans-serif;font-size:15px;line-height:1.55;-webkit-font-smoothing:antialiased;
+    background-image:radial-gradient(ellipse 80% 50% at 100% -5%,rgba(45,143,92,.05),transparent 55%)}
+  .wrap{max-width:920px;margin:0 auto;padding:56px 32px 110px}
+  .micro{font-family:var(--mono);font-size:10.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--text-muted)}
+  code{font-family:var(--mono);font-size:.84em;background:var(--bg-soft);padding:1px 6px;border-radius:4px;color:var(--text-dim)}
+  h1{font-family:'Playfair Display',serif;font-weight:700;font-size:clamp(34px,5vw,54px);letter-spacing:-.02em;margin:12px 0 14px;line-height:1.04}
+  h1 em{font-style:italic;color:var(--forest)}
+  .lede{font-size:18px;color:var(--text-dim);max-width:66ch;margin:0}
+  .legend{display:flex;gap:20px;flex-wrap:wrap;margin:22px 0 6px}
+  .sw{display:inline-flex;align-items:center;gap:8px;font-size:12.5px;color:var(--text-muted)}
+  .dot{width:15px;height:15px;border-radius:5px;border:1px solid rgba(0,0,0,.1)}
+
+  h2{font-family:'Playfair Display',serif;font-weight:600;font-size:26px;letter-spacing:-.015em;margin:54px 0 6px;display:flex;align-items:baseline;gap:12px}
+  h2 .n{font-family:var(--mono);font-size:13px;color:var(--forest-bright);font-weight:600;letter-spacing:0}
+  .sub{color:var(--text-muted);max-width:64ch;margin:0 0 22px;font-size:14px}
+
+  .card{background:var(--bg-panel);border:1px solid var(--border);border-radius:var(--r-lg);box-shadow:var(--shadow-sm);padding:20px 22px;margin-bottom:16px;display:grid;grid-template-columns:1fr auto;gap:8px 20px;align-items:start}
+  .card h3{font-family:'Playfair Display',serif;font-weight:600;font-size:20px;margin:0 0 2px}
+  .card .changed{font-size:14px;color:var(--text-dim);margin:6px 0 0;grid-column:1/2}
+  .card .look{font-size:13px;color:var(--text-muted);margin:8px 0 0;grid-column:1/2}
+  .card .look b{color:var(--text-dim);font-weight:600}
+  .open{grid-row:1/3;grid-column:2;align-self:center;white-space:nowrap;display:inline-flex;align-items:center;gap:7px;
+    padding:9px 16px;border-radius:var(--r-sm);font-size:13px;font-weight:600;text-decoration:none;
+    background:var(--forest);color:#fff;border:1px solid transparent;transition:filter .14s}
+  .open:hover{filter:brightness(1.08)}
+  .open.ghost{background:var(--bg-panel);color:var(--text);border-color:var(--border)}
+  .open.ghost:hover{background:var(--bg-subtle);filter:none;border-color:var(--border-strong)}
+  .note{grid-column:1/3;font-size:12px;color:var(--text-muted);background:var(--bg-inset);border:1px solid var(--border);border-radius:var(--r-sm);padding:8px 12px;margin-top:10px}
+  .tag{display:inline-block;font-family:var(--mono);font-size:9.5px;letter-spacing:.1em;text-transform:uppercase;padding:3px 8px;border-radius:var(--r-full);margin-bottom:4px}
+  .t-pre{background:#eef2f6;color:#4b6076}
+  .t-app{background:var(--forest-soft);color:#2b5221;border:1px solid var(--forest-border)}
+  footer{margin-top:64px;padding-top:24px;border-top:1px solid var(--border);font-size:13px;color:var(--text-muted)}
+  footer a{color:var(--forest)}
+  @media(max-width:640px){.card{grid-template-columns:1fr}.open{grid-row:auto;grid-column:1;justify-self:start}}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <span class="micro">Sapling · frontend changes · guided tour</span>
+  <h1>What changed, and <em>where</em> to look</h1>
+  <p class="lede">Two phases shipped: <b>tokens</b> (the colors/greens) and <b>components</b> (button shapes + shared primitives). Each card below links straight to the live screen with what changed and what to notice. The dev server is on <code>localhost:3000</code>.</p>
+  <div class="legend">
+    <span class="sw"><span class="dot" style="background:#1B6C42"></span>--brand-forest · primary action</span>
+    <span class="sw"><span class="dot" style="background:#2D8F5C"></span>--accent · highlight (was sage)</span>
+    <span class="sw"><span class="dot" style="background:#3a7d4e"></span>--positive · status (mastery/grade-A)</span>
+  </div>
+
+  <h2><span class="n">A</span> Pre-auth surface</h2>
+  <p class="sub">Phase 1 warmed the palette (was cool slate); Phase 2 sharpened the buttons.</p>
+
+  <div class="card">
+    <span class="tag t-pre">landing</span>
+    <h3>Landing</h3>
+    <a class="open" href="http://localhost:3000/" target="_blank">Open ↗</a>
+    <p class="changed">CTAs <b>de-pilled to sharp 6px</b> forest buttons ("Get Started", "Sign up for Beta Testing"). The infinite pulsing glow is gone; the beta CTA uses the new <code>lg</code> hero size so it stays substantial.</p>
+    <p class="look"><b>Look for:</b> the buttons are now crisp rectangles matching the app — not rounded pulsing pills. Borders/text are warm, not cool gray.</p>
+    <div class="note">Click <b>"Sign up for Beta Testing"</b> to see the beta modal, and <b>"Sign In"</b> for the sign-in modal — both warmed.</div>
+  </div>
+
+  <div class="card">
+    <span class="tag t-pre">/about · /careers · /privacy · /terms</span>
+    <h3>Marketing / legal pages</h3>
+    <a class="open" href="http://localhost:3000/about" target="_blank">Open ↗</a>
+    <p class="changed">Body text moved from cool slate (<code>#4b5563</code>) to warm <code>--text-dim</code>; the "Sapling" wordmark color is now tokenized. Moved under a new <code>(public)</code> route group (URLs unchanged).</p>
+    <p class="look"><b>Look for:</b> warm paper canvas + warm body text — feels like the same product as the app now. (Also <a href="http://localhost:3000/careers" target="_blank">/careers</a>, <a href="http://localhost:3000/privacy" target="_blank">/privacy</a>, <a href="http://localhost:3000/terms" target="_blank">/terms</a>.)</p>
+  </div>
+
+  <h2><span class="n">B</span> In-app surface</h2>
+  <p class="sub">Phase 2 collapsed the greens by role and introduced shared primitives.</p>
+
+  <div class="card">
+    <span class="tag t-app">/gradebook</span>
+    <h3>Grades</h3>
+    <a class="open" href="http://localhost:3000/gradebook" target="_blank">Open ↗</a>
+    <p class="changed">The greens collapsed: "Upload syllabus" went from muted <b>sage</b> → vivid <b>forest</b>; the A− card + percentage now use the single <code>--positive</code> status green. Was 3–4 mismatched greens, now 2 forest-family-by-role.</p>
+    <p class="look"><b>Look for:</b> the green button + the green grade card now clearly belong to the same family (no more sage-vs-forest clash).</p>
+  </div>
+
+  <div class="card">
+    <span class="tag t-app">/learn</span>
+    <h3>Tutor — Start a session</h3>
+    <a class="open" href="http://localhost:3000/learn" target="_blank">Open ↗</a>
+    <p class="changed">The <b>Mode</b> selector (Socratic / Expository / Teach-back) is now the shared <code>&lt;Toggle&gt;</code> — one connected segmented control instead of 3 separate pills.</p>
+    <p class="look"><b>Look for:</b> click between the three modes — the forest fill slides to the active one. (The Fast/Smart "ModelToggle" inside a live session was intentionally left as-is — it has its own animation + color semantics.)</p>
+  </div>
+
+  <div class="card">
+    <span class="tag t-app">/social</span>
+    <h3>Social — Study rooms</h3>
+    <a class="open" href="http://localhost:3000/social" target="_blank">Open ↗</a>
+    <p class="changed">Primary "Create" button is forest <code>&lt;Button&gt;</code> (sharp 6px); accent-green highlights (active states, mentions) are now forest-family rather than sage.</p>
+    <p class="look"><b>Look for:</b> the green "Create" matches the app's primary-button language exactly.</p>
+  </div>
+
+  <div class="card">
+    <span class="tag t-app">/achievements</span>
+    <h3>Achievements</h3>
+    <a class="open" href="http://localhost:3000/achievements" target="_blank">Open ↗</a>
+    <p class="changed">Rarity badges (Common/Uncommon/Rare) now route through the shared <code>&lt;Badge&gt;</code> (via <code>TitleFlair</code>) — hue on the border, neutral text (kept that way on purpose: colored text fails contrast on several tiers). "Uncommon" green is now the unified forest.</p>
+    <p class="look"><b>Look for:</b> the rarity badges read consistently; the "Uncommon" tier is forest, not the old cool green.</p>
+  </div>
+
+  <div class="card">
+    <span class="tag t-app">/dashboard</span>
+    <h3>Dashboard — the anchor</h3>
+    <a class="open ghost" href="http://localhost:3000/dashboard" target="_blank">Open ↗</a>
+    <p class="changed"><b>Deliberately unchanged</b> in structure — it's the source-of-truth the rest converges toward. Only delta: the "Mastered" legend dot + mastery indicators use the unified <code>--positive</code> green.</p>
+    <p class="look"><b>Look for:</b> nothing should feel different here — that's the point. Compare the other screens against it.</p>
+  </div>
+
+  <footer>
+    Full write-ups: <a href="http://127.0.0.1:8731/frontend-rhythm-audit.html" target="_blank">rhythm audit</a> ·
+    <a href="http://127.0.0.1:8731/button-shape-comparison.html" target="_blank">button shape comparison</a> ·
+    PRs <a href="https://github.com/SaplingLearn/Sapling/pull/286" target="_blank">#286 (tokens)</a> →
+    <a href="https://github.com/SaplingLearn/Sapling/pull/294" target="_blank">#294 (components)</a>.
+  </footer>
+</div>
+</body>
+</html>

--- a/docs/frontend-component-consistency-audit.md
+++ b/docs/frontend-component-consistency-audit.md
@@ -1,0 +1,88 @@
+# Frontend Component Consistency Audit — Buttons, Greens, Pills
+
+**Date:** 2026-06-30
+**Scope:** the *component-level* styling the token-unification (Phase 1) deliberately did **not** touch — button shapes, the green-by-role mess, and the pill/badge zoo. Grounded in code inventory + live screenshots of gradebook / social / achievements.
+
+## TL;DR
+
+Phase 1 fixed *which value a token resolves to*. This is the layer underneath: **there are no shared UI primitives**, so every surface reinvents buttons and pills with slightly different radii and greens. Two problems compound:
+
+1. **No shared `<Button>` / `<Pill>` / `<Badge>`** → 5 distinct button shapes, **18+** separate pill/badge implementations.
+2. **Too many greens with overlapping roles** → **5 active semantic greens**, two pairs visually indistinguishable, and the *most-used* "green" (`--accent` sage, 125 uses) isn't even the brand green.
+
+You can see all of it on one gradebook screen: a sage "Upload syllabus" button, a forest "Spring 2026" pill, a grade-A green card, and grade-band percentages — four greens, two button shapes.
+
+---
+
+## 1. Buttons — 5 shapes where there should be ~2
+
+The canonical `.btn` (globals.css) is **6px** (`--r-sm`) and ~211 buttons use it correctly. But a large minority go bespoke:
+
+| Shape bucket | Radius | Where | Verdict |
+|---|---|---|---|
+| **Canonical** | 6px `.btn` | Dashboard/Learn primary CTAs, most modals | ✅ the standard |
+| **Hard-coded 6px** | 6px (inline) | 5 Gradebook modal buttons (`LetterScaleEditor:107`, `SyllabusUploadFlow:220`, `AssignmentModal:346`, `EditWeightsModal:268`, `Gradebook/Course:186`) | ⚠️ right pixel, **bypasses `.btn`** — no hover/transition inheritance |
+| **Study 10px** | 10px `--r-md` | flashcard rating buttons (`Study.tsx:593`) — the most-tapped study control | ❌ off-standard, high-friction |
+| **Onboarding** | 8/12/14/100px | `OnboardingFlow.tsx` (multiple) | ❌ bespoke wizard (also dead code — see follow-up #292) |
+| **Pills** | 999px / `rounded-full` | landing CTAs (`(public)/page.tsx:705,781,911`), Learn mode toggles, ModelToggle | ⚠️ intentional for toggles, but the **landing primary CTAs** are pills while the **app primary CTAs** are 6px |
+
+**Worst inconsistency — the primary-action identity is split.** "Start learning" / "Start quiz" in the app are sharp 6px; "Get Started" / "Sign up for Beta" on the landing are fully-rounded pills. A user's first button (pill) contradicts every in-app button (6px).
+
+**Second — three separate toggle/segmented controls** (`Learn.tsx:473`, `Learn.tsx:562`, `ModelToggle.tsx:66`), all `--r-full` but with different padding/font. No shared `<Toggle>`.
+
+---
+
+## 2. Greens — 5 active, two pairs indistinguishable
+
+12 greens exist (8 tokens + 4 hard-coded); **5 are in active semantic use**:
+
+| Green | Token | Uses | Role | Problem |
+|---|---|---|---|---|
+| `#1B6C42` | `--brand-forest` | 45 | primary brand / action / rarity-uncommon | — |
+| `#8a9a5b` | `--accent` (sage) | **125** | UI accents, reactions, focus, "Upload syllabus" btn | **the most-used "green" is sage, not the brand forest** — this is the main "greens feel inconsistent" culprit |
+| `#3e8030` | `--c-sage` = `--grade-a` | 4 | grade-A display | **9 hex points from forest** — indistinguishable; on gradebook it reads as the brand green |
+| `#4a7d5c` | `--state-mastery` | 3 | dashboard mastery | barely used; a 4th near-forest green |
+| `#1a5c2a` | *(hard-coded, no token)* | 12 | landing logo, TopNav | **not in the token system** — brand drift risk |
+
+**The core issue:** "a green affordance" renders as forest in one place, sage in another, grade-green in a third — because the greens are split by *accidental history*, not by *role*. The 125-use sage `--accent` makes the app's de-facto "main green" a muted yellow-green that clashes with the forest brand.
+
+**Proposed green-by-role collapse (3 roles):**
+1. **Brand / primary action** → `--brand-forest` (one green for all primary buttons, active nav, brand marks). Tokenize the hard-coded `#1a5c2a` into it.
+2. **Positive status** (mastery, grade-A, success) → **one** status-green. Merge `--grade-a`/`--c-sage` and `--state-mastery` into a single `--positive` (distinct enough from forest to read as "status", or just = forest if we want them unified).
+3. **Decorative accent** → decide sage's fate: either keep `--accent` sage as a deliberately *different* hue (not green-family) so it stops competing with forest, or retire it toward forest. Recommend: **shift accent off the green family** (it's currently a near-green that muddies everything) OR rename it so its role is explicit.
+
+---
+
+## 3. Pills / badges — 18+ implementations → 3–4 components
+
+| # | Implementation | File |
+|---|---|---|
+| 1–5 | `.chip` + `--accent/--warn/--err/--info` | globals.css |
+| 6 | `Pill.tsx` (generic, `color` prop) | components/Pill.tsx |
+| 7 | `RoleBadge.tsx` (color-mix) | components/RoleBadge.tsx |
+| 8 | `TitleFlair.tsx` (rarity tokens) | components/TitleFlair.tsx |
+| 9–18+ | inline pills: Achievement rarity badges, Social reaction pills, Study badges, course category filters, graph badges, AI-disclaimer chip, term pills, filter chips… | many |
+
+**Proposed consolidation → 3 components:**
+- **`<Chip>`** — neutral / status / accent pills (replaces the `.chip` variants + most inline pills). One radius, one padding scale, variant prop.
+- **`<Badge>`** — rarity / role / grade badges (replaces `RoleBadge` + `TitleFlair` + achievement inline badges); centralizes the color-mix logic.
+- **(optional) `<StatPill>`** — mastery / grade / status indicators if they need distinct treatment.
+
+Estimated ~70–80% reduction in pill/badge code.
+
+---
+
+## Recommended approach (shared components to simplify)
+
+The order that de-risks and pays off fastest:
+
+1. **`<Button>` primitive** — wrap the `.btn` system in a React component with `variant` (primary/secondary/ghost/danger) + `size`, kill the 5 hard-coded gradebook radii and the off-standard Study 10px, and **pick one primary-action shape** (recommend 6px everywhere; pills reserved for true toggles). Migrate inline buttons to it.
+2. **`<Toggle>` / segmented control** — one component for the 3 mode/model toggles.
+3. **Green-by-role token cleanup** — collapse to brand / positive / accent; tokenize `#1a5c2a`; decide sage's role.
+4. **`<Chip>` + `<Badge>`** — collapse the 18 pill/badge implementations.
+
+Each is independently shippable and shrinks the codebase. (1) + (3) deliver the most visible consistency for the least risk.
+
+## Decision needed
+- **Primary-action shape:** sharp 6px everywhere (app's current identity) vs. soft pill everywhere (landing's identity)? Pick one — they can't coexist as "the primary button."
+- **Sage `--accent`:** keep as a deliberately non-green accent, or retire toward forest?

--- a/docs/superpowers/handoffs/2026-06-30-selector-consolidation.md
+++ b/docs/superpowers/handoffs/2026-06-30-selector-consolidation.md
@@ -1,0 +1,59 @@
+# Handoff — consolidate selector/sort/filter controls (continues PR #294)
+
+> Paste this into a fresh chat to continue the work. It carries the context, the concrete worklist, the design forks to resolve, and the gotchas.
+
+---
+
+You're continuing frontend design-consistency work on the Sapling repo at `/home/andresl/Projects/sapling` (Next.js app in `frontend/`). **Work on the existing branch `refactor/component-system`** (do NOT create a new branch) and update **PR #294**. Two phases already shipped: Phase 1 = token unification (PR #286), Phase 2 = shared UI primitives + green consolidation (PR #294, this branch).
+
+## Honor these decisions (already made with the user)
+- **Buttons are sharp 6px everywhere; pills are ONLY for true toggles/chips.**
+- **Greens by role:** `--brand-forest #1B6C42` (primary action) · `--accent #2D8F5C` (highlight/focus — the BRIGHT forest) · `--positive #3a7d4e` (status: mastery/grade). Sage retired. **Never use `--accent` as a button FILL** (use `--brand-forest`); it's for active-state highlights only.
+- **Don't force-consolidate specialized controls.** If a control has animation, per-option color semantics, or a11y needs that a generic primitive would degrade, LEAVE IT. (Precedents we set: kept `ModelToggle` for its sliding animation + Fast/Smart colors; kept rarity badges' a11y-neutral text because colored text fails 4.5:1.)
+
+## Shared primitives (in `frontend/src/components/ui/`, import from `@/components/ui`)
+- `<Button variant size>` — `variant`: primary|secondary|ghost|danger; `size`: sm|md|lg|xl; always 6px.
+- **`<Toggle options value onChange size>`** — `options: {value,label,title?}[]`, single-select **connected segmented pill** control, forest-filled active segment, `size`: sm|md. **This is the main primitive for this task.**
+- `<Chip variant icon>` — wraps the `.chip` classes.
+- `<Badge color bg>` — a11y-correct tinted badge (hue on border, neutral text).
+
+## YOUR TASK
+Consolidate the **selector / sort / filter / view-toggle / tab** controls across these 8 surfaces onto consistent shared components, committing per-surface, updating PR #294.
+
+## Inventory (verify each file:line before editing — counts/lines may have drifted)
+
+| Surface | Control | File:line | Current pattern | Target |
+|---|---|---|---|---|
+| Gradebook | Semester selector (Spring/Fall) | `components/Gradebook/SemesterChips.tsx:13–48` | custom pill buttons, accent-border active | `<Toggle>` |
+| Social | Overview/Chat/Study Match/Activity tabs | `components/screens/Social.tsx:1059–1073` | button row, accent-soft active | `<Toggle>` |
+| Achievements | all/activity/social/milestone/special filter | `components/screens/Achievements.tsx:210–214` | `<Pill>` row | filter-pills (see fork) |
+| Calendar | month/week/day/table view | `components/screens/Calendar.tsx:192–207` | button row in border, accent-soft active | `<Toggle>` |
+| Library | category filter (7, incl. dynamic) | `components/screens/Library.tsx:186–189` | `<Pill>` row | filter-pills (see fork) |
+| Library | grid/list view toggle | `components/screens/Library.tsx:196–209` | 2 buttons in border, accent-soft active | `<Toggle>` |
+| Study | Study Guide/Flashcards mode | `components/screens/Study.tsx:84–113` | **Framer-Motion spring** toggle | DECIDE (animation lost if migrated) |
+| Study | topic filter (All + dynamic) | `components/screens/Study.tsx:526–529` | `<Pill>` row | filter-pills (see fork) |
+| Tree | mastery tier (all/mastered/learning/struggling/unexplored) | `components/screens/Tree.tsx:270–275` | `<Pill>` row, **per-tier colors** | filter-pills + color (see fork) |
+| Tree | course filter (All + courses w/ colored dots) | `components/screens/Tree.tsx:293–308` | `<Pill>` row, **colored dots** | likely leave-specialized |
+| Quiz | question count (5/10/15) | `components/QuizPanel.tsx:186` | `<CustomSelect>` dropdown | DECIDE (Toggle vs keep) |
+| Quiz | difficulty (easy/med/hard/adaptive) | `components/QuizPanel.tsx:190` | `<CustomSelect>` dropdown | DECIDE (Toggle vs keep) |
+
+## Resolve these design forks FIRST (ask the user)
+1. **Two families, one or two components?** There are (a) **fixed segmented controls** (2–5 fixed options: Social tabs, Calendar views, Library grid/list, Gradebook semester, Study mode) that fit `<Toggle>` directly, and (b) **filter-pill groups** ("All" + N, often *dynamic/wrapping*: Achievements, Library categories, Study topics, Tree tiers) where a fixed connected segmented control does NOT fit — they need a **wrapping row of selectable pills**. Decide: add a wrapping/`variant="pills"` mode to `<Toggle>`, OR build a small `<FilterPills>`/`<ChipGroup>`. (The existing `<Pill>` component already exists — you may just standardize on it for family (b) and reserve `<Toggle>` for family (a).)
+2. **Per-option colors.** Tree's tier filter encodes state via color; Tree's course filter uses colored dots. The filter-pills component needs optional per-option `color`/`dot` support, or Tree's course filter stays specialized.
+3. **Study mode toggle** has a Framer-Motion spring animation — keep it specialized (like ModelToggle) or accept the plain `<Toggle>`? Get the user's call.
+4. **Quiz selectors** are `<CustomSelect>` dropdowns with small option sets (3–4) — convert to `<Toggle>` for visibility, or keep as dropdowns for consistency with other CustomSelect usage? User's call.
+
+## Process (mirror what worked this session)
+- Dev server: `cd frontend && npm run dev` (port 3000). The user is signed in, so authed pages (gradebook/social/etc.) load.
+- Migrate **one surface at a time**; after each, **screenshot it live and confirm the control still switches/filters correctly** (preserve every `onClick`/state handler — these are interactive). Commit per surface with a clear message.
+- Verify per change: `npx tsc --noEmit` (filter out stale `.next/types` route-validator errors — they're harmless), `npx eslint .` (**must be 0 errors**; ~37 warnings are fine), `npm run test` (vitest, **68 passing**).
+- Push to update **PR #294** after a coherent chunk; don't push on every micro-tweak.
+
+## Gotchas (learned this session)
+- `npm run build` sometimes exits **144** in this env — that's a resource/timeout kill, NOT a code error. Just retry; it passes. Don't run it concurrently with `next dev` (they fight over `.next`).
+- Stale `.next/types/validator.ts` typecheck errors appear after route moves — harmless, regenerate on build; grep them out of typecheck output.
+- `frontend/eslint-suppressions.json` keys on file **paths**. If you move/rename a file that has grandfathered (suppressed) lint errors, re-home its suppression entry to the new path or CI's eslint step fails (this exact thing bit us in Phase 1).
+- Shell is **fish** — quote grep globs: `grep -r 'x' --include='*.tsx'`.
+- Reference docs on the branch: `docs/frontend-component-consistency-audit.md`, `docs/superpowers/specs/2026-06-30-component-system-phase2-design.md`, `docs/changes-tour.html` (guided tour of changes), `docs/button-shape-comparison.html`.
+
+Start by reading `components/ui/Toggle.tsx` and 2–3 of the inventory files to ground yourself, then ask the user the 4 forks above before editing.

--- a/docs/superpowers/specs/2026-06-30-component-system-phase2-design.md
+++ b/docs/superpowers/specs/2026-06-30-component-system-phase2-design.md
@@ -1,0 +1,93 @@
+# Design Spec — Shared UI Primitives + Green Consolidation (Phase 2)
+
+**Date:** 2026-06-30
+**Status:** Approved design, pending spec review → implementation plan
+**Companion audit:** `docs/frontend-component-consistency-audit.md`
+**Builds on:** Phase 1 token unification (branch `refactor/token-unification`, PR #286)
+**User decisions:** sharp 6px primary buttons (+ dedicated `lg` hero size) · retire sage `--accent` toward the forest family · merge status greens into one `--positive` · scope = primitives + high-impact surfaces (long tail incremental)
+
+---
+
+## 1. Problem
+
+Phase 1 unified the *token values*. This phase fixes the *component layer* the audit found underneath:
+
+- **No shared primitives** → 5 distinct button shapes and **18+** pill/badge implementations; every surface reinvents them.
+- **Greens split by accident, not role** → 5 active greens; sage `--accent` (125×) competes with the forest brand; `--grade-a` (#3e8030) and `--brand-forest` (#1B6C42) are 9 hex apart and indistinguishable; `#1a5c2a` isn't even a token.
+
+## 2. Goals / Non-goals
+
+**Goals:**
+1. One **`<Button>`** primitive — variants + sizes, **6px radius always**, a dedicated **`lg` hero size** (so de-pilled landing CTAs keep presence: ~15–16px text, 600 weight, generous padding).
+2. One **`<Toggle>`** segmented control (replaces the 3 ad-hoc toggles).
+3. **`<Chip>`** + **`<Badge>`** primitives (collapse the 18 pill/badge implementations).
+4. **Green-by-role consolidation** (token-level): forest = brand/action; one `--positive` = status (mastery + grade-A); `--accent` re-homed into the forest family; tokenize `#1a5c2a`.
+5. Migrate the **high-impact surfaces** to the new primitives; leave the long tail on the still-working `.btn` CSS for incremental migration.
+
+**Non-goals (deferred / incremental):**
+- Migrating all ~211 `.btn` call-sites and every one of the 18 pill sites in this pass.
+- Re-skinning onboarding/pending, the beta glow, modal de-dup (those remain follow-ups #287–#293).
+- Any change to the app-shell *layout* or the Phase-1 token namespace.
+
+## 3. The primitives
+
+> All live under `frontend/src/components/ui/`. Each is a **thin wrapper over the existing `globals.css` classes** — the CSS stays the source of truth, the component enforces consistent usage. Un-migrated call-sites keep working.
+
+### `<Button>` — `components/ui/Button.tsx`
+```
+type ButtonProps = {
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger';  // default 'secondary'
+  size?: 'sm' | 'md' | 'lg';                                // default 'md'
+  // ...plus native button props, asChild?/href? optional for link-buttons
+}
+```
+- Maps to classes: `btn` + `btn--{variant}` + `btn--{size}`. `secondary` = base `.btn` (no modifier).
+- **Radius 6px for every variant/size.** Pills are never a Button.
+- New CSS needed: `.btn--lg` (the hero size — see §4) and `.btn--secondary` alias (= base, for explicitness). `.btn--primary/ghost/danger/sm` already exist.
+
+### `<Toggle>` — `components/ui/Toggle.tsx`
+- A segmented control: `options: {value,label}[]`, `value`, `onChange`. Pill container (`--r-full`), active segment filled forest. One implementation to replace `Learn.tsx:473`, `Learn.tsx:562`, `ModelToggle.tsx`.
+
+### `<Chip>` — `components/ui/Chip.tsx`
+- `variant?: 'neutral' | 'accent' | 'positive' | 'warn' | 'err' | 'info'`, optional leading dot/icon. Maps to the `.chip` + `.chip--*` classes. Replaces inline status pills, term pills, room-code chips, filter chips.
+
+### `<Badge>` — `components/ui/Badge.tsx`
+- For rarity / role / grade. Takes a semantic `tone` (or rarity tier) and centralizes the `color-mix` logic currently duplicated in `RoleBadge.tsx`, `TitleFlair.tsx`, and the Achievements inline badges.
+
+## 4. Token changes (`globals.css`)
+
+| Token | Now | After | Notes |
+|---|---|---|---|
+| `--accent` | `#8a9a5b` (sage) | a **brighter forest** (start: `#2D8F5C` = `--brand-forest-bright`; tune in build) | re-homes 125 usages into forest; brighter than `--brand-forest` so highlights/focus ≠ primary buttons |
+| `--accent-soft` | `--sap-50` (`#f1f6ee`) | unchanged (already a forest tint) | soft highlight bg |
+| `--accent-border` | `--sap-200` | unchanged | already forest-family |
+| `--state-mastery` `#4a7d5c` + `--grade-a`/`--c-sage` `#3e8030` | two near-forest greens | **`--positive`** (start: `#3a7d4e`; tune) — one status green | mastery + grade-A render identically; a mid-green, distinct from both action-forest (darker) and accent (brighter) |
+
+**Three distinct forest-family greens by role:** `--brand-forest #1B6C42` (primary action, darkest) · `--accent #2D8F5C` (highlight/focus, brightest) · `--positive #3a7d4e` (status, mid). One hue family, three legible weights.
+| `#1a5c2a` (hard-coded ×12) | not a token | `--brand-forest` (or add `--brand-forest-deep`) | landing logo / TopNav |
+
+`.btn--lg`: `padding: 13px 26px; font-size: 15px; font-weight: 600; border-radius: var(--r-sm);` (final values tuned against the hero CTA visually).
+
+> Exact green hexes are **tuned during the build with a side-by-side visual check** (the audit + comparison page give the reference). The spec fixes the *roles and consolidation*, not the final pixel of each hue.
+
+## 5. High-impact migration list (this phase)
+
+- **Landing CTAs** (`app/(public)/page.tsx:705, 781, 911`) → `<Button variant="primary" size="lg">`, sharp 6px (de-pill).
+- **Gradebook modal buttons** (`LetterScaleEditor:107`, `SyllabusUploadFlow:220`, `AssignmentModal:346`, `EditWeightsModal:268`, `Gradebook/Course:186`) → `<Button>` (kills the hard-coded `borderRadius:6`).
+- **Study flashcard ratings** (`Study.tsx:593`) → `<Button>` family (off the 10px).
+- **The 3 toggles** (`Learn.tsx:473`, `Learn.tsx:562`, `ModelToggle.tsx`) → `<Toggle>`.
+- **Worst pills** on gradebook/social/achievements → `<Chip>`/`<Badge>` (term pills, filter chips, rarity badges, room-code chip).
+
+## 6. Verification
+
+Same as Phase 1 — no component test harness for visuals, so: `npm run build` + `npx eslint .` (0 errors) + `npm run test` (vitest 68 passing) + **manual before/after screenshots** of gradebook, social, achievements, landing, and a couple of in-app screens (dashboard unchanged as anchor). Each green-token change is eyeballed against the comparison reference.
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| `--accent` re-point makes the UI monochrome-forest / loses hierarchy | choose a **brighter/lighter** forest for accent so highlights still separate from primary; visual review on dashboard + social |
+| `lg` hero size looks wrong after de-pilling | tune padding/size against the landing CTA live before committing |
+| Component migration breaks a call-site’s custom props | migrate incrementally, build + screenshot each surface; `.btn` CSS keeps working for un-migrated sites |
+| eslint suppressions keyed on moved/edited files | run `npx eslint .` per surface; re-home suppressions if a file’s grandfathered errors resurface (Phase-1 lesson) |
+| Scope creep into the long tail | §2 non-goals explicit; only the §5 list is in-scope |

--- a/frontend/src/app/(public)/about/page.tsx
+++ b/frontend/src/app/(public)/about/page.tsx
@@ -73,7 +73,7 @@ export default function AboutPage() {
                 fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif",
                 fontWeight: 700,
                 fontSize: 20,
-                color: "#1a5c2a",
+                color: "var(--brand-forest)",
                 letterSpacing: "-0.02em",
                 lineHeight: 1.1,
               }}

--- a/frontend/src/app/(public)/careers/page.tsx
+++ b/frontend/src/app/(public)/careers/page.tsx
@@ -54,7 +54,7 @@ export default function CareersPage() {
               style={{ width: 26, height: 26, flexShrink: 0, position: 'relative', top: -2 }}
             />
             <span
-              style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: 20, color: '#1a5c2a', letterSpacing: '-0.02em', lineHeight: 1.1 }}
+              style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: 20, color: 'var(--brand-forest)', letterSpacing: '-0.02em', lineHeight: 1.1 }}
             >
               Sapling
             </span>

--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -9,6 +9,7 @@ import HowItWorks from '@/components/HowItWorks';
 import SignInModal from '@/components/SignInModal';
 import { BRAND_FOREST } from '@/lib/brand';
 import { submitOnboardingProfile, type OnboardingProfilePayload } from '@/lib/api';
+import { Button } from "@/components/ui";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5000';
 
@@ -698,13 +699,13 @@ export default function LandingPage() {
         <div className="max-w-[88%] mx-auto flex items-center justify-between w-full">
           <button type="button" aria-label="Sapling — scroll to top" className="flex items-center cursor-pointer group" style={{ gap: '4px' }} onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>
             <img src="/sapling-icon.svg" alt="" style={{ width: '26px', height: '26px', flexShrink: 0, position: 'relative', top: '-2px' }} />
-            <span style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: '20px', color: '#1a5c2a', letterSpacing: '-0.02em', lineHeight: 1.1 }}>Sapling</span>
+            <span style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: '20px', color: 'var(--brand-forest)', letterSpacing: '-0.02em', lineHeight: 1.1 }}>Sapling</span>
           </button>
           <div className="flex items-center">
             <button onClick={() => { setSignInError(null); setSignInOpen(true); }} className="text-[var(--text-dim)] hover:text-[var(--text)] font-medium text-sm tracking-wide transition-all duration-300 mr-6 hidden sm:block">Sign In</button>
-            <button onClick={startOnboarding} className="relative overflow-hidden group bg-[var(--brand-forest)] text-white px-7 py-2.5 rounded-full font-medium text-sm tracking-wide shadow-sm hover:shadow-md transition-all duration-400 hover:scale-[1.04] active:scale-[0.97] landing-btn-shimmer">
+            <Button variant="primary" size="lg" onClick={startOnboarding}>
               Get Started
-            </button>
+            </Button>
           </div>
         </div>
       </nav>
@@ -776,15 +777,13 @@ export default function LandingPage() {
             transition: 'all 700ms cubic-bezier(0.22,1,0.36,1) 700ms',
           }} className="flex flex-col items-center gap-4 mt-10">
             <div style={{ position: 'relative', display: 'inline-flex', flexDirection: 'column', alignItems: 'center', gap: 6 }}>
-              <button
+              <Button
+                variant="primary"
+                size="lg"
                 onClick={() => { setBetaModalOpen(true); if (betaEverSubmitted) setBetaSubmitted(true); }}
-                className={`relative overflow-hidden group px-10 py-4 rounded-full font-medium text-base tracking-wide text-white shadow-[0_4px_14px_rgba(27,108,66,0.18)] hover:shadow-[0_6px_20px_rgba(27,108,66,0.28)] transition-all duration-500 hover:scale-[1.02] active:scale-[0.98] landing-btn-shimmer${betaEverSubmitted ? '' : ' beta-glow-btn'}`}
-                style={{ background: 'var(--brand-forest-bright)', border: 'none' }}
-                onMouseEnter={e => { e.currentTarget.style.background = 'var(--brand-forest-bright-hover)'; }}
-                onMouseLeave={e => { e.currentTarget.style.background = 'var(--brand-forest-bright)'; }}
               >
                 Sign up for Beta Testing
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -908,9 +907,9 @@ export default function LandingPage() {
             </h2>
             <p className="text-[var(--text-dim)] text-lg mt-6 font-light">Join students who learn smarter, not harder.</p>
             <div className="mt-10 flex flex-col items-center">
-              <button onClick={startOnboarding} className="relative overflow-hidden group bg-[var(--brand-forest)] text-white px-10 py-4 rounded-full font-medium text-base tracking-wide shadow-md hover:shadow-lg hover:bg-[#155A35] transition-all duration-500 hover:scale-[1.03] active:scale-[0.98] landing-btn-shimmer">
+              <Button variant="primary" size="lg" onClick={startOnboarding}>
                 Get Started
-              </button>
+              </Button>
             </div>
           </div>
         </section>
@@ -1015,7 +1014,7 @@ export default function LandingPage() {
             }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                 <img src="/sapling-icon.svg" alt="Sapling" style={{ width: 22, height: 22 }} />
-                <span style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: 17, color: '#1a5c2a', letterSpacing: '-0.02em' }}>Sapling</span>
+                <span style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: 17, color: 'var(--brand-forest)', letterSpacing: '-0.02em' }}>Sapling</span>
               </div>
               <div>
                 <div style={{ fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace", fontSize: 10.5, color: '#6b7280', letterSpacing: '0.22em', marginBottom: 14, textTransform: 'uppercase', fontWeight: 600 }}>Early access</div>

--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -907,7 +907,7 @@ export default function LandingPage() {
             </h2>
             <p className="text-[var(--text-dim)] text-lg mt-6 font-light">Join students who learn smarter, not harder.</p>
             <div className="mt-10 flex flex-col items-center">
-              <Button variant="primary" size="lg" onClick={startOnboarding}>
+              <Button variant="primary" size="xl" onClick={startOnboarding}>
                 Get Started
               </Button>
             </div>

--- a/frontend/src/app/(public)/privacy/page.tsx
+++ b/frontend/src/app/(public)/privacy/page.tsx
@@ -145,7 +145,7 @@ export default function PrivacyPage() {
                 fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif",
                 fontWeight: 700,
                 fontSize: 20,
-                color: "#1a5c2a",
+                color: "var(--brand-forest)",
                 letterSpacing: "-0.02em",
                 lineHeight: 1.1,
               }}

--- a/frontend/src/app/(public)/terms/page.tsx
+++ b/frontend/src/app/(public)/terms/page.tsx
@@ -111,7 +111,7 @@ export default function TermsPage() {
                 fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif",
                 fontWeight: 700,
                 fontSize: 20,
-                color: "#1a5c2a",
+                color: "var(--brand-forest)",
                 letterSpacing: "-0.02em",
                 lineHeight: 1.1,
               }}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -64,7 +64,7 @@
   --text-muted:#6f6857;  /* WCAG AA: darkened from --ink-400 (#8a8372, 3.4:1) to ≥4.5:1 on paper/inset */
   /* --accent (sage) is a distinct ROLE (highlights/focus), NOT a primary green.
      Do not consolidate into --brand-forest. */
-  --accent:    #8a9a5b;
+  --accent:    var(--brand-forest-bright);  /* sage retired → brighter forest (highlight/focus role) */
   --accent-fg: #ffffff;
   --accent-soft: var(--sap-50);
   --accent-border: var(--sap-200);
@@ -79,7 +79,9 @@
   /* Knowledge-status palette (mastery/progress/struggle legend + graph dots).
      Single source for the 3 previously-inlined copies in Dashboard / Tree /
      notetaker. Values are byte-identical to those inline copies. */
-  --state-mastery:  #4a7d5c;
+  /* Canonical "positive status" green — one value for mastery + grade-A (Phase 2 green collapse). */
+  --positive:       #3a7d4e;
+  --state-mastery:  var(--positive);
   --state-progress: #c89b5e;
   --state-struggle: #b25855;
   --state-neutral:  #9a9a9a;
@@ -111,7 +113,7 @@
 
   /* Grade-band semantic colors. Used by the Gradebook landing and any
    * future "grade pill" surface. Tied to the 90/80/70/60 letter scale. */
-  --grade-a: var(--c-sage);
+  --grade-a: var(--positive);
   --grade-b: var(--c-amber);
   --grade-c: var(--c-rust);
   --grade-d: var(--c-rose);
@@ -200,6 +202,7 @@ body { font-size: 14px; line-height: 1.5; }
 .btn--ghost:hover { background: var(--bg-soft); }
 .btn--danger { color: var(--err); border-color: rgba(168,58,58,0.3); }
 .btn--sm { padding: 5px 10px; font-size: 12px; }
+.btn--lg { padding: 13px 26px; font-size: 15px; font-weight: 600; }
 
 .card {
   background: var(--bg-panel); border: 1px solid var(--border);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -202,7 +202,8 @@ body { font-size: 14px; line-height: 1.5; }
 .btn--ghost:hover { background: var(--bg-soft); }
 .btn--danger { color: var(--err); border-color: rgba(168,58,58,0.3); }
 .btn--sm { padding: 5px 10px; font-size: 12px; }
-.btn--lg { padding: 13px 26px; font-size: 15px; font-weight: 600; }
+.btn--lg { padding: 9px 18px; font-size: 14px; font-weight: 600; }
+.btn--xl { padding: 14px 32px; font-size: 16px; font-weight: 600; }
 
 .card {
   background: var(--bg-panel); border: 1px solid var(--border);

--- a/frontend/src/components/Gradebook/AssignmentModal.tsx
+++ b/frontend/src/components/Gradebook/AssignmentModal.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { createPortal } from "react-dom";
 import type { GradedAssignment, GradeCategory } from "@/lib/types";
+import { Button } from "@/components/ui";
 
 export interface AssignmentDraft {
   title: string;
@@ -332,23 +333,18 @@ export function AssignmentModal({
           </div>
           <div style={{ display: "flex", gap: 8 }}>
             <button type="button" onClick={onClose}>Cancel</button>
-            <button
-              type="button"
+            <Button
+              variant="primary"
+              size="sm"
               disabled={!valid || saving}
               onClick={async () => {
                 setSaving(true);
                 try { await onSave(draft); onClose(); }
                 finally { setSaving(false); }
               }}
-              style={{
-                background: valid ? "var(--accent)" : "var(--bg-soft)",
-                color: valid ? "#fff" : "var(--text-dim)",
-                border: 0, borderRadius: 6, padding: "6px 14px",
-                cursor: valid ? "pointer" : "not-allowed",
-              }}
             >
               {saving ? "Saving…" : "Save"}
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/Gradebook/EditWeightsModal.tsx
+++ b/frontend/src/components/Gradebook/EditWeightsModal.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { createPortal } from "react-dom";
 import type { GradeCategory } from "@/lib/types";
+import { Button } from "@/components/ui";
 
 interface Draft {
   id?: string;
@@ -254,23 +255,18 @@ export function EditWeightsModal({ open, initial, onClose, onSave }: Props) {
           </span>
           <div style={{ display: "flex", gap: 8 }}>
             <button type="button" onClick={onClose}>Cancel</button>
-            <button
-              type="button"
+            <Button
+              variant="primary"
+              size="sm"
               disabled={!valid || saving}
               onClick={async () => {
                 setSaving(true);
                 try { await onSave(drafts); onClose(); }
                 finally { setSaving(false); }
               }}
-              style={{
-                background: valid ? "var(--accent)" : "var(--bg-soft)",
-                color: valid ? "#fff" : "var(--text-dim)",
-                border: 0, borderRadius: 6, padding: "6px 14px",
-                cursor: valid ? "pointer" : "not-allowed",
-              }}
             >
               {saving ? "Saving…" : "Save"}
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/Gradebook/LetterScaleEditor.tsx
+++ b/frontend/src/components/Gradebook/LetterScaleEditor.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { createPortal } from "react-dom";
 import type { LetterScaleTier } from "@/lib/types";
+import { Button } from "@/components/ui";
 
 const DEFAULT_SCALE: LetterScaleTier[] = [
   { min: 93, letter: "A" }, { min: 90, letter: "A-" },
@@ -93,23 +94,18 @@ export function LetterScaleEditor({ open, initial, onClose, onSave }: Props) {
           </button>
           <div style={{ display: "flex", gap: 8 }}>
             <button type="button" onClick={onClose}>Cancel</button>
-            <button
-              type="button"
+            <Button
+              variant="primary"
+              size="sm"
               disabled={!monotonic || saving}
               onClick={async () => {
                 setSaving(true);
                 try { await onSave(tiers); onClose(); }
                 finally { setSaving(false); }
               }}
-              style={{
-                background: monotonic ? "var(--accent)" : "var(--bg-soft)",
-                color: monotonic ? "#fff" : "var(--text-dim)",
-                border: 0, borderRadius: 6, padding: "6px 14px",
-                cursor: monotonic ? "pointer" : "not-allowed",
-              }}
             >
               {saving ? "Saving…" : "Save"}
-            </button>
+            </Button>
           </div>
         </div>
         {!monotonic && (

--- a/frontend/src/components/Gradebook/SemesterChips.tsx
+++ b/frontend/src/components/Gradebook/SemesterChips.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import { Toggle } from "@/components/ui";
 
 interface Props {
   semesters: string[];
@@ -7,42 +8,15 @@ interface Props {
   onSelect: (semester: string) => void;
 }
 
-const CHIP_TRANSITION =
-  "background-color var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease)";
-
 export function SemesterChips({ semesters, selected, onSelect }: Props) {
   return (
-    <div
-      role="tablist"
-      aria-label="Semester"
-      style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 16 }}
-    >
-      {semesters.map((s) => {
-        const active = s === selected;
-        return (
-          <button
-            key={s}
-            type="button"
-            role="tab"
-            aria-current={active ? "true" : undefined}
-            aria-selected={active}
-            onClick={() => onSelect(s)}
-            style={{
-              padding: "4px 12px",
-              borderRadius: "var(--r-full)",
-              border: `1px solid ${active ? "var(--accent)" : "var(--border)"}`,
-              background: active ? "var(--accent)" : "var(--bg)",
-              color: active ? "var(--accent-fg)" : "var(--text)",
-              fontSize: 12,
-              fontWeight: active ? 600 : 400,
-              cursor: "pointer",
-              transition: CHIP_TRANSITION,
-            }}
-          >
-            {s}
-          </button>
-        );
-      })}
+    <div style={{ marginBottom: 16 }}>
+      <Toggle
+        options={semesters.map((s) => ({ value: s, label: s }))}
+        value={selected}
+        onChange={onSelect}
+        size="sm"
+      />
     </div>
   );
 }

--- a/frontend/src/components/Gradebook/SyllabusUploadFlow.tsx
+++ b/frontend/src/components/Gradebook/SyllabusUploadFlow.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui";
 import {
   uploadSyllabus, applySyllabus, getCourses,
 } from "@/lib/api";
@@ -210,18 +211,14 @@ export function SyllabusUploadFlow({ open, userId, onClose }: Props) {
 
             <div style={{ marginTop: 16, display: "flex", justifyContent: "flex-end", gap: 8 }}>
               <button type="button" onClick={onClose}>Cancel</button>
-              <button
-                type="button"
+              <Button
+                variant="primary"
+                size="sm"
                 disabled={!weightsValid}
                 onClick={handleSave}
-                style={{
-                  background: weightsValid ? "var(--accent)" : "var(--bg-soft)",
-                  color: weightsValid ? "#fff" : "var(--text-dim)",
-                  border: 0, borderRadius: 6, padding: "6px 14px",
-                }}
               >
                 Save to gradebook
-              </button>
+              </Button>
             </div>
           </>
         )}

--- a/frontend/src/components/HowItWorks.tsx
+++ b/frontend/src/components/HowItWorks.tsx
@@ -42,14 +42,14 @@ function SeedSVG({ active }: { active: boolean }) {
       <g style={{ transformOrigin: '100px 215px', transform: 'scale(0.55)' }}>
         {/* Stem */}
         <motion.path d="M100 215 L100 137"
-          stroke="#1a5c2a" strokeWidth="5" strokeLinecap="round"
+          stroke="#1B6C42" strokeWidth="5" strokeLinecap="round"
           initial={{ pathLength: 0 }}
           animate={active ? { pathLength: 1 } : { pathLength: 0 }}
           transition={{ duration: 0.55, ease: 'easeOut' }}
         />
         {/* Left leaf */}
         <motion.path d="M100 167 C100 167 58 155 52 119 C52 119 94 113 100 167 Z"
-          fill="#1a5c2a"
+          fill="#1B6C42"
           initial={{ scale: 0 }} animate={active ? { scale: 1 } : { scale: 0 }}
           transition={{ duration: 0.55, delay: 0.42, ease: [0.34, 1.56, 0.64, 1] }}
           style={{ transformOrigin: '100px 167px' }}
@@ -62,7 +62,7 @@ function SeedSVG({ active }: { active: boolean }) {
           style={{ transformOrigin: '100px 143px' }}
         />
         {/* Tip bud */}
-        <motion.circle cx="100" cy="131" r="7" fill="#1a5c2a"
+        <motion.circle cx="100" cy="131" r="7" fill="#1B6C42"
           initial={{ scale: 0 }} animate={active ? { scale: 1 } : { scale: 0 }}
           transition={{ duration: 0.38, delay: 0.32, ease: [0.34, 1.56, 0.64, 1] }}
           style={{ transformOrigin: '100px 131px' }}

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -126,7 +126,7 @@ export function SideNav() {
                 fontFamily: "'Spectral', Georgia, serif",
                 fontWeight: 700,
                 fontSize: 20,
-                color: "#1a5c2a",
+                color: "var(--brand-forest)",
                 letterSpacing: "-0.02em",
                 textShadow: "0 0 12px rgba(26, 92, 42, 0.2)",
                 lineHeight: 1.1,

--- a/frontend/src/components/SignInModal.tsx
+++ b/frontend/src/components/SignInModal.tsx
@@ -251,7 +251,7 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
 
         <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 24 }}>
           <img src="/sapling-icon.svg" alt="Sapling" style={{ width: 22, height: 22 }} />
-          <span style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: 17, color: "#1a5c2a", letterSpacing: "-0.02em" }}>Sapling</span>
+          <span style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: 17, color: "var(--brand-forest)", letterSpacing: "-0.02em" }}>Sapling</span>
         </div>
 
         <h2 style={{

--- a/frontend/src/components/TitleFlair.tsx
+++ b/frontend/src/components/TitleFlair.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import type { Cosmetic } from "@/lib/types";
+import { Badge } from "@/components/ui";
 
 interface TitleFlairProps {
   cosmetic?: Cosmetic | null;
@@ -12,27 +13,16 @@ interface TitleFlairProps {
 export function TitleFlair({ cosmetic, className, style }: TitleFlairProps) {
   if (!cosmetic) return null;
   const rarity = cosmetic.rarity ?? "common";
-  // Rarity is never conveyed by colored text (fails 4.5:1 on several tiers);
-  // the border carries the color and the literal tier name carries the cue.
+  // The rarity hue is carried by the border + soft bg; the text stays neutral
+  // (Badge enforces this) — colored text fails 4.5:1 on several tiers.
   return (
-    <span
+    <Badge
       className={className}
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        padding: "2px 8px",
-        fontSize: 10,
-        fontFamily: "var(--font-mono)",
-        letterSpacing: "0.1em",
-        textTransform: "uppercase",
-        borderRadius: "var(--r-full)",
-        border: `1px solid var(--rarity-${rarity})`,
-        color: "var(--text)",
-        background: `var(--rarity-${rarity}-bg)`,
-        ...style,
-      }}
+      color={`var(--rarity-${rarity})`}
+      bg={`var(--rarity-${rarity}-bg)`}
+      style={style}
     >
       {cosmetic.name} · {rarity}
-    </span>
+    </Badge>
   );
 }

--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -186,7 +186,7 @@ export function TopNav() {
               fontFamily: "'Spectral', Georgia, serif",
               fontWeight: 700,
               fontSize: isMobile ? "17px" : "20px",
-              color: "#1a5c2a",
+              color: "var(--brand-forest)",
               letterSpacing: "-0.02em",
               textShadow: "0 0 12px rgba(26, 92, 42, 0.2)",
               lineHeight: 1.1,

--- a/frontend/src/components/screens/Achievements.tsx
+++ b/frontend/src/components/screens/Achievements.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 import { TopBar } from "../TopBar";
-import { Pill } from "../Pill";
+import { FilterPills } from "@/components/ui";
 import { Icon } from "../Icon";
 import { AchievementsSkeleton } from "../Skeleton";
 import { useToast } from "../ToastProvider";
@@ -207,10 +207,12 @@ export function Achievements() {
         title="Achievements"
         subtitle={`${earned.length} earned · ${available.length} in progress`}
       />
-      <div style={{ padding: "14px 32px", display: "flex", gap: 6, borderBottom: "1px solid var(--border)" }}>
-        {cats.map((c) => (
-          <Pill key={c} active={filter === c} onClick={() => setFilter(c)}>{c}</Pill>
-        ))}
+      <div style={{ padding: "14px 32px", borderBottom: "1px solid var(--border)" }}>
+        <FilterPills
+          options={cats.map((c) => ({ value: c, label: c }))}
+          value={filter}
+          onChange={setFilter}
+        />
       </div>
 
       {loading && <AchievementsSkeleton />}

--- a/frontend/src/components/screens/Calendar.tsx
+++ b/frontend/src/components/screens/Calendar.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { TopBar } from "../TopBar";
 import { Icon } from "../Icon";
-import { Pill } from "../Pill";
+import { Toggle } from "@/components/ui";
 import { CustomSelect } from "../CustomSelect";
 import { DocumentUploadModal } from "../DocumentUploadModal";
 import { CalendarMonthSkeleton } from "../Skeleton";
@@ -189,22 +189,17 @@ export function Calendar() {
 
   const topActions = (
     <>
-      <div style={{ display: "flex", border: "1px solid var(--border)", borderRadius: "var(--r-sm)", overflow: "hidden" }}>
-        {(["month", "week", "day", "table"] as View[]).map(v => (
-          <button
-            key={v}
-            onClick={() => setView(v)}
-            style={{
-              padding: "5px 10px", fontSize: 11,
-              background: view === v ? "var(--accent-soft)" : "transparent",
-              color: view === v ? "var(--accent)" : "var(--text-dim)",
-              textTransform: "capitalize",
-            }}
-          >
-            {v}
-          </button>
-        ))}
-      </div>
+      <Toggle
+        options={[
+          { value: "month", label: "Month" },
+          { value: "week", label: "Week" },
+          { value: "day", label: "Day" },
+          { value: "table", label: "Table" },
+        ]}
+        value={view}
+        onChange={setView}
+        size="sm"
+      />
       {view !== "table" && (
         <>
           <button className="btn btn--sm" onClick={() => shift(setCursor, view, -1)}>

--- a/frontend/src/components/screens/Gradebook/Course.tsx
+++ b/frontend/src/components/screens/Gradebook/Course.tsx
@@ -28,6 +28,7 @@ import { AmbientOrbs } from "@/components/Gradebook/AmbientOrbs";
 import { percentColor } from "@/components/Gradebook/CourseCard";
 import { projectGrade, droppedAssignmentIds } from "@/components/Gradebook/GradeProjector";
 import { GradePredictorPanel } from "@/components/Gradebook/GradePredictorPanel";
+import { Button } from "@/components/ui";
 import type {
   GradebookCourse,
   GradeCategory,
@@ -168,8 +169,9 @@ function CurveSettingsModal({
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 20,
           paddingTop: 12, borderTop: "1px solid var(--border)" }}>
           <button type="button" onClick={onClose}>Cancel</button>
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="sm"
             disabled={saving}
             onClick={async () => {
               setSaving(true);
@@ -181,13 +183,9 @@ function CurveSettingsModal({
                 onClose();
               } finally { setSaving(false); }
             }}
-            style={{
-              background: "var(--accent)", color: "#fff",
-              border: 0, borderRadius: 6, padding: "6px 14px", cursor: "pointer",
-            }}
           >
             {saving ? "Saving…" : "Save"}
-          </button>
+          </Button>
         </div>
       </div>
     </div>,

--- a/frontend/src/components/screens/Gradebook/Landing.tsx
+++ b/frontend/src/components/screens/Gradebook/Landing.tsx
@@ -13,6 +13,7 @@ import { getGradebookSummary, getCourses } from "@/lib/api";
 import type { EnrolledCourse } from "@/lib/api";
 import type { GradebookCourseSummary } from "@/lib/types";
 import { SyllabusUploadFlow } from "@/components/Gradebook/SyllabusUploadFlow";
+import { Button } from "@/components/ui";
 
 const SAMPLE_SEMESTERS = ["Spring 2026", "Fall 2025"];
 const SAMPLE_COURSES: Record<string, GradebookCourseSummary[]> = {
@@ -193,21 +194,9 @@ export function GradebookLanding() {
       <TopBar
         title="Grades"
         actions={
-          <button
-            type="button"
-            onClick={() => setUploadOpen(true)}
-            style={{
-              padding: "6px 12px",
-              borderRadius: "var(--r-sm)",
-              background: "var(--accent)",
-              color: "var(--accent-fg)",
-              fontSize: 13,
-              border: 0,
-              cursor: "pointer",
-            }}
-          >
+          <Button variant="primary" size="sm" onClick={() => setUploadOpen(true)}>
             Upload syllabus
-          </button>
+          </Button>
         }
       />
       <main

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -10,6 +10,7 @@ import { ChatPanel, type ChatMsg } from "../ChatPanel";
 import { SessionSummary } from "../SessionSummary";
 import { SharedContextToggle, useSharedContext } from "../SharedContextToggle";
 import { ModelToggle, useModelPref } from "../ModelToggle";
+import { Toggle } from "@/components/ui";
 import { DisclaimerModal } from "../DisclaimerModal";
 import { AIDisclaimerChip } from "../AIDisclaimerChip";
 import { KnowledgeGraph } from "../KnowledgeGraph";
@@ -468,25 +469,12 @@ function LearnInner() {
               selectedCourseId={selectedCourseId}
             />
             <div className="label-micro" style={{ marginBottom: 8 }}>Mode</div>
-            <div style={{ display: "flex", gap: 6, marginBottom: 20, flexWrap: "wrap" }}>
-              {MODES.map(m => (
-                <button
-                  key={m.id}
-                  onClick={() => setMode(m.id)}
-                  title={m.tip}
-                  style={{
-                    padding: "8px 16px",
-                    borderRadius: "var(--r-full)",
-                    fontSize: 13,
-                    fontWeight: 500,
-                    background: mode === m.id ? "var(--accent)" : "var(--bg-subtle)",
-                    color: mode === m.id ? "var(--accent-fg)" : "var(--text-dim)",
-                    border: mode === m.id ? "1px solid var(--accent)" : "1px solid var(--border)",
-                  }}
-                >
-                  {m.name}
-                </button>
-              ))}
+            <div style={{ marginBottom: 20 }}>
+              <Toggle
+                options={MODES.map(m => ({ value: m.id, label: m.name, title: m.tip }))}
+                value={mode}
+                onChange={setMode}
+              />
             </div>
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
               <SharedContextToggle enabled={sharedCtx} onChange={setSharedCtx} />

--- a/frontend/src/components/screens/Library.tsx
+++ b/frontend/src/components/screens/Library.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import { createPortal } from "react-dom";
 import { TopBar } from "../TopBar";
 import { Icon } from "../Icon";
-import { Pill } from "../Pill";
+import { FilterPills, Toggle } from "@/components/ui";
 import { DocumentUploadModal } from "../DocumentUploadModal";
 import { LibraryGridSkeleton, LibraryListSkeleton } from "../Skeleton";
 
@@ -183,31 +183,21 @@ export function Library() {
           padding: "14px 32px", display: "flex", gap: 6, alignItems: "center",
           borderBottom: "1px solid var(--border)", flexWrap: "wrap",
         }}>
-          {cats.map((c) => (
-            <Pill key={c} active={cat === c} onClick={() => setCat(c)}>
-              {c.replace("_", " ")}
-            </Pill>
-          ))}
+          <FilterPills
+            options={cats.map((c) => ({ value: c, label: c.replace("_", " ") }))}
+            value={cat}
+            onChange={setCat}
+          />
           <div style={{ flex: 1 }} />
-          <div style={{
-            display: "flex", border: "1px solid var(--border)",
-            borderRadius: "var(--r-sm)", overflow: "hidden",
-          }}>
-            {(["grid", "list"] as View[]).map((v) => (
-              <button
-                key={v}
-                onClick={() => setView(v)}
-                style={{
-                  padding: "4px 10px", fontSize: 11, textTransform: "capitalize",
-                  background: view === v ? "var(--accent-soft)" : "transparent",
-                  color: view === v ? "var(--accent)" : "var(--text-dim)",
-                  border: "none", cursor: "pointer",
-                }}
-              >
-                {v}
-              </button>
-            ))}
-          </div>
+          <Toggle
+            options={[
+              { value: "grid", label: "Grid" },
+              { value: "list", label: "List" },
+            ]}
+            value={view}
+            onChange={setView}
+            size="sm"
+          />
         </div>
 
         <div style={{ flex: 1, display: "flex", minHeight: 0 }}>

--- a/frontend/src/components/screens/Social.tsx
+++ b/frontend/src/components/screens/Social.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { Icon } from "../Icon";
 import { Avatar } from "../Avatar";
 import { CustomSelect } from "../CustomSelect";
+import { Toggle } from "@/components/ui";
 import { SocialRoomsSkeleton } from "../Skeleton";
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
@@ -1055,23 +1056,17 @@ export function Social() {
                   <span>{active.member_count} members</span>
                 </div>
               </div>
-              <div style={{ display: "flex", gap: 6 }}>
-                {(["overview", "chat", "match", "activity"] as Tab[]).map((t) => (
-                  <button
-                    key={t}
-                    onClick={() => setTab(t)}
-                    style={{
-                      padding: "6px 14px", fontSize: 12, fontWeight: 500,
-                      borderRadius: "var(--r-sm)",
-                      background: tab === t ? "var(--accent-soft)" : "transparent",
-                      color: tab === t ? "var(--accent)" : "var(--text-dim)",
-                      textTransform: "capitalize",
-                    }}
-                  >
-                    {t === "match" ? "Study match" : t}
-                  </button>
-                ))}
-              </div>
+              <Toggle
+                options={[
+                  { value: "overview", label: "Overview" },
+                  { value: "chat", label: "Chat" },
+                  { value: "match", label: "Study match" },
+                  { value: "activity", label: "Activity" },
+                ]}
+                value={tab}
+                onChange={setTab}
+                size="sm"
+              />
             </div>
             {tab === "chat" && <RoomChat roomId={active.id} members={members} />}
             {tab === "overview" && <RoomOverview roomId={active.id} onChange={load} />}

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -590,7 +590,7 @@ function FlashcardsMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMo
                     disabled={!flipped}
                     title={`${r.label} (press ${r.hint})`}
                     style={{
-                      padding: "10px 20px", borderRadius: "var(--r-md)",
+                      padding: "10px 20px", borderRadius: "var(--r-sm)",
                       border: `1.5px solid ${r.color}`,
                       background: "transparent", color: r.color,
                       fontWeight: 600, fontSize: 13, textTransform: "capitalize",

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -6,7 +6,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { TopBar } from "../TopBar";
 import { AIDisclaimerChip } from "../AIDisclaimerChip";
 import { Icon } from "../Icon";
-import { Pill } from "../Pill";
+import { FilterPills } from "@/components/ui";
 import { CustomSelect } from "../CustomSelect";
 
 // Lazy-load to keep mermaid/katex/highlight.js out of the OpenNext
@@ -523,10 +523,15 @@ function FlashcardsMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMo
     <div style={{ display: "flex", flex: 1, minHeight: 0 }}>
       <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
         <div style={{ padding: "14px 32px", display: "flex", alignItems: "center", gap: 8, borderBottom: "1px solid var(--border)", flexWrap: "wrap" }}>
-          <Pill active={topicFilter === "all"} onClick={() => setTopicFilter("all")}>All topics</Pill>
-          {topics.map(t => (
-            <Pill key={t} active={topicFilter === t} onClick={() => setTopicFilter(t)}>{t}</Pill>
-          ))}
+          <FilterPills
+            options={[
+              { value: "all", label: "All topics" },
+              ...topics.map((t) => ({ value: t, label: t })),
+            ]}
+            value={topicFilter}
+            onChange={setTopicFilter}
+            gap={8}
+          />
           <div style={{ flex: 1 }} />
           {docsUsed !== null && (
             <span className="chip chip--accent" title="Library documents used as context for generation">

--- a/frontend/src/components/screens/Tree.tsx
+++ b/frontend/src/components/screens/Tree.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { TopBar } from "../TopBar";
 import { Icon } from "../Icon";
 import { Pill } from "../Pill";
+import { FilterPills } from "@/components/ui";
 import { KnowledgeGraph } from "../KnowledgeGraph";
 import { GraphPanelSkeleton } from "../Skeleton";
 import { useUser } from "@/context/UserContext";
@@ -266,14 +267,18 @@ export function Tree() {
             <Icon name="search" size={12} />
           </span>
         </div>
-        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-          <Pill active={tier === "all"} onClick={() => setTier("all")}>All</Pill>
-          {(Object.keys(TIER_META) as Array<Exclude<Tier, "all">>).map(t => (
-            <Pill key={t} active={tier === t} onClick={() => setTier(t)} color={TIER_META[t].color}>
-              {TIER_META[t].label}
-            </Pill>
-          ))}
-        </div>
+        <FilterPills
+          options={[
+            { value: "all" as Tier, label: "All" },
+            ...(Object.keys(TIER_META) as Array<Exclude<Tier, "all">>).map((t) => ({
+              value: t as Tier,
+              label: TIER_META[t].label,
+              color: TIER_META[t].color,
+            })),
+          ]}
+          value={tier}
+          onChange={setTier}
+        />
         <div style={{ flex: 1 }} />
         <div className="mono" style={{ fontSize: 11, color: "var(--text-muted)" }}>
           {conceptCount} node{conceptCount === 1 ? "" : "s"}

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,31 @@
+"use client";
+import React from "react";
+
+// Shared badge for rarity / role / grade — anywhere a pill is tinted from a single
+// base hue. Reuses .chip for shape + typography and derives bg/border from `color`
+// via color-mix, centralizing the logic duplicated across RoleBadge / TitleFlair /
+// the Achievements inline badges.
+export function Badge({
+  color = "var(--text-dim)",
+  className,
+  children,
+  style,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement> & {
+  color?: string;
+}) {
+  return (
+    <span
+      className={["chip", className].filter(Boolean).join(" ")}
+      style={{
+        background: `color-mix(in oklab, ${color} 12%, var(--bg-panel))`,
+        color,
+        borderColor: `color-mix(in oklab, ${color} 35%, transparent)`,
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -2,25 +2,27 @@
 import React from "react";
 
 // Shared badge for rarity / role / grade — anywhere a pill is tinted from a single
-// base hue. Reuses .chip for shape + typography and derives bg/border from `color`
-// via color-mix, centralizing the logic duplicated across RoleBadge / TitleFlair /
-// the Achievements inline badges.
+// base hue. Reuses .chip for shape + typography. The HUE is carried by the border +
+// a soft background; the TEXT stays neutral (--text) because colored text on a tinted
+// pill fails 4.5:1 contrast on several tiers (the rule the rarity badges already follow).
 export function Badge({
-  color = "var(--text-dim)",
+  color = "var(--border)",
+  bg,
   className,
   children,
   style,
   ...props
 }: React.HTMLAttributes<HTMLSpanElement> & {
-  color?: string;
+  color?: string; // the hue (border)
+  bg?: string; // optional explicit soft background; derived from `color` if omitted
 }) {
   return (
     <span
       className={["chip", className].filter(Boolean).join(" ")}
       style={{
-        background: `color-mix(in oklab, ${color} 12%, var(--bg-panel))`,
-        color,
-        borderColor: `color-mix(in oklab, ${color} 35%, transparent)`,
+        borderColor: color,
+        background: bg ?? `color-mix(in oklab, ${color} 12%, var(--bg-panel))`,
+        color: "var(--text)",
         ...style,
       }}
       {...props}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 
 type Variant = "primary" | "secondary" | "ghost" | "danger";
-type Size = "sm" | "md" | "lg";
+type Size = "sm" | "md" | "lg" | "xl";
 
 // Shared button primitive. Wraps the canonical .btn classes in globals.css so
 // every action button is one shape (6px) with consistent hover/transitions.

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,31 @@
+"use client";
+import React from "react";
+
+type Variant = "primary" | "secondary" | "ghost" | "danger";
+type Size = "sm" | "md" | "lg";
+
+// Shared button primitive. Wraps the canonical .btn classes in globals.css so
+// every action button is one shape (6px) with consistent hover/transitions.
+// - variant: primary (forest fill) | secondary (bordered, default) | ghost | danger
+// - size:    sm | md (default) | lg (the hero size for de-pilled CTAs)
+// Pills are NOT a Button — use <Toggle> for segmented controls.
+export function Button({
+  variant = "secondary",
+  size = "md",
+  className,
+  type = "button",
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Variant;
+  size?: Size;
+}) {
+  const cls = [
+    "btn",
+    variant !== "secondary" && `btn--${variant}`,
+    size !== "md" && `btn--${size}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return <button type={type} className={cls} {...props} />;
+}

--- a/frontend/src/components/ui/Chip.tsx
+++ b/frontend/src/components/ui/Chip.tsx
@@ -1,0 +1,28 @@
+"use client";
+import React from "react";
+
+type ChipVariant = "neutral" | "accent" | "warn" | "err" | "info";
+
+// Shared chip/pill primitive for short status labels, tags, and filters.
+// Maps to the .chip / .chip--* classes in globals.css (one radius, one type scale).
+// For rarity/role/grade badges with a custom hue, use <Badge> instead.
+export function Chip({
+  variant = "neutral",
+  icon,
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement> & {
+  variant?: ChipVariant;
+  icon?: React.ReactNode;
+}) {
+  const cls = ["chip", variant !== "neutral" && `chip--${variant}`, className]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <span className={cls} {...props}>
+      {icon}
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/FilterPills.tsx
+++ b/frontend/src/components/ui/FilterPills.tsx
@@ -1,0 +1,43 @@
+"use client";
+import React from "react";
+import { Pill } from "../Pill";
+
+// Shared wrapping filter-group control (family "b"): a row of selectable pills
+// that wraps to multiple lines. Use for "All" + N dynamic filters (categories,
+// topics, tiers). For a fixed, connected segmented control (2–5 options), use
+// <Toggle> instead. Per-option `color` tints the active pill (e.g. mastery tiers);
+// per-option `icon` renders leading content (e.g. a colored dot).
+export function FilterPills<T extends string>({
+  options,
+  value,
+  onChange,
+  gap = 6,
+  className,
+  style,
+}: {
+  options: { value: T; label: React.ReactNode; color?: string; icon?: React.ReactNode }[];
+  value: T;
+  onChange: (v: T) => void;
+  gap?: number;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div
+      className={className}
+      style={{ display: "flex", gap, flexWrap: "wrap", ...style }}
+    >
+      {options.map((o) => (
+        <Pill
+          key={o.value}
+          active={o.value === value}
+          onClick={() => onChange(o.value)}
+          color={o.color}
+          icon={o.icon}
+        >
+          {o.label}
+        </Pill>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Toggle.tsx
+++ b/frontend/src/components/ui/Toggle.tsx
@@ -1,0 +1,57 @@
+"use client";
+import React from "react";
+
+// Shared segmented control (the ONE pill-shaped toggle). Replaces the ad-hoc
+// mode/model toggles. Pill shape is correct here — it signals "pick one of these",
+// distinct from a rectangular action <Button>.
+export function Toggle<T extends string>({
+  options,
+  value,
+  onChange,
+  size = "md",
+}: {
+  options: { value: T; label: React.ReactNode }[];
+  value: T;
+  onChange: (v: T) => void;
+  size?: "sm" | "md";
+}) {
+  const pad = size === "sm" ? "5px 12px" : "7px 15px";
+  const fs = size === "sm" ? 12 : 13;
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        background: "var(--bg-soft)",
+        borderRadius: "var(--r-full)",
+        padding: 3,
+        gap: 2,
+      }}
+    >
+      {options.map((o) => {
+        const on = o.value === value;
+        return (
+          <button
+            key={o.value}
+            type="button"
+            onClick={() => onChange(o.value)}
+            aria-pressed={on}
+            style={{
+              padding: pad,
+              fontSize: fs,
+              fontWeight: on ? 600 : 500,
+              borderRadius: "var(--r-full)",
+              border: 0,
+              cursor: "pointer",
+              background: on ? "var(--brand-forest)" : "transparent",
+              color: on ? "#fff" : "var(--text-dim)",
+              transition: "all var(--dur-fast) var(--ease)",
+              fontFamily: "var(--font-sans)",
+            }}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Toggle.tsx
+++ b/frontend/src/components/ui/Toggle.tsx
@@ -10,7 +10,7 @@ export function Toggle<T extends string>({
   onChange,
   size = "md",
 }: {
-  options: { value: T; label: React.ReactNode }[];
+  options: { value: T; label: React.ReactNode; title?: string }[];
   value: T;
   onChange: (v: T) => void;
   size?: "sm" | "md";
@@ -34,6 +34,7 @@ export function Toggle<T extends string>({
             key={o.value}
             type="button"
             onClick={() => onChange(o.value)}
+            title={o.title}
             aria-pressed={on}
             style={{
               padding: pad,

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -2,3 +2,4 @@ export { Button } from "./Button";
 export { Chip } from "./Chip";
 export { Toggle } from "./Toggle";
 export { Badge } from "./Badge";
+export { FilterPills } from "./FilterPills";

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,0 +1,4 @@
+export { Button } from "./Button";
+export { Chip } from "./Chip";
+export { Toggle } from "./Toggle";
+export { Badge } from "./Badge";


### PR DESCRIPTION
## Shared UI primitives + green consolidation (Phase 2)

Stacked on #286 (Phase 1 token unification). Where Phase 1 unified *token values*, this fixes the *component layer* the audit found underneath — inconsistent button shapes, a 5-greens-by-accident mess, and reinvented pills.

### Green-by-role consolidation (`globals.css`)
Three forest-family greens, by role — sage retired:
- `--brand-forest #1B6C42` — primary action (unchanged)
- `--accent → #2D8F5C` (was sage `#8a9a5b`) — highlight/focus (re-homes 125 usages into forest)
- `--positive #3a7d4e` — one status green, merging `--state-mastery` + `--grade-a`
- `#1a5c2a` (orphan, ×12) tokenized → `var(--brand-forest)`

### Shared primitives (`components/ui/`)
`<Button>` (variants × `sm`/`md`/`lg`/`xl`, **6px always**) · `<Toggle>` (segmented control) · `<Chip>` · `<Badge>` (a11y-correct: hue on border, neutral text). Thin wrappers over the canonical `.btn`/`.chip` classes so un-migrated call-sites keep working.

### High-impact migrations
- **Landing CTAs** → `<Button>`, **de-pilled to sharp 6px**, infinite glow removed.
- **5 gradebook modal buttons** → `<Button>` (kills hard-coded `borderRadius:6`).
- **Study flashcard ratings** 10px → 6px.
- **Learn mode selector** → `<Toggle>`.
- **`TitleFlair`** → `<Badge>`.

### Deliberately NOT consolidated (the honest part)
The pill/badge/toggle "zoo" is largely *intentional* specialization — forcing it into generic primitives would degrade it:
- **`ModelToggle`** (Fast/Smart): sliding animation + color semantics + tooltip → kept.
- **Rarity badges**: a11y-neutral text (colored text fails 4.5:1) → `<Badge>` enforces this.
- **Filter chips**: single-select *filters* (toggle-like), not static chips.

---

## Refinements (this iteration)

Button-shape decision: **sharp 6px everywhere; pills only for true toggles/chips** (see `docs/button-shape-comparison.html`). After de-pilling, dialed in the CTA sizing:
- **Tightened `.btn--lg`** (`13/26` → `9/18` padding) so de-pilled CTAs hug their text instead of being big empty rectangles — navbar "Get Started" + hero "Sign up for Beta Testing".
- **Added `.btn--xl`** for the closing **"Get Started"** under the *"Ready to Start Growing?"* hero, so it stays a prominent central focal CTA.
- **Fixed the gradebook "Upload syllabus" button** — it hard-coded `background: var(--accent)`, so after accent shifted to the *brighter* forest it rendered brighter than every other primary button. Now a proper `<Button variant="primary">` (`--brand-forest`), matching the term pills + app buttons. (Audited app-wide: it was the only *button* mis-filled with `--accent`; the other two accent fills are a progress bar + a status badge — correct as highlights.)
- Added `docs/changes-tour.html` — a guided tour of every changed screen.

### Verification
Clean `npm run build`; `npx eslint .` 0 errors; `vitest` 68/68; manual click-through of landing, gradebook, learn, social, achievements, dashboard (unchanged anchor).

### Next up (separate handoff)
Consolidating the **selector / sorting / filter / tab controls** across gradebook · social · achievements · calendar · library · study · tree · quiz onto the shared `<Toggle>` (single-select) / `<Chip>` (multi-select filters), leaving genuinely-specialized controls alone.

Docs: `docs/frontend-component-consistency-audit.md`, `docs/button-shape-comparison.html`, `docs/changes-tour.html`, `docs/superpowers/specs/2026-06-30-component-system-phase2-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)