### PR TITLE
fix(frontend): guard prod builds against staging deploy-config leak

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 // The dev-mode OpenNext hook lets `next dev` continue to work locally
 // against Cloudflare bindings (R2/KV/env vars). Safe no-op in prod builds.
 import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
+import { checkFrontendDeployEnv } from "./src/lib/deployGuard";
 
 // .trim() defends against a stray leading/trailing space in the build
 // variable: an untrimmed " https://..." makes the /api rewrite destination
@@ -34,6 +35,21 @@ if (process.env.NODE_ENV === "production") {
         JSON.stringify(process.env.BACKEND_URL) +
         ". A stray leading/trailing space is the usual cause (Next then rejects the " +
         "/api rewrite as 'Invalid rewrite found') — check the Cloudflare Workers Builds variable.",
+    );
+  }
+
+  // Guard against the "staging config on the prod worker" footgun: the prod
+  // `frontend` Workers Build once deployed with `--env staging`, baking staging
+  // API URLs + a `.staging` cookie domain onto saplinglearn.com and breaking
+  // sign-in. Fail the build if the deploy variables mix environments, or (when
+  // DEPLOY_ENV is set) don't match the intended one.
+  const deployProblems = checkFrontendDeployEnv(process.env);
+  if (deployProblems.length) {
+    throw new Error(
+      "Frontend deploy-config guard failed:\n  - " +
+        deployProblems.join("\n  - ") +
+        "\nCheck the Cloudflare Workers Build variables and deploy command " +
+        "(prod: 'npx wrangler deploy'; staging: 'npx wrangler deploy --env staging').",
     );
   }
 }

--- a/frontend/src/lib/deployGuard.test.ts
+++ b/frontend/src/lib/deployGuard.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { checkFrontendDeployEnv } from './deployGuard';
+
+const PROD = {
+  NEXT_PUBLIC_API_URL: 'https://api.saplinglearn.com',
+  BACKEND_URL: 'https://api.saplinglearn.com',
+  COOKIE_DOMAIN: '.saplinglearn.com',
+};
+const STAGING = {
+  NEXT_PUBLIC_API_URL: 'https://api.staging.saplinglearn.com',
+  BACKEND_URL: 'https://api.staging.saplinglearn.com',
+  COOKIE_DOMAIN: '.staging.saplinglearn.com',
+};
+
+describe('checkFrontendDeployEnv', () => {
+  it('passes a clean prod config', () => {
+    expect(checkFrontendDeployEnv(PROD)).toEqual([]);
+  });
+
+  it('passes a clean staging config', () => {
+    expect(checkFrontendDeployEnv(STAGING)).toEqual([]);
+  });
+
+  it('passes prod values with a matching DEPLOY_ENV', () => {
+    expect(checkFrontendDeployEnv({ ...PROD, DEPLOY_ENV: 'production' })).toEqual([]);
+  });
+
+  it('flags split-brain: prod API URL with a staging cookie domain', () => {
+    const problems = checkFrontendDeployEnv({ ...PROD, COOKIE_DOMAIN: '.staging.saplinglearn.com' });
+    expect(problems.some((p) => /mix environments/.test(p))).toBe(true);
+  });
+
+  it('catches the real bug: all-staging values on a prod deploy (DEPLOY_ENV=production)', () => {
+    const problems = checkFrontendDeployEnv({ ...STAGING, DEPLOY_ENV: 'production' });
+    expect(problems.some((p) => /DEPLOY_ENV=production/.test(p))).toBe(true);
+  });
+
+  it('rejects an unknown DEPLOY_ENV', () => {
+    const problems = checkFrontendDeployEnv({ ...PROD, DEPLOY_ENV: 'prod' });
+    expect(problems.some((p) => /DEPLOY_ENV must be one of/.test(p))).toBe(true);
+  });
+
+  it('is a no-op when the variables are unset (local/dev build)', () => {
+    expect(checkFrontendDeployEnv({})).toEqual([]);
+  });
+
+  it('ignores non-canonical values (e.g. a preview URL) rather than failing', () => {
+    expect(
+      checkFrontendDeployEnv({ NEXT_PUBLIC_API_URL: 'https://preview.example.workers.dev' }),
+    ).toEqual([]);
+  });
+
+  it('tolerates case/whitespace differences in values', () => {
+    expect(
+      checkFrontendDeployEnv({
+        NEXT_PUBLIC_API_URL: '  https://API.saplinglearn.com  ',
+        COOKIE_DOMAIN: '.saplinglearn.com',
+        DEPLOY_ENV: 'production',
+      }),
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/lib/deployGuard.ts
+++ b/frontend/src/lib/deployGuard.ts
@@ -1,0 +1,107 @@
+/**
+ * Fail-loud guard against the "staging config on the prod worker" footgun.
+ *
+ * The prod `frontend` Cloudflare Workers Build's deploy step was set to
+ * `npx wrangler deploy --env staging`, which applied wrangler.toml's
+ * `[env.staging.vars]` — staging API URLs and a `.staging.saplinglearn.com`
+ * cookie domain — to the PROD worker (wrangler even warned it overrode the
+ * worker name from "frontend-staging" back to "frontend"). Sign-in then broke
+ * on saplinglearn.com: the middleware routed auth to the staging backend and
+ * the `sapling_session` cookie was scoped to `.staging`, so it never stuck.
+ *
+ * NEXT_PUBLIC_API_URL is inlined and the `/api` rewrite bakes BACKEND_URL at
+ * BUILD time — wrangler.toml `[vars]` are runtime-only and can't fix a bad
+ * build after the fact. This guard runs during `next build` and turns the
+ * silent environment mixup into a hard failure.
+ */
+
+export const FRONTEND_ENVS = {
+  production: {
+    apiUrl: 'https://api.saplinglearn.com',
+    cookieDomain: '.saplinglearn.com',
+  },
+  staging: {
+    apiUrl: 'https://api.staging.saplinglearn.com',
+    cookieDomain: '.staging.saplinglearn.com',
+  },
+} as const;
+
+export type FrontendEnv = keyof typeof FRONTEND_ENVS;
+
+// Reads NEXT_PUBLIC_API_URL, BACKEND_URL, COOKIE_DOMAIN and DEPLOY_ENV. Typed as
+// a plain record so both `process.env` (index-signature only) and test fixtures
+// are accepted.
+type EnvSource = Readonly<Record<string, string | undefined>>;
+
+/** Match a value to a known environment, or null (empty / non-canonical). */
+function classify(
+  value: string | undefined,
+  field: 'apiUrl' | 'cookieDomain',
+): FrontendEnv | null {
+  const v = (value ?? '').trim().toLowerCase();
+  if (!v) return null;
+  for (const env of Object.keys(FRONTEND_ENVS) as FrontendEnv[]) {
+    if (FRONTEND_ENVS[env][field].toLowerCase() === v) return env;
+  }
+  // Non-canonical (e.g. a *.workers.dev preview URL): not this guard's call to reject.
+  return null;
+}
+
+/**
+ * Check the frontend deploy variables. Returns a list of problems (empty = OK).
+ * Pure — takes an env bag so it is unit-testable.
+ */
+export function checkFrontendDeployEnv(env: EnvSource): string[] {
+  const problems: string[] = [];
+
+  const classified: Partial<
+    Record<'NEXT_PUBLIC_API_URL' | 'BACKEND_URL' | 'COOKIE_DOMAIN', FrontendEnv>
+  > = {};
+  const api = classify(env.NEXT_PUBLIC_API_URL, 'apiUrl');
+  const backend = classify(env.BACKEND_URL, 'apiUrl');
+  const cookie = classify(env.COOKIE_DOMAIN, 'cookieDomain');
+  if (api) classified.NEXT_PUBLIC_API_URL = api;
+  if (backend) classified.BACKEND_URL = backend;
+  if (cookie) classified.COOKIE_DOMAIN = cookie;
+
+  // 1. Consistency (always on, no config needed): every canonical value must
+  //    name the SAME environment. Catches split-brain like a prod API URL with
+  //    a `.staging` cookie domain.
+  const distinct = new Set(Object.values(classified));
+  if (distinct.size > 1) {
+    const detail = Object.entries(classified)
+      .map(([k, v]) => `${k}→${v}`)
+      .join(', ');
+    problems.push(
+      `deploy variables mix environments (${detail}); NEXT_PUBLIC_API_URL, BACKEND_URL ` +
+        'and COOKIE_DOMAIN must all target one environment',
+    );
+  }
+
+  // 2. Explicit lock (opt-in via DEPLOY_ENV): every canonical value must match
+  //    the named environment. This is what catches an all-staging build shipped
+  //    to the prod worker — the exact bug — which check #1 alone cannot see
+  //    (all-staging is internally consistent). Set DEPLOY_ENV=production on the
+  //    prod Workers Build and DEPLOY_ENV=staging on the staging one.
+  const deployEnv = (env.DEPLOY_ENV ?? '').trim().toLowerCase();
+  if (deployEnv) {
+    if (!(deployEnv in FRONTEND_ENVS)) {
+      problems.push(
+        `DEPLOY_ENV must be one of ${Object.keys(FRONTEND_ENVS).join(' | ')}, ` +
+          `got ${JSON.stringify(env.DEPLOY_ENV)}`,
+      );
+    } else {
+      const want = FRONTEND_ENVS[deployEnv as FrontendEnv];
+      const mismatched = Object.entries(classified).filter(([, v]) => v !== deployEnv);
+      if (mismatched.length) {
+        const detail = mismatched.map(([k, v]) => `${k}→${v}`).join(', ');
+        problems.push(
+          `DEPLOY_ENV=${deployEnv} but ${detail} point elsewhere; expected ` +
+            `NEXT_PUBLIC_API_URL/BACKEND_URL=${want.apiUrl}, COOKIE_DOMAIN=${want.cookieDomain}`,
+        );
+      }
+    }
+  }
+
+  return problems;
+}


### PR DESCRIPTION
## Problem
The prod `frontend` Cloudflare Workers Build's deploy step was `npx wrangler deploy --env staging`. That applied `wrangler.toml`'s `[env.staging.vars]` — staging API URLs + a `.staging.saplinglearn.com` cookie domain — to the **prod** worker (wrangler even logged that it overrode the worker name `frontend-staging` → `frontend`). Sign-in on `saplinglearn.com` broke: the middleware routed auth to the staging backend and the `sapling_session` cookie was scoped to `.staging`, so it never stuck.

These values bake at **build** time (`NEXT_PUBLIC_API_URL` is inlined; the `/api` rewrite uses `BACKEND_URL`), so runtime `wrangler.toml [vars]` couldn't correct a build that already shipped the wrong values.

## Fix
Add `checkFrontendDeployEnv()` (`src/lib/deployGuard.ts`), called from `next.config.ts` on production builds (alongside the existing `BACKEND_URL` guard):

- **Consistency (always on, no config):** fail if `NEXT_PUBLIC_API_URL` / `BACKEND_URL` / `COOKIE_DOMAIN` describe more than one environment (e.g. prod API URL + `.staging` cookie domain).
- **Env-lock (opt-in via `DEPLOY_ENV`):** when set, fail if any value doesn't match that environment — this catches an *all-staging* build shipped to the prod worker (the exact bug), which the consistency check alone can't detect.

## Operator follow-up (not code — do in the Cloudflare dashboard)
1. Prod `frontend` Workers Build → **Deploy command**: `npx wrangler deploy --env staging` → **`npx wrangler deploy`**.
2. Set `DEPLOY_ENV=production` (prod build var) and `DEPLOY_ENV=staging` (staging build var) to activate the exact-match check.

## Tests
`src/lib/deployGuard.test.ts` — 9 cases: clean prod/staging, matching `DEPLOY_ENV`, split-brain mix, all-staging-on-prod, bad `DEPLOY_ENV`, unset/no-op (local dev), non-canonical preview URLs, whitespace/case tolerance. `tsc --noEmit` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger production build checks for frontend deployments.
  * Deployment settings are now validated together to catch mismatched staging/prod configurations earlier.
* **Bug Fixes**
  * Builds now fail with clear guidance when deployment variables don’t align.
  * Improved handling of unknown or preview values so they don’t trigger false failures.
* **Tests**
  * Added coverage for matching, mismatched, and malformed deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->