### PR TITLE
perf(images): lazy-load below-the-fold remote images (#111, part 1)

### DIFF
--- a/frontend/src/components/MarkdownChat.tsx
+++ b/frontend/src/components/MarkdownChat.tsx
@@ -199,6 +199,7 @@ const COMPONENTS: Components = {
     <img
       src={typeof src === "string" ? src : undefined}
       alt={alt || ""}
+      loading="lazy"
       style={{
         maxWidth: "100%",
         height: "auto",

--- a/frontend/src/components/screens/Admin.tsx
+++ b/frontend/src/components/screens/Admin.tsx
@@ -938,7 +938,7 @@ function CosmeticsTab() {
               />
             </div>
             {form.asset_url && (
-              <img src={form.asset_url} alt="" style={{ maxHeight: 56, marginTop: 6, borderRadius: "var(--r-sm)", border: "1px solid var(--border)" }} />
+              <img src={form.asset_url} alt="" loading="lazy" style={{ maxHeight: 56, marginTop: 6, borderRadius: "var(--r-sm)", border: "1px solid var(--border)" }} />
             )}
           </LabeledField>
         )}
@@ -985,7 +985,7 @@ function CosmeticsTab() {
               <CatalogRow
                 key={c.id}
                 left={c.asset_url ? (
-                  <img src={c.asset_url} alt="" style={{ width: 28, height: 28, borderRadius: "var(--r-sm)", objectFit: "cover", border: "1px solid var(--border)" }} />
+                  <img src={c.asset_url} alt="" width={28} height={28} loading="lazy" style={{ width: 28, height: 28, borderRadius: "var(--r-sm)", objectFit: "cover", border: "1px solid var(--border)" }} />
                 ) : c.css_value ? (
                   <span style={{ padding: "2px 6px", fontSize: 10, borderRadius: "var(--r-sm)", background: c.css_value, color: "#fff", border: "1px solid var(--border)" }}>
                     sample

--- a/frontend/src/components/screens/Settings.tsx
+++ b/frontend/src/components/screens/Settings.tsx
@@ -878,6 +878,7 @@ function CosmeticPreview({
           <img
             src={cosmetic.asset_url}
             alt=""
+            loading="lazy"
             style={{ position: "absolute", inset: 0, width: "100%", height: "100%", pointerEvents: "none", objectFit: "contain" }}
           />
         )}
@@ -887,7 +888,7 @@ function CosmeticPreview({
   if (cosmetic.type === "banner" && cosmetic.asset_url) {
     return (
       <div style={{ width: "100%", height: 48, borderRadius: "var(--r-sm)", overflow: "hidden", border: "1px solid var(--border)" }}>
-        <img src={cosmetic.asset_url} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+        <img src={cosmetic.asset_url} alt="" loading="lazy" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
       </div>
     );
   }

--- a/frontend/src/components/screens/Social.tsx
+++ b/frontend/src/components/screens/Social.tsx
@@ -495,7 +495,7 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
                     }}
                   >
                     {m.image_url && (
-                      <img src={m.image_url} alt="attachment" style={{ maxWidth: 260, borderRadius: "var(--r-sm)", marginBottom: m.text ? 6 : 0 }} />
+                      <img src={m.image_url} alt="attachment" loading="lazy" style={{ maxWidth: 260, borderRadius: "var(--r-sm)", marginBottom: m.text ? 6 : 0 }} />
                     )}
                     {renderText(m.text)}
                     {m.edited_at && <span style={{ fontSize: 10, opacity: 0.6, marginLeft: 6 }}>(edited)</span>}


### PR DESCRIPTION
Part of #111 (image-loading slice). Adds `loading="lazy"` to the 6 remote/user-content `<img>` elements that render below the fold: Social chat attachments, MarkdownChat markdown images, Settings cosmetic overlay + banner, Admin cosmetic preview + catalog thumbnails. The fixed 28×28 catalog thumb also gets `width`/`height` attrs to reserve space.

Responsive images get lazy only — forced fixed dims would distort them; their space is already reserved by the parent.

**Verified locally:** `npm run typecheck` clean; `eslint` 0 errors on the changed files (pre-existing `no-img-element` warnings unchanged).

**Deliberately not here** (the rest of #111):
- Runtime-animation perf — landing-canvas reduced-motion guard, per-frame `shadowBlur`/`querySelectorAll`, atmospheric-orb throttle, KnowledgeGraph2D per-tick re-render. Real work, separate PR.
- Full `next/image` — non-trivial on OpenNext/Cloudflare (no built-in optimizer; needs a custom loader).

So #111 stays open; this is the low-risk lazy-loading slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)