### PR TITLE
fix(a11y): restore visible focus on careers + onboarding inputs (closes #108)

### DIFF
--- a/frontend/src/app/(public)/careers/[slug]/ApplyForm.tsx
+++ b/frontend/src/app/(public)/careers/[slug]/ApplyForm.tsx
@@ -22,7 +22,6 @@ const INPUT_STYLE: React.CSSProperties = {
   fontSize: 14,
   color: 'var(--text)',
   fontFamily: 'var(--font-sans)',
-  outline: 'none',
   boxSizing: 'border-box',
   transition: 'border-color var(--dur-fast) var(--ease)',
 };

--- a/frontend/src/components/OnboardingFlow.tsx
+++ b/frontend/src/components/OnboardingFlow.tsx
@@ -273,7 +273,6 @@ export default function OnboardingFlow({ visible, onClose, onFinish, activeStep,
     borderRadius: '14px',
     padding: '14px 18px',
     fontSize: '15px',
-    outline: 'none',
     width: '100%',
     fontFamily: "var(--font-dm-sans), 'DM Sans', sans-serif",
   };


### PR DESCRIPTION
## What & why

Completes **#108 (restore visible focus + a11y labels/alt text)**. Auditing the issue's sites against `main` found that **almost all of #108 is already resolved** — but the acceptance criterion *"visible focus on every text input"* still failed on **two inputs the original audit missed**. This PR closes those.

Closes #108

## Current-state audit vs. the four acceptance criteria (on `main`)

| AC | Status on `main` | |
|---|---|---|
| **Visible focus on every text input/textarea** | ⚠️ **Partially** | 6 originally-cited sites already fixed (inline `outline:none` removed; global `:focus-visible` at `globals.css:384` covers them). But **2 sites the audit missed still suppress focus** → **fixed here** |
| **Accessible names on the listed controls** | ✅ done | `ChatPanel` textarea `aria-label="Message"`; `ManageCoursesModal` `aria-label="Search courses"`; `Calendar` select-all + row checkboxes labeled |
| **`SignInModal` traps + restores focus** | ✅ done | Saves/restores `previousFocusRef`, focuses first focusable on open, wraps Tab, Escape closes (hand-rolled, but meets the AC) |
| **Graph/plot/diagram expose a text alternative** | ✅ done | `FunctionPlot` + `MermaidBlock` have `role="img"`+`aria-label`; `KnowledgeGraph2D` has `role="img"`+label **and** the `SR_ONLY` off-screen node list mirroring the 3D variant |

## The fix

Two shared style objects set `outline: 'none'` with **no working focus fallback**, so keyboard focus was invisible on their inputs (the inline rule overrides the global `:focus-visible` ring):

- **`(public)/careers/[slug]/ApplyForm.tsx`** — `INPUT_STYLE` (all 5 application fields). No `onFocus`/`onBlur`, so the `border-color` transition never fired.
- **`OnboardingFlow.tsx`** — `inputStyle` (onboarding inputs). Its `onFocus`/`onBlur` only drive autocomplete state, not a focus ring.

Removing `outline: 'none'` restores the app-standard **2px accent focus ring** — the exact mechanism by which the other 6 inputs were already fixed. Value-neutral otherwise; no layout change.

## Not in scope (flagged for follow-up)

- `.assignment-grade-input:focus` (`globals.css:283`) uses `outline:none` with only a subtle border-opacity bump (10%→18%) as its focus indicator — weak but present, and an intentional dense-table design. Left as-is; could be strengthened in a later a11y-polish pass.
- `.glass-input:focus` and `Dialog.tsx:142` keep `outline:none` legitimately (former has a `box-shadow` ring; latter is the `tabIndex=-1` dialog panel).

## Test plan

- Frontend CI (`npm ci` + build/lint) is the gate; the change only deletes two style properties.
- Manual check (not run locally — `frontend` deps aren't installed here): tab into a careers-application field / onboarding input → a 2px accent ring should appear, matching every other input in the app. Happy to spin up the app for a visual confirmation if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
