### PR TITLE
fix(learn): relax concept-description output cap 240->400 (self-review hardening after #334)

### DIFF
--- a/backend/agents/concept_describe.py
+++ b/backend/agents/concept_describe.py
@@ -24,7 +24,12 @@ class ConceptDescription(BaseModel):
     """Typed output: a single short description sentence."""
 
     description: str = Field(
-        max_length=240,
+        # Generous guard, not a display target: the prompt governs length
+        # (~12-28 words). 240 was tight enough that a valid 28-word sentence
+        # with long technical terms could overflow it → schema-validation
+        # failure → retry → a user-facing 502. 400 keeps a hard ceiling on
+        # runaway output without rejecting legitimate one-sentence replies.
+        max_length=400,
         description=(
             "One concise, plain-language sentence explaining what the concept "
             "is. No preamble, no markdown, no trailing whitespace."


### PR DESCRIPTION
Follow-up to the code review of #334 (merged to `staging`).

`ConceptDescription.description` was capped at `max_length=240` while the prompt asks for a ~12-28 word sentence. A verbose sentence with long technical terms could overflow 240 → schema-validation failure → agent retry → `UnexpectedModelBehavior` → a user-facing **502** instead of a slightly-long-but-valid description.

Raises the ceiling to 400 (still bounded against runaway output) and documents why so it isn't tightened back. No test asserts the cap value; `test_graph_concept_description.py` 5/5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)