### PR TITLE
feat(agents): migrate remaining one-shot LLM calls to Pydantic AI agents (#147)

### DIFF
--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -29,6 +29,7 @@ from config import GEMINI_API_KEY
 AgentTask = Literal[
     "classifier", "summary", "concepts", "syllabus", "quiz", "chat_tutor",
     "note_summary", "note_concepts", "note_chat",
+    "study_guide", "social_summary",
 ]
 
 
@@ -52,6 +53,10 @@ _DEFAULTS: dict[AgentTask, str] = {
     "note_summary": "gemini-2.5-flash-lite",
     "note_concepts": "gemini-2.5-flash-lite",
     "note_chat": "gemini-2.5-flash",
+    # Study guide is quality-sensitive multi-topic generation → full Flash.
+    "study_guide": "gemini-2.5-flash",
+    # Social summary is short-form prose → the cheaper lite tier is enough.
+    "social_summary": "gemini-2.5-flash-lite",
 }
 
 

--- a/backend/agents/_run.py
+++ b/backend/agents/_run.py
@@ -1,0 +1,27 @@
+"""Sync→async bridge for driving Pydantic AI agents from sync route handlers.
+
+Some routes (study guide, social overview, the admin health probe) are plain
+sync `def` handlers: their surrounding data access is synchronous httpx
+`table()` calls that must not run on an event loop. FastAPI executes sync
+handlers in a worker thread that has no running event loop, so spinning up a
+fresh loop with ``asyncio.run`` to await a single agent run is safe here.
+
+Async handlers should keep using ``await agent.run(...)`` directly; this helper
+exists only for the synchronous seam.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Coroutine, TypeVar
+
+T = TypeVar("T")
+
+
+def run_agent_sync(coro: Coroutine[Any, Any, T]) -> T:
+    """Run an agent coroutine to completion from synchronous code.
+
+    Must be called from a thread with no running event loop (the case for
+    FastAPI sync handlers and direct unit-test calls under TestClient).
+    """
+    return asyncio.run(coro)

--- a/backend/agents/health.py
+++ b/backend/agents/health.py
@@ -1,0 +1,22 @@
+"""Gemini connectivity probe agent.
+
+Backs the admin-only ``/api/gemini-test`` health check. It runs through the
+same shared ``GoogleProvider`` the production agents use (via
+``agents._providers.google_model``), so a green probe means the real agent seam
+can reach Gemini — not just that some unrelated key exists.
+"""
+
+from __future__ import annotations
+
+from pydantic_ai import Agent
+
+from agents._providers import google_model
+
+
+# Cheapest model on the shared provider; the probe only needs a round-trip.
+health_probe_agent = Agent[None, str](
+    model=google_model("gemini-2.5-flash-lite"),
+    output_type=str,
+    system_prompt="You are a connectivity probe. Reply with exactly the text the user asks for.",
+    metadata={"agent": "health_probe"},
+)

--- a/backend/agents/social_summary.py
+++ b/backend/agents/social_summary.py
@@ -1,0 +1,44 @@
+"""Study-group summary agent.
+
+Replaces the inline ``call_gemini`` call in routes/social.py. Produces a short
+plain-text summary of a study group's collective knowledge, focused on
+complementary strengths and shared goals.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+from agents._providers import model_for
+from agents.deps import SaplingDeps
+
+
+class SocialSummary(BaseModel):
+    summary: str = Field(
+        description=(
+            "2-3 sentence summary of the study group's collective knowledge, "
+            "focused on complementary strengths and shared goals."
+        ),
+    )
+
+
+_SYSTEM_PROMPT = (
+    "You summarize a study group's collective knowledge for its members. Given "
+    "each member's mastered and struggling concepts, write a 2-3 sentence "
+    "summary that highlights the group's complementary strengths and shared "
+    "goals. Keep it encouraging and concrete. Do not invent members or topics "
+    "beyond what you are given."
+)
+_PROMPT_HASH = hashlib.sha256(_SYSTEM_PROMPT.encode("utf-8")).hexdigest()[:12]
+
+
+social_summary_agent = Agent[SaplingDeps, SocialSummary](
+    model=model_for("social_summary"),
+    deps_type=SaplingDeps,
+    output_type=SocialSummary,
+    system_prompt=_SYSTEM_PROMPT,
+    metadata={"prompt_version": _PROMPT_HASH, "agent": "social_summary"},
+)

--- a/backend/agents/study_guide.py
+++ b/backend/agents/study_guide.py
@@ -1,0 +1,62 @@
+"""Study-guide generation agent.
+
+Replaces the inline ``call_gemini_json`` call in routes/study_guide.py. The
+typed output mirrors the JSON contract the frontend already consumes
+(``exam / due_date / overview / topics[]``), so the route can ``model_dump()``
+the result straight into ``study_guides.content`` with no shape change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+from agents._providers import model_for
+from agents.deps import SaplingDeps
+
+
+class Topic(BaseModel):
+    """One study-guide topic."""
+
+    name: str = Field(description="Topic name.")
+    importance: str = Field(
+        description="One sentence explaining why this topic matters for the exam.",
+    )
+    concepts: list[str] = Field(
+        description="3-5 surface-level concept bullet points the student should understand.",
+    )
+
+
+class StudyGuide(BaseModel):
+    """Typed study guide. Serializes to the legacy JSON contract via model_dump()."""
+
+    exam: str = Field(description="The exam title.")
+    due_date: str = Field(description="The exam due date, YYYY-MM-DD.")
+    overview: str = Field(
+        description="2-3 sentence overview of what this exam covers and how to approach it.",
+    )
+    topics: list[Topic] = Field(description="The topics that make up the study guide.")
+
+
+_SYSTEM_PROMPT = (
+    "You are a study guide generator for a student exam-prep tool. Given an "
+    "exam and the student's course material, break the material into clear "
+    "topics. For each topic provide a topic name, 3-5 surface-level concept "
+    "bullet points the student should understand, and one sentence explaining "
+    "why the topic matters for the exam. Also produce a 2-3 sentence overview "
+    "of what the exam covers and how to approach it. Stay grounded in the "
+    "provided material; do not invent topics the material does not support. "
+    "Echo the exam title and due date you are given."
+)
+_PROMPT_HASH = hashlib.sha256(_SYSTEM_PROMPT.encode("utf-8")).hexdigest()[:12]
+
+
+study_guide_agent = Agent[SaplingDeps, StudyGuide](
+    model=model_for("study_guide"),
+    deps_type=SaplingDeps,
+    output_type=StudyGuide,
+    system_prompt=_SYSTEM_PROMPT,
+    metadata={"prompt_version": _PROMPT_HASH, "agent": "study_guide"},
+)

--- a/backend/main.py
+++ b/backend/main.py
@@ -210,16 +210,19 @@ def gemini_test(request: Request):
     key is missing/wrong.
 
     Gated behind `require_admin` (#198): every hit makes a real, billable
-    `call_gemini` round-trip, so an unauthenticated caller could burn Gemini
-    quota at will and use the `{"ok": ...}` response as an oracle for whether
-    the API key is configured. Only admins may trigger LLM spend here.
+    agent round-trip, so an unauthenticated caller could burn Gemini quota at
+    will and use the `{"ok": ...}` response as an oracle for whether the API
+    key is configured. Only admins may trigger LLM spend here.
     """
     from services.auth_guard import require_admin
     require_admin(request)  # 403 unless the session belongs to an admin; 401 if unauthenticated
-    from services.gemini_service import call_gemini
+    from agents._run import run_agent_sync
+    from agents.health import health_probe_agent
     try:
-        reply = call_gemini('Reply with exactly the text: Gemini OK', retries=0)
-        return {"ok": True, "reply": reply.strip()}
+        result = run_agent_sync(
+            health_probe_agent.run('Reply with exactly the text: Gemini OK')
+        )
+        return {"ok": True, "reply": result.output.strip()}
     except Exception as e:
         return {"ok": False, "error": str(e)}
 

--- a/backend/routes/social.py
+++ b/backend/routes/social.py
@@ -5,6 +5,9 @@ from collections import defaultdict
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
+from agents._run import run_agent_sync
+from agents.deps import SaplingDeps
+from agents.social_summary import social_summary_agent
 from db.connection import table
 from models import CreateRoomBody, JoinRoomBody, MatchBody, SendMessageBody, EditMessageBody, ToggleReactionBody, LeaveRoomBody
 from services.auth_guard import require_self, get_session_user_id
@@ -12,7 +15,7 @@ from services.encryption import encrypt_if_present, decrypt_if_present
 from services.profiles import get_display_name, get_display_names
 from services.graph_service import get_graph
 from services.matching_service import find_study_matches
-from services.gemini_service import call_gemini
+from services.request_context import current_request_id
 from services.social_cache_service import get_cached_summary, save_summary, invalidate as invalidate_summary
 
 router = APIRouter()
@@ -124,11 +127,20 @@ def room_overview(room_id: str, request: Request):
     ai_summary = get_cached_summary(room_id, member_summaries)
     if ai_summary is None:
         try:
-            ai_summary = call_gemini(
-                "Write a 2-3 sentence summary of this study group's collective knowledge:\n"
-                + "\n".join(member_summaries)
-                + "\nFocus on complementary strengths and shared goals."
+            from db.connection import _client  # opaque pass-through for SaplingDeps
+            deps = SaplingDeps(
+                user_id=viewer_id,  # already resolved at the membership gate above
+                course_id=None,
+                supabase=_client,
+                request_id=current_request_id() or "",
+                session_id=room_id,
             )
+            user_message = (
+                "Summarize this study group's collective knowledge:\n"
+                + "\n".join(member_summaries)
+            )
+            result = run_agent_sync(social_summary_agent.run(user_message, deps=deps))
+            ai_summary = result.output.summary
             save_summary(room_id, member_summaries, ai_summary)
         except Exception as e:
             print(f"Gemini summary failed: {e}")

--- a/backend/routes/study_guide.py
+++ b/backend/routes/study_guide.py
@@ -9,11 +9,14 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Body, HTTPException, Query, Request
 
+from agents._run import run_agent_sync
+from agents.deps import SaplingDeps
+from agents.study_guide import study_guide_agent
 from db.connection import table
 from services.academics import offering_course_id, resolve_offering
 from services.auth_guard import require_self
 from services.encryption import decrypt_if_present, decrypt_json
-from services.gemini_service import call_gemini_json
+from services.request_context import current_request_id
 
 router = APIRouter()
 
@@ -80,33 +83,29 @@ def _generate_and_insert(user_id: str, offering_id: str, exam_id: str) -> dict:
     combined_context = "\n\n".join(parts) if parts else "No course material available."
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
-    # 4. Call Gemini
-    prompt = (
-        "You are a study guide generator for a student exam prep tool.\n\n"
+    # 4. Generate the study guide via the study_guide agent. The agent owns the
+    #    persona + output schema; the user message carries the exam context.
+    user_message = (
         f"Exam: {exam_title}\n"
         f"Due date: {due_date}\n"
         f"Today: {today}\n\n"
-        f"Course material:\n{combined_context}\n\n"
-        "Generate a comprehensive study guide for this exam. Break the material into clear topics. "
-        "For each topic provide:\n"
-        "- A topic name\n"
-        "- 3-5 surface-level concept bullet points the student should understand\n"
-        "- One sentence explaining why this topic matters for the exam\n\n"
-        "Return ONLY a JSON object with this exact schema, no markdown fences:\n"
-        "{\n"
-        '  "exam": "<exam title>",\n'
-        '  "due_date": "<YYYY-MM-DD>",\n'
-        '  "overview": "<2-3 sentence overview of what this exam covers and how to approach it>",\n'
-        '  "topics": [\n'
-        "    {\n"
-        '      "name": "<topic name>",\n'
-        '      "importance": "<one sentence>",\n'
-        '      "concepts": ["<concept>", "<concept>", ...]\n'
-        "    }\n"
-        "  ]\n"
-        "}"
+        f"Course material:\n{combined_context}"
     )
-    content = call_gemini_json(prompt)
+    # course_id/session are unused by this toolless agent; deps satisfies the type.
+    from db.connection import _client  # opaque pass-through for SaplingDeps
+    deps = SaplingDeps(
+        user_id=user_id,
+        course_id=None,
+        supabase=_client,
+        request_id=current_request_id() or "",
+    )
+    try:
+        result = run_agent_sync(study_guide_agent.run(user_message, deps=deps))
+    except Exception as e:  # generation/transport failure → 502, not a raw 500
+        raise HTTPException(
+            status_code=502, detail="Study guide generation failed."
+        ) from e
+    content = result.output.model_dump()
 
     # 5. Insert into study_guides
     now = datetime.now(timezone.utc).isoformat()

--- a/backend/tests/test_gemini_test_auth.py
+++ b/backend/tests/test_gemini_test_auth.py
@@ -51,3 +51,15 @@ class TestGeminiTestAuth:
 
         assert r.status_code == 200
         assert r.json() == {"ok": True, "reply": "Gemini OK"}
+
+    def test_admin_probe_failure_returns_ok_false(self):
+        # Autouse bypass reaches the handler; when the probe raises, the endpoint
+        # surfaces the error as {"ok": False, "error": ...} and still returns 200.
+        probe = AsyncMock(side_effect=RuntimeError("bad key"))
+        with patch("agents.health.health_probe_agent.run", new=probe):
+            r = client.get("/api/gemini-test")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["ok"] is False
+        assert "bad key" in body["error"]

--- a/backend/tests/test_gemini_test_auth.py
+++ b/backend/tests/test_gemini_test_auth.py
@@ -10,7 +10,8 @@ The autouse `_bypass_session_auth` fixture in conftest.py stubs the auth guard
 so the admin-path test reaches the handler without minting tokens; the
 unauthenticated test restores the real guard to assert the 401.
 """
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -26,24 +27,26 @@ class TestGeminiTestAuth:
         # get_session_user_id first, which raises 401 before any role lookup.
         from services import auth_guard
 
+        probe = AsyncMock()
         with patch.object(
             auth_guard, "require_admin", auth_guard._real_require_admin
         ), patch.object(
             auth_guard, "get_session_user_id", auth_guard._real_get_session_user_id
         ), patch.object(
             auth_guard, "_decode_session", auth_guard._real_decode_session
-        ), patch("services.gemini_service.call_gemini") as call_gemini:
+        ), patch("agents.health.health_probe_agent.run", new=probe):
             r = client.get("/api/gemini-test")
 
         # Pre-fix this returned 200 with {"ok": ...}; the fix makes it 401 and,
         # critically, the LLM is never called for an anonymous request.
         assert r.status_code == 401
-        call_gemini.assert_not_called()
+        probe.assert_not_called()
 
     def test_admin_reaches_handler(self):
         # Autouse bypass stubs require_admin to a no-op, so an admin-equivalent
-        # request reaches the handler. Mock the LLM so the test is hermetic.
-        with patch("services.gemini_service.call_gemini", return_value="Gemini OK"):
+        # request reaches the handler. Mock the probe agent so the test is hermetic.
+        probe = AsyncMock(return_value=SimpleNamespace(output="Gemini OK"))
+        with patch("agents.health.health_probe_agent.run", new=probe):
             r = client.get("/api/gemini-test")
 
         assert r.status_code == 200

--- a/backend/tests/test_oneshot_agents.py
+++ b/backend/tests/test_oneshot_agents.py
@@ -1,0 +1,97 @@
+"""Tests for the #147 one-shot LLM → Pydantic AI agent migration.
+
+Covers the study-group summary paths on /api/social/rooms/{id}/overview
+(cache miss / cache hit / agent failure) and the StudyGuide typed output's
+serialization back to the legacy JSON contract.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+ROOM_ID = "room_1"
+
+
+def _social_table_side_effect(name):
+    m = MagicMock()
+    if name == "room_members":
+        # Same list serves both the membership gate and the member roster.
+        m.select.return_value = [{"user_id": "u1"}]
+    elif name == "rooms":
+        m.select.return_value = [{"id": ROOM_ID, "name": "Calc Crew", "topic": "Calc"}]
+    else:
+        m.select.return_value = []
+    return m
+
+
+_GRAPH = {"nodes": [
+    {"concept_name": "Limits", "mastery_tier": "mastered"},
+    {"concept_name": "Series", "mastery_tier": "struggling"},
+]}
+
+
+class TestRoomOverviewSummary:
+    def test_cache_miss_runs_agent_and_persists(self):
+        agent_run = AsyncMock(
+            return_value=SimpleNamespace(output=SimpleNamespace(summary="Strong together."))
+        )
+        save = MagicMock()
+        with patch("routes.social.table", side_effect=_social_table_side_effect), \
+             patch("routes.social.get_display_names", return_value={"u1": "Alice"}), \
+             patch("routes.social.get_graph", return_value=_GRAPH), \
+             patch("routes.social.get_cached_summary", return_value=None), \
+             patch("routes.social.social_summary_agent.run", new=agent_run), \
+             patch("routes.social.save_summary", new=save):
+            r = client.get(f"/api/social/rooms/{ROOM_ID}/overview")
+        assert r.status_code == 200
+        assert r.json()["ai_summary"] == "Strong together."
+        agent_run.assert_called_once()
+        save.assert_called_once()
+
+    def test_cache_hit_does_not_run_agent(self):
+        agent_run = AsyncMock()
+        with patch("routes.social.table", side_effect=_social_table_side_effect), \
+             patch("routes.social.get_display_names", return_value={"u1": "Alice"}), \
+             patch("routes.social.get_graph", return_value=_GRAPH), \
+             patch("routes.social.get_cached_summary", return_value="cached summary"), \
+             patch("routes.social.social_summary_agent.run", new=agent_run):
+            r = client.get(f"/api/social/rooms/{ROOM_ID}/overview")
+        assert r.status_code == 200
+        assert r.json()["ai_summary"] == "cached summary"
+        agent_run.assert_not_called()
+
+    def test_agent_failure_falls_back_and_returns_200(self):
+        boom = AsyncMock(side_effect=RuntimeError("gemini down"))
+        with patch("routes.social.table", side_effect=_social_table_side_effect), \
+             patch("routes.social.get_display_names", return_value={"u1": "Alice"}), \
+             patch("routes.social.get_graph", return_value=_GRAPH), \
+             patch("routes.social.get_cached_summary", return_value=None), \
+             patch("routes.social.social_summary_agent.run", new=boom):
+            r = client.get(f"/api/social/rooms/{ROOM_ID}/overview")
+        assert r.status_code == 200
+        assert r.json()["ai_summary"] == (
+            "This study group has complementary strengths across multiple subjects."
+        )
+
+
+class TestStudyGuideOutputShape:
+    def test_model_dumps_to_legacy_contract(self):
+        from agents.study_guide import StudyGuide, Topic
+
+        guide = StudyGuide(
+            exam="Midterm",
+            due_date="2026-05-01",
+            overview="Covers chapters 1-5.",
+            topics=[Topic(name="Limits", importance="Foundational.", concepts=["a", "b", "c"])],
+        )
+        d = guide.model_dump()
+        assert set(d.keys()) == {"exam", "due_date", "overview", "topics"}
+        assert d["topics"][0] == {
+            "name": "Limits",
+            "importance": "Foundational.",
+            "concepts": ["a", "b", "c"],
+        }

--- a/backend/tests/test_study_guide_routes.py
+++ b/backend/tests/test_study_guide_routes.py
@@ -7,7 +7,8 @@ Covers:
   - GET  /api/study-guide/{user_id}/guide           → get_guide (cached + fresh)
   - POST /api/study-guide/regenerate                → regenerate_guide
 """
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -18,6 +19,16 @@ client = TestClient(app)
 USER_ID = "user_test"
 COURSE_ID = "course_1"
 EXAM_ID = "exam_1"
+
+
+def _agent_run_returning(content):
+    """AsyncMock standing in for study_guide_agent.run; its .output.model_dump()
+    yields the given legacy-dict content."""
+    return AsyncMock(
+        return_value=SimpleNamespace(
+            output=SimpleNamespace(model_dump=lambda: content)
+        )
+    )
 
 
 # ── GET /api/study-guide/{user_id}/exams ─────────────────────────────────────
@@ -92,15 +103,16 @@ class TestGetGuide:
             "generated_at": "2026-04-01T00:00:00Z",
             "content": {"exam": "Midterm", "topics": []},
         }
+        agent_run = _agent_run_returning({"exam": "Midterm", "topics": []})
         with patch("routes.study_guide.table") as t, \
-             patch("routes.study_guide.call_gemini_json") as gem:
+             patch("routes.study_guide.study_guide_agent.run", new=agent_run):
             t.return_value.select.return_value = [cached_row]
             r = client.get(f"/api/study-guide/{USER_ID}/guide?course_id={COURSE_ID}&exam_id={EXAM_ID}")
         assert r.status_code == 200
         body = r.json()
         assert body["cached"] is True
         assert body["guide"]["exam"] == "Midterm"
-        gem.assert_not_called()
+        agent_run.assert_not_called()
 
     def test_generates_and_inserts_when_not_cached(self):
         fresh_content = {"exam": "Final", "topics": [{"name": "Topic 1"}]}
@@ -122,15 +134,16 @@ class TestGetGuide:
                 m.select.return_value = []
             return m
 
+        agent_run = _agent_run_returning(fresh_content)
         with patch("routes.study_guide.table", side_effect=table_side_effect), \
              patch("routes.study_guide.resolve_offering", return_value="off1") as ro, \
-             patch("routes.study_guide.call_gemini_json", return_value=fresh_content) as gem:
+             patch("routes.study_guide.study_guide_agent.run", new=agent_run):
             r = client.get(f"/api/study-guide/{USER_ID}/guide?course_id={COURSE_ID}&exam_id={EXAM_ID}")
         assert r.status_code == 200
         body = r.json()
         assert body["cached"] is False
         assert body["guide"]["exam"] == "Final"
-        gem.assert_called_once()
+        agent_run.assert_called_once()
         # Abstract course id resolved to the offering, and the row keys on it.
         ro.assert_called_once_with(COURSE_ID)
         assert captured["row"]["offering_id"] == "off1"
@@ -177,7 +190,7 @@ class TestRegenerateGuide:
             return m
 
         with patch("routes.study_guide.table", side_effect=table_side_effect), \
-             patch("routes.study_guide.call_gemini_json", return_value=fresh_content):
+             patch("routes.study_guide.study_guide_agent.run", new=_agent_run_returning(fresh_content)):
             r = client.post(
                 "/api/study-guide/regenerate",
                 json={"user_id": USER_ID, "course_id": COURSE_ID, "exam_id": EXAM_ID},
@@ -191,3 +204,26 @@ class TestRegenerateGuide:
     def test_missing_fields_returns_400(self):
         r = client.post("/api/study-guide/regenerate", json={"user_id": USER_ID})
         assert r.status_code == 400
+
+
+# ── agent-failure handling ───────────────────────────────────────────────────
+
+class TestGenerationFailure:
+    def test_agent_failure_returns_502(self):
+        """When the study_guide agent raises, the route surfaces a 502, not 500."""
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "study_guides":
+                m.select.return_value = []  # nothing cached → generate
+            elif name == "assignments":
+                m.select.return_value = [{"title": "Final", "due_date": "2026-05-01"}]
+            else:
+                m.select.return_value = []
+            return m
+
+        boom = AsyncMock(side_effect=RuntimeError("gemini exploded"))
+        with patch("routes.study_guide.table", side_effect=table_side_effect), \
+             patch("routes.study_guide.resolve_offering", return_value="off1"), \
+             patch("routes.study_guide.study_guide_agent.run", new=boom):
+            r = client.get(f"/api/study-guide/{USER_ID}/guide?course_id={COURSE_ID}&exam_id={EXAM_ID}")
+        assert r.status_code == 502

--- a/specs/147-oneshot-llm-agents.md
+++ b/specs/147-oneshot-llm-agents.md
@@ -1,0 +1,101 @@
+# Spec: Migrate remaining one-shot LLM calls to Pydantic AI agents (#147)
+
+## Context
+
+Part of the Agent-migration epic (#152), milestone "Agent migration surfaces + staging + performance".
+The backend is mid-migration from the legacy `services/gemini_service.py` helper (`call_gemini*`)
+onto typed Pydantic AI agents in `backend/agents/`. Three one-shot production call sites remain
+outside the intentional legacy chat fallback:
+
+- `backend/routes/study_guide.py:109` — `call_gemini_json(prompt)` (study-guide generation)
+- `backend/routes/social.py:127` — `call_gemini(...)` (study-group AI summary)
+- `backend/main.py:220` — `call_gemini('Reply with exactly the text: Gemini OK', retries=0)` (admin health probe)
+
+All three route handlers are **sync** `def`s; Pydantic AI agents are invoked with `await agent.run(...)`.
+Established agent conventions live in `backend/agents/` (see `note_summary.py`, `summary.py`,
+`_providers.py`, `deps.py`): each agent is an `Agent[SaplingDeps, OutputModel]` with a task default
+in `_providers._DEFAULTS`, a content-addressed `prompt_version` in `metadata`, and typed Pydantic output.
+
+## Goal
+
+Remove all three direct `call_gemini*` call sites, replacing each with a Pydantic AI agent, so that the
+only remaining `gemini_service` callers in the backend are the intentional legacy chat fallback
+(`routes/learn.py`, retired later in #151) and tests.
+
+## Requirements
+
+### R1 — Study-guide agent
+- Add `backend/agents/study_guide.py` defining `study_guide_agent = Agent[SaplingDeps, StudyGuide]`.
+- `StudyGuide` (Pydantic model) mirrors the existing JSON contract the frontend already consumes:
+  `exam: str`, `due_date: str`, `overview: str`, and `topics: list[Topic]` where
+  `Topic` = `{ name: str, importance: str, concepts: list[str] }`.
+- Register a `"study_guide"` task in `agents/_providers.py` (`AgentTask` literal + `_DEFAULTS`),
+  defaulting to `gemini-2.5-flash` (this is a quality-sensitive multi-topic generation).
+- `routes/study_guide.py::_generate_and_insert` calls the agent instead of `call_gemini_json`.
+  The value inserted into `study_guides.content` and returned as `{"content": ...}` MUST remain the
+  same JSON shape as today (a dict with `exam/due_date/overview/topics`), so cached-guide reads and the
+  frontend keep working unchanged. Serialize the agent's `StudyGuide` output back to that dict via
+  `.model_dump()`.
+- On agent failure, the route raises `HTTPException(status_code=502, ...)` (per the issue's audit note)
+  rather than surfacing a raw 500.
+- Remove the `from services.gemini_service import call_gemini_json` import from `study_guide.py`.
+
+### R2 — Study-group summary agent
+- Add `backend/agents/social_summary.py` defining `social_summary_agent = Agent[SaplingDeps, SocialSummary]`
+  (or a single-field model with a `summary: str`). Output is a 2–3 sentence plain-text summary of a study
+  group's collective knowledge, focused on complementary strengths and shared goals (preserve the intent
+  of the existing prompt).
+- Register a `"social_summary"` task in `_providers.py`, default `gemini-2.5-flash-lite` (short-form prose).
+- `routes/social.py::room_overview` calls the agent instead of `call_gemini`.
+- Preserve existing behavior: the cache check (`get_cached_summary`) runs first; on a cache miss the agent
+  runs and the result is persisted via `save_summary`; on agent failure the same graceful fallback string
+  ("This study group has complementary strengths across multiple subjects.") is used and the request still
+  returns 200. The member-summary input string is unchanged.
+- Remove the now-unused `from services.gemini_service import call_gemini` import from `social.py`.
+
+### R3 — Health probe off `call_gemini`
+- `backend/main.py::gemini_test` no longer imports or calls `call_gemini`.
+- Replace with a minimal provider-level probe that exercises the same Gemini seam the agents use
+  (the shared `GoogleProvider`/model from `agents/_providers.py`), e.g. a tiny `await <probe_agent>.run(...)`
+  or a direct model round-trip. Keep the response contract identical: `{"ok": True, "reply": "<text>"}`
+  on success and `{"ok": False, "error": "<msg>"}` on failure.
+- Keep the existing `require_admin(request)` gate and its ordering (admin check BEFORE any LLM spend).
+
+### R4 — Sync/async bridge
+- The three handlers stay sync `def` (their surrounding DB access is sync `table()` and must not block an
+  event loop). Introduce ONE small shared helper to run an agent coroutine from sync code
+  (e.g. `agents/_run.py::run_agent_sync(coro)` using `asyncio.run`, or reuse an existing bridge if one
+  already exists in the codebase). Do not convert the handlers to `async def` (that would run sync httpx
+  `table()` calls on the event loop). All three sites use the same helper.
+
+### R5 — No behavior/contract regressions
+- Existing tests continue to pass: `tests/test_study_guide_routes.py`, `tests/test_social_students.py`,
+  `tests/test_social_messages.py`, `tests/test_gemini_test_auth.py`, and the broader suite.
+- The `study_guides.content` JSON contract, the `/api/social/rooms/{room_id}/overview` response shape
+  (`{room, members, ai_summary}`), and the `/api/gemini-test` contract (`{ok, reply}` / `{ok, error}`)
+  are unchanged.
+
+## Acceptance criteria (verifiable)
+
+1. `grep -rn "call_gemini" backend/routes/study_guide.py backend/routes/social.py backend/main.py`
+   returns **no matches** (imports and calls both gone).
+2. The only backend `call_gemini*` importers remaining are `routes/learn.py` (legacy chat fallback),
+   `services/gemini_service.py` itself, and other not-in-scope surfaces — but specifically study_guide,
+   social, and main are clean. (Quiz/documents/calendar/flashcards are OUT of scope for #147.)
+3. New agents exist: `agents/study_guide.py`, `agents/social_summary.py`, each an
+   `Agent[SaplingDeps, <Model>]` with `metadata` carrying `prompt_version` + `agent` name, following the
+   `note_summary.py`/`summary.py` pattern.
+4. `_providers.py` `AgentTask` + `_DEFAULTS` include `study_guide` and `social_summary`.
+5. New/updated unit tests cover: study-guide agent output serializes to the legacy dict shape; social
+   summary cache-miss path calls the agent and cache-hit path does not; social agent-failure path returns
+   the fallback string with 200; study-guide agent-failure path returns 502; gemini-test success/failure
+   contracts and the admin gate. Agents are mocked (no live Gemini calls in tests), consistent with
+   `tests/conftest.py`.
+6. `python -m pytest tests/ -q` passes.
+7. `ruff check .` passes for changed files.
+
+## Out of scope
+- Quiz (`routes/quiz.py`), documents (`routes/documents.py`), calendar (`services/calendar_service.py`),
+  flashcards, and `course_context_service.py` — separate migration issues.
+- The legacy multi-turn chat fallback in `routes/learn.py` (retired in the #151 final cutover).
+- Deleting `services/gemini_service.py` (final cutover, #151).


### PR DESCRIPTION
Closes #147 (part of the Agent-migration epic #152, milestone "Agent migration surfaces + staging + performance").

## What

Retires the last three direct `call_gemini*` production call sites onto typed Pydantic AI agents. After this, the only backend `gemini_service` callers are the intentional legacy chat fallback (`routes/learn.py`, retired in the #151 cutover) and tests.

| Surface | Before | After |
|---|---|---|
| `routes/study_guide.py` | `call_gemini_json(prompt)` | `agents/study_guide.py` (`study_guide_agent`) |
| `routes/social.py` | `call_gemini(...)` | `agents/social_summary.py` (`social_summary_agent`) |
| `main.py` `/api/gemini-test` | `call_gemini(...)` | `agents/health.py` (`health_probe_agent`) |

## Notes

- **Contracts unchanged.** `StudyGuide`/`Topic` mirror the existing `exam/due_date/overview/topics` JSON; the route `model_dump()`s straight into `study_guides.content`, so cached reads and the frontend are unaffected. `/overview` and `/api/gemini-test` response shapes are identical.
- **Study-guide failures now return 502** (per the issue's audit note) instead of a raw 500.
- **Social summary** keeps the `get_cached_summary → run → save_summary` flow and the graceful fallback string (still 200) on agent failure.
- **Health probe** runs through the shared `GoogleProvider` from `agents/_providers.py`, so a green check means the real agent seam reaches Gemini. Admin-before-spend gate preserved.
- **Sync→async bridge:** `agents/_run.py::run_agent_sync` wraps `asyncio.run` for the three sync handlers (their surrounding httpx `table()` access stays synchronous). Handlers are not converted to `async def`.
- `_providers.py` registers `study_guide` (`gemini-2.5-flash`) and `social_summary` (`gemini-2.5-flash-lite`), both env-overridable via `SAPLING_MODEL_*`.

## Testing

- Updated `test_study_guide_routes.py` and `test_gemini_test_auth.py` to mock the agents; added `test_oneshot_agents.py` covering the 502 path, social cache-hit/miss/agent-failure, and the `StudyGuide → legacy-dict` shape.
- Full backend suite: **829 passed** (the 2 `test_storage_service` failures are pre-existing on `main` — missing SUPABASE env — verified by stash-and-run).
- `ruff check` clean on all changed files.

Out of scope (separate issues): quiz, documents, calendar, flashcards, `course_context_service`, the `learn.py` legacy fallback, and deleting `gemini_service.py` (#151).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-generated study guides and social room overview summaries using structured, typed outputs.
  * Updated the admin Gemini health check to run through the app’s agent-based flow (preserving `{ok, reply}` / `{ok, error}`).
* **Bug Fixes**
  * Improved resilience: cache-first behavior remains, and summary generation still falls back to the legacy contract when AI fails.
  * Study guide generation now returns a clearer `502` error when generation cannot be completed.
* **Tests**
  * Expanded and updated tests for agent execution, caching behavior, failure handling, and typed output shape serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->