### PR TITLE
feat(quiz): quiz-context + course-summary → agents, retire quiz-gen fallback (#145)

### DIFF
--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -30,6 +30,7 @@ AgentTask = Literal[
     "classifier", "summary", "concepts", "syllabus", "quiz", "chat_tutor",
     "note_summary", "note_concepts", "note_chat",
     "study_guide", "social_summary",
+    "course_summary", "quiz_context",
 ]
 
 
@@ -57,6 +58,10 @@ _DEFAULTS: dict[AgentTask, str] = {
     "study_guide": "gemini-2.5-flash",
     # Social summary is short-form prose → the cheaper lite tier is enough.
     "social_summary": "gemini-2.5-flash-lite",
+    # Instructor class summary — a few paragraphs of analysis → full Flash.
+    "course_summary": "gemini-2.5-flash",
+    # Quiz-context notes are short structured extraction → the lite tier.
+    "quiz_context": "gemini-2.5-flash-lite",
 }
 
 

--- a/backend/agents/course_summary.py
+++ b/backend/agents/course_summary.py
@@ -1,0 +1,43 @@
+"""Course (class) summary agent.
+
+Replaces the inline `call_gemini` in `services/course_context_service.py`.
+Produces the instructor-facing 2-3 paragraph summary of a class's mastery
+picture. Toolless and user-agnostic: the caller passes the aggregated metrics
+in the user message.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+from agents._providers import model_for
+
+
+class CourseSummary(BaseModel):
+    summary: str = Field(
+        description="2-3 paragraph instructor-facing summary of class performance.",
+    )
+
+
+_SYSTEM_PROMPT = (
+    "You are an expert education analyst summarizing a course for instructors. "
+    "Given the class's average mastery, top struggling concepts, and top "
+    "mastered concepts, write a concise 2-3 paragraph summary that: describes "
+    "overall class performance; highlights specific areas where students are "
+    "struggling and may need intervention; notes areas where students excel; "
+    "and gives actionable recommendations for the instructor. Write in a "
+    "professional but approachable tone — specific and data-driven. Do not "
+    "invent concepts or numbers beyond what you are given."
+)
+_PROMPT_HASH = hashlib.sha256(_SYSTEM_PROMPT.encode("utf-8")).hexdigest()[:12]
+
+
+course_summary_agent = Agent[None, CourseSummary](
+    model=model_for("course_summary"),
+    output_type=CourseSummary,
+    system_prompt=_SYSTEM_PROMPT,
+    metadata={"prompt_version": _PROMPT_HASH, "agent": "course_summary"},
+)

--- a/backend/agents/quiz_context.py
+++ b/backend/agents/quiz_context.py
@@ -1,0 +1,64 @@
+"""Quiz-context agent.
+
+Replaces the inline `call_gemini_json` in `routes/quiz.py::_update_context`.
+Maintains the per-concept "learning notes" that steer the next quiz. Output
+mirrors the legacy `quiz_context_update.txt` JSON schema exactly, so the stored
+`quiz_context.context_json` shape is unchanged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+from agents._providers import model_for
+
+
+class QuizContext(BaseModel):
+    """Typed quiz-context notes. Serializes (model_dump) to the legacy
+    context_json shape consumed by `save_quiz_context`."""
+
+    weak_areas: list[str] = Field(
+        default_factory=list,
+        description="Specific subtopics or skills the student is weak on.",
+    )
+    common_mistakes: list[str] = Field(
+        default_factory=list,
+        description="Specific misconceptions or common mistakes the student revealed.",
+    )
+    questions_seen_summary: str = Field(
+        default="",
+        description="Brief summary of question themes the student has now seen.",
+    )
+    recommended_difficulty: Literal["easy", "medium", "hard"] = Field(
+        default="medium",
+        description="Difficulty the next quiz should target.",
+    )
+    notes: str = Field(
+        default="",
+        description="Free-form observations to help generate a better next quiz.",
+    )
+
+
+_SYSTEM_PROMPT = (
+    "You maintain learning notes about a student's understanding of a single "
+    "concept, used to generate better quizzes over time. Given the concept, the "
+    "previous notes (may be empty), and the quiz the student just completed "
+    "(score and per-question results), update the notes: what subtopics the "
+    "student is weak on, what misconceptions they revealed, a brief summary of "
+    "question themes they've now seen (so they aren't repeated), the difficulty "
+    "the next quiz should be, and any other helpful observations. Base every "
+    "note on the provided results — do not invent performance the data doesn't show."
+)
+_PROMPT_HASH = hashlib.sha256(_SYSTEM_PROMPT.encode("utf-8")).hexdigest()[:12]
+
+
+quiz_context_agent = Agent[None, QuizContext](
+    model=model_for("quiz_context"),
+    output_type=QuizContext,
+    system_prompt=_SYSTEM_PROMPT,
+    metadata={"prompt_version": _PROMPT_HASH, "agent": "quiz_context"},
+)

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -10,12 +10,13 @@ from pydantic_ai.exceptions import UsageLimitExceeded, UnexpectedModelBehavior
 
 from agents.quiz import quiz_agent, Quiz, QuizQuestion
 from agents.deps import SaplingDeps
+from agents._run import run_agent_sync
+from agents.quiz_context import quiz_context_agent
 from db.connection import table
 from models import GenerateQuizBody, SubmitQuizBody
 from services.auth_guard import require_self
 from services.profiles import get_display_name
-from services.gemini_service import MODEL_LITE, MODEL_SMART, call_gemini_json
-from services.graph_service import apply_graph_update, get_graph
+from services.graph_service import apply_graph_update
 from services.quiz_context_service import get_quiz_context, save_quiz_context
 from services.fingerprint import fingerprint
 from services.request_context import current_request_id
@@ -207,95 +208,6 @@ async def _quiz_via_agent(
         )
     return wire_questions
 
-
-async def _legacy_generate_quiz(body: GenerateQuizBody, request: Request) -> list[dict]:
-    """The pre-agent quiz generation pipeline, kept as a fallback per ADR-0001.
-
-    Verbatim copy of the original generate_quiz body: prompt-template assembly,
-    course-context augmentation, and a single call_gemini_json.
-    Returns the raw `questions` list — the route handler is responsible for
-    persisting it and shaping the HTTP response.
-    """
-    node_rows = table("graph_nodes").select(
-        "*",
-        filters={"id": f"eq.{body.concept_node_id}", "user_id": f"eq.{body.user_id}"},
-    )
-    if not node_rows:
-        raise HTTPException(status_code=404, detail="Concept node not found")
-    node = node_rows[0]
-
-    graph_data = get_graph(body.user_id)
-    quiz_ctx = get_quiz_context(body.user_id, body.concept_node_id)
-    quiz_ctx_str = json.dumps(quiz_ctx, indent=2) if quiz_ctx else "No previous quiz history."
-
-    prompt = (
-        _load_prompt("quiz_generation.txt")
-        .replace("{concept_name}", node["concept_name"])
-        .replace("{mastery_score}", str(int(node["mastery_score"] * 100)))
-        .replace("{difficulty}", body.difficulty)
-        .replace("{num_questions}", str(body.num_questions))
-        .replace("{graph_json_subset}", json.dumps(graph_data["nodes"][:10], indent=2))
-        .replace("{quiz_context_json}", quiz_ctx_str)
-    )
-
-    # Append shared course-level context (misconceptions + weak areas) if available
-    course_id = node.get("course_id", "")
-    if body.use_shared_context and course_id:
-        from services.course_context_service import get_course_context
-        course_ctx = get_course_context(course_id)
-        if course_ctx:
-            misconceptions: list[str] = []
-            weak_areas: list[str] = []
-            seen_m: set[str] = set()
-            seen_w: set[str] = set()
-            for row in course_ctx.get("concept_stats") or []:
-                if not isinstance(row, dict):
-                    continue
-                for m in row.get("common_misconceptions") or []:
-                    m = (m or "").strip()
-                    if m and m.lower() not in seen_m:
-                        seen_m.add(m.lower())
-                        misconceptions.append(m)
-                for w in row.get("prerequisite_gaps") or []:
-                    w = (w or "").strip()
-                    if w and w.lower() not in seen_w:
-                        seen_w.add(w.lower())
-                        weak_areas.append(w)
-            if misconceptions or weak_areas:
-                addendum_parts = []
-                if misconceptions:
-                    addendum_parts.append(
-                        "Common misconceptions seen across the class for this subject "
-                        "(address these proactively in distractors and explanations):\n"
-                        + "\n".join(f"- {m}" for m in misconceptions[:10])
-                    )
-                if weak_areas:
-                    addendum_parts.append(
-                        "Weak areas to target:\n"
-                        + "\n".join(f"- {w}" for w in weak_areas[:10])
-                    )
-                prompt += "\n\n" + "\n\n".join(addendum_parts)
-
-    # Honor the same fast/smart toggle the agent path uses. The mapping
-    # mirrors _PREF_MODEL_NAMES exactly, so a user choosing "fast" gets
-    # the same upgraded model whether the agent succeeded or fell back
-    # here. Without this, "fast" was silently a no-op on the legacy
-    # path (still MODEL_LITE) — the kind of inconsistency that surfaces
-    # six months later as "why does Fast sometimes feel slower?"
-    if body.model_pref == "smart":
-        legacy_model = MODEL_SMART  # gemini-2.5-pro
-    elif body.model_pref == "fast":
-        legacy_model = MODEL_LITE  # gemini-2.5-flash-lite, matches _PREF_MODEL_NAMES
-    else:
-        legacy_model = MODEL_LITE  # gemini-2.5-flash-lite, agent default per ADR 0008
-    try:
-        result = call_gemini_json(prompt, model=legacy_model)
-    except Exception as e:
-        raise HTTPException(status_code=502, detail=f"Gemini error: {e}")
-
-    return result.get("questions", [])
-
-
 @router.post("/generate")
 async def generate_quiz(body: GenerateQuizBody, request: Request):
     require_self(body.user_id, request)
@@ -337,21 +249,24 @@ async def generate_quiz(body: GenerateQuizBody, request: Request):
             request_id=request_id,
             model_pref=body.model_pref,
         )
-    except (UsageLimitExceeded, UnexpectedModelBehavior) as e:
-        logger.warning(
-            "Quiz agent guardrails tripped; falling back to legacy",
-            exc_info=e,
-        )
-        questions = await _legacy_generate_quiz(body, request)
     except HTTPException:
-        # Legacy path raises HTTPException for known states (404/502); never
-        # treat those as a reason to fall back. Re-raise.
+        # The 404 for an unknown concept node is raised before the agent call;
+        # never swallow a known HTTP state.
         raise
-    except Exception:
-        logger.exception(
-            "Unexpected quiz-agent failure; falling back to legacy"
-        )
-        questions = await _legacy_generate_quiz(body, request)
+    except (UsageLimitExceeded, UnexpectedModelBehavior) as e:
+        # The raw-Gemini legacy fallback was retired in #145; degrade to 502
+        # rather than serving a quiz from a second LLM path.
+        logger.warning("Quiz agent guardrails tripped; returning 502", exc_info=e)
+        raise HTTPException(
+            status_code=502,
+            detail="Quiz generation is temporarily unavailable. Please try again.",
+        ) from e
+    except Exception as e:
+        logger.exception("Unexpected quiz-agent failure; returning 502")
+        raise HTTPException(
+            status_code=502,
+            detail="Quiz generation is temporarily unavailable. Please try again.",
+        ) from e
 
     quiz_id = str(uuid.uuid4())
     table("quiz_attempts").insert({
@@ -475,8 +390,8 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
 
     def _update_context(prompt: str, uid: str, node_id: str):
         try:
-            new_ctx = call_gemini_json(prompt, model=MODEL_LITE)
-            save_quiz_context(uid, node_id, new_ctx)
+            result = run_agent_sync(quiz_context_agent.run(prompt))
+            save_quiz_context(uid, node_id, result.output.model_dump())
         except Exception:
             pass
 

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -200,9 +200,9 @@ async def _quiz_via_agent(
         if mapped is not None:
             wire_questions.append(mapped)
     if not wire_questions:
-        # All questions dropped — degrade to legacy rather than serve
-        # an empty quiz. Raise a sentinel that generate_quiz catches
-        # and routes to the legacy fallback.
+        # All questions dropped — raise so generate_quiz's bare-Exception
+        # catch degrades to HTTP 502 (the raw-Gemini legacy fallback was
+        # retired in #145) rather than serving an empty quiz.
         raise RuntimeError(
             "quiz_agent produced no valid questions after wire-format validation"
         )

--- a/backend/services/course_context_service.py
+++ b/backend/services/course_context_service.py
@@ -16,7 +16,8 @@ import hashlib
 from datetime import datetime, timezone
 
 from db.connection import table
-from services.gemini_service import call_gemini
+from agents._run import run_agent_sync
+from agents.course_summary import course_summary_agent
 
 
 def _generate_data_hash(stats_rows: list) -> str:
@@ -33,31 +34,26 @@ def _generate_summary_with_gemini(
     top_mastered: list,
     student_count: int,
 ) -> str:
-    """Generate a natural language summary using Gemini."""
-    prompt = f"""You are an expert education analyst summarizing a course for instructors.
+    """Generate a natural-language class summary via the course_summary agent.
 
-Course: {course_code} - {course_name}
-Students enrolled: {student_count}
-Average class mastery: {avg_class_mastery:.1%}
-
-Top struggling concepts (needs attention):
-{chr(10).join(f"- {c}" for c in top_struggling) if top_struggling else "None identified"}
-
-Top mastered concepts (students doing well):
-{chr(10).join(f"- {c}" for c in top_mastered) if top_mastered else "None identified"}
-
-Write a concise 2-3 paragraph summary that:
-1. Describes the overall class performance
-2. Highlights specific areas where students are struggling and may need intervention
-3. Notes areas where students are excelling
-4. Provides actionable recommendations for the instructor
-
-Write in a professional but approachable tone. Be specific and data-driven."""
+    The agent owns the analyst persona; the aggregated metrics go in the user
+    message. On any agent failure we degrade to a deterministic template string
+    (no second LLM call), so a summary is always produced."""
+    user_message = (
+        f"Course: {course_code} - {course_name}\n"
+        f"Students enrolled: {student_count}\n"
+        f"Average class mastery: {avg_class_mastery:.1%}\n\n"
+        "Top struggling concepts (needs attention):\n"
+        f"{chr(10).join(f'- {c}' for c in top_struggling) if top_struggling else 'None identified'}\n\n"
+        "Top mastered concepts (students doing well):\n"
+        f"{chr(10).join(f'- {c}' for c in top_mastered) if top_mastered else 'None identified'}"
+    )
 
     try:
-        return call_gemini(prompt, retries=1)
+        result = run_agent_sync(course_summary_agent.run(user_message))
+        return result.output.summary
     except Exception:
-        # Fallback summary if Gemini fails
+        # Fallback summary if the agent fails
         return (
             f"Class average mastery: {avg_class_mastery:.1%}. "
             f"Students are struggling with: {', '.join(top_struggling[:3]) if top_struggling else 'No major areas identified'}. "

--- a/backend/tests/test_quiz_routes.py
+++ b/backend/tests/test_quiz_routes.py
@@ -6,7 +6,7 @@ Covers:
 - POST /api/quiz/submit — answer grading and result shape
 - POST /api/quiz/submit — 404 when quiz not found
 - POST /api/quiz/generate — agent success path (quiz_agent.run mocked)
-- POST /api/quiz/generate — agent failure falls back to legacy
+- POST /api/quiz/generate — agent failure degrades to 502
 """
 import pytest
 from contextlib import contextmanager
@@ -18,6 +18,15 @@ from main import app
 from agents.quiz import Quiz, QuizQuestion
 
 client = TestClient(app)
+
+
+def _noop_ctx_agent():
+    """AsyncMock for quiz_context_agent.run to neutralize the post-submit
+    background context update in tests. The real run_agent_sync drives it; the
+    fake output.model_dump() yields an empty context."""
+    return AsyncMock(
+        return_value=SimpleNamespace(output=SimpleNamespace(model_dump=lambda: {}))
+    )
 
 
 # ── Scoring formula (pure logic, no HTTP) ────────────────────────────────────
@@ -111,7 +120,7 @@ def _submit_quiz_mocks(questions=None):
         # graph path) instead of a direct graph_nodes.update.
         patch("routes.quiz.apply_graph_update"),
         patch("routes.quiz.get_quiz_context", return_value={}),
-        patch("routes.quiz.call_gemini_json", return_value={}),
+        patch("routes.quiz.quiz_context_agent.run", new=_noop_ctx_agent()),
     ):
         yield
 
@@ -229,7 +238,7 @@ class TestSubmitQuiz:
         with patch("routes.quiz.table", side_effect=factory):
             with patch("routes.quiz.apply_graph_update"):
                 with patch("routes.quiz.get_quiz_context", return_value={}):
-                    with patch("routes.quiz.call_gemini_json", return_value={}):
+                    with patch("routes.quiz.quiz_context_agent.run", new=_noop_ctx_agent()):
                         r = client.post("/api/quiz/submit", json={
                             "quiz_id": "quiz1",
                             "answers": [
@@ -350,7 +359,7 @@ class TestQuizNodeOwnership:
             patch("routes.quiz.table", side_effect=factory),
             patch("routes.quiz.apply_graph_update", new=apply_mock),
             patch("routes.quiz.get_quiz_context", return_value={}),
-            patch("routes.quiz.call_gemini_json", return_value={}),
+            patch("routes.quiz.quiz_context_agent.run", new=_noop_ctx_agent()),
         ):
             r = client.post("/api/quiz/submit", json={
                 "quiz_id": "quiz_a",
@@ -459,7 +468,7 @@ class TestSubmitQuizMasteryWrite:
             patch("routes.quiz.table", side_effect=factory),
             patch("routes.quiz.apply_graph_update", new=apply_mock),
             patch("routes.quiz.get_quiz_context", return_value={}),
-            patch("routes.quiz.call_gemini_json", return_value={}),
+            patch("routes.quiz.quiz_context_agent.run", new=_noop_ctx_agent()),
         ):
             r = client.post("/api/quiz/submit", json={
                 "quiz_id": "quiz1",
@@ -646,57 +655,58 @@ class TestQuizAgentSuccess:
         assert payload["questions_json"][0]["id"] == 1
 
 
-class TestQuizAgentFallback:
-    """When the agent trips, the route runs the legacy generation pipeline."""
+class TestQuizContextUpdate:
+    """#145: the post-submit background task runs quiz_context_agent and persists
+    its model_dump() dict via save_quiz_context — no raw Gemini call."""
 
-    def _legacy_response(self):
-        # The legacy-shape question that the original quiz_generation prompt
-        # produces: id, question, options[{label,text,correct}], etc.
-        return {
-            "questions": [
-                {
-                    "id": 1,
-                    "question": "Legacy fallback question?",
-                    "options": [
-                        {"label": "A", "text": "wrong", "correct": False},
-                        {"label": "B", "text": "right", "correct": True},
-                    ],
-                    "explanation": "Because.",
-                    "concept_tested": "Loops",
-                    "difficulty": "easy",
-                },
-            ]
-        }
+    def test_saves_agent_model_dump(self):
+        from agents.quiz_context import QuizContext
 
-    def _patch_legacy_dependencies(self):
-        """Patch every dep _legacy_generate_quiz reaches for besides table()."""
-        return (
-            patch(
-                "routes.quiz.get_graph",
-                return_value={"nodes": [], "edges": []},
-            ),
-            patch("routes.quiz.get_quiz_context", return_value={}),
-            patch(
-                "routes.quiz.call_gemini_json",
-                return_value=self._legacy_response(),
-            ),
+        ctx = QuizContext(
+            weak_areas=["recursion base case"],
+            common_mistakes=["off-by-one"],
+            questions_seen_summary="loops and recursion",
+            recommended_difficulty="hard",
+            notes="solid on iteration",
         )
+        run = AsyncMock(return_value=SimpleNamespace(output=ctx))
+        saved = {}
 
-    def test_falls_back_to_legacy_on_usage_limit_exceeded(self):
+        def _save(uid, node_id, context):
+            saved["ctx"] = context
+
+        with (
+            patch("routes.quiz.table", side_effect=_make_table(None)),
+            patch("routes.quiz.apply_graph_update"),
+            patch("routes.quiz.get_quiz_context", return_value={}),
+            patch("routes.quiz.quiz_context_agent.run", new=run),
+            patch("routes.quiz.save_quiz_context", side_effect=_save),
+        ):
+            r = client.post("/api/quiz/submit", json={
+                "quiz_id": "quiz1",
+                "answers": [{"question_id": 1, "selected_label": "A"}],
+            })
+
+        assert r.status_code == 200
+        run.assert_called_once()
+        # The background task saved exactly the agent output's model_dump().
+        assert saved["ctx"] == ctx.model_dump()
+        assert saved["ctx"]["recommended_difficulty"] == "hard"
+
+
+class TestQuizAgentDegrade:
+    """When the agent trips, the route degrades to HTTP 502 (the raw-Gemini
+    legacy fallback was retired in #145 — no second LLM path)."""
+
+    def test_degrades_on_usage_limit_exceeded(self):
         from pydantic_ai.exceptions import UsageLimitExceeded
 
-        get_graph_p, get_ctx_p, gemini_p = self._patch_legacy_dependencies()
         with (
             patch("routes.quiz.table", side_effect=_generate_table_factory()),
             patch(
                 "routes.quiz.quiz_agent.run",
-                new=AsyncMock(
-                    side_effect=UsageLimitExceeded("token cap"),
-                ),
+                new=AsyncMock(side_effect=UsageLimitExceeded("token cap")),
             ),
-            get_graph_p as _get_graph,
-            get_ctx_p as _get_ctx,
-            gemini_p as gemini_mock,
         ):
             r = client.post("/api/quiz/generate", json={
                 "user_id": "user_andres",
@@ -705,25 +715,15 @@ class TestQuizAgentFallback:
                 "difficulty": "easy",
                 "use_shared_context": False,
             })
+        assert r.status_code == 502
 
-        assert r.status_code == 200
-        gemini_mock.assert_called_once()  # legacy path actually ran
-        q = r.json()["questions"][0]
-        assert q["question"] == "Legacy fallback question?"
-        # Wire format from legacy is preserved verbatim (it already matches).
-        assert q["options"][1]["correct"] is True
-
-    def test_falls_back_to_legacy_on_unexpected_exception(self):
-        get_graph_p, get_ctx_p, gemini_p = self._patch_legacy_dependencies()
+    def test_degrades_on_unexpected_exception(self):
         with (
             patch("routes.quiz.table", side_effect=_generate_table_factory()),
             patch(
                 "routes.quiz.quiz_agent.run",
                 new=AsyncMock(side_effect=RuntimeError("boom")),
             ),
-            get_graph_p,
-            get_ctx_p,
-            gemini_p as gemini_mock,
         ):
             r = client.post("/api/quiz/generate", json={
                 "user_id": "user_andres",
@@ -732,23 +732,11 @@ class TestQuizAgentFallback:
                 "difficulty": "easy",
                 "use_shared_context": False,
             })
+        assert r.status_code == 502
 
-        assert r.status_code == 200
-        gemini_mock.assert_called_once()
-        assert r.json()["questions"][0]["question"] == "Legacy fallback question?"
-
-    def test_falls_back_to_legacy_when_all_questions_drift(self):
-        """Cascade: agent succeeds but every question fails wire-format
-        validation → _quiz_via_agent raises RuntimeError →
-        bare-Exception catch in generate_quiz routes to legacy.
-
-        This pins the path the 3 contract tests don't directly exercise
-        (they test _agent_question_to_wire in isolation; this exercises
-        the full route under the all-drift condition).
-        """
-        # Build a Quiz where every question's correct_answer doesn't
-        # appear in its options — schema-valid, but the wire-format
-        # check drops every one.
+    def test_degrades_when_all_questions_drift(self):
+        """Agent succeeds but every question fails wire-format validation ->
+        _quiz_via_agent raises RuntimeError -> bare-Exception catch -> 502."""
         drift_quiz = Quiz(questions=[
             QuizQuestion(
                 question=f"Q{i}?",
@@ -761,15 +749,10 @@ class TestQuizAgentFallback:
             )
             for i in range(3)
         ])
-
-        get_graph_p, get_ctx_p, gemini_p = self._patch_legacy_dependencies()
         agent_run_mock = AsyncMock(return_value=SimpleNamespace(output=drift_quiz))
         with (
             patch("routes.quiz.table", side_effect=_generate_table_factory()),
             patch("routes.quiz.quiz_agent.run", new=agent_run_mock),
-            get_graph_p,
-            get_ctx_p,
-            gemini_p as gemini_mock,
         ):
             r = client.post("/api/quiz/generate", json={
                 "user_id": "user_andres",
@@ -778,15 +761,8 @@ class TestQuizAgentFallback:
                 "difficulty": "easy",
                 "use_shared_context": False,
             })
-
-        assert r.status_code == 200
-        # Pin BOTH halves of the cascade contract:
-        #   1. The agent path was actually tried (not skipped).
-        agent_run_mock.assert_called_once()
-        #   2. The legacy path then fired (every question dropped →
-        #      RuntimeError → bare-Exception catch → _legacy_generate_quiz).
-        gemini_mock.assert_called_once()
-        assert r.json()["questions"][0]["question"] == "Legacy fallback question?"
+        assert r.status_code == 502
+        agent_run_mock.assert_called_once()  # the agent path was actually tried
 
 
 # ── Wire-format contract: pinned by tests so silent drift can't recur ───────
@@ -952,77 +928,3 @@ class TestQuizModelPref:
         assert _resolve_model_pref(None) is None
         assert _resolve_model_pref("") is None
         assert _resolve_model_pref("auto") is None  # not in the map
-
-    def test_legacy_fallback_uses_smart_when_pref_smart(self):
-        """If the agent path trips and we fall through to legacy,
-        the same preference must propagate — call_gemini_json gets
-        MODEL_SMART instead of MODEL_LITE."""
-        from services.gemini_service import MODEL_SMART
-        run_mock = AsyncMock(side_effect=RuntimeError("agent boom"))
-        gemini_mock = MagicMock(return_value={"questions": [{
-            "id": 1, "question": "Q?",
-            "options": [{"label": "A", "text": "x", "correct": True}],
-            "explanation": ".", "concept_tested": "X", "difficulty": "easy",
-        }]})
-        with (
-            patch("routes.quiz.table", side_effect=_generate_table_factory()),
-            patch("routes.quiz.quiz_agent.run", new=run_mock),
-            patch("routes.quiz.get_graph", return_value={"nodes": [], "edges": []}),
-            patch("routes.quiz.get_quiz_context", return_value={}),
-            patch("routes.quiz.call_gemini_json", new=gemini_mock),
-        ):
-            r = self._post({"model_pref": "smart"})
-        assert r.status_code == 200
-        # call_gemini_json was called with model=MODEL_SMART, not MODEL_LITE.
-        gemini_mock.assert_called_once()
-        assert gemini_mock.call_args.kwargs.get("model") == MODEL_SMART
-
-    def test_legacy_fallback_uses_lite_when_pref_fast(self):
-        """Symmetry contract: legacy "fast" must resolve to MODEL_LITE
-        (gemini-2.5-flash-lite) — same as the agent path's _PREF_MODEL_NAMES["fast"].
-        Pinned so a future change can't silently desynchronize the two paths.
-        """
-        from services.gemini_service import MODEL_LITE
-        run_mock = AsyncMock(side_effect=RuntimeError("agent boom"))
-        gemini_mock = MagicMock(return_value={"questions": [{
-            "id": 1, "question": "Q?",
-            "options": [{"label": "A", "text": "x", "correct": True}],
-            "explanation": ".", "concept_tested": "X", "difficulty": "easy",
-        }]})
-        with (
-            patch("routes.quiz.table", side_effect=_generate_table_factory()),
-            patch("routes.quiz.quiz_agent.run", new=run_mock),
-            patch("routes.quiz.get_graph", return_value={"nodes": [], "edges": []}),
-            patch("routes.quiz.get_quiz_context", return_value={}),
-            patch("routes.quiz.call_gemini_json", new=gemini_mock),
-        ):
-            r = self._post({"model_pref": "fast"})
-        assert r.status_code == 200
-        gemini_mock.assert_called_once()
-        chosen = gemini_mock.call_args.kwargs.get("model")
-        assert chosen == MODEL_LITE, (
-            f"Legacy fast→{chosen!r} expected MODEL_LITE (gemini-2.5-flash-lite); "
-            f"matches the agent path's _PREF_MODEL_NAMES['fast']."
-        )
-
-    def test_legacy_fallback_uses_lite_when_no_pref(self):
-        """Default path (no model_pref) keeps using MODEL_LITE — the
-        cheap baseline that's been in place since the route shipped."""
-        from services.gemini_service import MODEL_LITE
-        run_mock = AsyncMock(side_effect=RuntimeError("agent boom"))
-        gemini_mock = MagicMock(return_value={"questions": [{
-            "id": 1, "question": "Q?",
-            "options": [{"label": "A", "text": "x", "correct": True}],
-            "explanation": ".", "concept_tested": "X", "difficulty": "easy",
-        }]})
-        with (
-            patch("routes.quiz.table", side_effect=_generate_table_factory()),
-            patch("routes.quiz.quiz_agent.run", new=run_mock),
-            patch("routes.quiz.get_graph", return_value={"nodes": [], "edges": []}),
-            patch("routes.quiz.get_quiz_context", return_value={}),
-            patch("routes.quiz.call_gemini_json", new=gemini_mock),
-        ):
-            r = self._post({})  # no model_pref
-        assert r.status_code == 200
-        gemini_mock.assert_called_once()
-        assert gemini_mock.call_args.kwargs.get("model") == MODEL_LITE

--- a/backend/tests/test_quiz_routes.py
+++ b/backend/tests/test_quiz_routes.py
@@ -121,6 +121,9 @@ def _submit_quiz_mocks(questions=None):
         patch("routes.quiz.apply_graph_update"),
         patch("routes.quiz.get_quiz_context", return_value={}),
         patch("routes.quiz.quiz_context_agent.run", new=_noop_ctx_agent()),
+        # Also neutralize the persistence side of the background update so these
+        # submit tests don't do a hidden (mocked-table) write or swallow errors.
+        patch("routes.quiz.save_quiz_context"),
     ):
         yield
 

--- a/backend/tests/test_shared_course_context.py
+++ b/backend/tests/test_shared_course_context.py
@@ -1,8 +1,8 @@
 """
 Unit tests for the shared course context system.
 
-Tests: course_context_service, graph_service (apply_graph_update side-effects),
-       learn.py (build_system_prompt), quiz.py (generate_quiz prompt augmentation).
+Tests: course_context_service (incl. course_summary agent), graph_service
+       (apply_graph_update side-effects), learn.py (build_system_prompt).
 
 Run from backend/:
     python -m pytest tests/test_shared_course_context.py -v
@@ -11,7 +11,8 @@ import sys
 import os
 import json
 import unittest
-from unittest.mock import patch, MagicMock, call
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch, MagicMock, call
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -517,149 +518,35 @@ class TestLearnHelpers(unittest.TestCase):
 # 5. quiz.py — generate_quiz prompt augmentation
 # ─────────────────────────────────────────────────────────────────────────────
 
-class TestQuizPromptAugmentation(unittest.TestCase):
-    """Legacy prompt-augmentation tests.
 
-    Post-refactor (ADR 0005), generate_quiz routes through quiz_agent
-    first and only falls through to the legacy `_legacy_generate_quiz`
-    path on agent failure. Each test below patches `quiz_agent.run` to
-    raise so the legacy code path actually executes — that is the path
-    these assertions describe (manual prompt-string augmentation against
-    course_context_service output).
-    """
+class TestCourseSummaryAgent(unittest.TestCase):
+    """#145: _generate_summary_with_gemini runs the course_summary agent and
+    degrades to a deterministic template string on agent failure."""
 
-    def _make_generate_body(self):
-        return {
-            "user_id": "user1",
-            "concept_node_id": "node-abc",
-            "difficulty": "medium",
-            "num_questions": 3,
-        }
-
-    def _force_legacy(self):
-        """Patch quiz_agent.run to raise so the route falls back to legacy."""
-        from unittest.mock import AsyncMock
-        return patch(
-            "routes.quiz.quiz_agent.run",
-            new=AsyncMock(side_effect=RuntimeError("force legacy fallback for tests")),
+    def test_returns_agent_summary_on_success(self):
+        from services import course_context_service as ccs
+        run = AsyncMock(
+            return_value=SimpleNamespace(
+                output=SimpleNamespace(summary="Agent class summary.")
+            )
         )
+        with patch.object(ccs.course_summary_agent, "run", new=run):
+            out = ccs._generate_summary_with_gemini(
+                "CS101", "Intro", 0.6, ["Loops"], ["Vars"], 12,
+            )
+        self.assertEqual(out, "Agent class summary.")
+        run.assert_called_once()
 
-    def _post_generate(self):
-        """POST to /api/quiz/generate via TestClient."""
-        from fastapi.testclient import TestClient
-        from main import app
-        return TestClient(app).post("/api/quiz/generate", json=self._make_generate_body())
-
-    # get_course_context is lazily imported inside _legacy_generate_quiz;
-    # patch at the source module so the `from ... import` resolves to our mock.
-    @patch("services.course_context_service.get_course_context")
-    @patch("routes.quiz.call_gemini_json")
-    @patch("routes.quiz.get_quiz_context", return_value=None)
-    @patch("routes.quiz.get_graph")
-    @patch("routes.quiz.table")
-    def test_misconceptions_appended_to_prompt(
-        self, mock_table, mock_graph, mock_quiz_ctx, mock_gemini, mock_ctx
-    ):
-        mock_table.return_value.select.return_value = [{
-            "id": "node-abc", "concept_name": "Pointers",
-            "mastery_score": 0.3, "course_id": "c1",
-        }]
-        mock_table.return_value.insert.return_value = None
-        mock_graph.return_value = {"nodes": [], "edges": []}
-        mock_ctx.return_value = {
-            "course_summary": {"avg_class_mastery": 0.4},
-            "concept_stats": [
-                {
-                    "concept_name": "Pointers",
-                    "common_misconceptions": ["Dangling pointers", "Memory leaks"],
-                    "prerequisite_gaps": ["Pointer arithmetic"],
-                }
-            ],
-        }
-        mock_gemini.return_value = {"questions": []}
-
-        with self._force_legacy():
-            self._post_generate()
-
-        actual_prompt = mock_gemini.call_args[0][0]
-        self.assertIn("Dangling pointers", actual_prompt)
-        self.assertIn("Memory leaks", actual_prompt)
-        self.assertIn("Pointer arithmetic", actual_prompt)
-
-    @patch("services.course_context_service.get_course_context", return_value={})
-    @patch("routes.quiz.call_gemini_json")
-    @patch("routes.quiz.get_quiz_context", return_value=None)
-    @patch("routes.quiz.get_graph")
-    @patch("routes.quiz.table")
-    def test_no_augmentation_when_ctx_empty(
-        self, mock_table, mock_graph, mock_quiz_ctx, mock_gemini, mock_ctx
-    ):
-        mock_table.return_value.select.return_value = [{
-            "id": "node-abc", "concept_name": "Loops",
-            "mastery_score": 0.5, "course_id": "c1",
-        }]
-        mock_table.return_value.insert.return_value = None
-        mock_graph.return_value = {"nodes": [], "edges": []}
-        mock_gemini.return_value = {"questions": []}
-
-        with self._force_legacy():
-            self._post_generate()
-
-        actual_prompt = mock_gemini.call_args[0][0]
-        self.assertNotIn("Common misconceptions seen across the class", actual_prompt)
-
-    @patch("services.course_context_service.get_course_context")
-    @patch("routes.quiz.call_gemini_json")
-    @patch("routes.quiz.get_quiz_context", return_value=None)
-    @patch("routes.quiz.get_graph")
-    @patch("routes.quiz.table")
-    def test_augmentation_capped_at_10_items(
-        self, mock_table, mock_graph, mock_quiz_ctx, mock_gemini, mock_ctx
-    ):
-        mock_table.return_value.select.return_value = [{
-            "id": "node-abc", "concept_name": "Pointers",
-            "mastery_score": 0.3, "course_id": "c1",
-        }]
-        mock_table.return_value.insert.return_value = None
-        mock_graph.return_value = {"nodes": [], "edges": []}
-        mock_ctx.return_value = {
-            "course_summary": {"avg_class_mastery": 0.4},
-            "concept_stats": [
-                {
-                    "concept_name": "Pointers",
-                    "common_misconceptions": [f"mistake_{i}" for i in range(20)],
-                    "prerequisite_gaps": [],
-                }
-            ],
-        }
-        mock_gemini.return_value = {"questions": []}
-
-        with self._force_legacy():
-            self._post_generate()
-
-        actual_prompt = mock_gemini.call_args[0][0]
-        self.assertIn("mistake_9", actual_prompt)
-        self.assertNotIn("mistake_10", actual_prompt)
-
-    @patch("routes.quiz.call_gemini_json")
-    @patch("routes.quiz.get_quiz_context", return_value=None)
-    @patch("routes.quiz.get_graph")
-    @patch("routes.quiz.table")
-    def test_no_augmentation_when_node_has_no_course_id(
-        self, mock_table, mock_graph, mock_quiz_ctx, mock_gemini
-    ):
-        mock_table.return_value.select.return_value = [{
-            "id": "node-abc", "concept_name": "GenericConcept",
-            "mastery_score": 0.5, "course_id": "",
-        }]
-        mock_table.return_value.insert.return_value = None
-        mock_graph.return_value = {"nodes": [], "edges": []}
-        mock_gemini.return_value = {"questions": []}
-
-        with self._force_legacy():
-            with patch("services.course_context_service.get_course_context") as mock_ctx:
-                self._post_generate()
-                mock_ctx.assert_not_called()
+    def test_falls_back_to_template_on_agent_failure(self):
+        from services import course_context_service as ccs
+        run = AsyncMock(side_effect=RuntimeError("boom"))
+        with patch.object(ccs.course_summary_agent, "run", new=run):
+            out = ccs._generate_summary_with_gemini(
+                "CS101", "Intro", 0.6, ["Loops"], ["Vars"], 12,
+            )
+        # Deterministic template fallback — no second LLM call.
+        self.assertIn("Class average mastery", out)
+        self.assertIn("Loops", out)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_shared_course_context.py
+++ b/backend/tests/test_shared_course_context.py
@@ -12,7 +12,7 @@ import os
 import json
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch, MagicMock, call
+from unittest.mock import AsyncMock, patch, MagicMock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/specs/145-quiz-course-context-agents.md
+++ b/specs/145-quiz-course-context-agents.md
@@ -1,0 +1,94 @@
+# Spec: Quiz generation + course-context regen → agents (#145)
+
+## Context
+
+Agent-migration epic (#152), milestone #2. Three raw `call_gemini*` seams remain across the quiz surface:
+
+- `routes/quiz.py:292` — `call_gemini_json` inside `_legacy_generate_quiz`, the ADR-0001 legacy
+  **fallback** for quiz generation (the primary path, `_quiz_via_agent` → `quiz_agent`, already exists).
+- `routes/quiz.py:478` — `call_gemini_json(prompt, model=MODEL_LITE)` inside `_update_context`, a
+  **background task** that regenerates per-concept quiz context after a submission.
+- `services/course_context_service.py:58` — `call_gemini(prompt, retries=1)` inside
+  `_generate_summary_with_gemini`, generating the instructor-facing class summary.
+
+The `run_agent_sync` bridge (`agents/_run.py`, from #147/#296) is on `main` for the two sync call sites.
+`MODEL_LITE`/`MODEL_SMART` are used only by the legacy quiz path and `_update_context`; the agent path
+uses `_PREF_MODEL_NAMES` + `google_model`.
+
+**Coordination:** the quiz submit/generate handlers overlap with #128/#129 (quiz graph-write + scoring);
+this PR must not touch the scoring/`apply_graph_update` logic — only the LLM seams.
+
+## Goal
+
+No `call_gemini*` remains in `quiz.py` or `course_context_service.py`. Quiz-context regeneration and the
+class summary run through typed Pydantic AI agents; the removed quiz-generation legacy fallback degrades
+gracefully (HTTP 502) instead of a second LLM call.
+
+## Requirements
+
+### R1 — Course-summary agent
+- Add `agents/course_summary.py`: `course_summary_agent = Agent[..., CourseSummary]`, `CourseSummary`
+  = `{ summary: str }` (2–3 paragraph instructor summary). Register `course_summary` in `_providers`
+  (`gemini-2.5-flash`). Persona lives in the system prompt; the metrics go in the user message.
+- `course_context_service._generate_summary_with_gemini` calls the agent via `run_agent_sync`, returns
+  `result.output.summary`, and keeps the existing `except` → deterministic template fallback string.
+- Remove `from services.gemini_service import call_gemini` from `course_context_service.py`.
+
+### R2 — Quiz-context agent
+- Add `agents/quiz_context.py`: `quiz_context_agent = Agent[..., QuizContext]` where `QuizContext`
+  mirrors the `quiz_context_update.txt` schema exactly: `weak_areas: list[str]`,
+  `common_mistakes: list[str]`, `questions_seen_summary: str`,
+  `recommended_difficulty: Literal["easy","medium","hard"]`, `notes: str`. Register `quiz_context` in
+  `_providers` (`gemini-2.5-flash-lite`).
+- `routes/quiz.py::_update_context` runs the agent via `run_agent_sync`, converts output with
+  `.model_dump()`, and passes that dict to `save_quiz_context` (unchanged storage shape). Keep the
+  existing `try/except: pass` so a context-update failure never breaks submission.
+
+### R3 — Remove the quiz-generation legacy fallback
+- Delete `_legacy_generate_quiz` and the `from services.gemini_service import MODEL_LITE, MODEL_SMART,
+  call_gemini_json` import.
+- In `generate_quiz`, the agent-failure branches (`UsageLimitExceeded`/`UnexpectedModelBehavior` and
+  bare `Exception`) no longer call the legacy path; they raise
+  `HTTPException(status_code=502, detail=<clear message>)`. The `except HTTPException: raise` stays
+  (404 for unknown concept node is raised BEFORE the agent call and is unaffected).
+- `body.model_pref` "fast"/"smart" still works on the agent path via `_resolve_model_pref` (unchanged).
+
+### R4 — No scoring/graph changes (coordination guard)
+- `submit_quiz` scoring, `apply_graph_update`, and the `quiz_attempts` writes are unchanged (only the
+  `_update_context` LLM seam inside it changes). Don't touch #128/#129 territory.
+
+### R5 — Tests
+- `tests/test_quiz_routes.py`:
+  - The 4 submit tests that `patch("routes.quiz.call_gemini_json", return_value={})` (to no-op the
+    background context update) → repoint to `patch("routes.quiz._update_context")` (no-op the whole
+    background task), since `call_gemini_json` no longer exists in the module.
+  - `TestGenerateQuizLegacyFallback` → rewrite as degrade tests: agent `UsageLimitExceeded`, bare
+    `Exception`, and all-questions-drift now yield **HTTP 502** (not a legacy quiz). Remove
+    `_patch_legacy_dependencies` and the `call_gemini_json`/`MODEL_LITE`/`MODEL_SMART` legacy-model
+    tests (`test_legacy_fallback_uses_smart_when_pref_smart` etc.).
+  - Keep the agent-path happy-path + wire-shape tests unchanged.
+- Add `tests/test_oneshot_agents.py` (or a new file) coverage: `_update_context` runs the quiz-context
+  agent and calls `save_quiz_context` with the `model_dump()` dict; `_generate_summary_with_gemini`
+  returns the agent summary on success and the template on agent failure.
+- All agent runs mocked; no live Gemini in the default run.
+
+## Acceptance criteria (verifiable)
+1. `grep -rn "call_gemini" backend/routes/quiz.py backend/services/course_context_service.py` → no matches.
+2. New agents exist: `agents/course_summary.py`, `agents/quiz_context.py`, each `Agent[..., <Model>]`
+   with `metadata` (`prompt_version` + `agent`); `_providers` `AgentTask`+`_DEFAULTS` include
+   `course_summary` + `quiz_context`.
+3. `QuizContext` fields exactly match `quiz_context_update.txt`; `_update_context` saves `.model_dump()`.
+4. Agent-generation failure in `generate_quiz` returns **502** (no legacy quiz served), and a
+   pre-agent unknown-node still returns **404**.
+5. `_generate_summary_with_gemini` returns the agent summary on success and the deterministic template
+   on agent failure (test).
+6. `submit_quiz` scoring/`apply_graph_update`/`quiz_attempts` writes unchanged (existing scoring tests pass).
+7. `python -m pytest tests/test_quiz_routes.py tests/test_shared_course_context.py -q` passes; full
+   `python -m pytest tests/ -q` shows no new failures vs `main`.
+8. `ruff check .` passes for changed files.
+
+## Out of scope
+- Flashcards (#146), documents, the study-guide/social one-shots (#147, merged).
+- `quiz_agent` itself and the wire-format mapping (`_agent_question_to_wire`) — unchanged.
+- Scoring/graph-write logic (#128/#129).
+- Deleting `services/gemini_service.py` (#151).


### PR DESCRIPTION
Closes #145 (Agent-migration epic #152, milestone #2).

## What
Removes the last three raw `call_gemini*` seams from the quiz surface, folding them into the agent layer:

| Site | Before | After |
|---|---|---|
| `quiz.py` post-submit background task | `call_gemini_json` (quiz-context regen) | new `agents/quiz_context.py` (`quiz_context_agent`) |
| `course_context_service.py` | `call_gemini` (class summary) | new `agents/course_summary.py` (`course_summary_agent`) |
| `quiz.py` `_legacy_generate_quiz` | `call_gemini_json` fallback | **removed** → graceful 502 |

## Notes
- **`QuizContext`** mirrors `quiz_context_update.txt` exactly (`weak_areas`, `common_mistakes`, `questions_seen_summary`, `recommended_difficulty`, `notes`); `_update_context` saves `.model_dump()`, so the stored `quiz_context.context_json` shape is unchanged.
- **Course summary** keeps its deterministic template fallback on agent failure (no second LLM call), so a summary is always produced.
- **Quiz-gen fallback removed:** on agent guardrail-trip or unexpected failure, `generate_quiz` returns **502** rather than serving a quiz from a second LLM path. The pre-agent **404** (unknown concept node) is unchanged, and the fast/smart `model_pref` override still works on the agent path.
- Both sync call sites use the `run_agent_sync` bridge (from #147).

## ⚠️ Coordination (#128/#129)
This PR is scoped to the **LLM seams only**. It does **not** touch quiz scoring, `apply_graph_update`, or the `quiz_attempts` writes in `submit_quiz` — the #128/#129 territory. The only change inside `submit_quiz` is swapping the background context-update's LLM call for the agent.

## Testing
- Rewrote the legacy-fallback quiz tests → degrade-to-502; repointed the 4 submit context-update patches onto `quiz_context_agent`; removed the obsolete legacy prompt-augmentation class + legacy-model tests; added quiz-context-save, course-summary success/fallback, and degrade tests.
- Full backend suite: **826 passed** (the 2 `test_storage_service` failures pre-exist on `main` — missing SUPABASE env). `ruff` clean.

Out of scope: flashcards (#146), deleting `services/gemini_service.py` (#151).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered course summaries for instructors.
  * Added AI-generated quiz context updates to improve follow-up learning notes.

* **Bug Fixes**
  * Quiz generation now fails gracefully with a clear temporary-unavailable response instead of switching to an older fallback path.
  * Course and quiz context updates now use more consistent, structured outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->