### PR TITLE
fix(settings): make the Cosmetics tab reachable (#165)

### DIFF
--- a/frontend/src/components/screens/Settings.tsx
+++ b/frontend/src/components/screens/Settings.tsx
@@ -215,7 +215,7 @@ export function Settings() {
     }
   };
 
-  const tabs: Tab[] = ["profile", "preferences", "notifications", "data"];
+  const tabs: Tab[] = ["profile", "cosmetics", "preferences", "notifications", "data"];
 
   return (
     <FullHeightScreen>


### PR DESCRIPTION
## Summary
The Settings screen shipped with a `cosmetics` member in the `Tab` union, a render branch (`tab === "cosmetics"` → `CosmeticsManager`), and the full `CosmeticsManager` component — but `"cosmetics"` was never added to the `tabs` array that drives the sidebar nav (`Settings.tsx:218`). No click path could ever set the tab, so the entire manager was dead code.

This adds `"cosmetics"` to the nav array (labels render via `textTransform: capitalize`, so it shows as **Cosmetics**).

`CosmeticsManager` is safe to expose: it initializes empty per-type records, catches load errors, and falls back to `|| []` on every list read.

## Verification
- `npm run typecheck` clean.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added the Cosmetics tab to the Settings sidebar, making the existing cosmetics options accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->