### PR TITLE
feat(learn): Tutor knowledge-map rail overhaul + AI concept descriptions

### DIFF
--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -31,7 +31,7 @@ AgentTask = Literal[
     "note_summary", "note_concepts", "note_chat",
     "study_guide", "social_summary",
     "course_summary", "quiz_context",
-    "concept_scan",
+    "concept_scan", "concept_describe",
 ]
 
 
@@ -67,6 +67,9 @@ _DEFAULTS: dict[AgentTask, str] = {
     # context (existing concepts + optional doc summary) → the cheap lite
     # tier, matching the MODEL_LITE the legacy path used.
     "concept_scan": "gemini-2.5-flash-lite",
+    # One-sentence concept blurb for the knowledge-map rail — a tiny,
+    # short-output generation → the cheap lite tier.
+    "concept_describe": "gemini-2.5-flash-lite",
 }
 
 

--- a/backend/agents/concept_describe.py
+++ b/backend/agents/concept_describe.py
@@ -1,0 +1,63 @@
+"""Concept-describe agent.
+
+Given a concept name and its course context, returns ONE concise,
+student-facing sentence explaining what the concept is. Backs the knowledge-
+map rail's "Focused concept" blurb for concepts that don't already carry a
+stored description (e.g. ones the student just added by hand).
+
+Tool-less: the concept name and course label are handed in via the message,
+so the model has nothing to fetch — it only writes from what it knows.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+from agents._providers import model_for
+from agents.deps import SaplingDeps
+
+
+class ConceptDescription(BaseModel):
+    """Typed output: a single short description sentence."""
+
+    description: str = Field(
+        max_length=240,
+        description=(
+            "One concise, plain-language sentence explaining what the concept "
+            "is. No preamble, no markdown, no trailing whitespace."
+        ),
+    )
+
+
+_SYSTEM_PROMPT = (
+    "You explain academic concepts to students in one sentence. You are given "
+    "a concept name and, when available, the course it belongs to.\n\n"
+    "Write exactly ONE concise, plain-language sentence (roughly 12-28 words) "
+    "describing what the concept is and why it matters.\n"
+    "- Write for a student who is about to study it — clear, concrete, no "
+    "jargon they wouldn't already know.\n"
+    "- No preamble ('This concept is…'), no markdown, no lists, no quotes.\n"
+    "- If the concept name is ambiguous, interpret it in the context of the "
+    "given course."
+)
+_PROMPT_HASH = hashlib.sha256(_SYSTEM_PROMPT.encode("utf-8")).hexdigest()[:12]
+
+
+concept_describe_agent = Agent[SaplingDeps, ConceptDescription](
+    model=model_for("concept_describe"),
+    deps_type=SaplingDeps,
+    output_type=ConceptDescription,
+    system_prompt=_SYSTEM_PROMPT,
+    metadata={"prompt_version": _PROMPT_HASH, "agent": "concept_describe"},
+)
+
+
+def build_message(concept: str, course_label: str | None) -> str:
+    """Compose the single user message handed to the agent."""
+    concept = concept.strip()
+    if course_label:
+        return f"Concept: {concept}\nCourse: {course_label.strip()}"
+    return f"Concept: {concept}"

--- a/backend/routes/graph.py
+++ b/backend/routes/graph.py
@@ -1,3 +1,5 @@
+import uuid
+
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from typing import Optional
@@ -8,6 +10,11 @@ from services.graph_service import (
     get_courses, add_course, delete_course, update_course_color,
     delete_node, update_node_color,
 )
+from services.request_context import current_request_id
+from agents import WORKER_LIMITS
+from agents._run import run_agent_sync
+from agents.deps import SaplingDeps
+from agents.concept_describe import concept_describe_agent, build_message
 
 router = APIRouter()
 
@@ -38,6 +45,11 @@ class UpdateCourseColorBody(BaseModel):
 
 class UpdateNodeColorBody(BaseModel):
     color: Optional[str] = None
+
+
+class ConceptDescriptionBody(BaseModel):
+    concept: str
+    course_label: Optional[str] = None
 
 
 @router.get("/{user_id}/courses")
@@ -85,3 +97,33 @@ def set_node_color(user_id: str, node_id: str, body: UpdateNodeColorBody, reques
     if "error" in result:
         raise HTTPException(status_code=404, detail=result["error"])
     return result
+
+
+# ── Concept description (LLM) ─────────────────────────────────────────────────
+
+@router.post("/{user_id}/concept-description")
+def describe_concept(user_id: str, body: ConceptDescriptionBody, request: Request):
+    """Generate a one-sentence, student-facing description for a concept.
+
+    Backs the knowledge-map rail's focus card for concepts without a stored
+    description. Tool-less LLM call — the concept name and course label are
+    handed straight to the agent.
+    """
+    require_self(user_id, request)
+    concept = body.concept.strip()
+    if not concept:
+        raise HTTPException(status_code=400, detail="concept is required")
+    deps = SaplingDeps(
+        user_id=user_id,
+        course_id=None,
+        supabase=None,
+        request_id=current_request_id() or str(uuid.uuid4()),
+    )
+    result = run_agent_sync(
+        concept_describe_agent.run(
+            build_message(concept, body.course_label),
+            deps=deps,
+            usage_limits=WORKER_LIMITS,
+        )
+    )
+    return {"description": result.output.description}

--- a/backend/routes/graph.py
+++ b/backend/routes/graph.py
@@ -1,8 +1,10 @@
 import uuid
 
+import httpx
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from typing import Optional
+from pydantic_ai.exceptions import AgentRunError
 
 from services.auth_guard import require_self
 from services.graph_service import (
@@ -101,6 +103,12 @@ def set_node_color(user_id: str, node_id: str, body: UpdateNodeColorBody, reques
 
 # ── Concept description (LLM) ─────────────────────────────────────────────────
 
+# Bound the free-text handed to the agent. Concept names/course labels are short
+# in practice; caps keep a pathological payload from bloating the prompt.
+_MAX_CONCEPT_LEN = 200
+_MAX_COURSE_LABEL_LEN = 120
+
+
 @router.post("/{user_id}/concept-description")
 def describe_concept(user_id: str, body: ConceptDescriptionBody, request: Request):
     """Generate a one-sentence, student-facing description for a concept.
@@ -110,20 +118,28 @@ def describe_concept(user_id: str, body: ConceptDescriptionBody, request: Reques
     handed straight to the agent.
     """
     require_self(user_id, request)
-    concept = body.concept.strip()
+    concept = body.concept.strip()[:_MAX_CONCEPT_LEN]
     if not concept:
         raise HTTPException(status_code=400, detail="concept is required")
+    course_label = (body.course_label or "").strip()[:_MAX_COURSE_LABEL_LEN] or None
     deps = SaplingDeps(
         user_id=user_id,
         course_id=None,
         supabase=None,
         request_id=current_request_id() or str(uuid.uuid4()),
     )
-    result = run_agent_sync(
-        concept_describe_agent.run(
-            build_message(concept, body.course_label),
-            deps=deps,
-            usage_limits=WORKER_LIMITS,
+    try:
+        result = run_agent_sync(
+            concept_describe_agent.run(
+                build_message(concept, course_label),
+                deps=deps,
+                usage_limits=WORKER_LIMITS,
+            )
         )
-    )
+    except (AgentRunError, httpx.HTTPError, ValidationError) as e:
+        # Model / transport / output-validation failures are upstream problems —
+        # surface them as 502. Anything else propagates to the generic handler.
+        raise HTTPException(
+            status_code=502, detail=f"concept-description agent failed: {e}"
+        ) from e
     return {"description": result.output.description}

--- a/backend/tests/test_graph_concept_description.py
+++ b/backend/tests/test_graph_concept_description.py
@@ -1,0 +1,84 @@
+"""Route tests for the concept-description endpoint (routes/graph.py).
+
+Backs the knowledge-map rail's on-demand concept blurb. Covers:
+  - happy path returns the agent's description
+  - oversized concept / course_label are truncated before the agent sees them
+  - model / transport / validation failures translate to HTTP 502
+  - empty concept is rejected with 400
+  - unexpected exceptions still fall through to the generic 500 handler
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+from main import app
+from routes.graph import _MAX_CONCEPT_LEN, _MAX_COURSE_LABEL_LEN
+
+client = TestClient(app)
+
+URL = "/api/graph/user_andres/concept-description"
+
+
+def _result(description: str):
+    r = MagicMock()
+    r.output.description = description
+    return r
+
+
+# Stub the agent's async `run` so the handler never builds a real coroutine
+# (the patched run_agent_sync ignores it). Keeps `run_agent_sync` as the single
+# seam where we inject the success value or failure.
+def _agent_run_stub():
+    return patch("routes.graph.concept_describe_agent.run", MagicMock())
+
+
+def test_happy_path_returns_description():
+    with _agent_run_stub(), \
+         patch("routes.graph.run_agent_sync", return_value=_result("Recursion is a function calling itself.")):
+        resp = client.post(URL, json={"concept": "Recursion", "course_label": "CS 101"})
+    assert resp.status_code == 200
+    assert resp.json() == {"description": "Recursion is a function calling itself."}
+
+
+def test_oversized_inputs_truncated_before_agent():
+    seen = {}
+
+    def spy_build(concept, course_label):
+        seen["concept"] = concept
+        seen["course_label"] = course_label
+        return "msg"
+
+    with _agent_run_stub(), \
+         patch("routes.graph.build_message", side_effect=spy_build), \
+         patch("routes.graph.run_agent_sync", return_value=_result("ok")):
+        resp = client.post(URL, json={"concept": "x" * 500, "course_label": "y" * 300})
+
+    assert resp.status_code == 200
+    assert len(seen["concept"]) == _MAX_CONCEPT_LEN
+    assert len(seen["course_label"]) == _MAX_COURSE_LABEL_LEN
+
+
+def test_agent_failure_translates_to_502():
+    with _agent_run_stub(), \
+         patch("routes.graph.run_agent_sync", side_effect=UnexpectedModelBehavior("model exploded")):
+        resp = client.post(URL, json={"concept": "Recursion"})
+    assert resp.status_code == 502
+    assert "concept-description agent failed" in resp.json()["detail"]
+
+
+def test_empty_concept_rejected_with_400():
+    resp = client.post(URL, json={"concept": "   "})
+    assert resp.status_code == 400
+
+
+def test_unexpected_exception_falls_through_to_500():
+    # A non-LLM bug must NOT be masked as 502 — it goes to the generic handler.
+    safe_client = TestClient(app, raise_server_exceptions=False)
+    with _agent_run_stub(), \
+         patch("routes.graph.run_agent_sync", side_effect=ValueError("bug")):
+        resp = safe_client.post(URL, json={"concept": "Recursion"})
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Internal server error."

--- a/frontend/src/components/KnowledgeGraph2D.tsx
+++ b/frontend/src/components/KnowledgeGraph2D.tsx
@@ -276,6 +276,31 @@ function KnowledgeGraph2DImpl({
     return result;
   }, [nodes]);
 
+  // Constrain the pan/zoom transform so the graph can't be dragged off into
+  // empty space: the content's bounding box stays inside the window, or — when
+  // it's larger than the window — always covers it. Applied on pan and zoom.
+  const clampView = (tx: number, ty: number, scale: number) => {
+    const ns = simNodesRef.current;
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const n of ns) {
+      if (n.x == null || n.y == null) continue;
+      const r = nodeRadius(n) + 24; // node radius + label/glow allowance
+      if (n.x - r < minX) minX = n.x - r;
+      if (n.x + r > maxX) maxX = n.x + r;
+      if (n.y - r < minY) minY = n.y - r;
+      if (n.y + r > maxY) maxY = n.y + r;
+    }
+    if (!Number.isFinite(minX)) return { tx, ty };
+    const clamp = (v: number, a: number, b: number) => {
+      const lo = Math.min(a, b), hi = Math.max(a, b);
+      return Math.max(lo, Math.min(hi, v));
+    };
+    return {
+      tx: clamp(tx, -minX * scale, width - maxX * scale),
+      ty: clamp(ty, -minY * scale, height - maxY * scale),
+    };
+  };
+
   // ── Pointer interaction ─────────────────────────────────────────────────
   const clientToSvg = (clientX: number, clientY: number) => {
     const svg = svgRef.current;
@@ -322,12 +347,19 @@ function KnowledgeGraph2DImpl({
       const n = simNodesRef.current.find((sn) => sn.id === drag.nodeId);
       if (!n) return;
       const { x, y } = clientToSvg(e.clientX, e.clientY);
-      n.fx = x;
-      n.fy = y;
+      // Keep the dragged node inside the window: map the visible bounds back
+      // into content coords through the current view transform.
+      const r = nodeRadius(n);
+      const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+      n.fx = clamp(x, (r - view.tx) / view.scale, (width - r - view.tx) / view.scale);
+      n.fy = clamp(y, (r - view.ty) / view.scale, (height - r - view.ty) / view.scale);
     } else if (drag.kind === "pan") {
       const dx = e.clientX - drag.startX;
       const dy = e.clientY - drag.startY;
-      setView((v) => ({ ...v, tx: drag.originTx + dx, ty: drag.originTy + dy }));
+      setView((v) => {
+        const c = clampView(drag.originTx + dx, drag.originTy + dy, v.scale);
+        return { ...v, tx: c.tx, ty: c.ty };
+      });
     }
   };
 
@@ -358,11 +390,8 @@ function KnowledgeGraph2DImpl({
     setView((v) => {
       const nextScale = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, v.scale * (1 + delta)));
       const factor = nextScale / v.scale;
-      return {
-        tx: mx - (mx - v.tx) * factor,
-        ty: my - (my - v.ty) * factor,
-        scale: nextScale,
-      };
+      const c = clampView(mx - (mx - v.tx) * factor, my - (my - v.ty) * factor, nextScale);
+      return { tx: c.tx, ty: c.ty, scale: nextScale };
     });
   };
 
@@ -554,7 +583,11 @@ function KnowledgeGraph2DImpl({
         <button
           className="btn btn--ghost btn--sm"
           style={{ padding: "2px 8px", fontFamily: "var(--font-mono)" }}
-          onClick={() => setView((v) => ({ ...v, scale: Math.min(MAX_ZOOM, v.scale * 1.2) }))}
+          onClick={() => setView((v) => {
+            const s = Math.min(MAX_ZOOM, v.scale * 1.2);
+            const c = clampView(v.tx, v.ty, s);
+            return { tx: c.tx, ty: c.ty, scale: s };
+          })}
           title="Zoom in"
         >
           +
@@ -562,7 +595,11 @@ function KnowledgeGraph2DImpl({
         <button
           className="btn btn--ghost btn--sm"
           style={{ padding: "2px 8px", fontFamily: "var(--font-mono)" }}
-          onClick={() => setView((v) => ({ ...v, scale: Math.max(MIN_ZOOM, v.scale / 1.2) }))}
+          onClick={() => setView((v) => {
+            const s = Math.max(MIN_ZOOM, v.scale / 1.2);
+            const c = clampView(v.tx, v.ty, s);
+            return { tx: c.tx, ty: c.ty, scale: s };
+          })}
           title="Zoom out"
         >
           −

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -30,6 +30,9 @@ import {
   learnAction,
   getCourses,
   getGraph,
+  deleteGraphNode,
+  describeConcept,
+  IS_LOCAL_MODE,
   type Session,
   type SessionSummaryData,
   type EnrolledCourse,
@@ -54,6 +57,18 @@ const SESSION_END_COUNT_KEY = "sapling_session_end_count";
 const LAST_SESSION_CTX_KEY = "sapling_last_session_context";
 const RAIL_OPEN_KEY = "sapling_learn_rail_open";
 const RAIL_WIDTH = 400;
+
+// Mastery-tier vocabulary for the knowledge-map rail. Colors reuse the shared
+// --state-* tokens (same palette as Tree/Dashboard); labels follow the map's
+// student-facing wording. Note: the graph itself colors nodes by course, not
+// tier — these swatches document the branch list + focus badge.
+const TIER_META: Record<GraphNode["mastery_tier"], { label: string; color: string }> = {
+  mastered: { label: "Mastered", color: "var(--state-mastery)" },
+  learning: { label: "In progress", color: "var(--state-progress)" },
+  struggling: { label: "Needs work", color: "var(--state-struggle)" },
+  unexplored: { label: "Not started", color: "var(--state-neutral)" },
+};
+const TIER_ORDER: GraphNode["mastery_tier"][] = ["mastered", "learning", "struggling", "unexplored"];
 
 function normalizeMode(input: string | null): Mode {
   if (!input) return "socratic";
@@ -97,6 +112,21 @@ function LearnInner() {
   const [concepts, setConcepts] = useState<{ id: string; name: string; course_id: string | null; course_code: string | null }[]>([]);
   const [graphNodes, setGraphNodes] = useState<GraphNode[]>([]);
   const [graphEdges, setGraphEdges] = useState<GraphEdge[]>([]);
+
+  // The rail's focused node — independent of the active session's topic, so
+  // clicking around the map explores without touching the chat. Null means the
+  // focus follows the current session topic. `lastNodeClickRef` powers the
+  // double-click-to-switch shortcut.
+  const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
+  const lastNodeClickRef = useRef<{ id: string; t: number } | null>(null);
+  // Inline "add concept" composer state for the knowledge-map rail.
+  const [addingConcept, setAddingConcept] = useState(false);
+  const [newConceptName, setNewConceptName] = useState("");
+  // AI-generated concept descriptions, fetched lazily for the focused concept
+  // when it has no stored description (keyed by node id). `descInflightRef`
+  // dedupes concurrent fetches for the same node.
+  const [descCache, setDescCache] = useState<Record<string, string>>({});
+  const descInflightRef = useRef<Set<string>>(new Set());
 
   const [summary, setSummary] = useState<SessionSummaryData | null>(null);
   const [mobileTab, setMobileTab] = useState<"chat" | "graph">("chat");
@@ -181,14 +211,19 @@ function LearnInner() {
     } catch {}
   }, [railOpen, railHydrated]);
 
-  const handleStart = async () => {
-    const t = topicDraft.trim();
-    if (!t || !userId) return;
-    setTopic(t);
+  // Begins a fresh tutor session on `t`. Shared by the entry-screen Start
+  // button and the knowledge-map switch flow. Clears any map focus so the rail
+  // snaps back to following the (new) active topic.
+  const beginSession = async (t: string) => {
+    const topicName = t.trim();
+    if (!topicName || !userId) return;
+    setFocusedNodeId(null);
+    setTopic(topicName);
+    setTopicDraft(topicName);
     setMessages([{ id: msgId(), role: "assistant", content: "", loading: true }]);
     setStarting(true);
     try {
-      const res = await startSession(userId, t, mode, selectedCourseId || undefined, sharedCtx, modelPref);
+      const res = await startSession(userId, topicName, mode, selectedCourseId || undefined, sharedCtx, modelPref);
       setSessionId(res.session_id);
       setMessages([{ id: msgId(), role: "assistant", content: res.initial_message || "Let's begin." }]);
     } catch (err) {
@@ -198,6 +233,8 @@ function LearnInner() {
       setStarting(false);
     }
   };
+
+  const handleStart = () => beginSession(topicDraft);
 
   const handleResume = async (s: Session) => {
     try {
@@ -379,11 +416,34 @@ function LearnInner() {
     return graphNodes.find(n => n.name.toLowerCase() === topic.trim().toLowerCase())?.id;
   }, [suggestParam, graphNodes, topic]);
 
-  const handleNodeClick = useCallback((n: GraphNode) => {
-    if (!n.is_subject_root) {
-      router.replace(`/learn?topic=${encodeURIComponent(n.name)}&mode=${mode}`, { scroll: false });
+  // Jump the chat to `name`: resume an existing session on that concept if one
+  // exists, otherwise start a fresh one. Both paths clear the map focus so the
+  // rail follows the now-active session.
+  const switchToConcept = (name: string) => {
+    const existing = recentSessions.find(
+      s => s.topic.trim().toLowerCase() === name.trim().toLowerCase(),
+    );
+    if (existing) {
+      setFocusedNodeId(null);
+      handleResume(existing);
+    } else {
+      beginSession(name);
     }
-  }, [router, mode]);
+  };
+
+  // Single click focuses a concept in the rail (chat untouched); a second click
+  // on the same node within 350ms switches the session to it.
+  const handleNodeClick = (n: GraphNode) => {
+    if (n.is_subject_root) return;
+    const now = Date.now();
+    const last = lastNodeClickRef.current;
+    lastNodeClickRef.current = { id: n.id, t: now };
+    if (last && last.id === n.id && now - last.t < 350) {
+      switchToConcept(n.name);
+    } else {
+      setFocusedNodeId(n.id);
+    }
+  };
 
   // Edge-tab pointer handling: grab-drag moves the rail width live; a sub-4px
   // press is treated as a click (toggle). On release we snap open/closed at the
@@ -427,9 +487,13 @@ function LearnInner() {
     }
   };
 
+  // The rail focus: an explicitly-clicked node when present, otherwise the
+  // node for the active session topic. Drives the graph highlight, focus card,
+  // "In this branch", and "Elsewhere".
+  const activeFocusId = focusedNodeId ?? highlightId;
   const topicNode = useMemo(
-    () => graphNodes.find(n => n.id === highlightId),
-    [graphNodes, highlightId],
+    () => graphNodes.find(n => n.id === activeFocusId),
+    [graphNodes, activeFocusId],
   );
 
   const neighborIds = useMemo(() => {
@@ -443,20 +507,24 @@ function LearnInner() {
   }, [topicNode, graphEdges]);
 
   const cardCourseId = topicNode?.course_id || selectedCourseId || null;
+  const cardCourse = useMemo(
+    () => courses.find(c => c.course_id === cardCourseId) ?? null,
+    [courses, cardCourseId],
+  );
 
   const progressItems = useMemo(() => {
     if (topicNode && neighborIds.size > 0) {
       return graphNodes
         .filter(n => neighborIds.has(n.id) && !n.is_subject_root)
         .slice(0, 6)
-        .map(n => ({ name: n.name, complete: n.mastery_tier === "mastered" }));
+        .map(n => ({ id: n.id, name: n.name, tier: n.mastery_tier }));
     }
     if (cardCourseId) {
       return graphNodes
         .filter(n => n.course_id === cardCourseId && !n.is_subject_root)
         .sort((a, b) => (b.mastery_score ?? 0) - (a.mastery_score ?? 0))
         .slice(0, 6)
-        .map(n => ({ name: n.name, complete: n.mastery_tier === "mastered" }));
+        .map(n => ({ id: n.id, name: n.name, tier: n.mastery_tier }));
     }
     return [];
   }, [graphNodes, neighborIds, topicNode, cardCourseId]);
@@ -472,7 +540,7 @@ function LearnInner() {
         )
         .sort((a, b) => (b.mastery_score ?? 0) - (a.mastery_score ?? 0))
         .slice(0, 4)
-        .map(n => n.name);
+        .map(n => ({ id: n.id, name: n.name }));
     }
     if (cardCourseId) {
       const topicLower = topic.trim().toLowerCase();
@@ -484,18 +552,92 @@ function LearnInner() {
         )
         .sort((a, b) => (b.mastery_score ?? 0) - (a.mastery_score ?? 0))
         .slice(0, 4)
-        .map(n => n.name);
+        .map(n => ({ id: n.id, name: n.name }));
     }
     return [];
   }, [graphNodes, neighborIds, topicNode, cardCourseId, topic]);
 
-  const startSessionFromConcept = useCallback((concept: string) => {
-    setSessionId(null);
-    setMessages([]);
-    setTopicDraft(concept);
-    setTopic(concept);
-    router.replace(`/learn?topic=${encodeURIComponent(concept)}&mode=${mode}`, { scroll: false });
-  }, [router, mode]);
+  // The rail graph shows only the focused course's tree (its subject root +
+  // its concepts), not the full multi-course graph. Falls back to the whole
+  // graph when no course is resolved (free-text topic with no enrollment).
+  const railGraph = useMemo(() => {
+    if (!cardCourseId) return { nodes: graphNodes, edges: graphEdges };
+    const nodes = graphNodes.filter(n => n.course_id === cardCourseId);
+    if (nodes.length === 0) return { nodes: graphNodes, edges: graphEdges };
+    const ids = new Set(nodes.map(n => n.id));
+    const edges = graphEdges.filter(e => ids.has(e.source as string) && ids.has(e.target as string));
+    return { nodes, edges };
+  }, [graphNodes, graphEdges, cardCourseId]);
+
+  // The focus card anchors on the specific concept when the session topic is
+  // one; otherwise (course-level session) it anchors on the course itself.
+  const focusConcept = topicNode && !topicNode.is_subject_root ? topicNode : null;
+  const courseConceptCount = railGraph.nodes.filter(n => !n.is_subject_root).length;
+
+  // Whether the focused concept is the one already being chatted about (no
+  // switch needed), and whether a prior session exists to resume vs. start.
+  const focusIsCurrent = !!focusConcept && focusConcept.name.trim().toLowerCase() === topic.trim().toLowerCase();
+  const focusHasSession = !!focusConcept && recentSessions.some(
+    s => s.topic.trim().toLowerCase() === focusConcept.name.trim().toLowerCase(),
+  );
+
+  // Lazily fetch an AI description for the focused concept when it lacks a
+  // stored one (e.g. a manually-added concept). Skipped in local mode, which
+  // has no real AI — those fall back to the connected-concepts sentence.
+  const focusId = focusConcept?.id;
+  const focusName = focusConcept?.name;
+  const focusDesc = focusConcept?.description;
+  const focusCourseName = cardCourse?.course_name;
+  useEffect(() => {
+    if (IS_LOCAL_MODE || !userId || !focusId || !focusName) return;
+    if (focusDesc || descCache[focusId] || descInflightRef.current.has(focusId)) return;
+    descInflightRef.current.add(focusId);
+    let cancelled = false;
+    describeConcept(userId, focusName, focusCourseName)
+      .then(r => {
+        if (!cancelled && r?.description) {
+          setDescCache(prev => ({ ...prev, [focusId]: r.description }));
+        }
+      })
+      .catch(() => {})
+      .finally(() => { descInflightRef.current.delete(focusId); });
+    return () => { cancelled = true; };
+  }, [userId, focusId, focusName, focusDesc, focusCourseName, descCache]);
+
+  // Manually add a concept to the current course. The new node links to the
+  // focused concept (or the course root) so it joins the tree, starts as
+  // "unexplored", and becomes the focus. State-first so it works in local mode;
+  // real-backend persistence for add would need a dedicated endpoint.
+  const addConcept = (name: string) => {
+    const label = name.trim();
+    if (!label || !cardCourseId) return;
+    const root = graphNodes.find(n => n.is_subject_root && n.course_id === cardCourseId);
+    const anchorId = focusConcept?.id ?? root?.id;
+    const id = `node-new-${Date.now()}`;
+    const newNode: GraphNode = {
+      id,
+      name: label,
+      subject: cardCourse?.course_name ?? root?.subject ?? "",
+      color: root?.color ?? "var(--c-sage)",
+      mastery_tier: "unexplored",
+      mastery_score: 0,
+      course_id: cardCourseId,
+    };
+    setGraphNodes(prev => [...prev, newNode]);
+    if (anchorId) setGraphEdges(prev => [...prev, { source: anchorId, target: id, strength: 0.4 }]);
+    setFocusedNodeId(id);
+    setNewConceptName("");
+    setAddingConcept(false);
+  };
+
+  // Remove a concept: drop the node + its edges and clear focus if it was
+  // focused. Best-effort persistence via the delete endpoint on real backends.
+  const removeConcept = (nodeId: string) => {
+    setGraphNodes(prev => prev.filter(n => n.id !== nodeId));
+    setGraphEdges(prev => prev.filter(e => e.source !== nodeId && e.target !== nodeId));
+    setFocusedNodeId(cur => (cur === nodeId ? null : cur));
+    if (!IS_LOCAL_MODE && userId) deleteGraphNode(userId, nodeId).catch(() => {});
+  };
 
   // ────────── Entry screen (no active session) ──────────
   if (!sessionId && !starting) {
@@ -670,44 +812,266 @@ function LearnInner() {
                 boxSizing: "border-box",
                 borderLeft: isMobile ? "none" : "1px solid var(--border)",
                 background: "var(--bg-subtle)",
-                padding: 20,
                 overflowY: "auto",
+                overflowX: "hidden",
                 display: "flex",
                 flexDirection: "column",
-                gap: 16,
               }}
             >
-              <div>
-                <div className="label-micro">Session</div>
-                <div className="h-serif" style={{ fontSize: 18, marginTop: 4 }}>{topic}</div>
+              {/* Header */}
+              <div style={{ padding: "20px 22px 16px", borderBottom: "1px solid var(--border)" }}>
+                <div className="label-micro">Knowledge map</div>
+                {cardCourse && (
+                  <div style={{ marginTop: 8, fontFamily: "var(--font-mono)", fontSize: 12, fontWeight: 500, color: "var(--brand-forest)" }}>
+                    {cardCourse.course_code}
+                  </div>
+                )}
+                <div style={{ fontFamily: "var(--font-serif)", fontSize: 15, color: "var(--text-dim)", marginTop: 2, lineHeight: 1.35 }}>
+                  {cardCourse?.course_name ?? topic}
+                </div>
               </div>
-              {graphNodes.length > 0 && (
-                <SidebarKnowledgeGraph
-                  nodes={graphNodes}
-                  edges={graphEdges}
-                  highlightId={highlightId}
-                  onNodeClick={handleNodeClick}
-                />
+
+              {/* Graph + legend */}
+              {railGraph.nodes.length > 0 && (
+                <div
+                  style={{
+                    padding: "14px 14px 8px",
+                    background: "radial-gradient(ellipse 80% 70% at 55% 42%, color-mix(in srgb, var(--brand-forest-bright) 6%, transparent), transparent 70%)",
+                  }}
+                >
+                  <SidebarKnowledgeGraph
+                    nodes={railGraph.nodes}
+                    edges={railGraph.edges}
+                    highlightId={activeFocusId}
+                    onNodeClick={handleNodeClick}
+                  />
+                  <div style={{ display: "flex", gap: 14, justifyContent: "center", padding: "6px 0 4px", flexWrap: "wrap" }}>
+                    {TIER_ORDER.map(tier => (
+                      <span key={tier} style={{ display: "inline-flex", alignItems: "center", gap: 5, fontSize: 10.5, color: "var(--text-muted)" }}>
+                        <span style={{ width: 8, height: 8, borderRadius: "50%", background: TIER_META[tier].color }} />
+                        {TIER_META[tier].label}
+                      </span>
+                    ))}
+                  </div>
+                </div>
               )}
-              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-                <div className="card" style={{ padding: 12 }}>
-                  <div className="label-micro" style={{ marginBottom: 4 }}>Mode</div>
-                  <div style={{ fontSize: 13, fontWeight: 500, textTransform: "capitalize" }}>{mode}</div>
+
+              {/* Focused concept (or course anchor when no concept is focused) */}
+              {(focusConcept || cardCourse) && (
+                <div
+                  style={{
+                    margin: "6px 18px 0",
+                    padding: "15px 16px",
+                    background: "var(--bg-panel)",
+                    border: "1px solid var(--border)",
+                    borderRadius: 14,
+                    boxShadow: "var(--shadow-sm)",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                    <div className="label-micro">{focusConcept ? "Focused concept" : "Focused course"}</div>
+                    {focusConcept && (
+                      <span
+                        style={{
+                          fontSize: 10.5,
+                          fontWeight: 600,
+                          padding: "2px 9px",
+                          borderRadius: "var(--r-full)",
+                          color: "#fff",
+                          background: TIER_META[focusConcept.mastery_tier].color,
+                        }}
+                      >
+                        {TIER_META[focusConcept.mastery_tier].label}
+                      </span>
+                    )}
+                  </div>
+                  <div style={{ fontFamily: "var(--font-display)", fontSize: 19, fontWeight: 500, color: "var(--text)", marginTop: 7, lineHeight: 1.2 }}>
+                    {focusConcept ? focusConcept.name : (cardCourse?.course_name ?? topic)}
+                  </div>
+                  <div style={{ fontSize: 12.5, color: "var(--text-muted)", marginTop: 6, lineHeight: 1.5 }}>
+                    {focusConcept
+                      ? (focusConcept.description
+                          ?? descCache[focusConcept.id]
+                          ?? `${neighborIds.size} connected concepts · this is where your session is anchored on the course map.`)
+                      : `${courseConceptCount} concepts in this course · pick one to anchor your session.`}
+                  </div>
+                  {focusConcept && (
+                    <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+                      {!focusIsCurrent && (
+                        <button
+                          onClick={() => switchToConcept(focusConcept.name)}
+                          style={{
+                            flex: 1,
+                            display: "inline-flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            gap: 6,
+                            padding: "8px 12px",
+                            borderRadius: "var(--r-sm)",
+                            fontSize: 12.5,
+                            fontWeight: 600,
+                            border: "none",
+                            background: "var(--brand-forest)",
+                            color: "var(--accent-fg)",
+                            cursor: "pointer",
+                          }}
+                        >
+                          <Icon name="sparkle" size={12} />
+                          {focusHasSession ? "Resume session" : "Start session"}
+                        </button>
+                      )}
+                      <button
+                        onClick={() => removeConcept(focusConcept.id)}
+                        title="Remove concept"
+                        style={{
+                          flex: focusIsCurrent ? 1 : undefined,
+                          display: "inline-flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          gap: 6,
+                          padding: "8px 12px",
+                          borderRadius: "var(--r-sm)",
+                          fontSize: 12.5,
+                          fontWeight: 500,
+                          border: "1px solid var(--border)",
+                          background: "var(--bg-panel)",
+                          color: "var(--state-struggle)",
+                          cursor: "pointer",
+                        }}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  )}
                 </div>
-                <div className="card" style={{ padding: 12 }}>
-                  <div className="label-micro" style={{ marginBottom: 4 }}>Messages</div>
-                  <div className="mono" style={{ fontSize: 16 }}>{messages.length}</div>
+              )}
+
+              {/* In this branch */}
+              {progressItems.length > 0 && (
+                <div style={{ padding: "18px 22px 6px" }}>
+                  <div className="label-micro" style={{ marginBottom: 10 }}>In this branch</div>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 9 }}>
+                    {progressItems.map(p => (
+                      <button
+                        key={p.id}
+                        onClick={() => setFocusedNodeId(p.id)}
+                        title={`Focus ${p.name}`}
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 10,
+                          textAlign: "left",
+                          width: "100%",
+                          margin: "0 -7px",
+                          padding: "5px 7px",
+                          borderRadius: 8,
+                          background: p.id === activeFocusId ? "var(--bg-soft)" : "transparent",
+                          border: "none",
+                          cursor: "pointer",
+                        }}
+                      >
+                        <span style={{ width: 11, height: 11, borderRadius: "50%", flexShrink: 0, background: TIER_META[p.tier].color }} />
+                        <span style={{ flex: 1, fontSize: 13, color: "var(--text)", fontWeight: p.id === activeFocusId ? 600 : 400, lineHeight: 1.3 }}>{p.name}</span>
+                        <span style={{ fontSize: 10.5, color: "var(--text-muted)" }}>{TIER_META[p.tier].label}</span>
+                      </button>
+                    ))}
+                  </div>
                 </div>
-              </div>
-              <div className="card" style={{ padding: 12 }}>
-                <div className="label-micro" style={{ marginBottom: 4 }}>Context</div>
-                <div style={{ fontSize: 12, color: "var(--text-dim)" }}>
-                  {sharedCtx ? "Class intel: on" : "Class intel: off"}
-                </div>
-              </div>
-              {progressItems.length > 0 && <ProgressCard items={progressItems} />}
+              )}
+
+              {/* Elsewhere in course */}
               {relatedItems.length > 0 && (
-                <RelatedConceptsCard items={relatedItems} onSelect={startSessionFromConcept} />
+                <div style={{ padding: "16px 22px 24px" }}>
+                  <div className="label-micro" style={{ marginBottom: 10 }}>Elsewhere in course</div>
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: 7 }}>
+                    {relatedItems.map(r => {
+                      const active = r.id === activeFocusId;
+                      return (
+                        <button
+                          key={r.id}
+                          onClick={() => setFocusedNodeId(r.id)}
+                          title={`Focus ${r.name}`}
+                          style={{
+                            padding: "6px 12px",
+                            borderRadius: "var(--r-full)",
+                            fontSize: 12.5,
+                            fontWeight: 500,
+                            border: `1px solid ${active ? "var(--brand-forest)" : "var(--border)"}`,
+                            background: active ? "var(--accent-soft)" : "var(--bg-panel)",
+                            color: active ? "var(--text)" : "var(--text-dim)",
+                            cursor: "pointer",
+                          }}
+                        >
+                          {r.name}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Add concept */}
+              {cardCourseId && (
+                <div style={{ padding: "4px 22px 24px" }}>
+                  {addingConcept ? (
+                    <div style={{ display: "flex", gap: 6 }}>
+                      <input
+                        autoFocus
+                        value={newConceptName}
+                        onChange={e => setNewConceptName(e.target.value)}
+                        onKeyDown={e => {
+                          if (e.key === "Enter") addConcept(newConceptName);
+                          if (e.key === "Escape") { setAddingConcept(false); setNewConceptName(""); }
+                        }}
+                        placeholder="New concept name…"
+                        style={{
+                          flex: 1,
+                          minWidth: 0,
+                          padding: "7px 10px",
+                          fontSize: 12.5,
+                          border: "1px solid var(--border-strong)",
+                          borderRadius: "var(--r-sm)",
+                          background: "var(--bg-panel)",
+                          color: "var(--text)",
+                          outline: "none",
+                        }}
+                      />
+                      <button
+                        onClick={() => addConcept(newConceptName)}
+                        disabled={!newConceptName.trim()}
+                        style={{
+                          padding: "7px 12px",
+                          fontSize: 12.5,
+                          fontWeight: 600,
+                          borderRadius: "var(--r-sm)",
+                          border: "none",
+                          background: newConceptName.trim() ? "var(--brand-forest)" : "var(--bg-soft)",
+                          color: newConceptName.trim() ? "var(--accent-fg)" : "var(--text-muted)",
+                          cursor: newConceptName.trim() ? "pointer" : "not-allowed",
+                        }}
+                      >
+                        Add
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setAddingConcept(true)}
+                      style={{
+                        width: "100%",
+                        padding: "8px 12px",
+                        fontSize: 12.5,
+                        fontWeight: 500,
+                        borderRadius: "var(--r-sm)",
+                        border: "1px dashed var(--border-strong)",
+                        background: "transparent",
+                        color: "var(--text-muted)",
+                        cursor: "pointer",
+                      }}
+                    >
+                      ＋ Add concept
+                    </button>
+                  )}
+                </div>
               )}
             </div>
           </aside>
@@ -751,13 +1115,12 @@ function LearnInner() {
                 : "right var(--dur) var(--ease), color var(--dur) var(--ease)",
             }}
           >
-            {/* Knowledge-graph glyph: three nodes joined by two links. */}
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden="true">
-              <line x1="4.5" y1="5" x2="11" y2="4" />
-              <line x1="4.5" y1="5" x2="9" y2="11.5" />
-              <circle cx="4.5" cy="5" r="2" />
-              <circle cx="11" cy="4" r="2" />
-              <circle cx="9" cy="11.5" r="2" />
+            {/* Knowledge-graph glyph: three nodes joined in a triangle. */}
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <circle cx="6" cy="7" r="2" />
+              <circle cx="17.5" cy="6" r="2" />
+              <circle cx="13" cy="17.5" r="2.3" />
+              <path d="M7.7 8.6 12 15.4M15.7 7.8 13.7 15.2M8 7.2 15.6 6.2" />
             </svg>
             <svg
               width="12"
@@ -978,76 +1341,6 @@ function SessionRow({ s, onResume, onDelete, onRename }: {
       >
         {del.armed ? "Confirm" : <Icon name="x" size={12} />}
       </button>
-    </div>
-  );
-}
-
-function ProgressCard({ items }: { items: { name: string; complete: boolean }[] }) {
-  return (
-    <div className="card" style={{ padding: 12 }}>
-      <div className="label-micro" style={{ marginBottom: 8 }}>Progress</div>
-      <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
-        {items.map(item => (
-          <div key={item.name} style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <div
-              style={{
-                width: 12,
-                height: 12,
-                borderRadius: "50%",
-                flexShrink: 0,
-                background: item.complete ? "var(--accent)" : "transparent",
-                border: item.complete ? "1px solid var(--accent)" : "1.5px solid var(--border-strong)",
-              }}
-            />
-            <span
-              style={{
-                fontSize: 12,
-                color: item.complete ? "var(--text)" : "var(--text-dim)",
-                lineHeight: 1.3,
-              }}
-            >
-              {item.name}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function RelatedConceptsCard({
-  items,
-  onSelect,
-}: {
-  items: string[];
-  onSelect: (name: string) => void;
-}) {
-  return (
-    <div className="card" style={{ padding: 12 }}>
-      <div className="label-micro" style={{ marginBottom: 8 }}>Related</div>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-        {items.map(name => (
-          <button
-            key={name}
-            onClick={() => onSelect(name)}
-            style={{
-              padding: "5px 10px",
-              borderRadius: "var(--r-full)",
-              fontSize: 12,
-              fontWeight: 500,
-              border: "1px solid var(--border)",
-              background: "transparent",
-              color: "var(--text-dim)",
-              cursor: "pointer",
-              transition: "background 120ms",
-            }}
-            onMouseEnter={e => { e.currentTarget.style.background = "var(--bg-subtle)"; }}
-            onMouseLeave={e => { e.currentTarget.style.background = "transparent"; }}
-          >
-            {name}
-          </button>
-        ))}
-      </div>
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -74,6 +74,12 @@ export const updateCourseColor = (userId: string, courseId: string, color: strin
     { method: 'PATCH', body: JSON.stringify({ color }) }
   );
 
+export const describeConcept = (userId: string, concept: string, courseLabel?: string) =>
+  fetchJSON<{ description: string }>(
+    `/api/graph/${userId}/concept-description`,
+    { method: 'POST', body: JSON.stringify({ concept, course_label: courseLabel ?? null }) }
+  );
+
 export const deleteGraphNode = (userId: string, nodeId: string) =>
   fetchJSON<{ deleted: boolean }>(
     `/api/graph/${userId}/nodes/${encodeURIComponent(nodeId)}`,

--- a/frontend/src/lib/data.ts
+++ b/frontend/src/lib/data.ts
@@ -56,6 +56,7 @@ export type GraphNode = {
   mastery_tier: "mastered" | "learning" | "struggling" | "unexplored";
   mastery_score: number;
   course_id: string;
+  description?: string;
   last_studied_at?: string;
 };
 
@@ -88,6 +89,7 @@ export function apiToGraphNode(n: ApiNode, courses: EnrolledCourse[]): GraphNode
     mastery_tier: n.mastery_tier === "subject_root" ? "mastered" : n.mastery_tier,
     mastery_score: n.mastery_score,
     course_id: n.course_id || course?.course_id || "",
+    description: n.description || undefined,
     last_studied_at: n.last_studied_at || undefined,
   };
 }

--- a/frontend/src/lib/localData.ts
+++ b/frontend/src/lib/localData.ts
@@ -32,49 +32,64 @@ export const LOCAL_USER = {
 };
 
 const COURSES = [
-  { name: 'Calculus II', color: '#2563eb' },
-  { name: 'Intro to Psychology', color: '#9333ea' },
-  { name: 'Data Structures', color: '#059669' },
+  { name: 'Calculus II', course_code: 'MATH 242', color: '#2563eb' },
+  { name: 'Intro to Psychology', course_code: 'PSY 101', color: '#9333ea' },
+  { name: 'Data Structures', course_code: 'CS 210', color: '#059669' },
 ];
 
 function makeNodes(): GraphNode[] {
   const nodes: GraphNode[] = [];
-  const concepts: Record<string, { name: string; mastery: number; tier: GraphNode['mastery_tier']; studied: string | null }[]> = {
+  const concepts: Record<string, { name: string; mastery: number; tier: GraphNode['mastery_tier']; studied: string | null; desc: string }[]> = {
     'Calculus II': [
-      { name: 'Integration by Parts', mastery: 0.85, tier: 'mastered', studied: daysAgo(0) },
-      { name: 'Taylor Series', mastery: 0.62, tier: 'learning', studied: daysAgo(1) },
-      { name: 'Polar Coordinates', mastery: 0.35, tier: 'struggling', studied: daysAgo(3) },
-      { name: 'Sequences & Convergence', mastery: 0.0, tier: 'unexplored', studied: null },
-      { name: 'Partial Fractions', mastery: 0.91, tier: 'mastered', studied: daysAgo(2) },
+      { name: 'Integration by Parts', mastery: 0.85, tier: 'mastered', studied: daysAgo(0), desc: 'Reverses the product rule to integrate products like x·eˣ.' },
+      { name: 'Partial Fractions', mastery: 0.91, tier: 'mastered', studied: daysAgo(2), desc: 'Splits a rational function into simpler fractions you can integrate term by term.' },
+      { name: 'Improper Integrals', mastery: 0.74, tier: 'learning', studied: daysAgo(1), desc: 'Evaluates integrals with infinite limits or unbounded integrands using limits.' },
+      { name: 'Taylor Series', mastery: 0.62, tier: 'learning', studied: daysAgo(1), desc: 'Approximates a function as an infinite polynomial expanded around a point.' },
+      { name: 'Power Series', mastery: 0.5, tier: 'learning', studied: daysAgo(3), desc: 'Represents functions as sums of powers of x within a radius of convergence.' },
+      { name: 'Polar Coordinates', mastery: 0.35, tier: 'struggling', studied: daysAgo(3), desc: 'Describes points by radius and angle instead of x and y.' },
+      { name: 'Parametric Equations', mastery: 0.28, tier: 'struggling', studied: daysAgo(5), desc: 'Traces curves by expressing x and y as functions of a parameter t.' },
+      { name: 'Sequences & Convergence', mastery: 0.0, tier: 'unexplored', studied: null, desc: 'Studies whether an infinite list of terms settles toward a limit.' },
+      { name: 'Arc Length & Surface Area', mastery: 0.0, tier: 'unexplored', studied: null, desc: 'Uses integrals to measure curve length and surfaces of revolution.' },
     ],
     'Intro to Psychology': [
-      { name: 'Classical Conditioning', mastery: 0.78, tier: 'learning', studied: daysAgo(0) },
-      { name: 'Memory & Encoding', mastery: 0.45, tier: 'struggling', studied: daysAgo(2) },
-      { name: 'Cognitive Biases', mastery: 0.0, tier: 'unexplored', studied: null },
+      { name: 'Classical Conditioning', mastery: 0.78, tier: 'learning', studied: daysAgo(0), desc: 'Learning to associate a neutral stimulus with a reflexive response.' },
+      { name: 'Operant Conditioning', mastery: 0.82, tier: 'mastered', studied: daysAgo(1), desc: 'Shaping behavior through reinforcement and punishment.' },
+      { name: 'Neurons & Synapses', mastery: 0.88, tier: 'mastered', studied: daysAgo(4), desc: 'How nerve cells fire and pass signals across synaptic gaps.' },
+      { name: 'Memory & Encoding', mastery: 0.45, tier: 'struggling', studied: daysAgo(2), desc: 'How information is registered, stored, and later retrieved.' },
+      { name: 'Sensation & Perception', mastery: 0.54, tier: 'learning', studied: daysAgo(3), desc: 'How the senses gather stimuli and the brain interprets them.' },
+      { name: 'Cognitive Biases', mastery: 0.0, tier: 'unexplored', studied: null, desc: 'Systematic errors in judgment that skew reasoning and decisions.' },
+      { name: 'Developmental Stages', mastery: 0.0, tier: 'unexplored', studied: null, desc: 'How thinking and behavior change across the human lifespan.' },
     ],
     'Data Structures': [
-      { name: 'Binary Trees', mastery: 0.95, tier: 'mastered', studied: daysAgo(1) },
-      { name: 'Hash Maps', mastery: 0.7, tier: 'learning', studied: daysAgo(0) },
-      { name: 'Graph Algorithms', mastery: 0.2, tier: 'struggling', studied: daysAgo(4) },
-      { name: 'Dynamic Programming', mastery: 0.0, tier: 'unexplored', studied: null },
+      { name: 'Binary Trees', mastery: 0.95, tier: 'mastered', studied: daysAgo(1), desc: 'Hierarchical nodes with up to two children, enabling fast ordered lookups.' },
+      { name: 'Linked Lists', mastery: 0.9, tier: 'mastered', studied: daysAgo(3), desc: 'A chain of nodes each pointing to the next, allowing cheap insertions.' },
+      { name: 'Stacks & Queues', mastery: 0.87, tier: 'mastered', studied: daysAgo(5), desc: 'LIFO and FIFO collections for ordered, restricted access.' },
+      { name: 'Hash Maps', mastery: 0.7, tier: 'learning', studied: daysAgo(0), desc: 'Key-value storage with near-constant-time lookups via hashing.' },
+      { name: 'Heaps & Priority Queues', mastery: 0.48, tier: 'learning', studied: daysAgo(2), desc: 'Trees that keep the min or max at the root for fast priority access.' },
+      { name: 'Graph Algorithms', mastery: 0.2, tier: 'struggling', studied: daysAgo(4), desc: 'Traversals and shortest paths over networks of nodes and edges.' },
+      { name: 'Sorting Algorithms', mastery: 0.33, tier: 'struggling', studied: daysAgo(6), desc: 'Techniques to order data, trading off speed and memory.' },
+      { name: 'Dynamic Programming', mastery: 0.0, tier: 'unexplored', studied: null, desc: 'Solves problems by caching overlapping subproblem results.' },
+      { name: 'Recursion & Backtracking', mastery: 0.0, tier: 'unexplored', studied: null, desc: 'Functions that call themselves to explore and undo choices.' },
     ],
   };
 
-  for (const course of COURSES) {
+  COURSES.forEach((course, i) => {
+    const courseId = `c${i + 1}`;
     const rootId = `subject_root__${course.name}`;
     nodes.push({
       id: rootId, concept_name: course.name, mastery_score: 0, mastery_tier: 'subject_root',
       times_studied: 0, last_studied_at: null, subject: course.name, is_subject_root: true,
-      course_color: course.color,
+      course_id: courseId, course_color: course.color,
     });
     for (const c of concepts[course.name] ?? []) {
       nodes.push({
         id: `node-${slugify(c.name)}`, concept_name: c.name, mastery_score: c.mastery,
         mastery_tier: c.tier, times_studied: Math.floor(c.mastery * 10),
-        last_studied_at: c.studied, subject: course.name, course_color: course.color,
+        last_studied_at: c.studied, subject: course.name, description: c.desc,
+        course_id: courseId, course_color: course.color,
       });
     }
-  }
+  });
   return nodes;
 }
 
@@ -124,7 +139,7 @@ const LOCAL_ASSIGNMENTS: Assignment[] = [
 ];
 
 const LOCAL_COURSES = COURSES.map((c, i) => ({
-  enrollment_id: `enr-${i}`, course_id: `c${i + 1}`, course_code: '',
+  enrollment_id: `enr-${i}`, course_id: `c${i + 1}`, course_code: c.course_code,
   course_name: c.name, school: 'Local University', department: '',
   color: c.color, nickname: null,
   node_count: LOCAL_NODES.filter(n => n.subject === c.name && !n.is_subject_root).length,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -6,6 +6,7 @@ export interface GraphNode {
   times_studied: number;
   last_studied_at: string | null;
   subject: string;
+  description?: string | null;
   course_id?: string | null;
   course_color?: string | null;
   color?: string | null;


### PR DESCRIPTION
Rebuilds the Tutor active-session right rail into a working navigator over
the course knowledge map, plus supporting graph and backend changes.

### Frontend
- Rail matches the Tutor Session design: Knowledge-map header (course code +
  name), graph on a transparent radial-glow surface, tier legend, Focused-
  concept card, "In this branch" list, "Elsewhere in course" chips.
- Graph is scoped to the focused course's tree only.
- Focus is decoupled from the chat: clicking a node/list item focuses it in
  the rail without touching the conversation; Resume/Start (or double-click)
  switches the session — resume existing session for that concept, else new.
- Focus card anchors on the course when no concept is focused.
- Per-concept descriptions: stored → lazily-fetched (cached) → generic
  fallback. Fetch is skipped in local mode (no AI).
- Add a concept (links to the focused node / course root) or remove the
  focused one.

### Graph
- Clamp pan/zoom and node-drag to the viewport so the graph can't leave its
  box. Force-simulation params untouched.

### Backend
- `concept_describe` Pydantic AI agent (tool-less, one-sentence output) on
  the flash-lite tier, exposed via `POST /api/graph/{user_id}/concept-description`.

### Notes
- Local dataset gains real course_id + codes, richer concept lists, and
  per-concept descriptions.
- The AI-description path compiles/imports/lints but was **not exercised
  end-to-end** (no backend + Gemini key in the dev environment) — worth a
  live check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-generated descriptions for concepts, optionally tailored to a course.
  * Enhanced the knowledge map with focused concepts, branch and course navigation, mastery tiers, and double-click session shortcuts.
  * Added support for creating and removing concepts directly from the map.
  * Added richer local course and concept data, including descriptions and course codes.

* **Improvements**
  * Prevented panning, zooming, and dragging the knowledge map into empty space.
  * Concept descriptions now load automatically when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->