### PR TITLE
fix(security): final storage lockdown for #231 (private issues-media-files + drop anon policies)

### DIFF
--- a/backend/db/migrations/0029_storage_lockdown_231.sql
+++ b/backend/db/migrations/0029_storage_lockdown_231.sql
@@ -1,0 +1,48 @@
+-- 0029: Storage hardening (#231) — final lockdown of the last anon storage surface.
+--
+-- Most of #231 already shipped: issue-report screenshots now upload via the
+-- auth-gated backend endpoint POST /api/issue-reports/screenshot (service role,
+-- size + mime validated; routes/feedback.py); the frontend no longer uses the
+-- anon storage client (ReportIssueFlow.tsx); and application_resumes is already
+-- private (backend/service-key upload via routes/careers.py, returns a path).
+-- `avatars` stays public (intended public read). This migration closes what's left.
+--
+-- Verified against prod (read-only) before writing:
+--   * storage.buckets: issues-media-files public=true; application_resumes
+--     ALREADY public=false; avatars public=true.
+--   * storage.objects policies (both scoped to issues-media-files):
+--     "Allow public read" (anon SELECT) and "Allow uploads" (anon INSERT).
+-- So the UPDATE on application_resumes is a no-op, and the app's live paths
+-- (service-role upload + dashboard/signed-URL review) do not depend on the anon
+-- policies being dropped.
+--
+-- Idempotent / safe across environments: the WHERE-clauses affect zero rows
+-- where a bucket is absent (local/fresh), and DROP POLICY IF EXISTS no-ops when
+-- the policy is already gone.
+--
+-- PRIVILEGES: this touches the Supabase-managed `storage` schema. The migrate
+-- runner connects over SUPABASE_DB_URL as the DB owner (`postgres`), which on
+-- Supabase can alter storage.buckets and drop storage.objects policies (same
+-- role the dashboard SQL editor uses). If a locked-down environment's role lacks
+-- those privileges, apply this file with a storage-privileged role instead.
+
+-- 1. Make the screenshot bucket private. application_resumes is already private
+--    (kept here so a fresh environment converges to the same end state).
+update storage.buckets
+   set public = false
+ where id in ('issues-media-files', 'application_resumes');
+
+-- 2. Defence in depth: cap size + restrict mime on issues-media-files to match
+--    the upload endpoint (MAX_SCREENSHOT_BYTES = 5 MB; ALLOWED_SCREENSHOT_TYPES).
+--    Existing objects are grandfathered; the limit applies to new uploads.
+update storage.buckets
+   set file_size_limit = 5242880,  -- 5 MB
+       allowed_mime_types = array['image/png', 'image/jpeg', 'image/webp', 'image/gif']
+ where id = 'issues-media-files';
+
+-- 3. Drop the anonymous storage.objects policies the app no longer relies on.
+--    Uploads go through the service-role backend endpoint; screenshots are
+--    reviewed via the Supabase dashboard / a backend signed URL — never a public
+--    URL — so removing anon SELECT/INSERT breaks nothing.
+drop policy if exists "Allow uploads"     on storage.objects;  -- anon INSERT into issues-media-files
+drop policy if exists "Allow public read" on storage.objects;  -- anon SELECT on issues-media-files

--- a/docs/security/storage-hardening-plan.md
+++ b/docs/security/storage-hardening-plan.md
@@ -1,17 +1,22 @@
 # Storage hardening — PR-plan (#231)
 
-**Status: DRAFT plan for review. Nothing applied.**
+**Status (updated 2026-07-01): most of this plan has SHIPPED. The résumé-PII exposure is closed. Only the final SQL lockdown of `issues-media-files` remains — now in `backend/db/migrations/0029_storage_lockdown_231.sql` (pending review + apply; not yet run on prod).**
 
-## Live findings (Sapling prod, read-only)
+### Already shipped
+- `application_resumes` is **private** (`public=false`) — uploaded backend/service-key (`careers._upload_resume`, returns a path, not a public URL). Résumé PII is no longer publicly readable.
+- Issue-report screenshots upload via the **auth-gated backend endpoint** `POST /api/issue-reports/screenshot` (service role, content-type + 5 MB size validated; `routes/feedback.py`); `ReportIssueFlow.tsx` no longer uses the anon storage client.
+- The anon `"Allow uploads"` INSERT policy is **scoped to `issues-media-files`** (previously global / any-bucket).
+
+## Live findings (Sapling prod, re-verified 2026-07-01, read-only)
 Buckets that actually exist (3):
 
-| Bucket | `public` | Written by | Read by | Issue |
+| Bucket | `public` | Written by | Read by | Residual issue |
 |---|---|---|---|---|
-| `issues-media-files` (issue-report screenshots) | **true** | frontend **anon key** (`ReportIssueFlow.tsx`) | `getPublicUrl` (public) | anon upload + public read |
-| `application_resumes` (résumés) | **true** | backend service key (`careers.py`) | `getPublicUrl` (public) | **résumé PII publicly readable** |
+| `issues-media-files` (issue-report screenshots) | **true** | backend service key (`feedback.py`, `POST /api/issue-reports/screenshot`) | dashboard / signed URL (intended) | **still `public=true` + 2 anon policies** — the last surface (2 objects, ~7 MB) |
+| `application_resumes` (résumés) | **false** ✅ | backend service key (`careers.py`) | dashboard / signed URL | **fixed** (private) |
 | `avatars` | true | backend service key (`storage_service.py`) | public `<img>` | intended public read |
 
-`storage.objects` policies: `"Allow public read"` (SELECT, `{public}`, `issues-media-files`) and **`"Allow uploads"` (INSERT, `{public}`, no bucket/auth restriction)** → anyone can upload to **any** bucket, unauthenticated, unbounded (no size limit on `issues-media-files`/`application_resumes`).
+`storage.objects` policies (2, both scoped to `issues-media-files`): `"Allow public read"` (anon SELECT) and `"Allow uploads"` (anon INSERT). The app no longer uses either — both dropped by migration 0029.
 
 Note: `chat-images` and `cosmetic-assets` referenced in code **do not exist** — those upload paths are dead (separate cleanup; not a live exposure).
 
@@ -27,12 +32,13 @@ All storage writes go through the **backend (service_role)**; private buckets ar
 ## Changes
 
 ### SQL (review before applying)
+Canonical version now lives in `backend/db/migrations/0029_storage_lockdown_231.sql`
+(also adds a 5 MB size limit + mime allowlist on `issues-media-files`, matching the
+upload endpoint). Apply via `python -m db.migrate` (see the migration's privilege note).
 ```sql
-BEGIN;
-UPDATE storage.buckets SET public = false WHERE id IN ('issues-media-files','application_resumes');
-DROP POLICY IF EXISTS "Allow uploads"     ON storage.objects;  -- kills the global public INSERT
-DROP POLICY IF EXISTS "Allow public read" ON storage.objects;  -- issues-media-files public read
-COMMIT;
+UPDATE storage.buckets SET public = false WHERE id IN ('issues-media-files','application_resumes');  -- application_resumes already false → no-op
+DROP POLICY IF EXISTS "Allow uploads"     ON storage.objects;  -- anon INSERT (unused by app now)
+DROP POLICY IF EXISTS "Allow public read" ON storage.objects;  -- anon SELECT on issues-media-files
 ```
 No new storage.objects policies are needed: backend uploads/reads use `service_role` (bypasses storage RLS). `avatars` stays `public=true` so its objects remain readable without a policy.
 


### PR DESCRIPTION
Closes the **last** anon storage surface from #231. Investigation found the rest already shipped — this is the small remaining lockdown, delivered as **migration `0029_storage_lockdown_231.sql`** (not yet applied to prod).

## Verified live state (prod, read-only, 2026-07-01)
| Bucket | `public` | Note |
|---|---|---|
| `application_resumes` (résumés, 13 objs) | **false** ✅ | **already private** — résumé-PII exposure is closed |
| `avatars` | true | intended public read |
| `issues-media-files` (screenshots, 2 objs ~7 MB) | **true** ❌ | the only residual: `public=true` + 2 anon `storage.objects` policies |

The triage note ("`application_resumes` still public-read") and the old plan doc were **stale** — I've updated `storage-hardening-plan.md` to match reality.

## What already shipped (no change here)
- `feedback.py` `POST /api/issue-reports/screenshot` — auth-gated, service-role upload, content-type + 5 MB validated; `ReportIssueFlow.tsx` posts to it (no anon storage client).
- `application_resumes` private + backend/service-key upload (`careers.py`).
- Anon `"Allow uploads"` already scoped to `issues-media-files` (was global).

## This migration (0029)
1. `issues-media-files` → **private** (`application_resumes` already private → no-op).
2. Adds `file_size_limit = 5 MB` + mime allowlist on `issues-media-files` (defence in depth; the endpoint already validates).
3. Drops the two anon `storage.objects` policies (`"Allow uploads"` INSERT / `"Allow public read"` SELECT).

## Why it's safe
- Uploads use the **service role** (bypasses storage RLS) → dropping anon INSERT can't break them.
- Screenshots are reviewed via the **dashboard / signed URLs** — no code reads `issues-media-files` via `getPublicUrl` (verified) → private-flip can't break review.
- `avatars` untouched. Idempotent across envs (WHERE no-ops on absent buckets; `DROP … IF EXISTS`).

## Apply notes (not auto-applied)
- Run via `python -m db.migrate` against the target env's `SUPABASE_DB_URL`.
- ⚠️ **Privilege check:** this touches the Supabase-managed `storage` schema; the migrate role (`postgres`) can normally alter `storage.buckets` + drop `storage.objects` policies (same role the dashboard uses), but confirm in a locked-down env.
- Supersedes the storage portion of drafts **#232 / #238** (their realtime-RLS content is a separate concern, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Strengthened file storage access controls.
  * Résumé uploads are now private.
  * Media uploads are limited to approved image types and a 5MB maximum size.

* **Bug Fixes**
  * Removed anonymous public access to storage objects, reducing unintended file exposure.

* **Documentation**
  * Updated the storage hardening notes to reflect current rollout status and upload rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->