### PR TITLE
docs(followups): correct #292 — OnboardingFlow.tsx is still wired into the landing route

### DIFF
--- a/docs/superpowers/followups/2026-06-30-token-unification-followups.md
+++ b/docs/superpowers/followups/2026-06-30-token-unification-followups.md
@@ -27,8 +27,11 @@ Each is its own plan / PR. Severity tags map to `docs/frontend-rhythm-audit.md`.
       brief "you're in ✓" confirmation beat so the beta→pending transition isn't glow→silence.
 - [ ] **[P2-G] Normalize pre-auth motion** to one or two finite, purposeful moments
       (mesh blobs `sapling-blob`, `landing-card-float`, shimmer are currently infinite loops).
-- [ ] **[P2-I] Delete dead code** `components/OnboardingFlow.tsx` (36 KB, unused old-DNA onboarding
-      not imported by the active route).
+- [ ] **[P2-I] Delete dead code** `components/OnboardingFlow.tsx` (36 KB, old-DNA onboarding).
+      ⚠️ **Correction (2026-07-07):** this component is **not** actually dead — it is still imported
+      and rendered by the active public landing route (`app/(public)/page.tsx`: `import` at L7,
+      rendered at L1247 under `onboardingPhase !== 'idle'`). It must be **unwired from the landing
+      page first**, or deletion breaks the build. Re-scope #292 to "unwire, then delete." (#292)
 
 ## Directory / structural hygiene
 


### PR DESCRIPTION
## What
The token-unification follow-up **[P2-I]** described `components/OnboardingFlow.tsx` as dead code *"not imported by the active route."*

## Finding
It is actually **still imported and rendered** by the public landing page:
- `frontend/src/app/(public)/page.tsx` — `import OnboardingFlow` at **L7**
- rendered at **L1247** under `onboardingPhase !== 'idle'`

True on both `refactor/token-unification` and `main`. Deleting it as-is **breaks the build**.

## Change
Docs-only: re-scope the follow-up to *"unwire from the landing page first, then delete"* so #292 isn't actioned as a blind delete.

Refs #292

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>