### PR TITLE
fix(ui): finish frontend-audit P0 token migration (closes #103, #104)

### DIFF
--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -1151,7 +1151,7 @@ export default function LandingPage() {
                     transition: 'all 0.18s', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
                     fontFamily: "var(--font-dm-sans), 'DM Sans', sans-serif",
                   }}
-                  onMouseEnter={e => { if (!betaSubmitting) e.currentTarget.style.background = '#155A35'; }}
+                  onMouseEnter={e => { if (!betaSubmitting) e.currentTarget.style.background = 'var(--brand-forest-hover)'; }}
                   onMouseLeave={e => { if (!betaSubmitting) e.currentTarget.style.background = 'var(--brand-forest)'; }}
                 >
                   {betaSubmitting ? 'Planting your node…' : <>Sign Me Up <span style={{ opacity: 0.7 }}>→</span></>}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -20,6 +20,8 @@
 
   /* Canonical brand green ("forest"). Mirrored by BRAND_FOREST in lib/brand.ts. */
   --brand-forest: #1B6C42;
+  /* Hover-darken of the base forest, for primary-forest button :hover states. */
+  --brand-forest-hover: #155A35;
   /* Brighter forest used for the primary CTA fill + the hero "growth" leaf. */
   --brand-forest-bright: #2D8F5C;
   --brand-forest-bright-hover: #236F48;

--- a/frontend/src/components/HowItWorks.tsx
+++ b/frontend/src/components/HowItWorks.tsx
@@ -42,14 +42,14 @@ function SeedSVG({ active }: { active: boolean }) {
       <g style={{ transformOrigin: '100px 215px', transform: 'scale(0.55)' }}>
         {/* Stem */}
         <motion.path d="M100 215 L100 137"
-          stroke="#1B6C42" strokeWidth="5" strokeLinecap="round"
+          stroke="var(--brand-forest)" strokeWidth="5" strokeLinecap="round"
           initial={{ pathLength: 0 }}
           animate={active ? { pathLength: 1 } : { pathLength: 0 }}
           transition={{ duration: 0.55, ease: 'easeOut' }}
         />
         {/* Left leaf */}
         <motion.path d="M100 167 C100 167 58 155 52 119 C52 119 94 113 100 167 Z"
-          fill="#1B6C42"
+          fill="var(--brand-forest)"
           initial={{ scale: 0 }} animate={active ? { scale: 1 } : { scale: 0 }}
           transition={{ duration: 0.55, delay: 0.42, ease: [0.34, 1.56, 0.64, 1] }}
           style={{ transformOrigin: '100px 167px' }}
@@ -62,7 +62,7 @@ function SeedSVG({ active }: { active: boolean }) {
           style={{ transformOrigin: '100px 143px' }}
         />
         {/* Tip bud */}
-        <motion.circle cx="100" cy="131" r="7" fill="#1B6C42"
+        <motion.circle cx="100" cy="131" r="7" fill="var(--brand-forest)"
           initial={{ scale: 0 }} animate={active ? { scale: 1 } : { scale: 0 }}
           transition={{ duration: 0.38, delay: 0.32, ease: [0.34, 1.56, 0.64, 1] }}
           style={{ transformOrigin: '100px 131px' }}


### PR DESCRIPTION
## What & why

Closes out the **P0 wave of the Frontend UI audit (#113)**. Verifying #102/#103/#104 against `main` (`f472300`) showed the anti-patterns are essentially eliminated already — but #103 and #104 each had a **handful of raw brand-green hex literals** still lingering, which their acceptance criteria explicitly call out. This PR clears those last literals so both issues close with every box literally satisfied.

**Value-preserving:** every swap resolves to the identical hex via an existing token, so there is **no visual change** — pure token hygiene.

Closes #103
Closes #104

## Verification against acceptance criteria (on `main`)

| Issue | AC | State found on `main` | This PR |
|---|---|---|---|
| **#102** Remove Liquid Glass | no `backdrop-filter`/blur glass; solid surfaces; keep radial washes | ✅ Done already — 0 `backdrop-filter`; `.glass-*` render as opaque `--bg-panel` (`globals.css:601` documents the removal); only `blur()` uses are the allowed `.sapling-mesh-blob` / `AmbientOrbs` atmosphere | **no code needed** — verified done, closed separately |
| **#103** Remove gradient-text headings | no `bg-clip-text`; `#2D8F5C`/`#155A35` literals gone; headings solid | ✅ Headings solid, 0 `bg-clip-text`; `#2D8F5C` already folded into `--brand-forest-bright`. ❌ one raw `#155A35` left (`(public)/page.tsx:1154` beta-submit hover) | tokenize `#155A35` → `--brand-forest-hover` |
| **#104** Consolidate brand greens | `#1B6C42` single token, 0 raw literals; `--state-*` statuses; dedup `--brand-*`/rarity | ✅ `--brand-forest` canonical + `--state-*` defined + no inline graph-status hex + old `--brand-primary/success/...` fully removed + rarity single block. ❌ 3 raw `#1B6C42` left in `HowItWorks.tsx:45/52/65` | swap the 3 → `var(--brand-forest)` (matches the ~20 `var(--brand-forest)` sinks already in that file) |

## Changes

- **`globals.css`** — add `--brand-forest-hover: #155A35` (hover-darken of the base forest, for primary-forest button `:hover`).
- **`(public)/page.tsx`** — beta-submit `onMouseEnter` sets `var(--brand-forest-hover)` instead of raw `#155A35` (its `onMouseLeave` already used a token).
- **`HowItWorks.tsx`** — seed-SVG stem / left-leaf / tip-bud static `fill`/`stroke` now use `var(--brand-forest)`. These are static attributes (only `pathLength`/`scale` animate, not color), so `var()` resolves fine — same pattern as lines 97/104 in the same file.

## Not in scope (noted for follow-up)

- `HowItWorks.tsx:59` right-leaf `fill="#2d8a47"` — a distinct **decorative 2-tone-foliage** green (not `#1B6C42`), outside #104's AC. Left as-is; can be tokenized in a later polish pass if desired.

## Test plan

- Frontend CI (`npm ci` + build/lint) is the gate — all changes are string-value swaps mirroring patterns already compiling in the same files, with no type or identifier changes.
- No visual diff expected (identical rendered colors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated hover and illustration colors to use consistent theme colors across the site.
  * Added a new hover variant for the forest green brand color, improving visual consistency.
  * Refined the beta newsletter submit button hover state to match the updated theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->