### PR TITLE
feat(calendar): syllabus extraction via agent, retire raw-Gemini fallback (#144)

### DIFF
--- a/backend/services/calendar_service.py
+++ b/backend/services/calendar_service.py
@@ -10,14 +10,11 @@ from agents.deps import SaplingDeps
 from agents.syllabus_extraction import syllabus_extraction_agent
 from agents.tools.syllabus_adapter import syllabus_to_wire_dict
 from services.extraction_service import extract_text_from_file
-from services.gemini_service import call_gemini_json
 from services.assignment_dedupe import assignment_dedupe_key
 from services.encryption import encrypt_if_present
 from db.connection import table
 
 logger = logging.getLogger(__name__)
-
-PROMPT_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "prompts", "syllabus_extraction.txt")
 
 
 def load_existing_assignment_keys(user_id: str) -> set:
@@ -66,18 +63,19 @@ def insert_new_assignments(user_id: str, assignments: list[dict], *, source: str
     return len(rows)
 
 
-def parse_syllabus(extracted_text: str) -> dict:
-    """Use Gemini to parse assignments from extracted text.
-
-    Legacy fallback path retained per ADR-0001. The primary path now
-    runs through `_extract_via_agent` (syllabus_extraction_agent +
-    syllabus_to_wire_dict). This function stays so that the agent path
-    has a working degrade target when guardrails trip.
-    """
-    with open(PROMPT_PATH) as f:
-        prompt_template = f.read()
-    prompt = prompt_template + f"\n\nDOCUMENT TEXT:\n{extracted_text}"
-    return call_gemini_json(prompt)
+def _degraded_result(text: str) -> dict:
+    """Graceful degrade when the extraction agent fails. Returns the legacy
+    wire shape with no assignments and a user-facing warning — deliberately
+    NOT a second LLM call (the raw-Gemini fallback was retired in #144)."""
+    return {
+        "assignments": [],
+        "warnings": [
+            "Assignment extraction is temporarily unavailable. Please try again."
+        ],
+        "raw_text": text,
+        "course_title": None,
+        "grading_categories": [],
+    }
 
 
 async def _extract_via_agent(
@@ -89,7 +87,7 @@ async def _extract_via_agent(
     """Run syllabus_extraction_agent on `extracted_text` and convert
     its output to the legacy wire-format dict.
 
-    Returns the same shape as the legacy `parse_syllabus`:
+    Returns the legacy wire-format dict:
     {"assignments": [...], "warnings": [...], "raw_text": str,
      "course_title": str | None, "grading_categories": [...]}.
 
@@ -122,16 +120,14 @@ async def extract_assignments_from_file(
     user_id: str = "",
     request_id: str = "",
 ) -> dict:
-    """Extract text from file then parse assignments via the agent
-    (legacy fallback per ADR-0001).
+    """Extract text from a file, then parse assignments via
+    `syllabus_extraction_agent`.
 
-    Async because the syllabus-extraction agent is async; callers
-    must `await` this. Mirrors the orchestrator-vs-legacy fallback
-    pattern in `routes/quiz.py::_quiz_via_agent` and
-    `routes/learn.py::_chat_via_agent`: Pydantic-AI guardrail
-    exceptions and bare exceptions degrade to the legacy
-    `parse_syllabus` path so a single agent failure can't take the
-    syllabus-upload feature down.
+    Async because the agent is async; callers must `await` this. The
+    raw-Gemini legacy fallback was retired in #144: Pydantic-AI guardrail
+    exceptions and bare exceptions now degrade to `_degraded_result` (empty
+    assignments + a warning, no second LLM call) so a single agent failure
+    can't take the syllabus-upload feature down.
     """
     text = extract_text_from_file(file_bytes, filename, content_type)
     if not text.strip():
@@ -147,21 +143,15 @@ async def extract_assignments_from_file(
         )
     except (UsageLimitExceeded, UnexpectedModelBehavior) as e:
         logger.warning(
-            "Syllabus agent guardrails tripped; falling back to legacy",
+            "Syllabus agent guardrails tripped; degrading to empty result",
             exc_info=e,
         )
-        result = parse_syllabus(text)
-        result.setdefault("raw_text", text)
-        result.setdefault("course_title", None)
-        result.setdefault("grading_categories", [])
+        result = _degraded_result(text)
     except Exception:
         logger.exception(
-            "Unexpected syllabus-agent failure; falling back to legacy"
+            "Unexpected syllabus-agent failure; degrading to empty result"
         )
-        result = parse_syllabus(text)
-        result.setdefault("raw_text", text)
-        result.setdefault("course_title", None)
-        result.setdefault("grading_categories", [])
+        result = _degraded_result(text)
 
     return result
 

--- a/backend/tests/test_ocr_pipeline.py
+++ b/backend/tests/test_ocr_pipeline.py
@@ -1,5 +1,5 @@
 """
-Test the full OCR → Gemini → DB pipeline.
+Test the full OCR → agent → DB pipeline.
 
 Run from backend/:
     python3 tests/test_ocr_pipeline.py
@@ -10,7 +10,7 @@ import sys
 import os
 from datetime import date
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -45,21 +45,21 @@ TEST_USER = "user_andres"
 
 
 @_requires_gemini
-def test_gemini_parse():
-    print("\n[1] Testing Gemini parsing from raw text...")
-    from services.calendar_service import parse_syllabus
-    result = parse_syllabus(SAMPLE_SYLLABUS)
+def test_agent_parse():
+    print("\n[1] Testing agent parsing from raw text...")
+    from services.calendar_service import _extract_via_agent
+    result = asyncio.run(_extract_via_agent(SAMPLE_SYLLABUS))
     assignments = result.get("assignments", [])
-    assert len(assignments) > 0, "Gemini returned no assignments"
-    print(f"    Gemini extracted {len(assignments)} assignments:")
+    assert len(assignments) > 0, "Agent returned no assignments"
+    print(f"    Agent extracted {len(assignments)} assignments:")
     for a in assignments:
         print(f"      • {a.get('title')} | {a.get('due_date')} | {a.get('assignment_type')}")
 
 
 @pytest.fixture
 def parsed_assignments():
-    from services.calendar_service import parse_syllabus
-    result = parse_syllabus(SAMPLE_SYLLABUS)
+    from services.calendar_service import _extract_via_agent
+    result = asyncio.run(_extract_via_agent(SAMPLE_SYLLABUS))
     return result.get("assignments", [])
 
 
@@ -110,12 +110,13 @@ def test_full_pipeline():
 
 
 class TestExtractAssignmentsViaAgent:
-    """Unit tests for `extract_assignments_from_file` covering the
-    agent-first / legacy-fallback orchestration added in refactor #4.
+    """Unit tests for `extract_assignments_from_file` covering agent-first
+    extraction and graceful degrade. The raw-Gemini legacy fallback was
+    retired in #144, so agent failures now degrade to an empty result +
+    warning — no second LLM call.
 
-    These mocks bypass `extract_text_from_file`, the agent, and the
-    legacy parser so the tests run offline and don't depend on
-    GEMINI_API_KEY.
+    These mocks bypass `extract_text_from_file` and the agent so the tests
+    run offline and don't depend on GEMINI_API_KEY.
     """
 
     def _agent_output(self, *, due_date=None):
@@ -139,14 +140,11 @@ class TestExtractAssignmentsViaAgent:
 
     def test_returns_agent_assignments(self):
         """Happy path: agent.run returns a SyllabusAssignments and the
-        wire dict contains those values (not the legacy parser's)."""
+        wire dict contains those values."""
         from services import calendar_service
 
         agent_output = self._agent_output()
         agent_run = AsyncMock(return_value=SimpleNamespace(output=agent_output))
-
-        # Sentinel so we'd notice if the legacy path fired.
-        legacy_sentinel = {"assignments": [{"title": "LEGACY"}], "warnings": []}
 
         with (
             patch.object(
@@ -156,20 +154,14 @@ class TestExtractAssignmentsViaAgent:
             patch.object(
                 calendar_service.syllabus_extraction_agent, "run", agent_run,
             ),
-            patch.object(
-                calendar_service, "parse_syllabus",
-                return_value=legacy_sentinel,
-            ),
         ):
             result = asyncio.run(calendar_service.extract_assignments_from_file(
                 b"raw", "syllabus.pdf", "application/pdf",
             ))
 
-        # Agent path was used (not legacy sentinel).
         assert agent_run.await_count == 1
         titles = [a["title"] for a in result["assignments"]]
         assert titles == ["Lab 7: Recursion"]
-        assert "LEGACY" not in titles
         # Adapter-added keys flow through.
         assert result["course_title"] == "CS 101"
         assert "grading_categories" in result
@@ -180,16 +172,13 @@ class TestExtractAssignmentsViaAgent:
         assert first["assignment_type"] == "other"
         assert first["due_date"] == "2026-03-15"
 
-    def test_falls_back_to_legacy_on_usage_limit(self):
-        """UsageLimitExceeded from the agent triggers the legacy path."""
+    def test_degrades_gracefully_on_usage_limit(self):
+        """UsageLimitExceeded from the agent degrades to an empty result
+        with a warning — and does NOT make a second LLM call."""
         from services import calendar_service
         from pydantic_ai.exceptions import UsageLimitExceeded
 
         agent_run = AsyncMock(side_effect=UsageLimitExceeded("token cap"))
-        legacy_result = {
-            "assignments": [{"title": "Legacy assignment", "due_date": "2026-04-01"}],
-            "warnings": [],
-        }
 
         with (
             patch.object(
@@ -199,30 +188,21 @@ class TestExtractAssignmentsViaAgent:
             patch.object(
                 calendar_service.syllabus_extraction_agent, "run", agent_run,
             ),
-            patch.object(
-                calendar_service, "parse_syllabus",
-                return_value=dict(legacy_result),
-            ) as legacy_mock,
         ):
             result = asyncio.run(calendar_service.extract_assignments_from_file(
                 b"raw", "syllabus.pdf", "application/pdf",
             ))
 
         assert agent_run.await_count == 1
-        assert legacy_mock.call_count == 1
-        assert result["assignments"] == legacy_result["assignments"]
-        # raw_text is filled in by the fallback branch when missing.
+        assert result["assignments"] == []
+        assert result["warnings"]  # non-empty, user-facing
         assert result["raw_text"] == "text body"
 
-    def test_falls_back_to_legacy_on_unexpected_exception(self):
-        """A bare Exception from the agent also degrades to legacy."""
+    def test_degrades_gracefully_on_unexpected_exception(self):
+        """A bare Exception from the agent also degrades gracefully."""
         from services import calendar_service
 
         agent_run = AsyncMock(side_effect=RuntimeError("boom"))
-        legacy_result = {
-            "assignments": [{"title": "Fallback HW", "due_date": "2026-05-01"}],
-            "warnings": ["agent failed"],
-        }
 
         with (
             patch.object(
@@ -232,27 +212,22 @@ class TestExtractAssignmentsViaAgent:
             patch.object(
                 calendar_service.syllabus_extraction_agent, "run", agent_run,
             ),
-            patch.object(
-                calendar_service, "parse_syllabus",
-                return_value=dict(legacy_result),
-            ) as legacy_mock,
         ):
             result = asyncio.run(calendar_service.extract_assignments_from_file(
                 b"raw", "syllabus.pdf", "application/pdf",
             ))
 
         assert agent_run.await_count == 1
-        assert legacy_mock.call_count == 1
-        assert result["assignments"][0]["title"] == "Fallback HW"
-        assert result["warnings"] == ["agent failed"]
+        assert result["assignments"] == []
+        assert result["warnings"]
+        assert result["raw_text"] == "text body"
 
-    def test_legacy_path_still_works_when_text_empty(self):
+    def test_empty_text_shortcut(self):
         """Empty-text shortcut returns the placeholder dict and never
-        invokes either the agent or the legacy parser."""
+        invokes the agent."""
         from services import calendar_service
 
         agent_run = AsyncMock()
-        legacy_mock = AsyncMock()  # unused; just an assertion target
 
         with (
             patch.object(
@@ -261,9 +236,6 @@ class TestExtractAssignmentsViaAgent:
             ),
             patch.object(
                 calendar_service.syllabus_extraction_agent, "run", agent_run,
-            ),
-            patch.object(
-                calendar_service, "parse_syllabus", legacy_mock,
             ),
         ):
             result = asyncio.run(calendar_service.extract_assignments_from_file(
@@ -276,23 +248,19 @@ class TestExtractAssignmentsViaAgent:
         ]
         assert result["raw_text"] == ""
         assert agent_run.await_count == 0
-        assert legacy_mock.call_count == 0
 
 
-def test_agent_and_legacy_paths_share_required_keys():
-    """The agent path's wire format must be a SUPERSET of the legacy
-    path's. Any consumer (`routes/calendar.py::extract`,
-    `process_and_save_syllabus`) that worked on the legacy
-    `{assignments, warnings, raw_text}` keys MUST work on the agent
-    path too. Extra keys (`course_title`, `grading_categories`) are
-    additive — new fields, not replacements. This test pins the
-    invariant so a future refactor can't silently drop a key.
+def test_agent_and_degrade_paths_share_required_keys():
+    """Both the agent-success path and the degrade path must expose the
+    legacy-required keys {assignments, warnings, raw_text} so consumers
+    (`routes/calendar.py::extract`, `process_and_save_syllabus`) keep
+    working. This pins the invariant against a future refactor.
     """
     from services import calendar_service
 
     LEGACY_REQUIRED = {"assignments", "warnings", "raw_text"}
 
-    # ── Agent path ────────────────────────────────────────────────
+    # ── Agent success path ────────────────────────────────────────
     from agents.syllabus_extraction import (
         SyllabusAssignments,
         SyllabusAssignment,
@@ -330,14 +298,7 @@ def test_agent_and_legacy_paths_share_required_keys():
         f"{LEGACY_REQUIRED - set(agent_result.keys())}"
     )
 
-    # ── Legacy fallback path ──────────────────────────────────────
-    legacy_dict = {
-        "assignments": [{"title": "HW1", "due_date": "2026-03-01"}],
-        "warnings": [],
-        # Note: parse_syllabus historically did NOT set raw_text — the
-        # service backfills it via setdefault. The contract test must
-        # reflect the *post-fallback* shape that consumers actually see.
-    }
+    # ── Degrade path (agent fails) ────────────────────────────────
     agent_run_fail = AsyncMock(side_effect=RuntimeError("boom"))
     with (
         patch.object(
@@ -347,19 +308,62 @@ def test_agent_and_legacy_paths_share_required_keys():
         patch.object(
             calendar_service.syllabus_extraction_agent, "run", agent_run_fail,
         ),
-        patch.object(
-            calendar_service, "parse_syllabus",
-            return_value=dict(legacy_dict),
-        ),
     ):
-        legacy_result = asyncio.run(calendar_service.extract_assignments_from_file(
+        degrade_result = asyncio.run(calendar_service.extract_assignments_from_file(
             b"raw", "syllabus.pdf", "application/pdf",
         ))
 
-    assert LEGACY_REQUIRED.issubset(set(legacy_result.keys())), (
-        f"Legacy fallback path missing required legacy keys: "
-        f"{LEGACY_REQUIRED - set(legacy_result.keys())}"
+    assert LEGACY_REQUIRED.issubset(set(degrade_result.keys())), (
+        f"Degrade path missing required legacy keys: "
+        f"{LEGACY_REQUIRED - set(degrade_result.keys())}"
     )
+    assert degrade_result["assignments"] == []
+
+
+class TestNotesEncryptedAtWrite:
+    """#126 / #144 acceptance: assignment `notes` are encrypted at the write
+    boundary in `insert_new_assignments` — never persisted as plaintext."""
+
+    def test_notes_encrypted_on_insert(self):
+        from services import calendar_service
+
+        captured = {}
+
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "assignments":
+                def _insert(rows):
+                    captured["rows"] = rows
+                    return rows
+                m.insert.side_effect = _insert
+            m.select.return_value = []
+            return m
+
+        with (
+            patch.object(calendar_service, "table", side_effect=table_side_effect),
+            patch.object(
+                calendar_service, "load_existing_assignment_keys", return_value=set(),
+            ),
+            patch("services.academics.enrollment_id_for", return_value="enr-1"),
+            patch.object(
+                calendar_service, "encrypt_if_present",
+                side_effect=lambda v: f"enc({v})",
+            ) as enc,
+        ):
+            n = calendar_service.insert_new_assignments(
+                "user-1",
+                [{
+                    "title": "HW1", "due_date": "2026-03-01",
+                    "course_id": "c1", "notes": "secret note",
+                }],
+            )
+
+        assert n == 1
+        row = captured["rows"][0]
+        # notes went through encrypt_if_present — not persisted as plaintext.
+        enc.assert_any_call("secret note")
+        assert row["notes"] == "enc(secret note)"
+        assert row["notes"] != "secret note"
 
 
 if __name__ == "__main__":
@@ -369,13 +373,11 @@ if __name__ == "__main__":
     print("=" * 55)
 
     try:
-        from services.calendar_service import parse_syllabus
-        test_gemini_parse()
-        assignments = parse_syllabus(SAMPLE_SYLLABUS).get("assignments", [])
+        from services.calendar_service import _extract_via_agent
+        test_agent_parse()
+        assignments = asyncio.run(_extract_via_agent(SAMPLE_SYLLABUS)).get("assignments", [])
         test_save_to_db(assignments)
         test_full_pipeline()
         print("\n✓ All tests passed")
     except Exception as e:
         print(f"\n✗ Test failed: {e}")
-        import traceback; traceback.print_exc()
-        sys.exit(1)

--- a/backend/tests/test_ocr_pipeline.py
+++ b/backend/tests/test_ocr_pipeline.py
@@ -381,3 +381,5 @@ if __name__ == "__main__":
         print("\n✓ All tests passed")
     except Exception as e:
         print(f"\n✗ Test failed: {e}")
+        import traceback; traceback.print_exc()
+        sys.exit(1)

--- a/specs/144-calendar-agent.md
+++ b/specs/144-calendar-agent.md
@@ -1,0 +1,79 @@
+# Spec: Calendar assignment extraction → agent (#144)
+
+## Context
+
+Part of the Agent-migration epic (#152), milestone #2. `backend/services/calendar_service.py`
+already extracts syllabus assignments primarily through `syllabus_extraction_agent`
+(`_extract_via_agent`). The remaining raw-Gemini seam is the **legacy fallback** `parse_syllabus`
+(`calendar_service.py:80`, `call_gemini_json`), which `extract_assignments_from_file` degrades to when
+the agent trips guardrails (`UsageLimitExceeded`/`UnexpectedModelBehavior`) or raises unexpectedly.
+
+`parse_syllabus` is referenced across `tests/test_ocr_pipeline.py` (live-gated tests + mocked
+fallback tests). `notes` is already encrypted at the write boundary in `insert_new_assignments`
+(`calendar_service.py:61`, `encrypt_if_present`) per #126.
+
+## Goal
+
+Make `syllabus_extraction_agent` the sole extraction mechanism in `calendar_service`: remove the
+`call_gemini_json` legacy fallback entirely, degrading gracefully (no second LLM call) when the agent
+fails, without regressing the response contract or the `notes` encryption.
+
+## Requirements
+
+### R1 — Remove the raw-Gemini seam from `calendar_service`
+- Delete the `parse_syllabus` function and the `from services.gemini_service import call_gemini_json`
+  import. Remove the now-unused `PROMPT_PATH` module constant (only `parse_syllabus` used it).
+- `grep -n "call_gemini" backend/services/calendar_service.py` returns no matches.
+
+### R2 — Graceful degrade on agent failure (no second LLM call)
+- In `extract_assignments_from_file`, the two failure branches (`UsageLimitExceeded`/
+  `UnexpectedModelBehavior`, and bare `Exception`) no longer call `parse_syllabus`. Instead they log
+  (as today) and return a degrade result:
+  `{"assignments": [], "warnings": [<one clear user-facing message>], "raw_text": text,
+    "course_title": None, "grading_categories": []}`.
+- The happy path (agent succeeds) is unchanged: returns `syllabus_to_wire_dict(result.output, raw_text=text)`.
+- The empty-text shortcut (no extractable text) is unchanged.
+
+### R3 — Preserve the response contract
+- `extract_assignments_from_file` still returns a dict containing at least the legacy-required keys
+  `{"assignments", "warnings", "raw_text"}` on every path (success, degrade, empty-text). Downstream
+  consumers (`routes/calendar.py::extract`, `process_and_save_syllabus`) keep working unchanged.
+
+### R4 — Preserve `notes` encryption at write (#126)
+- `insert_new_assignments` continues to write `notes` via `encrypt_if_present` — no plaintext `notes`
+  reintroduced. (No functional change expected; this is a guard.)
+
+### R5 — Tests
+- Update `tests/test_ocr_pipeline.py`:
+  - Remove `parse_syllabus`-dependent legacy paths: drop `test_gemini_parse` and repoint the
+    `parsed_assignments` fixture + the `__main__` block off `parse_syllabus` (use the agent path or
+    remove), since the function no longer exists.
+  - Rewrite the two `test_falls_back_to_legacy_*` tests to assert the **graceful degrade**: on agent
+    `UsageLimitExceeded` and on a bare `Exception`, the result has `assignments == []`, a non-empty
+    `warnings`, `raw_text == <text>`, and `parse_syllabus` is never referenced.
+  - `test_returns_agent_assignments` and `test_agent_and_legacy_paths_share_required_keys`: drop the
+    `patch.object(calendar_service, "parse_syllabus", ...)`; keep the agent-path and required-keys
+    assertions (the required-keys check now covers success + degrade paths).
+  - `test_legacy_path_still_works_when_text_empty`: drop the `parse_syllabus` patch; keep the
+    empty-text-shortcut assertions.
+- Add a regression test that `insert_new_assignments` encrypts `notes` at write (asserts the inserted
+  row's `notes` is the `encrypt_if_present` output, not plaintext) — locks in R4 / #126.
+- All agent runs are mocked (`AsyncMock`); no live Gemini/Supabase in the default run, consistent with
+  the existing `TestExtractAssignmentsViaAgent` mocking and `_requires_gemini` gating.
+
+## Acceptance criteria (verifiable)
+1. `grep -rn "call_gemini\|parse_syllabus\|PROMPT_PATH" backend/services/calendar_service.py` → no matches.
+2. No test in `tests/test_ocr_pipeline.py` references `parse_syllabus`.
+3. `extract_assignments_from_file` returns `{assignments, warnings, raw_text}` (superset ok) on all
+   three paths — success, agent-failure degrade, empty-text — verified by tests.
+4. Agent-failure degrade returns `assignments == []` + a warning + `raw_text`, with no second LLM call.
+5. `insert_new_assignments` encrypts `notes` at write (regression test passes).
+6. `python -m pytest tests/test_ocr_pipeline.py tests/test_calendar_routes.py -q` passes; the broader
+   `python -m pytest tests/ -q` shows no new failures vs. `main`.
+7. `ruff check .` passes for changed files.
+
+## Out of scope
+- Other `gemini_service` call sites (quiz #145, flashcards #146, documents, course_context).
+- The `syllabus_extraction_agent` itself (unchanged), and `prompts/syllabus_extraction.txt`
+  (may remain on disk; just no longer read by `calendar_service`).
+- Deleting `services/gemini_service.py` (#151 final cutover).


### PR DESCRIPTION
Closes #144 (Agent-migration epic #152, milestone #2).

## What
`calendar_service.py` already extracted syllabus assignments through `syllabus_extraction_agent` as the primary path — the only remaining raw-Gemini seam was the legacy `parse_syllabus` / `call_gemini_json` fallback. This removes it:

- Deletes `parse_syllabus`, the `call_gemini_json` import, and the now-unused `PROMPT_PATH`.
- On agent guardrail-trip (`UsageLimitExceeded`/`UnexpectedModelBehavior`) or unexpected failure, `extract_assignments_from_file` now returns `_degraded_result` — empty assignments + a user-facing warning, **no second LLM call**. Resilience is preserved (a single agent failure can't take syllabus upload down) without a raw Gemini call.

## Contract & security preserved
- `extract_assignments_from_file` still returns `{assignments, warnings, raw_text}` (superset ok) on **every** path — success, degrade, and empty-text — so `routes/calendar.py::extract` and `process_and_save_syllabus` are unaffected.
- `notes` stay encrypted at the write boundary (`insert_new_assignments` → `encrypt_if_present`) per #126 — added a regression test that locks this in.

## Tests
- Rewrote the `parse_syllabus`-based fallback tests in `test_ocr_pipeline.py` to assert the graceful degrade (empty + warning, agent awaited once, no legacy path).
- Repointed the live `@_requires_gemini` fixtures/tests off `parse_syllabus` onto the agent.
- Added `TestNotesEncryptedAtWrite::test_notes_encrypted_on_insert`.
- Full backend suite: **831 passed** (the 2 `test_storage_service` failures are pre-existing on `main` — missing SUPABASE env). `ruff` clean.

Out of scope: quiz (#145), flashcards (#146), and the `services/gemini_service.py` deletion (#151 final cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Syllabus-to-assignments extraction now fails more gracefully, returning a usable result with a clear warning instead of falling back to a legacy path.
  * Empty or problematic uploads now preserve the extracted text and return an empty assignment list rather than breaking the flow.
  * Assignment notes continue to be stored securely without changing visible behavior.

* **Tests**
  * Updated automated checks to cover the new graceful-degradation behavior and ensure response fields stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->