### PR TITLE
fix(a11y): 44px touch targets for mobile nav (#110, part 1)

### DIFF
--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -138,8 +138,8 @@ export function TopNav() {
             aria-expanded={mobileOpen}
             onClick={() => setMobileOpen((o) => !o)}
             style={{
-              padding: 6, display: "flex", flexDirection: "column", gap: 4,
-              width: 28, alignItems: "center",
+              padding: 6, display: "flex", flexDirection: "column", justifyContent: "center", gap: 4,
+              minWidth: 44, minHeight: 44, alignItems: "center",
             }}
           >
             {[0, 1, 2].map((i) => (
@@ -215,7 +215,7 @@ export function TopNav() {
               title="Settings"
               style={{
                 display: "inline-flex", alignItems: "center", justifyContent: "center",
-                width: 32, height: 32, borderRadius: "var(--r-sm)",
+                width: 44, height: 44, borderRadius: "var(--r-sm)",
                 color: pathname.startsWith("/settings") ? "var(--text)" : "var(--text-muted)",
                 transition: "background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease)",
               }}
@@ -231,7 +231,7 @@ export function TopNav() {
                 title="Admin"
                 style={{
                   display: "inline-flex", alignItems: "center", justifyContent: "center",
-                  width: 32, height: 32, borderRadius: "var(--r-sm)",
+                  width: 44, height: 44, borderRadius: "var(--r-sm)",
                   color: pathname.startsWith("/admin") ? "var(--text)" : "var(--text-muted)",
                   transition: "background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease)",
                 }}
@@ -471,7 +471,7 @@ function MobilePanel({ pathname }: { pathname: string }) {
                 href={item.href}
                 style={{
                   display: "flex", alignItems: "center", gap: 10,
-                  padding: "10px 14px",
+                  padding: "10px 14px", minHeight: 44, boxSizing: "border-box",
                   fontSize: 14, fontWeight: itemActive ? 700 : 500,
                   color: itemActive ? "var(--text)" : "var(--text-dim)",
                   textDecoration: "none",


### PR DESCRIPTION
Part of #110 (touch-target half). Brings the genuine **mobile touch surfaces** in `TopNav` to the 44×44 minimum, keeping the existing icon sizes centered in the enlarged hit area:

- Hamburger: ~28×26 → 44×44 (bars centered)
- Settings + Admin icon links: 32×32 → 44×44
- Mobile menu rows: ~37px → `minHeight: 44`

**Verified locally:** `npm run typecheck` clean; `eslint` on the file has 0 errors (1 pre-existing `<img>` warning, unrelated).

**Deliberately not here** (flagged for follow-up):
- **SideNav** is the desktop sidebar (mouse; already meets the AA 24px floor). Forcing 44px there needs a visual pass on the compact layout.
- **SSR desktop-FOUC** (the other half of #110) is a separate change — needs an SSR/`useIsMobile` rework (`useState(false)` currently renders desktop on the server, then snaps on hydration). Tracked, not in this PR.

So #110 stays open; this is the low-risk touch-target slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)