### PR TITLE
fix(frontend): SemesterChips wrap + Pill button hardening (addresses #286 review)

### DIFF
--- a/frontend/src/components/Gradebook/SemesterChips.tsx
+++ b/frontend/src/components/Gradebook/SemesterChips.tsx
@@ -16,6 +16,7 @@ export function SemesterChips({ semesters, selected, onSelect }: Props) {
         value={selected}
         onChange={onSelect}
         size="sm"
+        wrap
       />
     </div>
   );

--- a/frontend/src/components/Pill.tsx
+++ b/frontend/src/components/Pill.tsx
@@ -16,7 +16,9 @@ export function Pill({
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
+      aria-pressed={active}
       style={{
         display: "inline-flex",
         alignItems: "center",

--- a/frontend/src/components/ui/Toggle.tsx
+++ b/frontend/src/components/ui/Toggle.tsx
@@ -9,18 +9,25 @@ export function Toggle<T extends string>({
   value,
   onChange,
   size = "md",
+  wrap = false,
 }: {
   options: { value: T; label: React.ReactNode; title?: string }[];
   value: T;
   onChange: (v: T) => void;
   size?: "sm" | "md";
+  // Allow the control to wrap onto multiple rows. Off by default (a segmented
+  // control is a short fixed set); on for unbounded lists like semesters, which
+  // would otherwise overflow horizontally. Uses block-level flex so the row is
+  // width-constrained and actually wraps.
+  wrap?: boolean;
 }) {
   const pad = size === "sm" ? "5px 12px" : "7px 15px";
   const fs = size === "sm" ? 12 : 13;
   return (
     <div
       style={{
-        display: "inline-flex",
+        display: wrap ? "flex" : "inline-flex",
+        flexWrap: wrap ? "wrap" : undefined,
         background: "var(--bg-soft)",
         borderRadius: "var(--r-full)",
         padding: 3,


### PR DESCRIPTION
Stacked fix for two issues found reviewing **#286** (token unification). Targets `refactor/token-unification` so it merges into #286 before that PR lands.

## 1. `Toggle` dropped wrapping → `SemesterChips` overflow (functional regression)
On `main`, `SemesterChips` rendered a `display:flex; flex-wrap:wrap` tablist. In #286 it delegates to `<Toggle>`, which is `inline-flex` with **no wrap**. `semesters: string[]` is unbounded and grows every term (and #280 is ingesting more BU terms), so the segmented control would overflow horizontally instead of wrapping on Gradebook + course-planner.

- Added an opt-in `wrap?: boolean` prop to `Toggle` (default `false`; segmented controls stay single-row). When `true`, the container is block-level `flex` + `flexWrap:"wrap"` so it's width-constrained and wraps — matching the original behavior.
- `SemesterChips` passes `wrap`.

## 2. `Pill` bare `<button>` (stability + a11y)
`Pill` rendered `<button onClick>` with no `type` (defaults to `submit` — submits any enclosing `<form>`) and no pressed state. Added `type="button"` and `aria-pressed={active}`.

## Notes
- Toggle's default stays single-row, so the 2D/3D, teaching-mode, and other fixed segmented controls are unchanged.
- CI (`tsc --noEmit` strict, eslint baseline, vitest) validates on this PR — changes are type-safe (optional prop w/ default, valid CSSProperties, standard button attrs).
- CodeRabbit's two `--accent` doc comments on #286 were checked and are **not** bugs: `globals.css` defines `--accent: var(--brand-forest-bright)` (#2D8F5C); the `changes-tour.html` legend is correct, and the audit doc intentionally describes the pre-change state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)