### PR TITLE
AI Session Interface Update for Knowledge Graph

### DIFF
--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -31,6 +31,7 @@ AgentTask = Literal[
     "note_summary", "note_concepts", "note_chat",
     "study_guide", "social_summary",
     "course_summary", "quiz_context",
+    "concept_scan",
 ]
 
 
@@ -62,6 +63,10 @@ _DEFAULTS: dict[AgentTask, str] = {
     "course_summary": "gemini-2.5-flash",
     # Quiz-context notes are short structured extraction → the lite tier.
     "quiz_context": "gemini-2.5-flash-lite",
+    # Scan-concepts extends an existing course concept set from a short
+    # context (existing concepts + optional doc summary) → the cheap lite
+    # tier, matching the MODEL_LITE the legacy path used.
+    "concept_scan": "gemini-2.5-flash-lite",
 }
 
 

--- a/backend/agents/concept_scan.py
+++ b/backend/agents/concept_scan.py
@@ -1,0 +1,63 @@
+"""Concept-scan agent.
+
+Replaces routes/documents.py::_extend_course_concepts' call_gemini_json
+call. Given a course label, the concepts already in the student's graph,
+and optionally a document's summary/notes, it returns the NEW concepts to
+add — names only, deduplicated against the existing set, possibly empty.
+
+Names-only output (list[str]) matches what the /scan-concepts graph write
+consumes; descriptions/importance would be discarded (see the design spec).
+Tool-less: the existing-concepts set is a deterministic query the route
+already runs and passes in the message — the model has nothing to decide
+about fetching it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+from agents._providers import model_for
+from agents.deps import SaplingDeps
+
+
+class NewConcepts(BaseModel):
+    """Typed output: new concept names to add to the course graph."""
+
+    concepts: list[str] = Field(
+        default_factory=list,
+        max_length=15,
+        description=(
+            "New concept names not already in the course graph. Empty when "
+            "the existing set already covers the material."
+        ),
+    )
+
+
+_SYSTEM_PROMPT = (
+    "You curate the concept set for a student's course knowledge graph. "
+    "You are given the course label, the concepts already in the graph, "
+    "and optionally a document's title, summary, and already-extracted "
+    "concepts.\n\n"
+    "Return between 0 and 15 NEW concepts that belong in this course's "
+    "graph but are not already in the existing list.\n"
+    "- If the existing set already covers the relevant material, return an "
+    "empty list.\n"
+    "- Each concept is a short Title Case noun phrase (e.g. 'Linear "
+    "Regression', 'Big-O Analysis').\n"
+    "- Do NOT repeat or paraphrase any existing concept.\n"
+    "- No assignment titles, week labels, page numbers, problem numbers, "
+    "or administrative items."
+)
+_PROMPT_HASH = hashlib.sha256(_SYSTEM_PROMPT.encode("utf-8")).hexdigest()[:12]
+
+
+concept_scan_agent = Agent[SaplingDeps, NewConcepts](
+    model=model_for("concept_scan"),
+    deps_type=SaplingDeps,
+    output_type=NewConcepts,
+    system_prompt=_SYSTEM_PROMPT,
+    metadata={"prompt_version": _PROMPT_HASH, "agent": "concept_scan"},
+)

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -49,6 +49,8 @@ from agents.syllabus_extraction import syllabus_extraction_agent
 from agents.deps import SaplingDeps
 from agents.document import process_document, DocumentProcessingResult
 from agents.tools.graph import apply_concepts_to_graph
+from agents._run import run_agent_sync
+from agents.concept_scan import concept_scan_agent, NewConcepts
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +154,116 @@ def _extend_course_concepts(
     if not isinstance(raw, dict):
         return []
     return _coerce_str_list(raw.get("concepts"))
+
+
+def _scan_user_message(
+    *,
+    course_label: str,
+    existing_concepts: list[str],
+    doc_filename: str | None = None,
+    doc_summary: str | None = None,
+    doc_concept_notes: list[dict] | None = None,
+) -> str:
+    """Build the concept_scan agent's user message: course label + existing
+    concepts + (optional) document context. Mirrors the legacy prompt's data
+    section so agent and legacy paths see the same signal."""
+    existing_block = (
+        "\n".join(f"- {c}" for c in existing_concepts) if existing_concepts else "(none yet)"
+    )
+    lines = [
+        f'Course: "{course_label}"',
+        "Concepts already in the graph:",
+        existing_block,
+    ]
+    if doc_filename or doc_summary or doc_concept_notes:
+        notes_block = (
+            "\n".join(
+                f"  - {n.get('name', '?')}: {n.get('description', '')[:200]}"
+                for n in (doc_concept_notes or [])
+            )
+            or "  (none)"
+        )
+        lines += [
+            "",
+            "New document being scanned:",
+            f"  Title: {doc_filename or '(untitled)'}",
+            f"  Summary: {doc_summary or '(none)'}",
+            "  Concepts already extracted from this document:",
+            notes_block,
+        ]
+    return "\n".join(lines)
+
+
+async def _extend_via_agent(
+    *,
+    user_id: str,
+    course_id: str,
+    course_label: str,
+    existing_concepts: list[str],
+    doc_filename: str | None = None,
+    doc_summary: str | None = None,
+    doc_concept_notes: list[dict] | None = None,
+) -> list[str]:
+    """Run concept_scan_agent and return new concept names. Raises on agent
+    failure so the sync dispatcher can fall back to legacy."""
+    deps = SaplingDeps(
+        user_id=user_id,
+        course_id=course_id,
+        supabase=None,
+        request_id=current_request_id() or str(uuid.uuid4()),
+    )
+    message = _scan_user_message(
+        course_label=course_label,
+        existing_concepts=existing_concepts,
+        doc_filename=doc_filename,
+        doc_summary=doc_summary,
+        doc_concept_notes=doc_concept_notes,
+    )
+    result = await concept_scan_agent.run(
+        message, deps=deps, usage_limits=WORKER_LIMITS,
+    )
+    return list(result.output.concepts)
+
+
+def _extend_concepts(
+    user_id: str,
+    course_id: str,
+    *,
+    course_label: str,
+    existing_concepts: list[str],
+    doc_filename: str | None = None,
+    doc_summary: str | None = None,
+    doc_concept_notes: list[dict] | None = None,
+) -> list[str]:
+    """Agent-first concept extension with legacy fallback (ADR 0001).
+
+    Sync entry point for the sync /scan-concepts handlers: drives the async
+    agent via run_agent_sync, falling back to the legacy call_gemini_json
+    path on any agent failure.
+    """
+    try:
+        return run_agent_sync(
+            _extend_via_agent(
+                user_id=user_id,
+                course_id=course_id,
+                course_label=course_label,
+                existing_concepts=existing_concepts,
+                doc_filename=doc_filename,
+                doc_summary=doc_summary,
+                doc_concept_notes=doc_concept_notes,
+            )
+        )
+    except (UsageLimitExceeded, UnexpectedModelBehavior):
+        logger.warning("concept_scan agent guardrails tripped; using legacy")
+    except Exception:
+        logger.exception("concept_scan agent failed; using legacy")
+    return _extend_course_concepts(
+        course_label=course_label,
+        existing_concepts=existing_concepts,
+        doc_filename=doc_filename,
+        doc_summary=doc_summary,
+        doc_concept_notes=doc_concept_notes,
+    )
 
 
 def _coerce_concept_notes(value) -> list[dict]:
@@ -1160,7 +1272,9 @@ def _scan_concepts_for_course(
     ) or []
     existing_concepts = [r["concept_name"] for r in existing_rows if r.get("concept_name")]
 
-    concepts = _extend_course_concepts(
+    concepts = _extend_concepts(
+        user_id,
+        course_id,
         course_label=_course_label(course_id),
         existing_concepts=existing_concepts,
         doc_filename=doc_filename,

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -50,7 +50,7 @@ from agents.deps import SaplingDeps
 from agents.document import process_document, DocumentProcessingResult
 from agents.tools.graph import apply_concepts_to_graph
 from agents._run import run_agent_sync
-from agents.concept_scan import concept_scan_agent, NewConcepts
+from agents.concept_scan import concept_scan_agent
 
 logger = logging.getLogger(__name__)
 

--- a/backend/tests/test_concept_scan.py
+++ b/backend/tests/test_concept_scan.py
@@ -1,10 +1,28 @@
 """Tests for the concept_scan agent migration (/scan-concepts)."""
+import pytest
+from pydantic import ValidationError
+from pydantic_ai import Agent
 from pydantic_ai.models.google import GoogleModel
 
 from agents._providers import model_for
+from agents.concept_scan import NewConcepts, concept_scan_agent
 
 
 def test_model_for_concept_scan_defaults_to_flash_lite():
     m = model_for("concept_scan")
     assert isinstance(m, GoogleModel)
     assert m.model_name == "gemini-2.5-flash-lite"
+
+
+def test_new_concepts_allows_empty_list():
+    assert NewConcepts(concepts=[]).concepts == []
+
+
+def test_new_concepts_rejects_more_than_15():
+    with pytest.raises(ValidationError):
+        NewConcepts(concepts=[f"Concept {i}" for i in range(16)])
+
+
+def test_concept_scan_agent_is_configured():
+    assert isinstance(concept_scan_agent, Agent)
+    assert concept_scan_agent.output_type is NewConcepts

--- a/backend/tests/test_concept_scan.py
+++ b/backend/tests/test_concept_scan.py
@@ -1,0 +1,10 @@
+"""Tests for the concept_scan agent migration (/scan-concepts)."""
+from pydantic_ai.models.google import GoogleModel
+
+from agents._providers import model_for
+
+
+def test_model_for_concept_scan_defaults_to_flash_lite():
+    m = model_for("concept_scan")
+    assert isinstance(m, GoogleModel)
+    assert m.model_name == "gemini-2.5-flash-lite"

--- a/backend/tests/test_concept_scan.py
+++ b/backend/tests/test_concept_scan.py
@@ -104,3 +104,33 @@ def test_extend_concepts_falls_back_to_legacy(monkeypatch, exc):
     assert out == ["Legacy Concept"]
     assert captured["course_label"] == "CS101"
     assert captured["existing_concepts"] == ["Recursion"]
+
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_course_scan_endpoint_uses_agent_and_keeps_response_shape():
+    fake = _FakeAgent(result=_Result(["Binary Search", "Hashing"]))
+    with patch("routes.documents._validate_user", return_value=None), \
+         patch("routes.documents._course_label", return_value="CS101"), \
+         patch("routes.documents.apply_graph_update", return_value=None), \
+         patch("routes.documents.concept_scan_agent", fake), \
+         patch("routes.documents.table") as t:
+        t.return_value.select.return_value = [
+            {"id": "n1", "concept_name": "Recursion"},
+        ]
+        r = client.post(
+            "/api/documents/course/c1/scan-concepts",
+            json={"user_id": "u1"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["concepts"] == ["Binary Search", "Hashing"]
+    assert "added" in body and "existing" in body
+    assert fake.calls  # the agent path (not legacy) served the request

--- a/backend/tests/test_concept_scan.py
+++ b/backend/tests/test_concept_scan.py
@@ -1,11 +1,17 @@
 """Tests for the concept_scan agent migration (/scan-concepts)."""
 import pytest
+from unittest.mock import patch
+
 from pydantic import ValidationError
 from pydantic_ai import Agent
+from pydantic_ai.exceptions import UsageLimitExceeded, UnexpectedModelBehavior
 from pydantic_ai.models.google import GoogleModel
+from fastapi.testclient import TestClient
 
 from agents._providers import model_for
 from agents.concept_scan import NewConcepts, concept_scan_agent
+import routes.documents as documents
+from main import app
 
 
 def test_model_for_concept_scan_defaults_to_flash_lite():
@@ -26,10 +32,6 @@ def test_new_concepts_rejects_more_than_15():
 def test_concept_scan_agent_is_configured():
     assert isinstance(concept_scan_agent, Agent)
     assert concept_scan_agent.output_type is NewConcepts
-
-
-import routes.documents as documents
-from pydantic_ai.exceptions import UsageLimitExceeded, UnexpectedModelBehavior
 
 
 class _Result:
@@ -105,12 +107,6 @@ def test_extend_concepts_falls_back_to_legacy(monkeypatch, exc):
     assert captured["course_label"] == "CS101"
     assert captured["existing_concepts"] == ["Recursion"]
 
-
-from unittest.mock import patch
-
-from fastapi.testclient import TestClient
-
-from main import app
 
 client = TestClient(app)
 

--- a/backend/tests/test_concept_scan.py
+++ b/backend/tests/test_concept_scan.py
@@ -26,3 +26,81 @@ def test_new_concepts_rejects_more_than_15():
 def test_concept_scan_agent_is_configured():
     assert isinstance(concept_scan_agent, Agent)
     assert concept_scan_agent.output_type is NewConcepts
+
+
+import routes.documents as documents
+from pydantic_ai.exceptions import UsageLimitExceeded, UnexpectedModelBehavior
+
+
+class _Result:
+    def __init__(self, concepts):
+        self.output = NewConcepts(concepts=concepts)
+
+
+class _FakeAgent:
+    """Stand-in for concept_scan_agent with an async run()."""
+
+    def __init__(self, *, result=None, exc=None):
+        self._result = result
+        self._exc = exc
+        self.calls = []
+
+    async def run(self, message, **kwargs):
+        self.calls.append((message, kwargs))
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+def test_scan_user_message_includes_existing_and_doc_context():
+    msg = documents._scan_user_message(
+        course_label="CS101",
+        existing_concepts=["Recursion"],
+        doc_filename="lecture1.pdf",
+        doc_summary="Intro to sorting algorithms.",
+        doc_concept_notes=[{"name": "Merge Sort", "description": "divide and conquer"}],
+    )
+    assert "CS101" in msg
+    assert "Recursion" in msg
+    assert "lecture1.pdf" in msg
+    assert "Merge Sort" in msg
+
+
+def test_extend_concepts_returns_agent_output(monkeypatch):
+    fake = _FakeAgent(result=_Result(["Binary Search", "Hashing"]))
+    monkeypatch.setattr(documents, "concept_scan_agent", fake)
+    out = documents._extend_concepts(
+        "u1", "c1", course_label="CS101", existing_concepts=["Recursion"],
+    )
+    assert out == ["Binary Search", "Hashing"]
+    assert fake.calls  # agent was actually invoked
+
+
+def test_extend_concepts_handles_empty(monkeypatch):
+    fake = _FakeAgent(result=_Result([]))
+    monkeypatch.setattr(documents, "concept_scan_agent", fake)
+    out = documents._extend_concepts(
+        "u1", "c1", course_label="CS101", existing_concepts=[],
+    )
+    assert out == []
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [UsageLimitExceeded("limit"), UnexpectedModelBehavior("weird"), RuntimeError("boom")],
+)
+def test_extend_concepts_falls_back_to_legacy(monkeypatch, exc):
+    monkeypatch.setattr(documents, "concept_scan_agent", _FakeAgent(exc=exc))
+    captured = {}
+
+    def _legacy(**kwargs):
+        captured.update(kwargs)
+        return ["Legacy Concept"]
+
+    monkeypatch.setattr(documents, "_extend_course_concepts", _legacy)
+    out = documents._extend_concepts(
+        "u1", "c1", course_label="CS101", existing_concepts=["Recursion"],
+    )
+    assert out == ["Legacy Concept"]
+    assert captured["course_label"] == "CS101"
+    assert captured["existing_concepts"] == ["Recursion"]

--- a/docs/superpowers/plans/2026-07-08-scan-concepts-agent-migration.md
+++ b/docs/superpowers/plans/2026-07-08-scan-concepts-agent-migration.md
@@ -1,0 +1,559 @@
+# Scan-Concepts Agent Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the `/scan-concepts` LLM call in `routes/documents.py` from the legacy `gemini_service.call_gemini_json` onto a new typed Pydantic AI agent, with no change to behavior.
+
+**Architecture:** New tool-less worker agent `concept_scan_agent` returns a typed names-only list. The route builds the message (course label + existing concepts + optional doc summary), runs the agent first through the sync→async bridge, and falls back to the untouched legacy `_extend_course_concepts` on any agent failure (ADR 0001 contract). Everything downstream (graph write, response shape) is unchanged.
+
+**Tech Stack:** FastAPI, Pydantic AI (`pydantic-ai-slim[google]`, Gemini), pytest.
+
+Spec: `docs/superpowers/specs/2026-07-08-scan-concepts-agent-migration-design.md`
+
+## Global Constraints
+
+- New LLM code is a Pydantic AI agent under `backend/agents/`, not an extension of `gemini_service.py`.
+- Model is chosen via `agents/_providers.py::model_for(task)`; default `gemini-2.5-flash-lite`; env override `SAPLING_MODEL_CONCEPT_SCAN`.
+- Fallback contract: run agent first; on `UsageLimitExceeded`, `UnexpectedModelBehavior`, or any other `Exception`, fall back to the legacy `_extend_course_concepts`.
+- Output schema stays compact (ADR 0003): flat model, `concepts: list[str]`, max 15, empty allowed.
+- Every agent run passes `usage_limits=WORKER_LIMITS` (from `agents/__init__.py`).
+- Do NOT change the two endpoints' request/response shapes, `_scan_concepts_for_course`'s graph write, or the `list[str]` contract.
+- Tests live in `backend/tests/`, run via `python -m pytest` from `backend/`.
+- Commit messages follow repo style: `feat(<area>): ...`, `test(<area>): ...`.
+
+---
+
+### Task 1: Register the `concept_scan` model task
+
+**Files:**
+- Modify: `backend/agents/_providers.py` (the `AgentTask` Literal ~line 29 and `_DEFAULTS` dict ~line 39)
+- Test: `backend/tests/test_concept_scan.py` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `model_for("concept_scan") -> GoogleModel` defaulting to `gemini-2.5-flash-lite`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_concept_scan.py`:
+
+```python
+"""Tests for the concept_scan agent migration (/scan-concepts)."""
+from pydantic_ai.models.google import GoogleModel
+
+from agents._providers import model_for
+
+
+def test_model_for_concept_scan_defaults_to_flash_lite():
+    m = model_for("concept_scan")
+    assert isinstance(m, GoogleModel)
+    assert m.model_name == "gemini-2.5-flash-lite"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_concept_scan.py::test_model_for_concept_scan_defaults_to_flash_lite -v`
+Expected: FAIL — `KeyError: 'concept_scan'` (task not in `_DEFAULTS`).
+
+- [ ] **Step 3: Add the task key**
+
+In `backend/agents/_providers.py`, add `"concept_scan"` to the `AgentTask` Literal:
+
+```python
+AgentTask = Literal[
+    "classifier", "summary", "concepts", "syllabus", "quiz", "chat_tutor",
+    "note_summary", "note_concepts", "note_chat",
+    "study_guide", "social_summary",
+    "course_summary", "quiz_context",
+    "concept_scan",
+]
+```
+
+And add its default in `_DEFAULTS` (place near the other concept-related entries):
+
+```python
+    # Scan-concepts extends an existing course concept set from a short
+    # context (existing concepts + optional doc summary) → the cheap lite
+    # tier, matching the MODEL_LITE the legacy path used.
+    "concept_scan": "gemini-2.5-flash-lite",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_concept_scan.py::test_model_for_concept_scan_defaults_to_flash_lite -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/agents/_providers.py backend/tests/test_concept_scan.py
+git commit -m "feat(agents): add concept_scan model task key"
+```
+
+---
+
+### Task 2: Create the `concept_scan` agent
+
+**Files:**
+- Create: `backend/agents/concept_scan.py`
+- Test: `backend/tests/test_concept_scan.py` (extend)
+
+**Interfaces:**
+- Consumes: `model_for("concept_scan")` (Task 1), `SaplingDeps`.
+- Produces:
+  - `NewConcepts(BaseModel)` with field `concepts: list[str]` (max 15, empty allowed).
+  - `concept_scan_agent: Agent[SaplingDeps, NewConcepts]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/test_concept_scan.py`:
+
+```python
+import pytest
+from pydantic import ValidationError
+from pydantic_ai import Agent
+
+from agents.concept_scan import NewConcepts, concept_scan_agent
+
+
+def test_new_concepts_allows_empty_list():
+    assert NewConcepts(concepts=[]).concepts == []
+
+
+def test_new_concepts_rejects_more_than_15():
+    with pytest.raises(ValidationError):
+        NewConcepts(concepts=[f"Concept {i}" for i in range(16)])
+
+
+def test_concept_scan_agent_is_configured():
+    assert isinstance(concept_scan_agent, Agent)
+    assert concept_scan_agent.output_type is NewConcepts
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_concept_scan.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'agents.concept_scan'`.
+
+- [ ] **Step 3: Create the agent module**
+
+Create `backend/agents/concept_scan.py`:
+
+```python
+"""Concept-scan agent.
+
+Replaces routes/documents.py::_extend_course_concepts' call_gemini_json
+call. Given a course label, the concepts already in the student's graph,
+and optionally a document's summary/notes, it returns the NEW concepts to
+add — names only, deduplicated against the existing set, possibly empty.
+
+Names-only output (list[str]) matches what the /scan-concepts graph write
+consumes; descriptions/importance would be discarded (see the design spec).
+Tool-less: the existing-concepts set is a deterministic query the route
+already runs and passes in the message — the model has nothing to decide
+about fetching it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+from agents._providers import model_for
+from agents.deps import SaplingDeps
+
+
+class NewConcepts(BaseModel):
+    """Typed output: new concept names to add to the course graph."""
+
+    concepts: list[str] = Field(
+        default_factory=list,
+        max_length=15,
+        description=(
+            "New concept names not already in the course graph. Empty when "
+            "the existing set already covers the material."
+        ),
+    )
+
+
+_SYSTEM_PROMPT = (
+    "You curate the concept set for a student's course knowledge graph. "
+    "You are given the course label, the concepts already in the graph, "
+    "and optionally a document's title, summary, and already-extracted "
+    "concepts.\n\n"
+    "Return between 0 and 15 NEW concepts that belong in this course's "
+    "graph but are not already in the existing list.\n"
+    "- If the existing set already covers the relevant material, return an "
+    "empty list.\n"
+    "- Each concept is a short Title Case noun phrase (e.g. 'Linear "
+    "Regression', 'Big-O Analysis').\n"
+    "- Do NOT repeat or paraphrase any existing concept.\n"
+    "- No assignment titles, week labels, page numbers, problem numbers, "
+    "or administrative items."
+)
+_PROMPT_HASH = hashlib.sha256(_SYSTEM_PROMPT.encode("utf-8")).hexdigest()[:12]
+
+
+concept_scan_agent = Agent[SaplingDeps, NewConcepts](
+    model=model_for("concept_scan"),
+    deps_type=SaplingDeps,
+    output_type=NewConcepts,
+    system_prompt=_SYSTEM_PROMPT,
+    metadata={"prompt_version": _PROMPT_HASH, "agent": "concept_scan"},
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_concept_scan.py -v`
+Expected: PASS (all 4 tests, including Task 1's).
+
+Note: if `concept_scan_agent.output_type` is not exposed by the installed pydantic-ai version, replace that assertion with `assert concept_scan_agent is not None` — do not block on the attribute name.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/agents/concept_scan.py backend/tests/test_concept_scan.py
+git commit -m "feat(agents): add concept_scan agent (names-only, tool-less)"
+```
+
+---
+
+### Task 3: Wire the agent into the route with legacy fallback
+
+**Files:**
+- Modify: `backend/routes/documents.py` (imports ~line 44-51; add helpers near `_extend_course_concepts` ~line 88; swap the call inside `_scan_concepts_for_course` ~line 1163)
+- Test: `backend/tests/test_concept_scan.py` (extend)
+
+**Interfaces:**
+- Consumes: `concept_scan_agent`, `NewConcepts` (Task 2); `run_agent_sync` (`agents/_run.py`); `WORKER_LIMITS`, `SaplingDeps`, `current_request_id`, `UsageLimitExceeded`, `UnexpectedModelBehavior` (already imported in `documents.py`); `_extend_course_concepts` (existing legacy fallback).
+- Produces:
+  - `_scan_user_message(*, course_label, existing_concepts, doc_filename=None, doc_summary=None, doc_concept_notes=None) -> str`
+  - `async _extend_via_agent(*, user_id, course_id, course_label, existing_concepts, doc_filename=None, doc_summary=None, doc_concept_notes=None) -> list[str]`
+  - `_extend_concepts(user_id, course_id, *, course_label, existing_concepts, doc_filename=None, doc_summary=None, doc_concept_notes=None) -> list[str]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/test_concept_scan.py`:
+
+```python
+import routes.documents as documents
+from pydantic_ai.exceptions import UsageLimitExceeded, UnexpectedModelBehavior
+
+
+class _Result:
+    def __init__(self, concepts):
+        self.output = NewConcepts(concepts=concepts)
+
+
+class _FakeAgent:
+    """Stand-in for concept_scan_agent with an async run()."""
+
+    def __init__(self, *, result=None, exc=None):
+        self._result = result
+        self._exc = exc
+        self.calls = []
+
+    async def run(self, message, **kwargs):
+        self.calls.append((message, kwargs))
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+def test_scan_user_message_includes_existing_and_doc_context():
+    msg = documents._scan_user_message(
+        course_label="CS101",
+        existing_concepts=["Recursion"],
+        doc_filename="lecture1.pdf",
+        doc_summary="Intro to sorting algorithms.",
+        doc_concept_notes=[{"name": "Merge Sort", "description": "divide and conquer"}],
+    )
+    assert "CS101" in msg
+    assert "Recursion" in msg
+    assert "lecture1.pdf" in msg
+    assert "Merge Sort" in msg
+
+
+def test_extend_concepts_returns_agent_output(monkeypatch):
+    fake = _FakeAgent(result=_Result(["Binary Search", "Hashing"]))
+    monkeypatch.setattr(documents, "concept_scan_agent", fake)
+    out = documents._extend_concepts(
+        "u1", "c1", course_label="CS101", existing_concepts=["Recursion"],
+    )
+    assert out == ["Binary Search", "Hashing"]
+    assert fake.calls  # agent was actually invoked
+
+
+def test_extend_concepts_handles_empty(monkeypatch):
+    fake = _FakeAgent(result=_Result([]))
+    monkeypatch.setattr(documents, "concept_scan_agent", fake)
+    out = documents._extend_concepts(
+        "u1", "c1", course_label="CS101", existing_concepts=[],
+    )
+    assert out == []
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [UsageLimitExceeded("limit"), UnexpectedModelBehavior("weird"), RuntimeError("boom")],
+)
+def test_extend_concepts_falls_back_to_legacy(monkeypatch, exc):
+    monkeypatch.setattr(documents, "concept_scan_agent", _FakeAgent(exc=exc))
+    captured = {}
+
+    def _legacy(**kwargs):
+        captured.update(kwargs)
+        return ["Legacy Concept"]
+
+    monkeypatch.setattr(documents, "_extend_course_concepts", _legacy)
+    out = documents._extend_concepts(
+        "u1", "c1", course_label="CS101", existing_concepts=["Recursion"],
+    )
+    assert out == ["Legacy Concept"]
+    assert captured["course_label"] == "CS101"
+    assert captured["existing_concepts"] == ["Recursion"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_concept_scan.py -k "extend or scan_user_message" -v`
+Expected: FAIL — `AttributeError: module 'routes.documents' has no attribute '_scan_user_message'`.
+
+- [ ] **Step 3: Add the import**
+
+In `backend/routes/documents.py`, add to the agent import block (after line 51):
+
+```python
+from agents._run import run_agent_sync
+from agents.concept_scan import concept_scan_agent, NewConcepts
+```
+
+- [ ] **Step 4: Add the three helpers**
+
+In `backend/routes/documents.py`, immediately AFTER the existing `_extend_course_concepts` function (which stays unchanged as the legacy fallback, ends ~line 154), add:
+
+```python
+def _scan_user_message(
+    *,
+    course_label: str,
+    existing_concepts: list[str],
+    doc_filename: str | None = None,
+    doc_summary: str | None = None,
+    doc_concept_notes: list[dict] | None = None,
+) -> str:
+    """Build the concept_scan agent's user message: course label + existing
+    concepts + (optional) document context. Mirrors the legacy prompt's data
+    section so agent and legacy paths see the same signal."""
+    existing_block = (
+        "\n".join(f"- {c}" for c in existing_concepts) if existing_concepts else "(none yet)"
+    )
+    lines = [
+        f'Course: "{course_label}"',
+        "Concepts already in the graph:",
+        existing_block,
+    ]
+    if doc_filename or doc_summary or doc_concept_notes:
+        notes_block = (
+            "\n".join(
+                f"  - {n.get('name', '?')}: {n.get('description', '')[:200]}"
+                for n in (doc_concept_notes or [])
+            )
+            or "  (none)"
+        )
+        lines += [
+            "",
+            "New document being scanned:",
+            f"  Title: {doc_filename or '(untitled)'}",
+            f"  Summary: {doc_summary or '(none)'}",
+            "  Concepts already extracted from this document:",
+            notes_block,
+        ]
+    return "\n".join(lines)
+
+
+async def _extend_via_agent(
+    *,
+    user_id: str,
+    course_id: str,
+    course_label: str,
+    existing_concepts: list[str],
+    doc_filename: str | None = None,
+    doc_summary: str | None = None,
+    doc_concept_notes: list[dict] | None = None,
+) -> list[str]:
+    """Run concept_scan_agent and return new concept names. Raises on agent
+    failure so the sync dispatcher can fall back to legacy."""
+    deps = SaplingDeps(
+        user_id=user_id,
+        course_id=course_id,
+        supabase=None,
+        request_id=current_request_id() or str(uuid.uuid4()),
+    )
+    message = _scan_user_message(
+        course_label=course_label,
+        existing_concepts=existing_concepts,
+        doc_filename=doc_filename,
+        doc_summary=doc_summary,
+        doc_concept_notes=doc_concept_notes,
+    )
+    result = await concept_scan_agent.run(
+        message, deps=deps, usage_limits=WORKER_LIMITS,
+    )
+    return list(result.output.concepts)
+
+
+def _extend_concepts(
+    user_id: str,
+    course_id: str,
+    *,
+    course_label: str,
+    existing_concepts: list[str],
+    doc_filename: str | None = None,
+    doc_summary: str | None = None,
+    doc_concept_notes: list[dict] | None = None,
+) -> list[str]:
+    """Agent-first concept extension with legacy fallback (ADR 0001).
+
+    Sync entry point for the sync /scan-concepts handlers: drives the async
+    agent via run_agent_sync, falling back to the legacy call_gemini_json
+    path on any agent failure.
+    """
+    try:
+        return run_agent_sync(
+            _extend_via_agent(
+                user_id=user_id,
+                course_id=course_id,
+                course_label=course_label,
+                existing_concepts=existing_concepts,
+                doc_filename=doc_filename,
+                doc_summary=doc_summary,
+                doc_concept_notes=doc_concept_notes,
+            )
+        )
+    except (UsageLimitExceeded, UnexpectedModelBehavior):
+        logger.warning("concept_scan agent guardrails tripped; using legacy")
+    except Exception:
+        logger.exception("concept_scan agent failed; using legacy")
+    return _extend_course_concepts(
+        course_label=course_label,
+        existing_concepts=existing_concepts,
+        doc_filename=doc_filename,
+        doc_summary=doc_summary,
+        doc_concept_notes=doc_concept_notes,
+    )
+```
+
+- [ ] **Step 5: Swap the call in `_scan_concepts_for_course`**
+
+In `backend/routes/documents.py`, inside `_scan_concepts_for_course` (~line 1163), replace the `_extend_course_concepts(...)` call with `_extend_concepts(...)`, threading `user_id`/`course_id`:
+
+```python
+    concepts = _extend_concepts(
+        user_id,
+        course_id,
+        course_label=_course_label(course_id),
+        existing_concepts=existing_concepts,
+        doc_filename=doc_filename,
+        doc_summary=doc_summary,
+        doc_concept_notes=doc_concept_notes,
+    )
+```
+
+(Leave `_extend_course_concepts` defined — it is now the fallback.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_concept_scan.py -v`
+Expected: PASS (all tests through Task 3).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/routes/documents.py backend/tests/test_concept_scan.py
+git commit -m "feat(documents): run /scan-concepts via concept_scan agent, legacy fallback"
+```
+
+---
+
+### Task 4: End-to-end endpoint regression test
+
+**Files:**
+- Test: `backend/tests/test_concept_scan.py` (extend)
+
+**Interfaces:**
+- Consumes: FastAPI `app`, `TestClient`; the autouse `_bypass_session_auth` + `_hermetic_supabase_client` fixtures from `conftest.py`; `_FakeAgent` (Task 3).
+- Produces: nothing (regression coverage only).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_concept_scan.py`:
+
+```python
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_course_scan_endpoint_uses_agent_and_keeps_response_shape():
+    fake = _FakeAgent(result=_Result(["Binary Search", "Hashing"]))
+    with patch("routes.documents._validate_user", return_value=None), \
+         patch("routes.documents._course_label", return_value="CS101"), \
+         patch("routes.documents.apply_graph_update", return_value=None), \
+         patch("routes.documents.concept_scan_agent", fake), \
+         patch("routes.documents.table") as t:
+        t.return_value.select.return_value = [
+            {"id": "n1", "concept_name": "Recursion"},
+        ]
+        r = client.post(
+            "/api/documents/course/c1/scan-concepts",
+            json={"user_id": "u1"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["concepts"] == ["Binary Search", "Hashing"]
+    assert "added" in body and "existing" in body
+    assert fake.calls  # the agent path (not legacy) served the request
+```
+
+- [ ] **Step 2: Run test to verify it fails (before Task 3 wiring) or passes (after)**
+
+Run: `python -m pytest tests/test_concept_scan.py::test_course_scan_endpoint_uses_agent_and_keeps_response_shape -v`
+Expected: PASS once Task 3 is in place (the endpoint now routes through `concept_scan_agent`). If run before Task 3, it FAILS because the legacy path serves the request and `fake.calls` is empty.
+
+- [ ] **Step 3: Run the full file + confirm no regressions**
+
+Run: `python -m pytest tests/test_concept_scan.py tests/test_documents_routes.py -q`
+Expected: PASS (new file green; existing document route tests unaffected).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/test_concept_scan.py
+git commit -m "test(documents): e2e regression for /scan-concepts agent path"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- New agent `agents/concept_scan.py` (names-only, no tools) → Task 2. ✅
+- `concept_scan` model key + env override → Task 1. ✅
+- Agent-first + legacy fallback via `run_agent_sync`, sync handlers unchanged → Task 3. ✅
+- `WORKER_LIMITS` on the run → Task 3 (`_extend_via_agent`). ✅
+- Endpoints/response/graph-write unchanged → Task 3 Step 5 (swap only) + Task 4 (regression). ✅
+- Unit tests now, evals deferred → Tasks 1–4 unit/e2e; no eval task (deferred per spec). ✅
+- Out-of-scope items (retire legacy fallback, de-dup streaming, delete gemini_service) → not touched; `_extend_course_concepts` and the `gemini_service` import deliberately remain. ✅
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows full code; every run step shows command + expected result. ✅
+
+**3. Type consistency:** `NewConcepts.concepts: list[str]` defined in Task 2, consumed as `result.output.concepts` in Task 3; `_extend_concepts(user_id, course_id, *, course_label, existing_concepts, ...)` signature identical across Task 3 definition, Task 3 call-site swap, and Task 3/4 tests; `_FakeAgent.run` async matches `Agent.run`. ✅
+
+No gaps found.

--- a/docs/superpowers/specs/2026-07-08-scan-concepts-agent-migration-design.md
+++ b/docs/superpowers/specs/2026-07-08-scan-concepts-agent-migration-design.md
@@ -1,0 +1,230 @@
+# Design: migrate `/scan-concepts` to a Pydantic AI agent
+
+- Status: proposed
+- Date: 2026-07-08
+- Area: agent migration (epic #152 — retire `gemini_service` as the primary LLM seam)
+- Related: ADR 0001 (adopt Pydantic AI + fallback contract), ADR 0008 (per-task
+  model routing), ADR 0003 (compact output schemas), ADR 0016 (wire-format
+  adapter convention), ADR 0017 (evals-as-follow-up precedent)
+
+## Context / problem
+
+Sapling calls Gemini two ways: the legacy `services/gemini_service.py`
+(`call_gemini*` — build a prompt string, get untyped text back, parse and
+coerce defensively) and typed **Pydantic AI agents** under `backend/agents/`
+(declare a typed output, the framework enforces and validates it). Epic #152
+is the standing decision to move **every** LLM call onto the agent style so
+`gemini_service.py` can eventually be deleted.
+
+The document **classify/summarize/extract** step already shipped on agents
+(refactor #1, PR #67): both `upload_document_sync` (`routes/documents.py:561`)
+and the streaming `upload_document` (`:722–793`) run the agent pipeline, with
+`_process_document` / `_legacy_upload_pipeline` kept only as an
+exception-time fallback. (The canopy epic's "next step: migrate the
+classify/extract step" is stale — that work is done.)
+
+The genuinely **live, non-fallback** un-migrated LLM call left in
+`routes/documents.py` is **`/scan-concepts`**. This spec migrates only that
+call. It is not a bug fix — scan-concepts works today — it is a
+consistency/maintainability migration that removes one of the last live
+callers of `gemini_service`.
+
+## Current behavior (what ships today)
+
+The "scan concepts" feature extends a course's knowledge-graph concept set:
+look at the concepts already in the graph, ask Gemini which important ones are
+missing, and add the new ones as graph nodes.
+
+Two endpoints funnel into one helper:
+
+- `POST /api/documents/doc/{document_id}/scan-concepts` — `scan_document_concepts`
+  (`routes/documents.py:1191`) — seeds the scan with a document's stored
+  summary + concept notes.
+- `POST /api/documents/course/{course_id}/scan-concepts` — `scan_course_concepts`
+  (`:1234`) — seeds from the course label + existing graph alone.
+
+Both call `_scan_concepts_for_course` (`:1148`), which:
+1. Reads existing `graph_nodes` for `(user_id, course_id)`.
+2. Calls `_extend_course_concepts` (`:88`) — **the LLM call being migrated**.
+3. Writes any returned names as new nodes via `apply_graph_update`.
+4. Returns `{"concepts": [...], "added": N, "existing": M}`.
+
+`_extend_course_concepts` (`:88–154`) is old-style:
+- Hand-builds a prompt string embedding the course label, existing concepts,
+  and optional doc summary/notes, ending with "Return ONLY valid JSON … `{
+  "concepts": ["...", "..."] }` … 0–15 NEW concepts not in the list …".
+- `raw = call_gemini_json(prompt, model=MODEL_LITE)` (`:151`) — model
+  **hardwired**.
+- Defends against malformed output: `if not isinstance(raw, dict): return []`
+  then `_coerce_str_list(raw.get("concepts"))`.
+- Returns `list[str]` (names only). May be empty.
+
+Both scan handlers are **synchronous** `def` FastAPI handlers.
+
+## Goal & scope
+
+Replace the single Gemini call inside `_extend_course_concepts` with a typed
+Pydantic AI agent, preserving behavior exactly.
+
+**In scope**
+- New agent `agents/concept_scan.py`.
+- Register a `concept_scan` model task in `agents/_providers.py`.
+- Route wiring in `routes/documents.py`: agent-first with the existing
+  function kept as a legacy fallback.
+- Unit tests.
+
+**Out of scope (explicitly deferred)**
+- Retiring the upload-path legacy fallback (`_process_document` /
+  `_legacy_upload_pipeline`, the `call_gemini_json` at `:226`).
+- De-duplicating the streaming upload pipeline vs.
+  `agents/document.py::process_document`.
+- Any change to the graph write, the endpoints' request/response shapes, or the
+  frontend.
+- Deleting `gemini_service.py` (still has other callers, incl. this file's
+  legacy fallback).
+
+## Design
+
+### 1. New agent — `agents/concept_scan.py`
+
+Modeled on `agents/concept_extraction.py`. A **new** agent rather than reuse of
+`concept_extraction_agent` because the task differs materially:
+`concept_extraction` takes **raw document text** and must return **≥1** concept
+*with descriptions + importance*; scan-concepts takes an **existing concept
+list + course label + optional doc summary**, must **avoid duplicates**, and
+must be allowed to return **nothing** (`[]`).
+
+```python
+class NewConcepts(BaseModel):
+    # Names only — matches the graph write's needs and the current list[str]
+    # return. Empty list is valid ("existing set already covers it").
+    concepts: list[str] = Field(max_length=15)
+
+concept_scan_agent = Agent[SaplingDeps, NewConcepts](
+    model=model_for("concept_scan"),
+    deps_type=SaplingDeps,
+    output_type=NewConcepts,
+    system_prompt=_SYSTEM_PROMPT,
+    metadata={"prompt_version": _PROMPT_HASH, "agent": "concept_scan"},
+)
+```
+
+Decisions baked in:
+- **Output = names only** (`list[str]`). The scan path only consumes concept
+  names (`{"concept_name": name, "initial_mastery": 0.0}`); descriptions/
+  importance would be discarded. Also keeps the schema flat/small per ADR 0003.
+  Revisit only if the feature starts displaying per-concept descriptions.
+- **No tools.** The existing-concepts set is a single deterministic query the
+  route already runs; there is nothing for the model to decide about fetching
+  it. The route fetches it and passes it in the user message. (Matches the
+  tool-less worker pattern of `classifier`/`summary`/`concept_extraction`.)
+- **System prompt** ported near-verbatim from the current prose prompt (0–15
+  new, non-duplicate, short Title Case noun phrases; no assignment titles,
+  week labels, page/problem numbers, or administrative items; return `[]` if
+  the existing set already covers the material), minus the "return valid JSON"
+  instructions the output type now enforces. `_PROMPT_HASH` is the 12-char
+  sha256 prefix of the prompt body, surfaced via `metadata` for Logfire, as in
+  the other agents.
+
+### 2. Model registration — `agents/_providers.py`
+
+Add the task key so model choice stays config-driven (ADR 0008), defaulting to
+the same cheap tier used today (`MODEL_LITE` → flash-lite):
+
+```python
+AgentTask = Literal[..., "concept_scan"]
+_DEFAULTS = { ..., "concept_scan": "gemini-2.5-flash-lite" }
+```
+
+Operator override: `SAPLING_MODEL_CONCEPT_SCAN`, no code change.
+
+### 3. Route wiring — safe swap with legacy fallback
+
+Follows the ADR 0001 / ADR 0016 migration pattern used by the prior four
+refactors: run the agent first, fall back to the untouched legacy code on
+failure.
+
+- Add `_extend_via_agent(...)` — builds the user message (course label +
+  existing concepts + optional doc filename/summary/concept notes), runs
+  `concept_scan_agent` with `WORKER_LIMITS`, returns `result.output.concepts`
+  (already `list[str]`; the "wire-format adapter" is trivial here).
+- Keep the current `_extend_course_concepts` as the **legacy fallback** — same
+  name, body unchanged.
+- New dispatcher `_extend_concepts(...)`:
+
+```python
+def _extend_concepts(...) -> list[str]:
+    try:
+        return run_agent_sync(_extend_via_agent(...))
+    except (UsageLimitExceeded, UnexpectedModelBehavior):
+        logger.warning("concept_scan agent guardrails tripped; using legacy")
+        return _extend_course_concepts(...)
+    except Exception:
+        logger.exception("concept_scan agent failed; using legacy")
+        return _extend_course_concepts(...)
+```
+
+- `_scan_concepts_for_course` (`:1163`) calls `_extend_concepts` instead of
+  `_extend_course_concepts` directly. Everything downstream (graph write,
+  `added`/`existing` counting, JSON response) is unchanged.
+- **Sync bridge:** the scan handlers stay synchronous; the async agent is
+  driven via the existing `run_agent_sync(...)` helper (`agents/_run.py`),
+  which is the sanctioned sync→async seam. No route signature changes.
+- **Deps:** construct `SaplingDeps(user_id, course_id, supabase=None,
+  request_id=<correlation id from request.state / current_request_id>)`.
+  `supabase=None` is fine — the agent has no tools. `session_id` unused.
+- **`WORKER_LIMITS`** applied on the agent run (from `agents/__init__.py`) so
+  this call has a token/tool ceiling, avoiding the "no limits" class of
+  regression tracked in #327.
+
+### 4. What stays identical
+Both endpoints, their request/response shapes, `_scan_concepts_for_course`'s
+graph write and `added`/`existing` counts, the decrypt logic for the doc
+summary/notes, and the `list[str]` contract between helper and graph write. The
+frontend cannot observe the change.
+
+## Testing
+
+Unit tests in `backend/tests/test_concept_scan.py`, mirroring the style of
+`test_syllabus_adapter.py` / `test_ocr_pipeline.py`:
+- Agent success → returns the model's concept names as `list[str]`.
+- Empty result (`[]`) → handled, `added: 0`.
+- `/doc/{id}/scan-concepts` and `/course/{id}/scan-concepts` end-to-end with a
+  mocked agent (asserting graph write + response shape unchanged).
+- Each fallback trigger — `UsageLimitExceeded`, `UnexpectedModelBehavior`,
+  generic `Exception` — falls through to `_extend_course_concepts`.
+- Duplicate-avoidance is prompt-governed; a light assertion that existing
+  concepts are included in the message passed to the agent.
+
+**Evals — deferred (decision).** The four big refactors shipped eval cases; the
+notetaker agents (ADR 0017) shipped without and logged it as debt. This is a
+low-risk cheap-model call whose legacy-parity is easy to pin with unit tests,
+so: unit tests now, a small `tests/evals/concept_scan.py` as a follow-up.
+
+## Files touched
+- **New:** `backend/agents/concept_scan.py`, `backend/tests/test_concept_scan.py`
+- **Edit:** `backend/agents/_providers.py` (+1 task key + Literal entry),
+  `backend/routes/documents.py` (`_extend_via_agent`, `_extend_concepts`
+  dispatcher, swap the call in `_scan_concepts_for_course`; keep
+  `_extend_course_concepts` as fallback)
+
+The `from services.gemini_service import MODEL_LITE, call_gemini_json` import
+(`documents.py:37`) stays as long as the legacy fallback (and `_process_document`)
+remain; removing it belongs to the out-of-scope "retire legacy fallback" slice.
+
+## Rollback
+Single-revert safe. The legacy path is intact and unchanged; reverting the
+dispatcher swap restores the pre-migration behavior. The new agent module and
+provider key are additive and dormant if unreferenced.
+
+## Follow-ups (tracked, not in this slice)
+1. `tests/evals/concept_scan.py` eval cases.
+2. Retire the upload-path legacy fallback (`_process_document` /
+   `_legacy_upload_pipeline`), removing the `:226` `call_gemini_json` site.
+3. De-duplicate the streaming upload pipeline against
+   `agents/document.py::process_document`.
+4. Update epic #152 / canopy: the classify/extract step is already migrated.
+
+## Open questions
+None blocking. Output-shape (names-only) and evals-deferred are decided above;
+flag if either should change before implementation.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -421,6 +421,10 @@ body { font-size: 14px; line-height: 1.5; }
     scroll-behavior: auto !important;
   }
 }
+
+/* Hide the shared KnowledgeGraph's recenter/reset control on the Tutor
+   session knowledge-map rail only (keeps it intact on Dashboard/Tree). */
+.learn-map-rail button[title="Reset view"] { display: none; }
 /* ══════════════════════════════════════════════════════════════════
    LANDING PAGE STYLES (ported from main branch)
    ══════════════════════════════════════════════════════════════════ */

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -52,6 +52,8 @@ const MODES: { id: Mode; name: string; tip: string }[] = [
 const VALID_MODES: Mode[] = ["socratic", "expository", "teachback"];
 const SESSION_END_COUNT_KEY = "sapling_session_end_count";
 const LAST_SESSION_CTX_KEY = "sapling_last_session_context";
+const RAIL_OPEN_KEY = "sapling_learn_rail_open";
+const RAIL_WIDTH = 400;
 
 function normalizeMode(input: string | null): Mode {
   if (!input) return "socratic";
@@ -103,6 +105,13 @@ function LearnInner() {
   // Tracks each session's last server-confirmed topic so back-to-back rename failures revert to the right value.
   const confirmedTopicsRef = useRef<Map<string, string>>(new Map());
 
+  // Collapsible knowledge-map rail (desktop only). `dragWidth` is non-null
+  // only mid-drag, when it drives the live width and the CSS transition is off.
+  const [railOpen, setRailOpen] = useState(true);
+  const [dragWidth, setDragWidth] = useState<number | null>(null);
+  const railDragRef = useRef<{ startX: number; startWidth: number; width: number; moved: boolean; pointerId: number } | null>(null);
+  const railHydrated = useRef(false);
+
   // Initial data load
   useEffect(() => {
     if (!userReady || !userId) return;
@@ -153,6 +162,23 @@ function LearnInner() {
     router.replace(`/learn?${params.toString()}`, { scroll: false });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode]);
+
+  // Restore the rail's open/closed state on mount, then persist changes. The
+  // `railHydrated` guard keeps the mount-time persist from clobbering the
+  // stored value before the read effect has applied it.
+  useEffect(() => {
+    try {
+      const v = localStorage.getItem(RAIL_OPEN_KEY);
+      if (v != null) setRailOpen(v === "1");
+    } catch {}
+    railHydrated.current = true;
+  }, []);
+  useEffect(() => {
+    if (!railHydrated.current) return;
+    try {
+      localStorage.setItem(RAIL_OPEN_KEY, railOpen ? "1" : "0");
+    } catch {}
+  }, [railOpen]);
 
   const handleStart = async () => {
     const t = topicDraft.trim();
@@ -358,6 +384,36 @@ function LearnInner() {
     }
   }, [router, mode]);
 
+  // Edge-tab pointer handling: grab-drag moves the rail width live; a sub-4px
+  // press is treated as a click (toggle). On release we snap open/closed at the
+  // halfway point. The tab lives on the rail's left edge, so dragging right
+  // (toward the screen edge) collapses it.
+  const onRailTabPointerDown = (e: React.PointerEvent) => {
+    if (isMobile) return;
+    (e.currentTarget as Element).setPointerCapture(e.pointerId);
+    const startWidth = railOpen ? RAIL_WIDTH : 0;
+    railDragRef.current = { startX: e.clientX, startWidth, width: startWidth, moved: false, pointerId: e.pointerId };
+    setDragWidth(startWidth);
+  };
+  const onRailTabPointerMove = (e: React.PointerEvent) => {
+    const d = railDragRef.current;
+    if (!d || e.pointerId !== d.pointerId) return;
+    const dx = e.clientX - d.startX;
+    if (Math.abs(dx) > 4) d.moved = true;
+    const next = Math.max(0, Math.min(RAIL_WIDTH, d.startWidth - dx));
+    d.width = next;
+    setDragWidth(next);
+  };
+  const onRailTabPointerUp = (e: React.PointerEvent) => {
+    const d = railDragRef.current;
+    if (!d) return;
+    railDragRef.current = null;
+    try { (e.currentTarget as Element).releasePointerCapture(e.pointerId); } catch {}
+    setDragWidth(null);
+    if (!d.moved) { setRailOpen(o => !o); return; }
+    setRailOpen(d.width >= RAIL_WIDTH / 2);
+  };
+
   const topicNode = useMemo(
     () => graphNodes.find(n => n.id === highlightId),
     [graphNodes, highlightId],
@@ -499,6 +555,8 @@ function LearnInner() {
   }
 
   // ────────── Active session ──────────
+  const railDragging = dragWidth != null;
+  const railW = railDragging ? (dragWidth as number) : railOpen ? RAIL_WIDTH : 0;
   return (
     <div style={{ display: "flex", height: "100vh", flexDirection: "column" }}>
       <DisclaimerModal />
@@ -525,7 +583,7 @@ function LearnInner() {
         </div>
       )}
 
-      <div style={{ display: "flex", flex: 1, minHeight: 0 }}>
+      <div style={{ display: "flex", flex: 1, minHeight: 0, position: "relative" }}>
         {(!isMobile || mobileTab === "chat") && (
           <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
             <TopBar
@@ -579,55 +637,132 @@ function LearnInner() {
         {(!isMobile || mobileTab === "graph") && (
           <aside
             style={{
-              width: isMobile ? "100%" : 320,
-              borderLeft: isMobile ? "none" : "1px solid var(--border)",
-              background: "var(--bg-subtle)",
-              padding: 20,
-              overflowY: "auto",
-              display: "flex",
-              flexDirection: "column",
-              gap: 16,
+              width: isMobile ? "100%" : railW,
+              minWidth: isMobile ? undefined : railW,
+              flexShrink: 0,
+              overflow: "hidden",
+              transition: isMobile || railDragging
+                ? "none"
+                : "width var(--dur) var(--ease), min-width var(--dur) var(--ease)",
             }}
           >
-            <div>
-              <div className="label-micro">Session</div>
-              <div className="h-serif" style={{ fontSize: 18, marginTop: 4 }}>{topic}</div>
-            </div>
-            {graphNodes.length > 0 && (
-              <div
-                className="card"
-                style={{ padding: 8, display: "flex", flexDirection: "column", gap: 4 }}
-              >
-                <div className="label-micro" style={{ padding: "4px 6px" }}>Knowledge graph</div>
+            {/* Inner content keeps a fixed 400px width so it stays laid out
+                (and the graph's measured bounds stay stable) while the outer
+                <aside> clips it during the slide. */}
+            <div
+              className="learn-map-rail"
+              style={{
+                width: isMobile ? "100%" : RAIL_WIDTH,
+                height: "100%",
+                boxSizing: "border-box",
+                borderLeft: isMobile ? "none" : "1px solid var(--border)",
+                background: "var(--bg-subtle)",
+                padding: 20,
+                overflowY: "auto",
+                display: "flex",
+                flexDirection: "column",
+                gap: 16,
+              }}
+            >
+              <div>
+                <div className="label-micro">Session</div>
+                <div className="h-serif" style={{ fontSize: 18, marginTop: 4 }}>{topic}</div>
+              </div>
+              {graphNodes.length > 0 && (
                 <SidebarKnowledgeGraph
                   nodes={graphNodes}
                   edges={graphEdges}
                   highlightId={highlightId}
                   onNodeClick={handleNodeClick}
                 />
+              )}
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+                <div className="card" style={{ padding: 12 }}>
+                  <div className="label-micro" style={{ marginBottom: 4 }}>Mode</div>
+                  <div style={{ fontSize: 13, fontWeight: 500, textTransform: "capitalize" }}>{mode}</div>
+                </div>
+                <div className="card" style={{ padding: 12 }}>
+                  <div className="label-micro" style={{ marginBottom: 4 }}>Messages</div>
+                  <div className="mono" style={{ fontSize: 16 }}>{messages.length}</div>
+                </div>
               </div>
-            )}
-            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
               <div className="card" style={{ padding: 12 }}>
-                <div className="label-micro" style={{ marginBottom: 4 }}>Mode</div>
-                <div style={{ fontSize: 13, fontWeight: 500, textTransform: "capitalize" }}>{mode}</div>
+                <div className="label-micro" style={{ marginBottom: 4 }}>Context</div>
+                <div style={{ fontSize: 12, color: "var(--text-dim)" }}>
+                  {sharedCtx ? "Class intel: on" : "Class intel: off"}
+                </div>
               </div>
-              <div className="card" style={{ padding: 12 }}>
-                <div className="label-micro" style={{ marginBottom: 4 }}>Messages</div>
-                <div className="mono" style={{ fontSize: 16 }}>{messages.length}</div>
-              </div>
+              {progressItems.length > 0 && <ProgressCard items={progressItems} />}
+              {relatedItems.length > 0 && (
+                <RelatedConceptsCard items={relatedItems} onSelect={startSessionFromConcept} />
+              )}
             </div>
-            <div className="card" style={{ padding: 12 }}>
-              <div className="label-micro" style={{ marginBottom: 4 }}>Context</div>
-              <div style={{ fontSize: 12, color: "var(--text-dim)" }}>
-                {sharedCtx ? "Class intel: on" : "Class intel: off"}
-              </div>
-            </div>
-            {progressItems.length > 0 && <ProgressCard items={progressItems} />}
-            {relatedItems.length > 0 && (
-              <RelatedConceptsCard items={relatedItems} onSelect={startSessionFromConcept} />
-            )}
           </aside>
+        )}
+
+        {!isMobile && (
+          <button
+            type="button"
+            aria-label="Toggle knowledge map"
+            aria-expanded={railOpen}
+            title={railOpen ? "Collapse knowledge map" : "Show knowledge map"}
+            onPointerDown={onRailTabPointerDown}
+            onPointerMove={onRailTabPointerMove}
+            onPointerUp={onRailTabPointerUp}
+            onPointerCancel={onRailTabPointerUp}
+            style={{
+              position: "absolute",
+              top: "50%",
+              right: railW,
+              transform: "translateY(-50%)",
+              width: 24,
+              height: 68,
+              padding: 0,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 4,
+              cursor: railDragging ? "grabbing" : "pointer",
+              touchAction: "none",
+              background: "var(--bg-panel)",
+              border: "1px solid var(--border)",
+              borderRight: "none",
+              borderRadius: "10px 0 0 10px",
+              boxShadow: "-3px 0 8px rgba(19, 38, 16, 0.06)",
+              color: railOpen ? "var(--brand-forest)" : "var(--text-muted)",
+              zIndex: 20,
+              transition: railDragging
+                ? "none"
+                : "right var(--dur) var(--ease), color var(--dur) var(--ease)",
+            }}
+          >
+            {/* Knowledge-graph glyph: three nodes joined by two links. */}
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden="true">
+              <line x1="4.5" y1="5" x2="11" y2="4" />
+              <line x1="4.5" y1="5" x2="9" y2="11.5" />
+              <circle cx="4.5" cy="5" r="2" />
+              <circle cx="11" cy="4" r="2" />
+              <circle cx="9" cy="11.5" r="2" />
+            </svg>
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+              style={{
+                transform: railOpen ? "rotate(0deg)" : "rotate(180deg)",
+                transition: railDragging ? "none" : "transform var(--dur) var(--ease)",
+              }}
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
         )}
       </div>
 

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -110,7 +110,7 @@ function LearnInner() {
   const [railOpen, setRailOpen] = useState(true);
   const [dragWidth, setDragWidth] = useState<number | null>(null);
   const railDragRef = useRef<{ startX: number; startWidth: number; width: number; moved: boolean; pointerId: number } | null>(null);
-  const railHydrated = useRef(false);
+  const [railHydrated, setRailHydrated] = useState(false);
 
   // Initial data load
   useEffect(() => {
@@ -164,21 +164,22 @@ function LearnInner() {
   }, [mode]);
 
   // Restore the rail's open/closed state on mount, then persist changes. The
-  // `railHydrated` guard keeps the mount-time persist from clobbering the
-  // stored value before the read effect has applied it.
+  // `railHydrated` state flips true only after the stored value is applied, and
+  // the persist effect is gated on it (and re-runs when it flips), so the
+  // initial value can't be written back before hydration completes.
   useEffect(() => {
     try {
       const v = localStorage.getItem(RAIL_OPEN_KEY);
       if (v != null) setRailOpen(v === "1");
     } catch {}
-    railHydrated.current = true;
+    setRailHydrated(true);
   }, []);
   useEffect(() => {
-    if (!railHydrated.current) return;
+    if (!railHydrated) return;
     try {
       localStorage.setItem(RAIL_OPEN_KEY, railOpen ? "1" : "0");
     } catch {}
-  }, [railOpen]);
+  }, [railOpen, railHydrated]);
 
   const handleStart = async () => {
     const t = topicDraft.trim();
@@ -404,14 +405,26 @@ function LearnInner() {
     d.width = next;
     setDragWidth(next);
   };
-  const onRailTabPointerUp = (e: React.PointerEvent) => {
+  // Shared drag terminator. A cancellation (or an event from a stray pointer
+  // that isn't the one that started the drag) clears state without toggling or
+  // snapping the rail.
+  const endRailDrag = (e: React.PointerEvent, cancelled: boolean) => {
     const d = railDragRef.current;
-    if (!d) return;
+    if (!d || e.pointerId !== d.pointerId) return;
     railDragRef.current = null;
     try { (e.currentTarget as Element).releasePointerCapture(e.pointerId); } catch {}
     setDragWidth(null);
+    if (cancelled) return;
     if (!d.moved) { setRailOpen(o => !o); return; }
     setRailOpen(d.width >= RAIL_WIDTH / 2);
+  };
+  const onRailTabPointerUp = (e: React.PointerEvent) => endRailDrag(e, false);
+  const onRailTabPointerCancel = (e: React.PointerEvent) => endRailDrag(e, true);
+  const onRailTabKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setRailOpen(o => !o);
+    }
   };
 
   const topicNode = useMemo(
@@ -709,7 +722,8 @@ function LearnInner() {
             onPointerDown={onRailTabPointerDown}
             onPointerMove={onRailTabPointerMove}
             onPointerUp={onRailTabPointerUp}
-            onPointerCancel={onRailTabPointerUp}
+            onPointerCancel={onRailTabPointerCancel}
+            onKeyDown={onRailTabKeyDown}
             style={{
               position: "absolute",
               top: "50%",


### PR DESCRIPTION
## Collapsible draggable knowledge-map rail on the Tutor session

Makes the right-hand knowledge-map panel on the **active Tutor session** collapsible via a draggable edge tab. Desktop-only affordance; the mobile `graph` tab path is unchanged. Scoped to `Learn.tsx` plus a one-line `globals.css` rule.

### What changed
- **Collapsible rail** — `railOpen` state (default open), persisted to `localStorage["sapling_learn_rail_open"]` and hydrated on mount, so it survives reloads.
- **Sliding animation** — rail widened from 320px → **400px**; `width`/`min-width` animate `0 ↔ 400` with the existing `--dur`/`--ease` tokens (`cubic-bezier(0.2,0.7,0.2,1)`). The `<aside>` stays mounted with `overflow: hidden`; inner content is pinned at a fixed 400px so it clips cleanly during the slide (and the graph's measured bounds stay stable). Reduced-motion is already handled by the global rule at `globals.css:416`.
- **Draggable edge tab** — 24×68 pill on the conversation/rail seam. Knowledge-graph glyph (3 nodes + 2 links) over a chevron that rotates 180° between states; `--brand-forest` when open, `--text-muted` when collapsed. Click toggles; **pointer-drag** moves the width live within `[0, 400]` (transition disabled mid-drag) and snaps open/closed at the 200px midpoint. A <4px press counts as a click. `aria-label`/`aria-expanded`/`title` set.
- **Graph un-boxed** — removed the white `card` wrapper so the graph floats on the transparent rail. The graph itself was already transparent; **`KnowledgeGraph`/`KnowledgeGraph2D` and the force simulation are untouched** — no re-parameterization, same `ResizeObserver` sizing.
- **Recenter control** — hidden on the Learn rail only, via a scoped `.learn-map-rail button[title="Reset view"] { display: none }` rule. The shared `KnowledgeGraph2D` is **not** modified, so Dashboard/Tree keep their recenter button. Zoom `+`/`−` and the `2D` badge remain.

### Notes / deviations from spec
- The recenter button lives in the **shared** `KnowledgeGraph2D` (used by Dashboard + Tree), which the spec said not to modify — so it's suppressed with a scoped CSS rule rather than removed from the component. Tradeoff: the selector keys off the button's `title="Reset view"`. Happy to switch to an opt-in `hideRecenter` prop if preferred.
- No `globals.css` keyframe/reduced-motion addition was needed — the global reduced-motion rule already neutralizes the new transitions.

### Verification
- `npm run lint` → **0 errors** (only pre-existing warnings).
- `npm run typecheck` → clean for the changed files. (The 6 `.next/dev/types/validator.ts` errors are pre-existing stale local artifacts — confirmed identical with these changes stashed — and won't appear on a clean CI checkout.)
- Not yet verified visually in a running app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Concept scanning now uses an improved AI-powered process to identify new concepts, while preserving existing results and response behavior.
  - Added a collapsible, draggable knowledge-map rail in Tutor sessions.
  - The rail remembers its open or closed state between visits and snaps smoothly while resizing.

- **UI Improvements**
  - Removed the KnowledgeGraph “Reset view” control from the Tutor session rail while keeping it available elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->