### PR TITLE
chore(lint): fix ruff violations in RAG scripts unblocking main CI

### DIFF
--- a/backend/scripts/benchmark_rag.py
+++ b/backend/scripts/benchmark_rag.py
@@ -8,7 +8,6 @@ Run from backend/:
 """
 
 import argparse
-import os
 import sys
 import textwrap
 from pathlib import Path
@@ -23,8 +22,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from dotenv import load_dotenv
 load_dotenv(Path(__file__).parent.parent / ".env.staging")  # use staging DB
 
-from routes.learn import _get_catalog_chunk
-from services.gemini_service import call_gemini
+from routes.learn import _get_catalog_chunk  # noqa: E402
+from services.gemini_service import call_gemini  # noqa: E402
 
 
 # ── Ground-truth test cases ────────────────────────────────────────────────────
@@ -519,7 +518,7 @@ def main() -> None:
     if filter_course:
         print(f"Filtered to: {filter_course}")
 
-    chunk_results = run_chunk_tests(cases)
+    run_chunk_tests(cases)
 
     if not args.chunks_only:
         llm_results = run_llm_tests(cases, filter_course=filter_course)

--- a/backend/scripts/ingest_catalog.py
+++ b/backend/scripts/ingest_catalog.py
@@ -27,7 +27,7 @@ from google.genai import types as genai_types
 load_dotenv(Path(__file__).parent.parent / ".env")
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from db.connection import table
+from db.connection import table  # noqa: E402
 
 # ── Config ─────────────────────────────────────────────────────────────────────
 
@@ -144,7 +144,7 @@ def main() -> None:
         rec["embedding"] = vec
 
     # Upsert to Supabase in batches of BATCH_SIZE
-    print(f"\nUpserting to course_chunks...")
+    print("\nUpserting to course_chunks...")
     db = table("course_chunks")
     inserted = 0
 

--- a/backend/scripts/scrape_bu_catalog.py
+++ b/backend/scripts/scrape_bu_catalog.py
@@ -13,7 +13,6 @@ Resume: re-running skips already-scraped URLs automatically.
 import asyncio
 import json
 import re
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -349,7 +348,7 @@ async def main() -> None:
         for school in SCHOOLS:
             print(f"\n>> {school}", flush=True)
             before = len(all_courses)
-            school_courses = await scrape_school(client, school, seen_urls, on_batch=save_checkpoint)
+            await scrape_school(client, school, seen_urls, on_batch=save_checkpoint)
             print(f"  [{school}] +{len(all_courses) - before} -> total {len(all_courses)}", flush=True)
 
     elapsed = (datetime.now(timezone.utc) - start).total_seconds()


### PR DESCRIPTION
main’s CI **Backend (pytest)** job has been red since the RAG pipeline scripts landed (~Jul 3): 8 un-baselined ruff errors made `ruff check .` exit 1, which **skips pytest entirely**. Because `main` isn’t a protected branch, merges kept going through the red and it went unnoticed — and every open PR inherits the failure via the `pull_request` merge check.

## Violations fixed (all pre-existing on `main`, behavior-preserving)
| File | Rule | Fix |
|---|---|---|
| `scripts/benchmark_rag.py` | F401 | drop unused `import os` |
| | E402 ×2 | `# noqa: E402` on the two intentional post-`sys.path` imports |
| | F841 | drop unused `chunk_results` binding (keeps the side-effecting `run_chunk_tests(cases)` call) |
| `scripts/ingest_catalog.py` | E402 | `# noqa: E402` on the post-`sys.path` import |
| | F541 | drop stray `f` prefix on a placeholder-less string |
| `scripts/scrape_bu_catalog.py` | F401 | drop unused `import sys` |
| | F841 | drop unused `school_courses` binding (keeps the side-effecting `scrape_school(...)` call) |

No behavior change — only unused bindings/imports removed and intentional bootstrap imports annotated.

## Verification
`ruff 0.15.20 check .` (same version + `ruff.toml` as CI) → **All checks passed.** This PR’s own CI should now run pytest (previously skipped) and go green, un-reding the whole PR backlog’s Backend job.

@Darkest-Teddy heads-up — these are your RAG scripts; open PRs (#318/#323) may need a trivial rebase after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)