### PR TITLE
fix(ui): clear landing neon-blue + gradebook category stripe (closes #106, #112)

### DIFF
--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -15,8 +15,8 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5000';
 
 const SCRAMBLE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!<>-_\\/[]{}=+*^?#_";
 
-const CLUSTER_COLORS = ['#9CA3AF', '#D97706', '#3B82F6', '#8A63D2', '#14B8A6', '#EF4444'];
-const OB_STEP_COLORS  = ['#D97706', '#8A63D2', '#3B82F6', '#14B8A6', '#EF4444'];
+const CLUSTER_COLORS = ['#9CA3AF', '#D97706', '#3e6f8a', '#8A63D2', '#14B8A6', '#EF4444'];
+const OB_STEP_COLORS  = ['#D97706', '#8A63D2', '#3e6f8a', '#14B8A6', '#EF4444'];
 const CLUSTER_SEEDS_BG = [10.0, 11.3, 12.6, 13.9, 15.2, 16.5];
 const CLUSTER_INIT_POS = [
   { ox: -222, oy: -29, oz:  15 },
@@ -197,7 +197,7 @@ export default function LandingPage() {
     let animId: number;
 
     const palette = [
-      { c: '#8A63D2', w: 0.24 }, { c: '#3B82F6', w: 0.24 },
+      { c: '#8A63D2', w: 0.24 }, { c: '#3e6f8a', w: 0.24 },
       { c: '#D97706', w: 0.20 }, { c: '#14B8A6', w: 0.15 },
       { c: '#9CA3AF', w: 0.10 }, { c: '#D1D5DB', w: 0.07 },
     ];

--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -15,6 +15,9 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5000';
 
 const SCRAMBLE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!<>-_\\/[]{}=+*^?#_";
 
+// Hand-tuned atmospheric orb palettes, hardcoded because they feed canvas
+// fillStyle where CSS var() doesn't resolve. #3e6f8a mirrors --info in
+// globals.css — the muted blue chosen to de-neon the old #3B82F6 (#106).
 const CLUSTER_COLORS = ['#9CA3AF', '#D97706', '#3e6f8a', '#8A63D2', '#14B8A6', '#EF4444'];
 const OB_STEP_COLORS  = ['#D97706', '#8A63D2', '#3e6f8a', '#14B8A6', '#EF4444'];
 const CLUSTER_SEEDS_BG = [10.0, 11.3, 12.6, 13.9, 15.2, 16.5];
@@ -196,6 +199,7 @@ export default function LandingPage() {
     let rotAngle = 0;
     let animId: number;
 
+    // #3e6f8a mirrors --info (globals.css); literal because canvas can't resolve var().
     const palette = [
       { c: '#8A63D2', w: 0.24 }, { c: '#3e6f8a', w: 0.24 },
       { c: '#D97706', w: 0.20 }, { c: '#14B8A6', w: 0.15 },

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -524,7 +524,7 @@ body { font-size: 14px; line-height: 1.5; }
 
 .landing-intro-orbit-node--green  { background: var(--brand-forest);  top: -3px;  left: 50%; transform: translateX(-50%); }
 .landing-intro-orbit-node--amber  { background: #D97706;  right: -3px; top: 45%; transform: translateY(-50%); }
-.landing-intro-orbit-node--blue   { background: #3B82F6;  bottom: -3px; left: 35%; transform: translateX(-50%); }
+.landing-intro-orbit-node--blue   { background: var(--info);  bottom: -3px; left: 35%; transform: translateX(-50%); }
 .landing-intro-orbit-node--purple { background: #8A63D2;  left: -3px; top: 30%; transform: translateY(-50%); }
 
 /* ── Button shimmer ────────────────────────────────────────────── */
@@ -860,7 +860,7 @@ input[type="reset"]:disabled {
 .landing-page .landing-intro-orbit-node { position: absolute; width: 10px; height: 10px; border-radius: 999px; }
 .landing-page .landing-intro-orbit-node--green  { background: var(--brand-forest);  top: -3px;  left: 50%; transform: translateX(-50%); }
 .landing-page .landing-intro-orbit-node--amber  { background: #D97706;  right: -3px; top: 45%; transform: translateY(-50%); }
-.landing-page .landing-intro-orbit-node--blue   { background: #3B82F6;  bottom: -3px; left: 35%; transform: translateX(-50%); }
+.landing-page .landing-intro-orbit-node--blue   { background: var(--info);  bottom: -3px; left: 35%; transform: translateX(-50%); }
 .landing-page .landing-intro-orbit-node--purple { background: #8A63D2;  left: -3px; top: 30%; transform: translateY(-50%); }
 
 /* Button shimmer. */

--- a/frontend/src/components/Gradebook/AssignmentList.tsx
+++ b/frontend/src/components/Gradebook/AssignmentList.tsx
@@ -354,6 +354,10 @@ function CategoryGroup({
         }}
       >
         <span
+          aria-hidden="true"
+          style={{ width: 8, height: 8, borderRadius: "50%", background: color, flexShrink: 0 }}
+        />
+        <span
           className="mono"
           style={{
             fontSize: 11,
@@ -401,7 +405,7 @@ function CategoryGroup({
           listStyle: "none",
           margin: 0,
           padding: "0 0 0 20px",
-          borderLeft: `2px solid ${color}`,
+          borderLeft: "1px solid var(--border)",
           display: "flex",
           flexDirection: "column",
         }}


### PR DESCRIPTION
## What & why

Clears the last residuals on two frontend-audit issues that were **mostly already resolved on `main`** (by #102's glass removal, the token migration, and prior polish). Verified each acceptance box, then fixed only what genuinely remained.

Closes #106
Closes #112

## #106 — landing hero glass cards + neon-blue accents

| AC | State on `main` | This PR |
|---|---|---|
| No big-number stat tiles in the hero | ✅ already done (#102 removed them; the two floating cards are now a color legend + action chips, no numbers, opaque `--bg-panel`) | — |
| No `#3B82F6` neon-blue on hero surfaces | ❌ residual: the intro-orbit blue node + hero-canvas graph palette | **fixed** |

- `globals.css`: `.landing-intro-orbit-node--blue` → `background: var(--info)` (both the base rule and the `.landing-page`-scoped duplicate).
- `(public)/page.tsx`: the hero-canvas `palette`, `CLUSTER_COLORS`, and `OB_STEP_COLORS` blue entries → `#3e6f8a` (the concrete `--info` value — these are JS canvas / inline sinks where `var()` doesn't resolve). This is exactly the shift the issue's Fix note requested ("toward the warmer `--info #3e6f8a`").

## #112 — polish (side-stripes / white panels / easing / Inter)

| AC | State on `main` | This PR |
|---|---|---|
| No `border-left/right > 1px` colored accent stripes | ❌ one left: the gradebook category list | **fixed** |
| Panels/inputs tinted off pure white | ✅ done (`--bg-panel`/`--bg-input` = `#fdfcf9` warm paper) | — |
| `--ease` used instead of overshoot easing | ✅ cited CSS overshoot removed → `var(--ease)` | — |
| Inter removed; `--font-inter` → DM Sans | ✅ done (Inter dropped from `layout.tsx`; `--font-inter` → `--font-sans`) | — |

- `Gradebook/AssignmentList.tsx`: the category `<ul>` used `borderLeft: 2px solid ${color}` as its **only** category-color indicator. Moved the color to a **leading dot** in the category header (the treatment the issue recommends, matching the existing `AchievementUnlockToast` dot) and made the list border a **1px neutral `--border`** divider. No information lost.

## Not in scope (flagged, deliberate)

- **`OnboardingFlow.tsx:12`** still has `#3B82F6` for the "Academics" onboarding step — a categorical step color in the onboarding modal, a *separate* surface from #106's hero. Left as-is; trivial follow-up if the team wants it to match the landing's shifted blue.
- **`HowItWorks.tsx`** framer-motion `[0.34, 1.56, 0.64, 1]` overshoot curves are a deliberate landing spring-reveal motion (12 of them), not the CSS hover overshoot #112 targeted (which is fixed). Left intentionally.

## Test plan

- Frontend CI (`npm ci` + build/lint) is the gate; changes are color-value swaps + one standard JSX dot span (mirrors `AchievementUnlockToast`).
- No functional/layout change beyond the intended visuals; `--info` and `#3e6f8a` are the same color, so the orbit node + canvas stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
