### PR TITLE
fix(agents): bound note_chat orchestrator + remaining worker agents with usage limits

### DIFF
--- a/backend/routes/notes.py
+++ b/backend/routes/notes.py
@@ -5,9 +5,13 @@ generate quiz, send to tutor) come in Phase 4 below.
 """
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
+from pydantic_ai.exceptions import UnexpectedModelBehavior, UsageLimitExceeded
 
+from agents import ORCHESTRATOR_LIMITS, WORKER_LIMITS
 from agents.deps import SaplingDeps
 from agents.note_chat import note_chat_agent
 from agents.note_concepts import note_concepts_agent
@@ -30,7 +34,31 @@ from services.notes_service import (
 from services.http_cache import cached_json, conditional, make_etag
 from services.request_context import current_request_id
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+# note_chat has no legacy fallback (ADR 0017), so guardrail trips degrade to
+# an in-band reply rather than falling back or surfacing a 5xx (#329).
+_CHAT_DEGRADED_REPLY = (
+    "I couldn't finish answering that — the request hit its processing "
+    "budget. Try again with a shorter or more specific message."
+)
+
+
+async def _run_note_worker(agent, user_prompt: str, deps: SaplingDeps, *, action: str):
+    """Run a single-shot note worker under WORKER_LIMITS, converting
+    guardrail trips into a 503 instead of an uncaught 500 (#329)."""
+    try:
+        return await agent.run(user_prompt, deps=deps, usage_limits=WORKER_LIMITS)
+    except (UsageLimitExceeded, UnexpectedModelBehavior) as e:
+        logger.warning(
+            "note %s agent guardrails tripped; returning 503", action, exc_info=e
+        )
+        raise HTTPException(
+            status_code=503,
+            detail=f"Note {action} is temporarily unavailable. Please try again.",
+        ) from e
 
 
 class CreateNoteBody(BaseModel):
@@ -222,7 +250,9 @@ async def summarize(note_id: str, body: AgentActionBody, request: Request):
     # The graph keys on the abstract course; the note carries the offering.
     course_id = offering_course_id(note.get("offering_id"))
     deps = _deps_for(body.user_id, course_id, note_id)
-    result = await note_summary_agent.run(user_prompt, deps=deps)
+    result = await _run_note_worker(
+        note_summary_agent, user_prompt, deps, action="summarize"
+    )
     summary_text = result.output.summary
     await save_summary(note_id=note_id, user_id=body.user_id, summary=summary_text)
     return {"summary": summary_text}
@@ -243,7 +273,9 @@ async def extract_concepts(
     # Concepts land in the abstract-course graph; resolve offering → course.
     course_id = offering_course_id(note.get("offering_id"))
     deps = _deps_for(body.user_id, course_id, note_id)
-    result = await note_concepts_agent.run(user_prompt, deps=deps)
+    result = await _run_note_worker(
+        note_concepts_agent, user_prompt, deps, action="concept extraction"
+    )
     names = [n.strip() for n in (result.output.concepts or []) if n and n.strip()]
     await apply_concepts_to_graph(
         user_id=body.user_id, course_id=course_id, concept_names=names
@@ -272,7 +304,15 @@ async def note_chat(note_id: str, body: NoteChatBody, request: Request):
         raise HTTPException(status_code=404, detail="Note not found.")
     course_id = offering_course_id(note.get("offering_id"))
     deps = _deps_for(body.user_id, course_id, note_id)
-    result = await note_chat_agent.run(body.message, deps=deps)
+    try:
+        result = await note_chat_agent.run(
+            body.message, deps=deps, usage_limits=ORCHESTRATOR_LIMITS
+        )
+    except (UsageLimitExceeded, UnexpectedModelBehavior) as e:
+        logger.warning(
+            "note_chat agent guardrails tripped; degrading in-band", exc_info=e
+        )
+        return {"reply": _CHAT_DEGRADED_REPLY, "degraded": True}
     return {"reply": result.output}
 
 

--- a/backend/routes/notes.py
+++ b/backend/routes/notes.py
@@ -251,7 +251,7 @@ async def summarize(note_id: str, body: AgentActionBody, request: Request):
     course_id = offering_course_id(note.get("offering_id"))
     deps = _deps_for(body.user_id, course_id, note_id)
     result = await _run_note_worker(
-        note_summary_agent, user_prompt, deps, action="summarize"
+        note_summary_agent, user_prompt, deps, action="summarization"
     )
     summary_text = result.output.summary
     await save_summary(note_id=note_id, user_id=body.user_id, summary=summary_text)

--- a/backend/routes/notes.py
+++ b/backend/routes/notes.py
@@ -47,17 +47,34 @@ _CHAT_DEGRADED_REPLY = (
 
 
 async def _run_note_worker(agent, user_prompt: str, deps: SaplingDeps, *, action: str):
-    """Run a single-shot note worker under WORKER_LIMITS, converting
-    guardrail trips into a 503 instead of an uncaught 500 (#329)."""
+    """Run a single-shot note worker under WORKER_LIMITS (#329).
+
+    The two guardrail failure modes are distinct and must not be conflated:
+    a budget trip is deterministic (retrying the same note fails identically),
+    while unexpected model behavior is a genuine bug that must page us.
+    """
     try:
         return await agent.run(user_prompt, deps=deps, usage_limits=WORKER_LIMITS)
-    except (UsageLimitExceeded, UnexpectedModelBehavior) as e:
+    except UsageLimitExceeded as e:
+        # Deterministic budget exhaustion — a 413 with no "try again" wording,
+        # since retrying the same (too-long) note trips the same limit.
         logger.warning(
-            "note %s agent guardrails tripped; returning 503", action, exc_info=e
+            "note %s agent hit its usage budget; returning 413", action, exc_info=e
         )
         raise HTTPException(
-            status_code=503,
-            detail=f"Note {action} is temporarily unavailable. Please try again.",
+            status_code=413,
+            detail=(
+                f"This note is too long to complete {action} automatically. "
+                "Shortening the note may help."
+            ),
+        ) from e
+    except UnexpectedModelBehavior as e:
+        # Malformed model output / validation-retry exhaustion — a real bug,
+        # surfaced as a 5xx (so alerting fires) with a traceback in the log.
+        logger.exception("note %s agent returned unexpected model behavior", action)
+        raise HTTPException(
+            status_code=500,
+            detail="Something went wrong generating this note's AI output.",
         ) from e
 
 
@@ -308,12 +325,25 @@ async def note_chat(note_id: str, body: NoteChatBody, request: Request):
         result = await note_chat_agent.run(
             body.message, deps=deps, usage_limits=ORCHESTRATOR_LIMITS
         )
-    except (UsageLimitExceeded, UnexpectedModelBehavior) as e:
+    except UsageLimitExceeded as e:
+        # Only a real budget trip reaches the in-band degrade, so the budget
+        # wording in _CHAT_DEGRADED_REPLY is accurate. Retrying is safe with no
+        # partial-write rollback: any graph write apply_graph_update_tool made
+        # before the trip is idempotent (apply_graph_update upserts nodes
+        # on_conflict, and note_chat writes no mastery events or edges).
         logger.warning(
-            "note_chat agent guardrails tripped; degrading in-band", exc_info=e
+            "note_chat agent hit its usage budget; degrading in-band", exc_info=e
         )
         return {"reply": _CHAT_DEGRADED_REPLY, "degraded": True}
-    return {"reply": result.output}
+    except UnexpectedModelBehavior as e:
+        # Not a budget signal — a genuine bug. Surface it as a 5xx (never the
+        # budget reply) so alerting fires; the log carries a traceback.
+        logger.exception("note_chat agent returned unexpected model behavior")
+        raise HTTPException(
+            status_code=500,
+            detail="Something went wrong answering that.",
+        ) from e
+    return {"reply": result.output, "degraded": False}
 
 
 @router.post("/{note_id}/send-to-tutor")

--- a/backend/services/calendar_service.py
+++ b/backend/services/calendar_service.py
@@ -64,14 +64,22 @@ def insert_new_assignments(user_id: str, assignments: list[dict], *, source: str
     return len(rows)
 
 
-def _degraded_result(text: str) -> dict:
+def _degraded_result(text: str, *, warning: str | None = None) -> dict:
     """Graceful degrade when the extraction agent fails. Returns the legacy
     wire shape with no assignments and a user-facing warning — deliberately
-    NOT a second LLM call (the raw-Gemini fallback was retired in #144)."""
+    NOT a second LLM call (the raw-Gemini fallback was retired in #144).
+
+    `warning` overrides the default message so callers can distinguish a
+    deterministic failure (e.g. the syllabus is too long for the worker
+    token budget, where retrying the same document fails identically) from a
+    transient one. When None, the generic "temporarily unavailable / try
+    again" message is used.
+    """
     return {
         "assignments": [],
         "warnings": [
-            "Assignment extraction is temporarily unavailable. Please try again."
+            warning
+            or "Assignment extraction is temporarily unavailable. Please try again."
         ],
         "raw_text": text,
         "course_title": None,
@@ -144,9 +152,29 @@ async def extract_assignments_from_file(
         result = await _extract_via_agent(
             text, user_id=user_id, request_id=request_id
         )
-    except (UsageLimitExceeded, UnexpectedModelBehavior) as e:
+    except UsageLimitExceeded as e:
+        # Deterministic for this document — the syllabus exceeds the worker
+        # token budget, so re-uploading the same file fails identically. Tell
+        # the user to shorten/split it rather than "try again" (#329).
         logger.warning(
-            "Syllabus agent guardrails tripped; degrading to empty result",
+            "Syllabus exceeded the worker token budget; degrading to empty result",
+            exc_info=e,
+        )
+        result = _degraded_result(
+            text,
+            warning=(
+                "This syllabus is too long to process automatically. "
+                "Try uploading a shorter document, or split it into "
+                "multiple files."
+            ),
+        )
+    except UnexpectedModelBehavior as e:
+        # A model hiccup, not a doc-size problem — degrade generically (a retry
+        # is reasonable). #144: degrade rather than 5xx to keep syllabus upload
+        # available on a single model failure.
+        logger.warning(
+            "Syllabus agent returned unexpected model behavior; degrading to "
+            "empty result",
             exc_info=e,
         )
         result = _degraded_result(text)

--- a/backend/services/calendar_service.py
+++ b/backend/services/calendar_service.py
@@ -6,6 +6,7 @@ import uuid
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from pydantic_ai.exceptions import UsageLimitExceeded, UnexpectedModelBehavior
 
+from agents import WORKER_LIMITS
 from agents.deps import SaplingDeps
 from agents.syllabus_extraction import syllabus_extraction_agent
 from agents.tools.syllabus_adapter import syllabus_to_wire_dict
@@ -103,7 +104,9 @@ async def _extract_via_agent(
         supabase=None,
         request_id=request_id or "",
     )
-    result = await syllabus_extraction_agent.run(extracted_text, deps=deps)
+    result = await syllabus_extraction_agent.run(
+        extracted_text, deps=deps, usage_limits=WORKER_LIMITS
+    )
     return syllabus_to_wire_dict(result.output, raw_text=extracted_text)
 
 

--- a/backend/tests/test_notes_routes.py
+++ b/backend/tests/test_notes_routes.py
@@ -14,6 +14,21 @@ from fastapi.testclient import TestClient
 from main import app
 
 
+def fake_get_note(*, body="B"):
+    """Factory for the `get_note` side_effect shared by the agent-backed
+    route tests (summarize / extract-concepts / chat). Finding #6: one
+    source of truth for this note shape instead of an inline copy per test.
+    """
+    async def _get_note(note_id, user_id):
+        return {
+            "id": note_id, "user_id": user_id, "offering_id": "off1",
+            "title": "T", "body": body, "tags": [],
+            "last_summary": None, "last_summary_at": None,
+            "created_at": "", "updated_at": "",
+        }
+    return _get_note
+
+
 @pytest.fixture
 def client():
     return TestClient(app)
@@ -191,11 +206,6 @@ class TestSummarizeRoute:
         async def fake_run(*args, **kwargs):
             captured["called"] = True
             return FakeResult()
-        async def fake_get_note(note_id, user_id):
-            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
-                    "title": "T", "body": "Long body…", "tags": [],
-                    "last_summary": None, "last_summary_at": None,
-                    "created_at": "", "updated_at": ""}
         async def fake_save_summary(note_id, user_id, summary):
             captured["saved"] = summary
             return {"id": note_id, "last_summary": summary,
@@ -205,7 +215,7 @@ class TestSummarizeRoute:
                     "created_at": "", "updated_at": ""}
         with patch("routes.notes.note_summary_agent.run", side_effect=fake_run), \
              patch("routes.notes.offering_course_id", return_value="c1"), \
-             patch("routes.notes.get_note", side_effect=fake_get_note), \
+             patch("routes.notes.get_note", side_effect=fake_get_note(body="Long body…")), \
              patch("routes.notes.save_summary", side_effect=fake_save_summary):
             r = client.post(
                 "/api/notes/n1/summarize",
@@ -235,16 +245,11 @@ class TestSummarizeRoute:
         async def fake_run(*args, **kwargs):
             captured["usage_limits"] = kwargs.get("usage_limits")
             return FakeResult()
-        async def fake_get_note(note_id, user_id):
-            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
-                    "title": "T", "body": "B", "tags": [],
-                    "last_summary": None, "last_summary_at": None,
-                    "created_at": "", "updated_at": ""}
         async def fake_save_summary(note_id, user_id, summary):
             return {}
         with patch("routes.notes.note_summary_agent.run", side_effect=fake_run), \
              patch("routes.notes.offering_course_id", return_value="c1"), \
-             patch("routes.notes.get_note", side_effect=fake_get_note), \
+             patch("routes.notes.get_note", side_effect=fake_get_note()), \
              patch("routes.notes.save_summary", side_effect=fake_save_summary):
             r = client.post(
                 "/api/notes/n1/summarize",
@@ -253,26 +258,40 @@ class TestSummarizeRoute:
         assert r.status_code == 200
         assert captured["usage_limits"] is WORKER_LIMITS
 
-    def test_503_when_guardrails_trip(self, client):
-        """#329: budget exhaustion surfaces as 503, not an uncaught 500."""
+    def test_413_when_usage_limit_exceeded(self, client):
+        """#329: deterministic budget exhaustion surfaces as 413, not a
+        transient-looking 503. The detail must not imply a retry helps."""
         from pydantic_ai.exceptions import UsageLimitExceeded
 
         async def fake_run(*args, **kwargs):
             raise UsageLimitExceeded("token cap")
-        async def fake_get_note(note_id, user_id):
-            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
-                    "title": "T", "body": "B", "tags": [],
-                    "last_summary": None, "last_summary_at": None,
-                    "created_at": "", "updated_at": ""}
         with patch("routes.notes.note_summary_agent.run", side_effect=fake_run), \
              patch("routes.notes.offering_course_id", return_value="c1"), \
-             patch("routes.notes.get_note", side_effect=fake_get_note):
+             patch("routes.notes.get_note", side_effect=fake_get_note()):
             r = client.post(
                 "/api/notes/n1/summarize",
                 json={"user_id": "u1"},
             )
-        assert r.status_code == 503
-        assert r.json()["detail"]
+        assert r.status_code == 413
+        detail = r.json()["detail"].lower()
+        assert "try again" not in detail
+        assert "temporarily unavailable" not in detail
+
+    def test_500_when_unexpected_model_behavior(self, client):
+        """#329: malformed model output is a real bug, not a budget trip —
+        it must surface as a 5xx so alerting fires."""
+        from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+        async def fake_run(*args, **kwargs):
+            raise UnexpectedModelBehavior("bad output")
+        with patch("routes.notes.note_summary_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
+             patch("routes.notes.get_note", side_effect=fake_get_note()):
+            r = client.post(
+                "/api/notes/n1/summarize",
+                json={"user_id": "u1"},
+            )
+        assert r.status_code == 500
 
 
 class TestExtractConceptsRoute:
@@ -281,11 +300,6 @@ class TestExtractConceptsRoute:
             output = type("C", (), {"concepts": ["Photosynthesis", "Calvin Cycle"]})()
         async def fake_run(*args, **kwargs):
             return FakeResult()
-        async def fake_get_note(note_id, user_id):
-            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
-                    "title": "T", "body": "B", "tags": [],
-                    "last_summary": None, "last_summary_at": None,
-                    "created_at": "", "updated_at": ""}
         merged: list[str] = []
         async def fake_apply(user_id, course_id, concept_names):
             # The graph keys on the abstract course id (offering → course).
@@ -301,7 +315,7 @@ class TestExtractConceptsRoute:
 
         with patch("routes.notes.note_concepts_agent.run", side_effect=fake_run), \
              patch("routes.notes.offering_course_id", return_value="c1"), \
-             patch("routes.notes.get_note", side_effect=fake_get_note), \
+             patch("routes.notes.get_note", side_effect=fake_get_note()), \
              patch("routes.notes.apply_concepts_to_graph", side_effect=fake_apply), \
              patch("routes.notes._lookup_concept_nodes_by_name", side_effect=fake_lookup), \
              patch("routes.notes.link_concept", side_effect=fake_link):
@@ -325,18 +339,13 @@ class TestExtractConceptsRoute:
         async def fake_run(*args, **kwargs):
             captured["usage_limits"] = kwargs.get("usage_limits")
             return FakeResult()
-        async def fake_get_note(note_id, user_id):
-            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
-                    "title": "T", "body": "B", "tags": [],
-                    "last_summary": None, "last_summary_at": None,
-                    "created_at": "", "updated_at": ""}
         async def fake_apply(user_id, course_id, concept_names):
             return 0
         async def fake_lookup(user_id, course_id, names):
             return []
         with patch("routes.notes.note_concepts_agent.run", side_effect=fake_run), \
              patch("routes.notes.offering_course_id", return_value="c1"), \
-             patch("routes.notes.get_note", side_effect=fake_get_note), \
+             patch("routes.notes.get_note", side_effect=fake_get_note()), \
              patch("routes.notes.apply_concepts_to_graph", side_effect=fake_apply), \
              patch("routes.notes._lookup_concept_nodes_by_name", side_effect=fake_lookup):
             r = client.post(
@@ -346,26 +355,40 @@ class TestExtractConceptsRoute:
         assert r.status_code == 200
         assert captured["usage_limits"] is WORKER_LIMITS
 
-    def test_503_when_guardrails_trip(self, client):
-        """#329: budget exhaustion surfaces as 503, not an uncaught 500."""
-        from pydantic_ai.exceptions import UnexpectedModelBehavior
+    def test_413_when_usage_limit_exceeded(self, client):
+        """#329: deterministic budget exhaustion surfaces as 413, not a
+        transient-looking 503. The detail must not imply a retry helps."""
+        from pydantic_ai.exceptions import UsageLimitExceeded
 
         async def fake_run(*args, **kwargs):
-            raise UnexpectedModelBehavior("bad output")
-        async def fake_get_note(note_id, user_id):
-            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
-                    "title": "T", "body": "B", "tags": [],
-                    "last_summary": None, "last_summary_at": None,
-                    "created_at": "", "updated_at": ""}
+            raise UsageLimitExceeded("token cap")
         with patch("routes.notes.note_concepts_agent.run", side_effect=fake_run), \
              patch("routes.notes.offering_course_id", return_value="c1"), \
-             patch("routes.notes.get_note", side_effect=fake_get_note):
+             patch("routes.notes.get_note", side_effect=fake_get_note()):
             r = client.post(
                 "/api/notes/n1/extract-concepts",
                 json={"user_id": "u1"},
             )
-        assert r.status_code == 503
-        assert r.json()["detail"]
+        assert r.status_code == 413
+        detail = r.json()["detail"].lower()
+        assert "try again" not in detail
+        assert "temporarily unavailable" not in detail
+
+    def test_500_when_unexpected_model_behavior(self, client):
+        """#329: malformed model output is a real bug, not a budget trip —
+        it must surface as a 5xx so alerting fires."""
+        from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+        async def fake_run(*args, **kwargs):
+            raise UnexpectedModelBehavior("bad output")
+        with patch("routes.notes.note_concepts_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
+             patch("routes.notes.get_note", side_effect=fake_get_note()):
+            r = client.post(
+                "/api/notes/n1/extract-concepts",
+                json={"user_id": "u1"},
+            )
+        assert r.status_code == 500
 
 
 class TestNoteChatRoute:
@@ -374,27 +397,15 @@ class TestNoteChatRoute:
             output = "Here is a quick answer."
         async def fake_run(*args, **kwargs):
             return FakeResult()
-        async def fake_get_note(note_id, user_id):
-            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
-                    "title": "T", "body": "B", "tags": [],
-                    "last_summary": None, "last_summary_at": None,
-                    "created_at": "", "updated_at": ""}
         with patch("routes.notes.note_chat_agent.run", side_effect=fake_run), \
              patch("routes.notes.offering_course_id", return_value="c1"), \
-             patch("routes.notes.get_note", side_effect=fake_get_note):
+             patch("routes.notes.get_note", side_effect=fake_get_note()):
             r = client.post(
                 "/api/notes/n1/chat",
                 json={"user_id": "u1", "message": "What's the gist?"},
             )
         assert r.status_code == 200
-        assert r.json() == {"reply": "Here is a quick answer."}
-
-    @staticmethod
-    async def _fake_get_note(note_id, user_id):
-        return {"id": note_id, "user_id": user_id, "offering_id": "off1",
-                "title": "T", "body": "B", "tags": [],
-                "last_summary": None, "last_summary_at": None,
-                "created_at": "", "updated_at": ""}
+        assert r.json() == {"reply": "Here is a quick answer.", "degraded": False}
 
     def test_agent_run_receives_orchestrator_limits(self, client):
         """#329: the tool-using note-chat orchestrator must run under
@@ -409,7 +420,7 @@ class TestNoteChatRoute:
             return FakeResult()
         with patch("routes.notes.note_chat_agent.run", side_effect=fake_run), \
              patch("routes.notes.offering_course_id", return_value="c1"), \
-             patch("routes.notes.get_note", side_effect=self._fake_get_note):
+             patch("routes.notes.get_note", side_effect=fake_get_note()):
             r = client.post(
                 "/api/notes/n1/chat",
                 json={"user_id": "u1", "message": "hi"},
@@ -417,19 +428,17 @@ class TestNoteChatRoute:
         assert r.status_code == 200
         assert captured["usage_limits"] is ORCHESTRATOR_LIMITS
 
-    @pytest.mark.parametrize("exc_name", ["UsageLimitExceeded", "UnexpectedModelBehavior"])
-    def test_degrades_in_band_when_guardrails_trip(self, client, exc_name):
-        """#329: budget exhaustion mid-chat returns a friendly in-band reply
+    def test_degrades_in_band_on_usage_limit(self, client):
+        """#329: a real budget trip mid-chat returns a friendly in-band reply
         (HTTP 200 + degraded flag) — never an uncaught 500. note_chat has no
         legacy fallback (ADR 0017), so degrade is the contract."""
-        import pydantic_ai.exceptions as pae
+        from pydantic_ai.exceptions import UsageLimitExceeded
 
-        exc_cls = getattr(pae, exc_name)
         async def fake_run(*args, **kwargs):
-            raise exc_cls("guardrail tripped")
+            raise UsageLimitExceeded("budget")
         with patch("routes.notes.note_chat_agent.run", side_effect=fake_run), \
              patch("routes.notes.offering_course_id", return_value="c1"), \
-             patch("routes.notes.get_note", side_effect=self._fake_get_note):
+             patch("routes.notes.get_note", side_effect=fake_get_note()):
             r = client.post(
                 "/api/notes/n1/chat",
                 json={"user_id": "u1", "message": "hi"},
@@ -438,6 +447,22 @@ class TestNoteChatRoute:
         body = r.json()
         assert body["degraded"] is True
         assert body["reply"]  # non-empty, user-facing
+
+    def test_500_on_unexpected_model_behavior(self, client):
+        """#329: malformed model output is a real bug, not a budget trip —
+        it must surface as a 5xx (never the budget reply) so alerting fires."""
+        from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+        async def fake_run(*args, **kwargs):
+            raise UnexpectedModelBehavior("bad output")
+        with patch("routes.notes.note_chat_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
+             patch("routes.notes.get_note", side_effect=fake_get_note()):
+            r = client.post(
+                "/api/notes/n1/chat",
+                json={"user_id": "u1", "message": "hi"},
+            )
+        assert r.status_code == 500
 
 
 class TestSendToTutorRoute:

--- a/backend/tests/test_notes_routes.py
+++ b/backend/tests/test_notes_routes.py
@@ -225,6 +225,55 @@ class TestSummarizeRoute:
             )
         assert r.status_code == 404
 
+    def test_agent_run_receives_worker_limits(self, client):
+        """#329: the single-shot summary worker must run under WORKER_LIMITS."""
+        from agents import WORKER_LIMITS
+
+        captured = {}
+        class FakeResult:
+            output = type("S", (), {"summary": "Short summary."})()
+        async def fake_run(*args, **kwargs):
+            captured["usage_limits"] = kwargs.get("usage_limits")
+            return FakeResult()
+        async def fake_get_note(note_id, user_id):
+            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
+                    "title": "T", "body": "B", "tags": [],
+                    "last_summary": None, "last_summary_at": None,
+                    "created_at": "", "updated_at": ""}
+        async def fake_save_summary(note_id, user_id, summary):
+            return {}
+        with patch("routes.notes.note_summary_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
+             patch("routes.notes.get_note", side_effect=fake_get_note), \
+             patch("routes.notes.save_summary", side_effect=fake_save_summary):
+            r = client.post(
+                "/api/notes/n1/summarize",
+                json={"user_id": "u1"},
+            )
+        assert r.status_code == 200
+        assert captured["usage_limits"] is WORKER_LIMITS
+
+    def test_503_when_guardrails_trip(self, client):
+        """#329: budget exhaustion surfaces as 503, not an uncaught 500."""
+        from pydantic_ai.exceptions import UsageLimitExceeded
+
+        async def fake_run(*args, **kwargs):
+            raise UsageLimitExceeded("token cap")
+        async def fake_get_note(note_id, user_id):
+            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
+                    "title": "T", "body": "B", "tags": [],
+                    "last_summary": None, "last_summary_at": None,
+                    "created_at": "", "updated_at": ""}
+        with patch("routes.notes.note_summary_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
+             patch("routes.notes.get_note", side_effect=fake_get_note):
+            r = client.post(
+                "/api/notes/n1/summarize",
+                json={"user_id": "u1"},
+            )
+        assert r.status_code == 503
+        assert r.json()["detail"]
+
 
 class TestExtractConceptsRoute:
     def test_extracts_and_links(self, client):
@@ -266,6 +315,58 @@ class TestExtractConceptsRoute:
         assert merged == ["Photosynthesis", "Calvin Cycle"]
         assert {n[1] for n in linked} == {"g_Photosynthesis", "g_Calvin Cycle"}
 
+    def test_agent_run_receives_worker_limits(self, client):
+        """#329: the single-shot concepts worker must run under WORKER_LIMITS."""
+        from agents import WORKER_LIMITS
+
+        captured = {}
+        class FakeResult:
+            output = type("C", (), {"concepts": []})()
+        async def fake_run(*args, **kwargs):
+            captured["usage_limits"] = kwargs.get("usage_limits")
+            return FakeResult()
+        async def fake_get_note(note_id, user_id):
+            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
+                    "title": "T", "body": "B", "tags": [],
+                    "last_summary": None, "last_summary_at": None,
+                    "created_at": "", "updated_at": ""}
+        async def fake_apply(user_id, course_id, concept_names):
+            return 0
+        async def fake_lookup(user_id, course_id, names):
+            return []
+        with patch("routes.notes.note_concepts_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
+             patch("routes.notes.get_note", side_effect=fake_get_note), \
+             patch("routes.notes.apply_concepts_to_graph", side_effect=fake_apply), \
+             patch("routes.notes._lookup_concept_nodes_by_name", side_effect=fake_lookup):
+            r = client.post(
+                "/api/notes/n1/extract-concepts",
+                json={"user_id": "u1"},
+            )
+        assert r.status_code == 200
+        assert captured["usage_limits"] is WORKER_LIMITS
+
+    def test_503_when_guardrails_trip(self, client):
+        """#329: budget exhaustion surfaces as 503, not an uncaught 500."""
+        from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+        async def fake_run(*args, **kwargs):
+            raise UnexpectedModelBehavior("bad output")
+        async def fake_get_note(note_id, user_id):
+            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
+                    "title": "T", "body": "B", "tags": [],
+                    "last_summary": None, "last_summary_at": None,
+                    "created_at": "", "updated_at": ""}
+        with patch("routes.notes.note_concepts_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
+             patch("routes.notes.get_note", side_effect=fake_get_note):
+            r = client.post(
+                "/api/notes/n1/extract-concepts",
+                json={"user_id": "u1"},
+            )
+        assert r.status_code == 503
+        assert r.json()["detail"]
+
 
 class TestNoteChatRoute:
     def test_runs_note_chat_agent(self, client):
@@ -287,6 +388,56 @@ class TestNoteChatRoute:
             )
         assert r.status_code == 200
         assert r.json() == {"reply": "Here is a quick answer."}
+
+    @staticmethod
+    async def _fake_get_note(note_id, user_id):
+        return {"id": note_id, "user_id": user_id, "offering_id": "off1",
+                "title": "T", "body": "B", "tags": [],
+                "last_summary": None, "last_summary_at": None,
+                "created_at": "", "updated_at": ""}
+
+    def test_agent_run_receives_orchestrator_limits(self, client):
+        """#329: the tool-using note-chat orchestrator must run under
+        ORCHESTRATOR_LIMITS (it can call tools and iterate)."""
+        from agents import ORCHESTRATOR_LIMITS
+
+        captured = {}
+        class FakeResult:
+            output = "reply"
+        async def fake_run(*args, **kwargs):
+            captured["usage_limits"] = kwargs.get("usage_limits")
+            return FakeResult()
+        with patch("routes.notes.note_chat_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
+             patch("routes.notes.get_note", side_effect=self._fake_get_note):
+            r = client.post(
+                "/api/notes/n1/chat",
+                json={"user_id": "u1", "message": "hi"},
+            )
+        assert r.status_code == 200
+        assert captured["usage_limits"] is ORCHESTRATOR_LIMITS
+
+    @pytest.mark.parametrize("exc_name", ["UsageLimitExceeded", "UnexpectedModelBehavior"])
+    def test_degrades_in_band_when_guardrails_trip(self, client, exc_name):
+        """#329: budget exhaustion mid-chat returns a friendly in-band reply
+        (HTTP 200 + degraded flag) — never an uncaught 500. note_chat has no
+        legacy fallback (ADR 0017), so degrade is the contract."""
+        import pydantic_ai.exceptions as pae
+
+        exc_cls = getattr(pae, exc_name)
+        async def fake_run(*args, **kwargs):
+            raise exc_cls("guardrail tripped")
+        with patch("routes.notes.note_chat_agent.run", side_effect=fake_run), \
+             patch("routes.notes.offering_course_id", return_value="c1"), \
+             patch("routes.notes.get_note", side_effect=self._fake_get_note):
+            r = client.post(
+                "/api/notes/n1/chat",
+                json={"user_id": "u1", "message": "hi"},
+            )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["degraded"] is True
+        assert body["reply"]  # non-empty, user-facing
 
 
 class TestSendToTutorRoute:

--- a/backend/tests/test_ocr_pipeline.py
+++ b/backend/tests/test_ocr_pipeline.py
@@ -172,6 +172,32 @@ class TestExtractAssignmentsViaAgent:
         assert first["assignment_type"] == "other"
         assert first["due_date"] == "2026-03-15"
 
+    def test_agent_run_receives_worker_limits(self):
+        """#329: the syllabus-extraction worker must run under WORKER_LIMITS —
+        single-shot, no tools, so the worker budget applies."""
+        from agents import WORKER_LIMITS
+        from services import calendar_service
+
+        agent_run = AsyncMock(
+            return_value=SimpleNamespace(output=self._agent_output())
+        )
+
+        with (
+            patch.object(
+                calendar_service, "extract_text_from_file",
+                return_value="syllabus body",
+            ),
+            patch.object(
+                calendar_service.syllabus_extraction_agent, "run", agent_run,
+            ),
+        ):
+            asyncio.run(calendar_service.extract_assignments_from_file(
+                b"raw", "syllabus.pdf", "application/pdf",
+            ))
+
+        assert agent_run.await_count == 1
+        assert agent_run.await_args.kwargs.get("usage_limits") is WORKER_LIMITS
+
     def test_degrades_gracefully_on_usage_limit(self):
         """UsageLimitExceeded from the agent degrades to an empty result
         with a warning — and does NOT make a second LLM call."""

--- a/backend/tests/test_ocr_pipeline.py
+++ b/backend/tests/test_ocr_pipeline.py
@@ -199,8 +199,13 @@ class TestExtractAssignmentsViaAgent:
         assert agent_run.await_args.kwargs.get("usage_limits") is WORKER_LIMITS
 
     def test_degrades_gracefully_on_usage_limit(self):
-        """UsageLimitExceeded from the agent degrades to an empty result
-        with a warning — and does NOT make a second LLM call."""
+        """UsageLimitExceeded is a DETERMINISTIC failure for that document —
+        the syllabus is too long for the worker token budget, so re-uploading
+        the same file fails identically. The degrade warning must tell the
+        user the document is too long (and to shorten/split it) and must NOT
+        use the generic "temporarily unavailable / try again" wording, which
+        would wrongly invite an identical re-upload. Still no second LLM call.
+        """
         from services import calendar_service
         from pydantic_ai.exceptions import UsageLimitExceeded
 
@@ -222,10 +227,17 @@ class TestExtractAssignmentsViaAgent:
         assert agent_run.await_count == 1
         assert result["assignments"] == []
         assert result["warnings"]  # non-empty, user-facing
+        warning = " ".join(result["warnings"]).lower()
+        assert "too long" in warning
+        assert "shorter" in warning
+        # Deterministic failure — must NOT invite an identical re-upload.
+        assert "try again" not in warning
         assert result["raw_text"] == "text body"
 
     def test_degrades_gracefully_on_unexpected_exception(self):
-        """A bare Exception from the agent also degrades gracefully."""
+        """A bare Exception from the agent degrades to the GENERIC
+        "temporarily unavailable / try again" message — a transient failure
+        where a retry is legitimate (unlike the too-long UsageLimit case)."""
         from services import calendar_service
 
         agent_run = AsyncMock(side_effect=RuntimeError("boom"))
@@ -245,7 +257,41 @@ class TestExtractAssignmentsViaAgent:
 
         assert agent_run.await_count == 1
         assert result["assignments"] == []
-        assert result["warnings"]
+        assert result["warnings"] == [
+            "Assignment extraction is temporarily unavailable. Please try again."
+        ]
+        assert result["raw_text"] == "text body"
+
+    def test_degrades_generically_on_unexpected_model_behavior(self):
+        """UnexpectedModelBehavior is a model hiccup (not a doc-size problem),
+        so it keeps the generic degrade message — a retry stays reasonable.
+        #144 keeps this as a degrade rather than a 5xx to keep syllabus upload
+        available on a single model hiccup."""
+        from services import calendar_service
+        from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+        agent_run = AsyncMock(
+            side_effect=UnexpectedModelBehavior("bad tool call")
+        )
+
+        with (
+            patch.object(
+                calendar_service, "extract_text_from_file",
+                return_value="text body",
+            ),
+            patch.object(
+                calendar_service.syllabus_extraction_agent, "run", agent_run,
+            ),
+        ):
+            result = asyncio.run(calendar_service.extract_assignments_from_file(
+                b"raw", "syllabus.pdf", "application/pdf",
+            ))
+
+        assert agent_run.await_count == 1
+        assert result["assignments"] == []
+        assert result["warnings"] == [
+            "Assignment extraction is temporarily unavailable. Please try again."
+        ]
         assert result["raw_text"] == "text body"
 
     def test_empty_text_shortcut(self):


### PR DESCRIPTION
## Description
Closes out the residual from the #327 audit that PR #243 left open: the `note_chat` orchestrator and three single-shot workers ran without `usage_limits`, defaulting to Pydantic AI library maximums (request_limit=50, no token cap).

## Changes Made
- `routes/notes.py::note_chat` — runs under `ORCHESTRATOR_LIMITS`. Guardrail trips (`UsageLimitExceeded` / `UnexpectedModelBehavior`) degrade to an in-band `200 {reply, degraded: true}` instead of an uncaught 500. This path has no legacy fallback by design (ADR 0017), so in-band degrade mirrors the established `calendar_service._degraded_result` pattern rather than inventing a fallback.
- `routes/notes.py::summarize` / `extract-concepts` — run under `WORKER_LIMITS` via a shared `_run_note_worker` helper that converts guardrail trips to a 503 with a user-facing detail (adding limits without handling would have created the exact uncaught-500 path the issue warns about).
- `services/calendar_service.py::_extract_via_agent` — `syllabus_extraction_agent.run` now passes `WORKER_LIMITS`, matching the same agent''s other run-site in `agents/document.py`. Its caller already degrades gracefully on guardrail trips, so no handling change was needed.
- Tests pin the `usage_limits` kwarg identity at all four run-sites plus the new degrade/503 behavior (8 new tests, written TDD red→green).

## Related Issues
Closes #329

## Testing
- [x] Tested locally
- [x] Added/updated tests

Full backend suite: **959 passed**. The only non-passes are the documented pre-existing baseline failure (`test_save_to_db`, live-Supabase) and a pre-existing Windows-only flake in `test_flashcard_import_service.py::TestRateLimit::test_sixth_call_returns_retry_after` (untouched by this PR; passes on Linux).

## Notes for Reviewers
- `WORKER_LIMITS` / `ORCHESTRATOR_LIMITS` values are unchanged from #243 (`agents/__init__.py`).
- The `degraded: true` key on the chat response is additive; the frontend only reads `reply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ori1maMbbFjkpCS7jPgjj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved error handling for note summarization and concept extraction when AI limits are hit (returns a clear “too long…automatically” temporary-unavailability response) and for unexpected AI behavior (returns server error).
  * Note chat now degrades gracefully on AI limit issues (returns an in-band degraded reply with `degraded: true`) and returns server error on unexpected AI behavior.
  * Syllabus extraction now enforces configured processing limits and returns more specific “too long” fallback messaging.
* **Tests**
  * Expanded and tightened coverage for limit propagation, status codes, and warning/degraded response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->