### PR TITLE
feat(learn): stream tutor replies over SSE with live graph deltas (#70, #74)

### DIFF
--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -371,9 +371,11 @@ def _function_model_for(task: AgentTask) -> "Model":
     """Build a FunctionModel that dispatches to the task's registered handler at
     run time. The lookup is deferred to the call (not capture time) so a handler
     registered after the agent was imported still takes effect."""
-    from pydantic_ai.models.function import FunctionModel
+    import json
 
-    def _dispatch(messages, info):
+    from pydantic_ai.models.function import DeltaToolCall, FunctionModel
+
+    def _resolve_handler() -> FunctionModelHandler:
         handler = _FUNCTION_HANDLERS.get(task)
         if handler is None:
             # Out-of-process runs (E2E uvicorn) register via the env-named
@@ -387,9 +389,38 @@ def _function_model_for(task: AgentTask) -> "Model":
                 f"{task!r}, ...) before running the agent (or point "
                 f"SAPLING_FUNCTION_HANDLERS at a module that does)."
             )
-        return handler(messages, info)
+        return handler
 
-    return FunctionModel(_dispatch, model_name=f"function:{task}")
+    def _dispatch(messages, info):
+        return _resolve_handler()(messages, info)
+
+    async def _stream_dispatch(messages, info):
+        # Streamed runs (`agent.run_stream_events`, the SSE tutor routes) reuse
+        # the SAME registered handler rather than a parallel stream registry:
+        # the handler's ModelResponse is replayed as a stream — each text part
+        # as one delta, each tool call as a DeltaToolCall — so a task's handler
+        # constants stay byte-identical between the JSON and streamed lanes
+        # (spec assertions compare against the same E2E_* constants either way).
+        response = _resolve_handler()(messages, info)
+        for index, part in enumerate(response.parts):
+            kind = getattr(part, "part_kind", "")
+            if kind == "text":
+                if part.content:
+                    yield part.content
+            elif kind == "tool-call":
+                args = part.args
+                json_args = args if isinstance(args, str) else json.dumps(args or {})
+                yield {
+                    index: DeltaToolCall(
+                        name=part.tool_name,
+                        json_args=json_args,
+                        tool_call_id=part.tool_call_id,
+                    )
+                }
+
+    return FunctionModel(
+        _dispatch, stream_function=_stream_dispatch, model_name=f"function:{task}"
+    )
 
 
 def model_name_for(task: AgentTask) -> str:

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -871,11 +871,14 @@ async def start_session_stream(body: StartSessionBody, request: Request):
 
     Rung 1 (agent fails before any token) falls back to
     `_start_session_legacy` — the JSON route's own pipeline, per the spec's
-    fallback ladder. `stream_agent_turn` guarantees exactly one of
+    fallback ladder. `stream_agent_turn` guarantees AT MOST one of
     `on_complete` (`_stash`, below) / `legacy_fallback` (`_legacy`, below)
-    runs per turn, so PENDING_SESSIONS is stashed exactly once either way:
-    `_stash` on the agent-success path, `_start_session_legacy` internally
-    on the Rung-1 fallback path — never both.
+    runs per turn — never both — so PENDING_SESSIONS is stashed at most
+    once: `_stash` on the agent-success path, `_start_session_legacy`
+    internally on the Rung-1 fallback path. A Rung-2 error (failure after
+    the greeting started streaming) stashes NOTHING for this session_id —
+    the client never received it in a `done` event, so a retry simply mints
+    a fresh session.
     """
     require_self(body.user_id, request)
     request_id = (

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -7,6 +7,7 @@ import os
 from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Query, Request
+from sse_starlette.sse import EventSourceResponse
 
 from pydantic_ai.exceptions import UsageLimitExceeded, UnexpectedModelBehavior
 from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
@@ -17,7 +18,9 @@ from agents.deps import SaplingDeps
 from db.connection import table
 from services.academics import offering_course_id, resolve_offering
 from models import StartSessionBody, ChatBody, EndSessionBody, ActionBody, ModeSwitchBody, RenameSessionBody
+from services.agent_events import sapling_event_to_sse
 from services.auth_guard import require_self, get_session_user_id
+from services.chat_stream import merge_graph_updates, stream_agent_turn
 from services.encryption import encrypt_if_present, encrypt_json, decrypt_if_present, decrypt_json
 from services.profiles import get_display_name
 from services.gemini_service import (
@@ -450,17 +453,32 @@ def _ensure_session_ready(session_id: str, user_id: str) -> None:
     _consume_pending(session_id, user_id)
 
 
-@router.post("/start-session")
-def start_session(body: StartSessionBody, request: Request):
-    # TODO(refactor-3 follow-up): migrate `start_session` to chat_tutor_agent
-    # using the same try-agent-then-legacy pattern as `chat`. Current PR scopes
-    # the agent-path migration to the main `chat` route only.
-    require_self(body.user_id, request)
-    session_id = str(uuid.uuid4())
+def _start_session_legacy(body: StartSessionBody, session_id: str | None = None) -> dict:
+    """Core start-session pipeline: call_gemini_multiturn -> extract_graph_update
+    -> apply_graph_update -> stash PENDING_SESSIONS.
+
+    Extracted so the JSON route and the streaming route's Rung-1
+    `legacy_fallback` (agent failed before any token) share this verbatim —
+    the JSON route's external behavior stays byte-identical (ADR 0001/0015),
+    it just reshapes this dict into its historical response below.
+
+    `session_id`: the streaming route already minted one up front (it needs
+    it for SaplingDeps before it knows whether the agent or this fallback
+    will serve the turn); passing it through here means a turn only ever
+    has ONE session_id and PENDING_SESSIONS is stashed exactly once,
+    regardless of which path serves it. `None` (the JSON route's case)
+    mints a fresh one, matching the original inline behavior.
+
+    Returns {"session_id", "reply", "graph_update", "mastery_changes",
+    "graph_state"} — a superset of what the JSON route needs, and exactly
+    the shape the streaming `done` event / frontend `ChatResult` expects.
+    """
+    if session_id is None:
+        session_id = str(uuid.uuid4())
 
     student_name = get_user_name(body.user_id)
     graph_data = get_graph(body.user_id)
-    
+
     # Use abstract course_id from body, or resolve it from the topic. The graph
     # + shared context key on this abstract id; documents + the session row key
     # on the offering it resolves to (current term).
@@ -486,7 +504,7 @@ def start_session(body: StartSessionBody, request: Request):
         raise HTTPException(status_code=502, detail=f"Gemini error: {e}")
 
     reply, graph_update = extract_graph_update(raw)
-    apply_graph_update(body.user_id, graph_update, course_id=course_id)
+    mastery_changes = apply_graph_update(body.user_id, graph_update, course_id=course_id)
 
     PENDING_SESSIONS[session_id] = {
         "user_id": body.user_id,
@@ -501,12 +519,30 @@ def start_session(body: StartSessionBody, request: Request):
 
     return {
         "session_id": session_id,
-        "initial_message": reply,
+        "reply": reply,
+        "graph_update": graph_update,
+        "mastery_changes": mastery_changes,
         "graph_state": get_graph(body.user_id),
     }
 
 
-async def _chat_via_agent(
+@router.post("/start-session")
+def start_session(body: StartSessionBody, request: Request):
+    # TODO(refactor-3 follow-up): migrate `start_session` to chat_tutor_agent
+    # using the same try-agent-then-legacy pattern as `chat`. Current PR scopes
+    # the agent-path migration to the main `chat` route only. (The streamed
+    # counterpart, /start-session/stream, already does this — see below;
+    # this JSON route stays the untouched rollback target per ADR 0001/0015.)
+    require_self(body.user_id, request)
+    result = _start_session_legacy(body)
+    return {
+        "session_id": result["session_id"],
+        "initial_message": result["reply"],
+        "graph_state": result["graph_state"],
+    }
+
+
+def _prepare_chat_run(
     *,
     user_id: str,
     session_id: str,
@@ -517,23 +553,12 @@ async def _chat_via_agent(
     use_shared_context: bool,
     request_id: str,
     model_pref: str | None = None,
-) -> dict:
-    """Run chat_tutor_agent and return the legacy response shape.
+) -> tuple:
+    """Build (agent, assembled_message, run_kwargs, deps) for a chat turn.
 
-    Returns ``{"reply": str, "graph_update": dict, "mastery_changes": list}``.
-    Graph changes are persisted in-band during the agent run by
-    `apply_graph_update_tool` / `update_mastery_tool` (registered on
-    chat_tutor); the tools also accumulate their payloads on `deps` so the
-    route can echo `graph_update` (for graph_update_json / concepts_covered)
-    and the real `mastery_changes` deltas back to the client, matching the
-    legacy path. Both are empty when nothing changed this turn.
-
-    `use_shared_context=False` flips the model into "no class-aggregate"
-    mode by appending a constraint instruction to the user message —
-    the chat tutor's class-aggregate tools (read_user_progress, etc.)
-    aggregate per-user data, but a future shared-context tool would
-    need this guard rail. Keeping the constraint in-band rather than
-    branching the agent surface keeps the agent definition stable.
+    Shared verbatim by the JSON path (`_chat_via_agent`) and the streaming
+    route so prompt assembly never forks. Extracted from `_chat_via_agent`;
+    behavior is unchanged.
     """
     agent = agent_for_mode(mode)
 
@@ -588,16 +613,57 @@ async def _chat_via_agent(
     if model_pref != "fast":
         run_kwargs["model_settings"] = _build_pro_model_settings()
 
+    return agent, user_message, run_kwargs, deps
+
+
+async def _chat_via_agent(
+    *,
+    user_id: str,
+    session_id: str,
+    course_id: str,
+    mode: str,
+    user_message: str,
+    message_history: list,
+    use_shared_context: bool,
+    request_id: str,
+    model_pref: str | None = None,
+) -> dict:
+    """Run chat_tutor_agent and return the legacy response shape.
+
+    Returns ``{"reply": str, "graph_update": dict, "mastery_changes": list}``.
+    Graph changes are persisted in-band during the agent run by
+    `apply_graph_update_tool` / `update_mastery_tool` (registered on
+    chat_tutor); the tools also accumulate their payloads on `deps` so the
+    route can echo `graph_update` (for graph_update_json / concepts_covered)
+    and the real `mastery_changes` deltas back to the client, matching the
+    legacy path. Both are empty when nothing changed this turn.
+
+    `use_shared_context=False` flips the model into "no class-aggregate"
+    mode by appending a constraint instruction to the user message —
+    the chat tutor's class-aggregate tools (read_user_progress, etc.)
+    aggregate per-user data, but a future shared-context tool would
+    need this guard rail. Keeping the constraint in-band rather than
+    branching the agent surface keeps the agent definition stable.
+    """
+    agent, user_message, run_kwargs, deps = _prepare_chat_run(
+        user_id=user_id,
+        session_id=session_id,
+        course_id=course_id,
+        mode=mode,
+        user_message=user_message,
+        message_history=message_history,
+        use_shared_context=use_shared_context,
+        request_id=request_id,
+        model_pref=model_pref,
+    )
+
     result = await agent.run(user_message, **run_kwargs)
     reply = result.output  # str — chat_tutor agents return plain Markdown.
 
     # Merge all graph update payloads accumulated by tools during this run
     # into a single dict so the route can persist graph_update_json and
     # end_session can derive concepts_covered correctly.
-    merged_graph_update: dict = {}
-    for gu in deps.graph_updates:
-        for key, items in gu.items():
-            merged_graph_update.setdefault(key, []).extend(items)
+    merged_graph_update = merge_graph_updates(deps.graph_updates)
 
     return {
         "reply": reply,
@@ -720,6 +786,172 @@ async def chat(body: ChatBody, request: Request):
     save_message(body.session_id, "assistant", response["reply"], graph_update)
 
     return response
+
+
+@router.post("/chat/stream")
+async def chat_stream(body: ChatBody, request: Request):
+    """SSE token-streaming chat turn (#70) with live graph deltas (#74).
+
+    The JSON /chat route stays the non-streaming fallback (ADR 0001). No DBOS
+    wrap here — stream routes are deliberately outside durable execution
+    (ADR 0011); retries are client-driven and idempotent via X-Request-ID.
+    """
+    require_self(body.user_id, request)
+    _consume_pending(body.session_id, body.user_id)
+
+    request_id = (
+        getattr(request.state, "request_id", None)
+        or current_request_id()
+        or str(uuid.uuid4())
+    )
+
+    offering_id = _get_session_offering_id(body.session_id)
+    course_id = offering_course_id(offering_id) if offering_id else ""
+    # Load prior turns BEFORE the new user row is written, so history is
+    # conversation state up to (not including) this turn.
+    message_history = _load_message_history(body.session_id)
+
+    agent, assembled, run_kwargs, deps = _prepare_chat_run(
+        user_id=body.user_id,
+        session_id=body.session_id,
+        course_id=course_id,
+        mode=body.mode,
+        user_message=body.message,
+        message_history=message_history,
+        use_shared_context=body.use_shared_context,
+        request_id=request_id,
+        model_pref=body.model_pref,
+    )
+    # No extra model override here: _prepare_chat_run already applied the
+    # seam-aware fast/smart preference (_resolve_model_pref), and the agent's
+    # own model is _LoopSafeGoogleModel in real mode / FunctionModel under
+    # SAPLING_MODEL_MODE=function — forcing a GoogleModel here would bypass
+    # the e2e seam and re-create the cross-loop client problem #453 solved.
+
+    def _persist(reply: str, graph_update: dict, mastery_changes: list) -> dict:
+        # Mirrors chat()'s ordering: user row, then assistant row. Runs only
+        # after the agent run completes, so a disconnect mid-generation
+        # persists nothing. Encryption happens inside save_message.
+        save_message(body.session_id, "user", body.message)
+        save_message(body.session_id, "assistant", reply, graph_update or None)
+        return {}
+
+    async def _legacy() -> dict:
+        # Rung 1 only (agent failed before any token). _legacy_chat persists
+        # its own user + assistant rows, so _persist must not also run —
+        # stream_agent_turn enforces that exclusivity.
+        return await _legacy_chat(body, request)
+
+    async def event_stream():
+        async for ev in stream_agent_turn(
+            agent=agent,
+            user_message=assembled,
+            run_kwargs=run_kwargs,
+            deps=deps,
+            on_complete=_persist,
+            legacy_fallback=_legacy,
+            request_id=request_id,
+        ):
+            yield sapling_event_to_sse(ev)
+
+    return EventSourceResponse(
+        event_stream(), headers={"X-Request-ID": request_id}
+    )
+
+
+@router.post("/start-session/stream")
+async def start_session_stream(body: StartSessionBody, request: Request):
+    """Streamed session opener — closes ADR-0015's start_session TODO by
+    running chat_tutor_agent instead of call_gemini_multiturn, and removes a
+    legacy call site on the primary path (#152/#151).
+
+    The JSON /start-session route is unchanged and remains the fallback.
+    PENDING_SESSIONS lazy materialization is preserved exactly: the row is
+    still written on first chat, by _consume_pending.
+
+    Rung 1 (agent fails before any token) falls back to
+    `_start_session_legacy` — the JSON route's own pipeline, per the spec's
+    fallback ladder. `stream_agent_turn` guarantees exactly one of
+    `on_complete` (`_stash`, below) / `legacy_fallback` (`_legacy`, below)
+    runs per turn, so PENDING_SESSIONS is stashed exactly once either way:
+    `_stash` on the agent-success path, `_start_session_legacy` internally
+    on the Rung-1 fallback path — never both.
+    """
+    require_self(body.user_id, request)
+    request_id = (
+        getattr(request.state, "request_id", None)
+        or current_request_id()
+        or str(uuid.uuid4())
+    )
+    session_id = str(uuid.uuid4())
+
+    course_id = body.course_id or _get_course_id_for_topic(body.topic, body.user_id)
+    offering_id = resolve_offering(course_id, create=True) if course_id else ""
+
+    user_message = (
+        f"Student wants to learn about: {body.topic}\n\n"
+        "Begin the session with a warm greeting and your first question or explanation."
+    )
+
+    agent, assembled, run_kwargs, deps = _prepare_chat_run(
+        user_id=body.user_id,
+        session_id=session_id,
+        course_id=course_id,
+        mode=body.mode,
+        user_message=user_message,
+        message_history=[],
+        use_shared_context=body.use_shared_context,
+        request_id=request_id,
+        model_pref=body.model_pref,
+    )
+    # No extra model override here: _prepare_chat_run already applied the
+    # seam-aware fast/smart preference (_resolve_model_pref), and the agent's
+    # own model is _LoopSafeGoogleModel in real mode / FunctionModel under
+    # SAPLING_MODEL_MODE=function — forcing a GoogleModel here would bypass
+    # the e2e seam and re-create the cross-loop client problem #453 solved.
+
+    def _stash(reply: str, graph_update: dict, mastery_changes: list) -> dict:
+        # Agent path succeeded. Same lazy contract as the JSON route:
+        # nothing hits `sessions` until the first chat turn calls
+        # _consume_pending. Mutually exclusive with `_legacy` below — see
+        # the docstring above.
+        PENDING_SESSIONS[session_id] = {
+            "user_id": body.user_id,
+            "mode": body.mode,
+            "topic": body.topic,
+            "course_id": course_id,
+            "offering_id": offering_id,
+            "use_shared_context": body.use_shared_context,
+            "assistant_reply": reply,
+            "graph_update": graph_update,
+        }
+        return {"session_id": session_id, "graph_state": get_graph(body.user_id)}
+
+    async def _legacy() -> dict:
+        # Rung 1 only (agent failed before any token). Reuses the SAME
+        # session_id already minted above — via `session_id=` — so this
+        # turn only ever has one session_id, whichever path serves it.
+        # `_start_session_legacy` stashes PENDING_SESSIONS itself; `_stash`
+        # above must NOT also run, and stream_agent_turn enforces that
+        # exclusivity (exactly one of on_complete/legacy_fallback executes
+        # per turn — see stream_agent_turn's docstring).
+        return _start_session_legacy(body, session_id)
+
+    async def event_stream():
+        async for ev in stream_agent_turn(
+            agent=agent,
+            user_message=assembled,
+            run_kwargs=run_kwargs,
+            deps=deps,
+            on_complete=_stash,
+            legacy_fallback=_legacy,
+            request_id=request_id,
+        ):
+            yield sapling_event_to_sse(ev)
+
+    return EventSourceResponse(
+        event_stream(), headers={"X-Request-ID": request_id}
+    )
 
 
 @router.post("/end-session")

--- a/backend/services/agent_events.py
+++ b/backend/services/agent_events.py
@@ -12,7 +12,11 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 
-SaplingEventType = Literal["status", "progress", "result", "error"]
+# "status"/"progress"/"result" are the document-pipeline vocabulary (ADR 0006).
+# "token"/"graph_update"/"done" extend it for chat streams; "error" is shared.
+SaplingEventType = Literal[
+    "status", "progress", "result", "error", "token", "graph_update", "done"
+]
 
 
 class SaplingEvent(BaseModel):

--- a/backend/services/chat_stream.py
+++ b/backend/services/chat_stream.py
@@ -1,0 +1,238 @@
+# backend/services/chat_stream.py
+"""Translate a Pydantic AI chat run into Sapling SSE events.
+
+The single seam for streaming chat turns (ADR 0006 vocabulary). Iterates
+`agent.run_stream_events()` — the only API that yields BOTH text deltas and
+mid-run tool events in one pass — and emits:
+
+    status:start -> token* -> (progress:<tool> -> graph_update)* -> done
+
+Graph deltas are READ from `deps.graph_updates` / `deps.mastery_changes`,
+which the graph tools populate as they write through
+`graph_service.apply_graph_update` (ADR 0004). This module never writes the
+graph and never persists a message: persistence is the route's, via
+`on_complete`.
+
+Exactly one of `on_complete` / `legacy_fallback` runs per turn — see
+`stream_agent_turn` for the rungs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, AsyncIterator, Awaitable, Callable
+
+from services.agent_events import SaplingEvent
+
+logger = logging.getLogger(__name__)
+
+
+def merge_graph_updates(updates: list[dict]) -> dict:
+    """Merge tool-emitted payloads into one {key: [items]} dict.
+
+    Mirrors the merge in `routes.learn._chat_via_agent` verbatim: keys
+    concatenate (setdefault + extend), never clobber.
+    """
+    merged: dict = {}
+    for gu in updates:
+        for key, items in gu.items():
+            merged.setdefault(key, []).extend(items)
+    return merged
+
+
+def _text_from(event: Any) -> str | None:
+    """Extract a NEW text chunk from a stream event, or None.
+
+    Dispatches on class name, which matters more than it looks (all three
+    shapes below were observed live against gemini-2.5-pro on 2026-07-16):
+
+      PartStartEvent  -> part.content        the reply's FIRST chunk
+      PartDeltaEvent  -> delta.content_delta each subsequent chunk
+      PartEndEvent    -> part.content        the FULL assembled text — SKIP
+
+    Reading `part.content` generically would emit the whole reply a second
+    time when PartEndEvent lands ("hello world" -> "hello worldhello
+    world"). Reading only deltas would drop the opening chunk. Both are
+    regression-tested.
+
+    Class-name dispatch alone is NOT enough, though: `PartStartEvent` and
+    `PartDeltaEvent` wrap ANY part kind, not just text — a `ThinkingPart` /
+    `ThinkingPartDelta` (pydantic-ai 1.89.1, `pydantic_ai.messages`) rides
+    the exact same event classes with the exact same attribute names
+    (`.part.content` / `.delta.content_delta`). Gate on the part's own
+    discriminator so reasoning content can never masquerade as reply text:
+    `TextPart.part_kind == "text"`, `TextPartDelta.part_delta_kind ==
+    "text"` (verified by inspecting the installed library — `ThinkingPart`/
+    `ThinkingPartDelta` carry `"thinking"` in the same fields). Today
+    `_build_pro_model_settings` never sets `include_thoughts`, so this is
+    latent — but the moment thought summaries are enabled, an ungated
+    reader would stream raw chain-of-thought into a student's chat bubble.
+    """
+    cls_name = type(event).__name__
+
+    if cls_name == "PartDeltaEvent":
+        delta = getattr(event, "delta", None)
+        if getattr(delta, "part_delta_kind", None) != "text":
+            return None
+        content_delta = getattr(delta, "content_delta", None)
+        return content_delta if isinstance(content_delta, str) and content_delta else None
+
+    if cls_name == "PartStartEvent":
+        part = getattr(event, "part", None)
+        if getattr(part, "part_kind", None) != "text":
+            return None
+        content = getattr(part, "content", None)
+        return content if isinstance(content, str) and content else None
+
+    # PartEndEvent / FinalResultEvent / tool + result events carry no NEW text.
+    return None
+
+
+def _tool_name_from(event: Any) -> str | None:
+    for path in ("part.tool_name", "tool_name", "result.tool_name"):
+        obj: Any = event
+        try:
+            for attr in path.split("."):
+                obj = getattr(obj, attr)
+            if isinstance(obj, str):
+                return obj
+        except AttributeError:
+            continue
+    return None
+
+
+async def stream_agent_turn(
+    *,
+    agent: Any,
+    user_message: str,
+    run_kwargs: dict,
+    deps: Any,
+    on_complete: Callable[[str, dict, list], dict | None],
+    legacy_fallback: Callable[[], Awaitable[dict]] | None = None,
+    request_id: str = "",
+) -> AsyncIterator[SaplingEvent]:
+    """Stream one agent turn as SaplingEvents.
+
+    on_complete(reply, merged_graph_update, mastery_changes) -> extra `done`
+    data. It persists; it is called exactly once, after the run completes and
+    BEFORE `done` is yielded, so a mid-generation disconnect (which cancels
+    this generator at its current yield) persists nothing.
+
+    legacy_fallback() -> awaitable returning the route's pre-agent result,
+    used ONLY when the agent fails before emitting any text (Rung 1). It is
+    async because the routes' legacy paths are (`_legacy_chat`). It owns its
+    own persistence, so on_complete is NOT called on that branch — calling
+    both double-writes.
+    """
+    yield SaplingEvent(type="status", step="start", message="Starting.")
+
+    chunks: list[str] = []
+    final_output: str | None = None
+    # High-water marks: how much of deps.* we have already emitted.
+    graph_hw = 0
+    mastery_hw = 0
+
+    try:
+        async for event in agent.run_stream_events(user_message, **run_kwargs):
+            text = _text_from(event)
+            if text:
+                chunks.append(text)
+                yield SaplingEvent(
+                    type="token", step="reply", message="", data={"delta": text}
+                )
+                continue
+
+            cls_name = type(event).__name__
+
+            if cls_name == "FunctionToolCallEvent":
+                tool = _tool_name_from(event) or "tool"
+                yield SaplingEvent(
+                    type="progress", step=tool, message=f"Calling {tool}."
+                )
+                continue
+
+            if cls_name == "FunctionToolResultEvent":
+                # A graph tool may have just written. Emit only what is new.
+                new_nodes = merge_graph_updates(deps.graph_updates[graph_hw:])
+                new_mastery = deps.mastery_changes[mastery_hw:]
+                graph_hw = len(deps.graph_updates)
+                mastery_hw = len(deps.mastery_changes)
+                if new_nodes or new_mastery:
+                    yield SaplingEvent(
+                        type="graph_update",
+                        step="graph",
+                        message="Knowledge graph updated.",
+                        data={"nodes": new_nodes, "mastery_changes": new_mastery},
+                    )
+                continue
+
+            if cls_name == "AgentRunResultEvent":
+                output = getattr(getattr(event, "result", None), "output", None)
+                if isinstance(output, str):
+                    final_output = output
+
+    # Catches UsageLimitExceeded / UnexpectedModelBehavior (both Exception
+    # subclasses) and anything else the model or a tool raises. Deliberately
+    # NOT BaseException: asyncio.CancelledError must propagate so a client
+    # disconnect stays a cancellation — never a "fallback to legacy".
+    except Exception as exc:
+        if chunks:
+            # Rung 2: text already shown. Never silently re-run — the user
+            # would see the reply restart. Terminal error; persist nothing.
+            logger.warning("Chat stream failed mid-generation", exc_info=exc)
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor was interrupted. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+
+        # Rung 1: nothing shown yet — degrade to the route's legacy path.
+        logger.warning("Chat agent failed before first token; using legacy", exc_info=exc)
+        if legacy_fallback is None:
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor is unavailable. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+        try:
+            legacy = await legacy_fallback()
+        except Exception:
+            logger.exception("Legacy fallback also failed")
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor is unavailable. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+        # legacy_fallback persisted its own rows; do NOT call on_complete.
+        yield SaplingEvent(
+            type="token", step="reply", message="",
+            data={"delta": legacy.get("reply", "")},
+        )
+        yield SaplingEvent(
+            type="done", step="reply", message="Complete.", data=legacy
+        )
+        return
+
+    reply = final_output if final_output is not None else "".join(chunks)
+    merged = merge_graph_updates(deps.graph_updates)
+    mastery = list(deps.mastery_changes)
+
+    extra = on_complete(reply, merged, mastery) or {}
+
+    yield SaplingEvent(
+        type="done",
+        step="reply",
+        message="Complete.",
+        data={
+            "reply": reply,
+            "graph_update": merged,
+            "mastery_changes": mastery,
+            **extra,
+        },
+    )

--- a/backend/services/chat_stream.py
+++ b/backend/services/chat_stream.py
@@ -13,8 +13,8 @@ which the graph tools populate as they write through
 graph and never persists a message: persistence is the route's, via
 `on_complete`.
 
-Exactly one of `on_complete` / `legacy_fallback` runs per turn — see
-`stream_agent_turn` for the rungs.
+At most one of `on_complete` / `legacy_fallback` runs per turn — never both,
+and the error rungs run neither. See `stream_agent_turn` for the rungs.
 """
 
 from __future__ import annotations
@@ -114,15 +114,21 @@ async def stream_agent_turn(
     """Stream one agent turn as SaplingEvents.
 
     on_complete(reply, merged_graph_update, mastery_changes) -> extra `done`
-    data. It persists; it is called exactly once, after the run completes and
-    BEFORE `done` is yielded, so a mid-generation disconnect (which cancels
-    this generator at its current yield) persists nothing.
+    data. It persists; on the success path it is called once, after the run
+    completes and BEFORE `done` is yielded, so a mid-generation disconnect
+    (which cancels this generator at its current yield) persists nothing.
 
     legacy_fallback() -> awaitable returning the route's pre-agent result,
     used ONLY when the agent fails before emitting any text (Rung 1). It is
     async because the routes' legacy paths are (`_legacy_chat`). It owns its
     own persistence, so on_complete is NOT called on that branch — calling
     both double-writes.
+
+    Invariant: AT MOST one of on_complete / legacy_fallback runs per turn —
+    never both. The error rungs run NEITHER: Rung 2 (failure after tokens
+    streamed), Rung 1 with no fallback, and a Rung-1 fallback that itself
+    raises all yield an `error` event and persist nothing (regression-tested
+    in test_chat_stream.py).
     """
     yield SaplingEvent(type="status", step="start", message="Starting.")
 
@@ -223,7 +229,24 @@ async def stream_agent_turn(
     merged = merge_graph_updates(deps.graph_updates)
     mastery = list(deps.mastery_changes)
 
-    extra = on_complete(reply, merged, mastery) or {}
+    try:
+        extra = on_complete(reply, merged, mastery) or {}
+    except Exception as exc:
+        # Persistence failed AFTER the reply fully streamed. Letting this
+        # propagate would abort the ASGI response mid-stream with no closing
+        # event (sse_starlette has already flushed headers), leaving the
+        # client an unstructured network error. Emit the structured error
+        # instead so the ADR-0020 interrupted-turn treatment (keep partial
+        # text, offer Retry) applies; the turn persisted at most a partial
+        # write, and Retry re-sends it.
+        logger.warning("on_complete persistence failed after streamed reply", exc_info=exc)
+        yield SaplingEvent(
+            type="error",
+            step="reply",
+            message="The tutor was interrupted. Please retry.",
+            data={"request_id": request_id},
+        )
+        return
 
     yield SaplingEvent(
         type="done",

--- a/backend/tests/test_agent_events.py
+++ b/backend/tests/test_agent_events.py
@@ -1,0 +1,15 @@
+import json
+
+from services.agent_events import SaplingEvent, sapling_event_to_sse
+
+
+def test_token_event_serializes_to_sse():
+    ev = SaplingEvent(type="token", step="reply", message="", data={"delta": "Hi"})
+    wire = sapling_event_to_sse(ev)
+    assert wire["event"] == "token"
+    assert json.loads(wire["data"])["data"]["delta"] == "Hi"
+
+
+def test_graph_update_and_done_types_accepted():
+    for t in ("graph_update", "done"):
+        assert SaplingEvent(type=t, step="reply", message="").type == t

--- a/backend/tests/test_chat_stream.py
+++ b/backend/tests/test_chat_stream.py
@@ -308,3 +308,35 @@ def test_cancel_mid_stream_persists_nothing():
         assert on_complete_calls == [], "a partial reply must never persist"
 
     asyncio.run(run())
+
+
+def test_on_complete_raising_yields_error_not_unhandled_exception():
+    """Persistence failing AFTER the reply fully streamed must surface as a
+    structured `error` event (ADR-0020 interrupted-turn treatment), never an
+    unhandled exception — sse_starlette has already flushed headers by then,
+    so a propagated exception aborts the response with no closing event at
+    all and the client sees an unstructured network failure."""
+    async def run():
+        agent = FakeAgent(
+            [PartStartEvent("hi"), AgentRunResultEvent("hi")]
+        )
+        legacy_calls = []
+
+        def failing_persist(reply, graph_update, mastery_changes):
+            raise RuntimeError("db write failed")
+
+        async def fake_legacy():
+            legacy_calls.append(1)
+            return {"reply": "nope"}
+
+        events = await collect(
+            agent, make_deps(),
+            on_complete=failing_persist,
+            legacy_fallback=fake_legacy,
+        )
+        assert events[-1].type == "error"
+        assert events[-1].data["request_id"] == "r1"
+        assert all(e.type != "done" for e in events), "no done after failed persistence"
+        assert legacy_calls == [], "reply already streamed — never re-run legacy"
+
+    asyncio.run(run())

--- a/backend/tests/test_chat_stream.py
+++ b/backend/tests/test_chat_stream.py
@@ -1,0 +1,310 @@
+"""Unit tests for services/chat_stream.py against a fake event stream.
+
+No live LLM: FakeAgent yields stand-ins whose CLASS NAMES and attribute
+shapes match Pydantic AI 1.89.1 (verified by inspection), which is all
+stream_agent_turn dispatches on.
+"""
+import asyncio
+
+from agents.deps import SaplingDeps
+from services.chat_stream import merge_graph_updates, stream_agent_turn
+
+
+# ── Fakes mirroring pydantic_ai event shapes ──────────────────────────────
+
+class TextPartDelta:
+    def __init__(self, content_delta):
+        self.content_delta = content_delta
+        self.part_delta_kind = "text"
+
+
+class ThinkingPartDelta:
+    """Mirrors pydantic_ai.messages.ThinkingPartDelta: same attribute name
+    (`content_delta`) as TextPartDelta, discriminated only by
+    `part_delta_kind`. Must never surface as a `token` event."""
+    def __init__(self, content_delta):
+        self.content_delta = content_delta
+        self.part_delta_kind = "thinking"
+
+
+class PartDeltaEvent:
+    def __init__(self, content_delta, part_delta_kind="text"):
+        self.delta = (
+            ThinkingPartDelta(content_delta)
+            if part_delta_kind == "thinking"
+            else TextPartDelta(content_delta)
+        )
+
+
+class _TextPart:
+    def __init__(self, content):
+        self.content = content
+        self.part_kind = "text"
+
+
+class _ThinkingPart:
+    """Mirrors pydantic_ai.messages.ThinkingPart: same attribute name
+    (`content`) as TextPart, discriminated only by `part_kind`. Must never
+    surface as a `token` event."""
+    def __init__(self, content):
+        self.content = content
+        self.part_kind = "thinking"
+
+
+class PartStartEvent:
+    """First text chunk arrives here — NOT as a delta."""
+    def __init__(self, content, part_kind="text"):
+        self.part = _ThinkingPart(content) if part_kind == "thinking" else _TextPart(content)
+
+
+class PartEndEvent:
+    """Carries the FULL assembled text on the same `.part.content`
+    attribute PartStartEvent uses. Must NOT produce a token."""
+    def __init__(self, content):
+        self.part = _TextPart(content)
+
+
+class _ToolPart:
+    def __init__(self, tool_name):
+        self.tool_name = tool_name
+
+
+class FunctionToolCallEvent:
+    def __init__(self, tool_name):
+        self.part = _ToolPart(tool_name)
+
+
+class FunctionToolResultEvent:
+    def __init__(self, on_fire=None):
+        # Simulates the tool having written to deps during its execution.
+        if on_fire:
+            on_fire()
+
+
+class _Result:
+    def __init__(self, output):
+        self.output = output
+
+
+class AgentRunResultEvent:
+    def __init__(self, output):
+        self.result = _Result(output)
+
+
+class FakeAgent:
+    def __init__(self, events, raise_after=None):
+        self._events = events
+        self._raise_after = raise_after
+
+    async def run_stream_events(self, user_message, **kwargs):
+        for i, ev in enumerate(self._events):
+            if self._raise_after is not None and i == self._raise_after:
+                raise RuntimeError("model blew up")
+            yield ev
+
+
+def make_deps():
+    return SaplingDeps(
+        user_id="u1", course_id="c1", supabase=None,
+        request_id="r1", session_id="s1",
+    )
+
+
+async def collect(agent, deps, on_complete, legacy_fallback=None):
+    events = []
+    async for ev in stream_agent_turn(
+        agent=agent, user_message="hi", run_kwargs={}, deps=deps,
+        on_complete=on_complete, legacy_fallback=legacy_fallback,
+        request_id="r1",
+    ):
+        events.append(ev)
+    return events
+
+
+# ── merge ─────────────────────────────────────────────────────────────────
+
+def test_merge_concatenates_and_never_clobbers():
+    merged = merge_graph_updates(
+        [{"new_nodes": [{"n": 1}]}, {"new_nodes": [{"n": 2}]}, {"updated_nodes": [{"n": 3}]}]
+    )
+    assert merged == {"new_nodes": [{"n": 1}, {"n": 2}], "updated_nodes": [{"n": 3}]}
+
+
+# ── happy path ────────────────────────────────────────────────────────────
+
+def test_first_chunk_from_part_start_is_not_dropped():
+    """PartStartEvent carries the reply's FIRST chunk. Regression: handling
+    only PartDeltaEvent silently truncates the opening."""
+    async def run():
+        agent = FakeAgent([
+            PartStartEvent("Hello "),
+            PartDeltaEvent("world"),
+            AgentRunResultEvent("Hello world"),
+        ])
+        saved = {}
+        events = await collect(agent, make_deps(), lambda r, g, m: saved.update(reply=r) or {})
+        tokens = [e.data["delta"] for e in events if e.type == "token"]
+        assert tokens == ["Hello ", "world"]
+        assert saved["reply"] == "Hello world"
+
+    asyncio.run(run())
+
+
+def test_part_end_event_does_not_duplicate_the_reply():
+    """PartEndEvent carries the FULL assembled text on .part.content — the
+    same attribute PartStartEvent uses for the FIRST chunk. Emitting a token
+    for it duplicates the whole reply in the user's bubble.
+
+    Regression: a duck-typed `getattr(event.part, 'content')` reader turns
+    "hello world" into "hello worldhello world". Observed live in Task 1's
+    spike."""
+    async def run():
+        agent = FakeAgent([
+            PartStartEvent("hello "),
+            PartDeltaEvent("world"),
+            PartEndEvent("hello world"),      # full text — must be ignored
+            AgentRunResultEvent("hello world"),
+        ])
+        events = await collect(agent, make_deps(), lambda r, g, m: {})
+        tokens = [e.data["delta"] for e in events if e.type == "token"]
+        assert tokens == ["hello ", "world"], "PartEndEvent must not re-emit the reply"
+        assert "".join(tokens) == "hello world"
+
+    asyncio.run(run())
+
+
+def test_thinking_part_never_produces_a_token():
+    """`_text_from` dispatches on event CLASS, but PartStartEvent/
+    PartDeltaEvent wrap ANY part kind — a ThinkingPart/ThinkingPartDelta
+    rides the identical `.part.content` / `.delta.content_delta`
+    attributes a TextPart/TextPartDelta uses. Without gating on
+    part_kind/part_delta_kind, reasoning content would stream into the
+    student's chat bubble the moment thought summaries are enabled
+    (latent today only because _build_pro_model_settings doesn't set
+    include_thoughts). Text-shaped parts in the same run must still
+    produce tokens normally."""
+    async def run():
+        agent = FakeAgent([
+            PartStartEvent("Let me reason about this privately...", part_kind="thinking"),
+            PartDeltaEvent(" and some more private reasoning.", part_delta_kind="thinking"),
+            PartStartEvent("The answer is "),
+            PartDeltaEvent("42."),
+            AgentRunResultEvent("The answer is 42."),
+        ])
+        events = await collect(agent, make_deps(), lambda r, g, m: {})
+        tokens = [e.data["delta"] for e in events if e.type == "token"]
+        assert tokens == ["The answer is ", "42."], (
+            "thinking-shaped parts must never be emitted as tokens, "
+            "and text-shaped parts in the same run must still stream"
+        )
+
+    asyncio.run(run())
+
+
+def test_event_order_and_single_persistence():
+    async def run():
+        agent = FakeAgent([
+            PartStartEvent("Hi"),
+            AgentRunResultEvent("Hi"),
+        ])
+        calls = []
+        events = await collect(agent, make_deps(), lambda r, g, m: calls.append(r) or {"extra": 1})
+        assert [e.type for e in events] == ["status", "token", "done"]
+        assert calls == ["Hi"], "on_complete must fire exactly once"
+        done = events[-1]
+        assert done.data["reply"] == "Hi"
+        assert done.data["extra"] == 1, "on_complete's return merges into done"
+
+    asyncio.run(run())
+
+
+def test_graph_update_emitted_once_per_new_write():
+    """High-water mark: an already-emitted delta must not re-emit on the
+    next tool result."""
+    async def run():
+        deps = make_deps()
+
+        def first_write():
+            deps.graph_updates.append({"new_nodes": [{"name": "Eigenvalues"}]})
+            deps.mastery_changes.append({"concept": "Eigenvalues", "before": 0.1, "after": 0.6})
+
+        agent = FakeAgent([
+            FunctionToolCallEvent("update_mastery_tool"),
+            FunctionToolResultEvent(on_fire=first_write),
+            PartStartEvent("Done."),
+            FunctionToolCallEvent("search_course_materials_tool"),
+            FunctionToolResultEvent(),          # writes nothing new
+            AgentRunResultEvent("Done."),
+        ])
+        events = await collect(agent, deps, lambda r, g, m: {})
+        graph_events = [e for e in events if e.type == "graph_update"]
+        assert len(graph_events) == 1, "second tool result added nothing — must not re-emit"
+        assert graph_events[0].data["nodes"] == {"new_nodes": [{"name": "Eigenvalues"}]}
+        assert graph_events[0].data["mastery_changes"][0]["after"] == 0.6
+        assert [e.type for e in events].index("graph_update") < [e.type for e in events].index("done")
+
+    asyncio.run(run())
+
+
+# ── failure rungs ─────────────────────────────────────────────────────────
+
+def test_rung1_failure_before_any_token_uses_legacy_and_skips_on_complete():
+    async def run():
+        agent = FakeAgent([PartStartEvent("x")], raise_after=0)
+        on_complete_calls = []
+
+        async def fake_legacy():
+            # async because the real routes' legacy paths are (_legacy_chat)
+            return {"reply": "legacy reply", "graph_update": {}, "mastery_changes": []}
+
+        events = await collect(
+            agent, make_deps(),
+            on_complete=lambda r, g, m: on_complete_calls.append(r),
+            legacy_fallback=fake_legacy,
+        )
+        assert [e.type for e in events] == ["status", "token", "done"]
+        assert events[1].data["delta"] == "legacy reply"
+        assert events[-1].data["reply"] == "legacy reply"
+        assert on_complete_calls == [], "legacy owns persistence — on_complete must NOT run"
+
+    asyncio.run(run())
+
+
+def test_rung2_failure_after_tokens_errors_and_persists_nothing():
+    async def run():
+        agent = FakeAgent([PartStartEvent("Half a th"), PartDeltaEvent("ought")], raise_after=1)
+        on_complete_calls = []
+        legacy_calls = []
+
+        async def fake_legacy():
+            legacy_calls.append(1)
+            return {"reply": "nope"}
+
+        events = await collect(
+            agent, make_deps(),
+            on_complete=lambda r, g, m: on_complete_calls.append(r),
+            legacy_fallback=fake_legacy,
+        )
+        assert events[-1].type == "error"
+        assert events[-1].data["request_id"] == "r1"
+        assert on_complete_calls == [], "nothing may persist after a mid-stream failure"
+        assert legacy_calls == [], "never silently re-run once text was shown"
+
+    asyncio.run(run())
+
+
+def test_cancel_mid_stream_persists_nothing():
+    """Client disconnect cancels the generator at its current yield."""
+    async def run():
+        agent = FakeAgent([PartStartEvent("a"), PartDeltaEvent("b"), AgentRunResultEvent("ab")])
+        on_complete_calls = []
+        gen = stream_agent_turn(
+            agent=agent, user_message="hi", run_kwargs={}, deps=make_deps(),
+            on_complete=lambda r, g, m: on_complete_calls.append(r), request_id="r1",
+        )
+        await gen.__anext__()   # status
+        await gen.__anext__()   # first token
+        await gen.aclose()      # disconnect
+        assert on_complete_calls == [], "a partial reply must never persist"
+
+    asyncio.run(run())

--- a/backend/tests/test_learn_stream_routes.py
+++ b/backend/tests/test_learn_stream_routes.py
@@ -1,0 +1,198 @@
+# backend/tests/test_learn_stream_routes.py
+"""Route-level tests for the SSE chat streams."""
+import inspect
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def _sse_events(text: str) -> list[str]:
+    """Event names from a raw SSE body."""
+    return [
+        line.split("event:", 1)[1].strip()
+        for line in text.splitlines()
+        if line.startswith("event:")
+    ]
+
+
+class TestChatStream:
+    def test_streams_tokens_then_done(self):
+        # Distinctive sentinel (not []) so an accidental `message_history=[]`
+        # in the route is caught by the assertion below, instead of silently
+        # matching whatever the mock happens to default to.
+        history_sentinel = [{"sentinel": "prior-turns"}]
+
+        stream_kwargs = {}
+
+        async def fake_stream(**kwargs):
+            # Capture exactly what the route hands to stream_agent_turn,
+            # so we can assert on legacy_fallback wiring after the request.
+            stream_kwargs.update(kwargs)
+            from services.agent_events import SaplingEvent
+            yield SaplingEvent(type="status", step="start", message="Starting.")
+            yield SaplingEvent(type="token", step="reply", message="", data={"delta": "Hi"})
+            kwargs["on_complete"]("Hi", {}, [])
+            yield SaplingEvent(type="done", step="reply", message="Complete.",
+                               data={"reply": "Hi", "graph_update": {}, "mastery_changes": []})
+
+        saved = []
+        with patch("routes.learn.stream_agent_turn", fake_stream), \
+             patch("routes.learn._prepare_chat_run",
+                   return_value=(MagicMock(), "msg", {}, MagicMock())) as prep, \
+             patch("routes.learn._consume_pending"), \
+             patch("routes.learn._get_session_offering_id", return_value="off-1"), \
+             patch("routes.learn.offering_course_id", return_value="c1"), \
+             patch("routes.learn._load_message_history", return_value=history_sentinel), \
+             patch("routes.learn.save_message", side_effect=lambda *a, **k: saved.append(a)):
+            r = client.post("/api/learn/chat/stream", json={
+                "session_id": "s1", "user_id": "u1", "message": "hello", "mode": "socratic",
+                "model_pref": "smart",
+            })
+
+        assert r.status_code == 200
+        assert "text/event-stream" in r.headers["content-type"]
+        assert _sse_events(r.text) == ["status", "token", "done"]
+        assert [a[1] for a in saved] == ["user", "assistant"], "user row persists before assistant"
+
+        # Wiring into _prepare_chat_run: prior turns loaded before the new
+        # user row is written (message_history), correct course scoping,
+        # the actual user message, and the model override — all as the
+        # route actually passes them, not whatever the mock defaults to.
+        prep_kwargs = prep.call_args.kwargs
+        assert prep_kwargs["message_history"] is history_sentinel, (
+            "message_history must be exactly what _load_message_history returned "
+            "(loaded BEFORE the new user row is written), not [] or something else"
+        )
+        assert prep_kwargs["course_id"] == "c1"
+        assert prep_kwargs["user_message"] == "hello"
+        assert prep_kwargs["model_pref"] == "smart"
+
+        # Rung-1 legacy fallback must be wired into stream_agent_turn so an
+        # agent failure before any token degrades to _legacy_chat instead of
+        # erroring outright.
+        assert stream_kwargs.get("legacy_fallback") is not None, (
+            "legacy_fallback must be passed to stream_agent_turn (Rung-1 fallback)"
+        )
+        assert inspect.iscoroutinefunction(stream_kwargs["legacy_fallback"])
+
+    def test_requires_self(self):
+        """The guard must run BEFORE any streaming work starts.
+
+        Note the strict assertions: an earlier draft wrapped this in
+        try/except Exception: pass, which swallowed the AssertionError and
+        made the test pass even when auth was bypassed entirely.
+        """
+        from fastapi import HTTPException
+
+        with patch("routes.learn.require_self",
+                   side_effect=HTTPException(status_code=403, detail="forbidden")) as guard, \
+             patch("routes.learn._consume_pending"), \
+             patch("routes.learn._prepare_chat_run") as prep:
+            r = client.post("/api/learn/chat/stream", json={
+                "session_id": "s1", "user_id": "someone-else",
+                "message": "hi", "mode": "socratic",
+            })
+
+        assert r.status_code == 403
+        guard.assert_called_once()
+        assert not prep.called, "auth must gate before any agent setup"
+
+
+class TestStartSessionStream:
+    def test_stashes_pending_session_and_does_not_write_db(self):
+        async def fake_stream(**kwargs):
+            from services.agent_events import SaplingEvent
+            extra = kwargs["on_complete"]("Welcome!", {}, [])
+            yield SaplingEvent(type="done", step="reply", message="Complete.",
+                               data={"reply": "Welcome!", **extra})
+
+        from routes.learn import PENDING_SESSIONS
+        PENDING_SESSIONS.clear()
+
+        with patch("routes.learn.stream_agent_turn", fake_stream), \
+             patch("routes.learn._prepare_chat_run",
+                   return_value=(MagicMock(), "msg", {}, MagicMock())) as prep, \
+             patch("routes.learn._get_course_id_for_topic", return_value="c1"), \
+             patch("routes.learn.resolve_offering", return_value="off-1"), \
+             patch("routes.learn.get_graph", return_value={"nodes": []}), \
+             patch("routes.learn.table") as tbl:
+            r = client.post("/api/learn/start-session/stream", json={
+                "user_id": "u1", "topic": "Eigenvalues", "mode": "socratic",
+            })
+
+        assert r.status_code == 200
+        assert len(PENDING_SESSIONS) == 1, "session must be stashed, not written"
+        stashed = next(iter(PENDING_SESSIONS.values()))
+        assert stashed["assistant_reply"] == "Welcome!"
+        assert stashed["topic"] == "Eigenvalues"
+        tbl.assert_not_called()
+
+        # A brand-new session genuinely has no prior turns; pin that literal
+        # (not a mock artifact) so a regression that starts loading history
+        # here — or drops it — is caught.
+        assert prep.call_args.kwargs["message_history"] == [], (
+            "a new session must start with no prior message history"
+        )
+
+    def test_legacy_fallback_wired_and_stashes_exactly_once(self):
+        """Finding 1 regression: start_session_stream used to pass
+        legacy_fallback=None, diverging from the spec's Rung 1 ("falls back
+        to the existing start_session body"). Mirrors TestChatStream's
+        wiring assertion, then goes further: simulates stream_agent_turn's
+        REAL mutual-exclusion contract (Rung 1 invokes ONLY
+        legacy_fallback, never on_complete) and proves the fallback stashes
+        PENDING_SESSIONS exactly once via the shared _start_session_legacy
+        helper — no double-stash, no double-persist.
+        """
+        stream_kwargs = {}
+
+        async def fake_stream(**kwargs):
+            stream_kwargs.update(kwargs)
+            from services.agent_events import SaplingEvent
+            # Rung 1: agent failed before any token. Real stream_agent_turn
+            # calls ONLY legacy_fallback here, never on_complete — that
+            # exclusivity is exactly what this test is pinning.
+            legacy_result = await kwargs["legacy_fallback"]()
+            yield SaplingEvent(type="token", step="reply", message="",
+                                data={"delta": legacy_result["reply"]})
+            yield SaplingEvent(type="done", step="reply", message="Complete.",
+                                data=legacy_result)
+
+        from routes.learn import PENDING_SESSIONS
+        PENDING_SESSIONS.clear()
+
+        with patch("routes.learn.stream_agent_turn", fake_stream), \
+             patch("routes.learn._prepare_chat_run",
+                   return_value=(MagicMock(), "msg", {}, MagicMock())), \
+             patch("routes.learn._get_course_id_for_topic", return_value="c1"), \
+             patch("routes.learn.resolve_offering", return_value="off-1"), \
+             patch("routes.learn.get_graph", return_value={"nodes": []}), \
+             patch("routes.learn.get_user_name", return_value="Student"), \
+             patch("routes.learn._get_course_documents", return_value=[]), \
+             patch("routes.learn.build_system_prompt", return_value="prompt"), \
+             patch("routes.learn.call_gemini_multiturn", return_value="raw"), \
+             patch("routes.learn.extract_graph_update",
+                   return_value=("Legacy greeting", {"new_nodes": []})), \
+             patch("routes.learn.apply_graph_update", return_value=[]):
+            r = client.post("/api/learn/start-session/stream", json={
+                "user_id": "u1", "topic": "Eigenvalues", "mode": "socratic",
+            })
+
+        assert r.status_code == 200
+        assert stream_kwargs.get("legacy_fallback") is not None, (
+            "legacy_fallback must be passed to stream_agent_turn (Rung-1 fallback)"
+        )
+        assert inspect.iscoroutinefunction(stream_kwargs["legacy_fallback"])
+
+        assert len(PENDING_SESSIONS) == 1, (
+            "legacy_fallback must stash PENDING_SESSIONS exactly once "
+            "(via _start_session_legacy) — never zero, never twice"
+        )
+        stashed = next(iter(PENDING_SESSIONS.values()))
+        assert stashed["assistant_reply"] == "Legacy greeting"
+        assert stashed["topic"] == "Eigenvalues"
+        assert "Legacy greeting" in r.text, "the legacy reply must reach the client as a token/done"

--- a/backend/tests/test_model_mode_seam.py
+++ b/backend/tests/test_model_mode_seam.py
@@ -301,3 +301,104 @@ def test_default_real_mode_agent_run_still_trips_the_guard():
     class identities differ)."""
     with pytest.raises(RuntimeError, match="unstubbed LLM egress"):
         classifier_agent.run_sync("anything", deps=_deps())
+
+
+# ── Streamed runs (#349): the seam serves run_stream_events too ───────────
+
+
+def test_function_mode_streams_text_from_the_same_handler(monkeypatch):
+    """The SSE tutor routes drive agents via `run_stream_events`. A streamed
+    run in function mode must be served by the SAME registered handler as a
+    JSON run — its text replayed as stream deltas — so spec assertions can
+    compare both lanes against one E2E_* constant. Before #349 the seam's
+    FunctionModel had no `stream_function`, so every streamed turn errored
+    into the legacy fallback and the streamed path was untestable."""
+    import asyncio
+
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    register_function_handler(
+        "note_chat",
+        lambda m, i: ModelResponse(parts=[TextPart(content="streamed seam reply")]),
+    )
+
+    async def collect() -> tuple[list[str], str | None]:
+        deltas: list[str] = []
+        final: str | None = None
+        with note_chat_agent.override(model=model_for("note_chat")):
+            async for event in note_chat_agent.run_stream_events(
+                "hello", deps=_deps()
+            ):
+                cls_name = type(event).__name__
+                if cls_name == "PartStartEvent":
+                    part = getattr(event, "part", None)
+                    if getattr(part, "part_kind", None) == "text" and part.content:
+                        deltas.append(part.content)
+                elif cls_name == "PartDeltaEvent":
+                    delta = getattr(event, "delta", None)
+                    if getattr(delta, "part_delta_kind", None) == "text":
+                        deltas.append(delta.content_delta)
+                elif cls_name == "AgentRunResultEvent":
+                    final = event.result.output
+        return deltas, final
+
+    deltas, final = asyncio.run(collect())
+    assert "".join(deltas) == "streamed seam reply"
+    assert final == "streamed seam reply"
+
+
+def test_function_mode_streams_scripted_tool_calls(monkeypatch):
+    """A streamed function-mode run must also replay scripted TOOL CALLS (as
+    DeltaToolCall chunks) through the real tool-registration/validation loop —
+    the streamed twin of the JSON-lane acceptance test above."""
+    import asyncio
+
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+
+    received: dict = {}
+
+    async def _spy_search(course_id, query, limit=5, *, user_id):
+        received.update(query=query, limit=limit)
+        return []
+
+    monkeypatch.setattr(
+        "agents.tools.chat_context.search_course_materials", _spy_search
+    )
+
+    calls = {"n": 0}
+
+    def handler(messages, info) -> ModelResponse:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="search_course_materials_tool",
+                        args={"query": "eigenvalues", "limit": 2},
+                    )
+                ]
+            )
+        return ModelResponse(parts=[TextPart(content="used the tool")])
+
+    register_function_handler("note_chat", handler)
+
+    async def run() -> tuple[str | None, list[str]]:
+        final: str | None = None
+        tool_events: list[str] = []
+        with note_chat_agent.override(model=model_for("note_chat")):
+            async for event in note_chat_agent.run_stream_events(
+                "find eigenvalues", deps=_deps()
+            ):
+                cls_name = type(event).__name__
+                if cls_name == "FunctionToolCallEvent":
+                    tool_events.append(cls_name)
+                elif cls_name == "AgentRunResultEvent":
+                    final = event.result.output
+        return final, tool_events
+
+    final, tool_events = asyncio.run(run())
+    # The scripted call streamed as a real mid-run tool event, was
+    # schema-validated, and dispatched to the real (spied) tool body.
+    assert tool_events == ["FunctionToolCallEvent"]
+    assert received == {"query": "eigenvalues", "limit": 2}
+    assert final == "used the tool"
+    assert calls["n"] == 2

--- a/docs/decisions/0020-streaming-tutor-interrupt-retry.md
+++ b/docs/decisions/0020-streaming-tutor-interrupt-retry.md
@@ -1,0 +1,69 @@
+# 0020 — Interrupted tutor turns keep the partial reply and offer Retry (#356 item 5)
+
+**Status:** decided · **Issue:** #356 (PR #349 e2e-smoke item 5) · **Implements:** the streaming feature in PR #349
+
+## The decision
+
+When a streaming tutor turn is **stopped by the user** or **fails mid-stream**
+(a Rung-2 `error` event, including during a Rung-3 JSON fallback), the client
+**keeps the partial reply text visible, marks the bubble interrupted, and offers
+Retry**. Because nothing is persisted until a turn completes, Retry simply
+re-sends the same turn. This is the behavior the streaming spec already
+specifies — we adopt it rather than amend the spec.
+
+## Context
+
+PR #349 shipped the SSE streaming tutor with a known divergence from spec,
+called out in its "Known gaps":
+
+> **Stop/Rung-2 discards the partial reply and offers no Retry.** As shipped,
+> Stop appends nothing (leaving the user's message with no reply) and Rung 2
+> shows a generic error.
+
+The e2e-smoke item 5 (#356) asked us to confirm this live and decide:
+**(a)** implement per spec — keep the partial, mark it interrupted, offer Retry;
+or **(b)** amend the spec to bless the discard.
+
+The spec (`docs/superpowers/specs/2026-07-16-streaming-design.md`) is explicit:
+
+- Bubble-state table (§ "failed / stopped"): *"mid-stream `error` or user Stop:
+  keep the partial text visually, mark it interrupted, offer Retry (nothing was
+  persisted, so Retry re-sends the turn)."*
+- Failure ladder: *"persist nothing; client marks the bubble interrupted and
+  offers Retry. No silent auto-retry."*
+
+## Why (a), not (b)
+
+- **No dropped turns.** Discarding on Stop leaves the user's own message sitting
+  with no reply and no affordance to recover — the worst outcome of the two,
+  and precisely what a "Stop" (pause, not delete) does not imply.
+- **The partial is real output.** Tokens already rendered are the model's actual
+  answer so far; keeping them visible (dimmed/"interrupted") is more useful than
+  blanking the bubble.
+- **Retry is already safe.** The persistence contract persists exactly once, on
+  completion, before `done` — so a stopped/failed turn wrote nothing, and Retry
+  re-sends without risk of a double-write or a phantom half-message. (`CancelledError`
+  is deliberately not caught; a mid-stream disconnect cancels the generator
+  before persistence — covered by `backend/tests/test_chat_stream.py`.)
+- **Consistency across rungs.** The same interrupted+Retry affordance covers a
+  user Stop, a Rung-2 mid-stream error, and a failure during the Rung-3 JSON
+  fallback, so degraded states never look "frozen."
+
+## Scope / where it lands
+
+The streaming chat UI (`frontend/src/components/ChatPanel.tsx`,
+`frontend/src/components/screens/Learn.tsx`, `frontend/src/lib/api.ts`) lives on
+the **PR #349 branch (`feat/streaming-tutor`)**, not on `main`. This ADR records
+the product decision; the implementation is a follow-up on that branch (or
+immediately after it merges), not part of the `main`-based follow-up branch that
+carries #354/#355. Acceptance for item 5 in #356 is: this decision recorded
+(done here) and implemented on the streaming branch.
+
+## Consequences
+
+- ChatPanel gains an `interrupted` bubble treatment (keep `streamingText`, style
+  as interrupted) and a Retry action; Learn wires Retry to re-dispatch the
+  turn's original `message`/`mode`.
+- No backend change: the persistence contract and fallback ladder already
+  guarantee "nothing persisted on stop/failure," which is what makes Retry a
+  plain re-send. This is a client-rendering decision on top of the existing seam.

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -134,6 +134,7 @@ route:
 | `tutor-messages` | conversation log (`role="log"`) |
 | `tutor-input` | message `<textarea>` |
 | `tutor-send` | send button |
+| `tutor-stop` | stop-streaming button (visible only while a streamed reply is in flight, #349) |
 | `tutor-action-hint` | "Hint" |
 | `tutor-action-confused` | "I'm confused" |
 | `tutor-action-skip` | "Skip" |

--- a/docs/superpowers/plans/2026-07-16-streaming-tutor.md
+++ b/docs/superpowers/plans/2026-07-16-streaming-tutor.md
@@ -1,0 +1,1642 @@
+# Streaming Tutor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stream the Learn tutor's replies token-by-token over SSE with live knowledge-graph deltas on the same stream, and migrate `start_session` onto the chat agent so its greeting streams too.
+
+**Architecture:** One new async generator (`services/chat_stream.py::stream_agent_turn`) wraps `agent.run_stream_events()` and translates Pydantic AI events into the existing `SaplingEvent` SSE envelope, extended with three new types (`token`, `graph_update`, `done`). Two thin new routes (`/api/learn/chat/stream`, `/api/learn/start-session/stream`) hand that generator to `EventSourceResponse`. The existing JSON routes are untouched and remain the fallback. The frontend consumes it through one `streamChat()` built on the existing `streamSSE`.
+
+**Tech Stack:** FastAPI · sse-starlette `EventSourceResponse` · Pydantic AI 1.89.1 (`run_stream_events`) · pytest · Next.js/React · vitest
+
+**Spec:** `docs/superpowers/specs/2026-07-16-streaming-design.md`
+**Issues:** #70 (token streaming), #74 (live graph deltas). Also advances #152/#151 and closes ADR-0015's `start_session` TODO.
+**Branch:** `feat/streaming-tutor` (already exists, spec committed at `ea149f7`)
+
+## Global Constraints
+
+- **Never adopt a second SSE protocol or parser.** New event types extend `SaplingEvent` in `backend/services/agent_events.py`; the frontend consumes via `frontend/src/lib/sse.ts::streamSSE`. (ADR 0006)
+- **All graph mutations flow through `graph_service.apply_graph_update`.** Streamed deltas are *read from* `deps.graph_updates` / `deps.mastery_changes`, which the tools populate. Never write the graph from the stream module. (ADR 0004)
+- **Encryption boundary:** persist only via `routes/learn.py::save_message` (which calls `encrypt_if_present`). Never add a second persistence path. (ADR 0015 + CLAUDE.md)
+- **Legacy fallback survives.** `_legacy_chat` and the JSON `/chat` + `/start-session` routes stay callable and behaviorally unchanged. (ADR 0001/0015)
+- **Never wrap a stream route in a DBOS workflow.** (ADR 0011)
+- **Never use FastAPI `BackgroundTasks` in a streaming route** — it does not fire. Use `asyncio.create_task(asyncio.to_thread(...))` if post-stream work is ever needed. (`docs/attempts/2026-05-03-vault-gap-prompts-13-14.md`)
+- **No hardcoded model names** in new code. Model choice comes from `agents/_providers.py` slots; `learn.py::_resolve_model_pref` resolves the user's `model_pref`. (ADR 0008)
+- **Usage limits:** every agent run passes `usage_limits=ORCHESTRATOR_LIMITS` (from `agents/__init__.py`).
+- **Stamp `X-Request-ID`** on every stream; include `request_id` in every `error` payload. (ADR 0009)
+- Run backend commands from `backend/` using `venv/bin/python`. Frontend commands from `frontend/`.
+- `ruff check .` must pass before every backend commit.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `backend/services/agent_events.py` (modify) | Add `token` / `graph_update` / `done` to `SaplingEventType`. Wire-format helper `sapling_event_to_sse` unchanged. |
+| `backend/services/chat_stream.py` (create) | **New.** `stream_agent_turn()` — the only place that iterates a Pydantic AI event stream for chat, emits SaplingEvents, owns the graph-delta high-water mark, the completion/persistence handoff, and the fallback rungs. |
+| `backend/routes/learn.py` (modify) | Extract `_prepare_chat_run()` from `_chat_via_agent`; add `POST /chat/stream` and `POST /start-session/stream`. Existing routes untouched. |
+| `backend/tests/test_chat_stream.py` (create) | Unit tests for `stream_agent_turn` against a fake event stream. |
+| `backend/tests/test_learn_stream_routes.py` (create) | Route-level tests (auth, SSE wire format, PENDING_SESSIONS). |
+| `frontend/src/lib/sse.ts` (modify) | Add optional `idleTimeoutMs` stall guard. |
+| `frontend/src/lib/api.ts` (modify) | Add `streamChat()` / `startSessionStream()` + `GraphDelta` / `ChatResult` types. |
+| `frontend/src/lib/api.stream.test.ts` (create) | vitest for the consumer. |
+| `frontend/src/components/ChatPanel.tsx` (modify) | Streaming bubble states + Stop. |
+| `frontend/src/components/screens/Learn.tsx` (modify) | Call `streamChat`, reduce graph deltas, fallback to `sendChat`. |
+
+**Task order rationale:** Task 1 is a spike that gates everything (ADR-0012's open question). Tasks 2–5 are backend, bottom-up. Tasks 6–9 are frontend. Each task ends green and committed.
+
+---
+
+### Task 1: Spike — prove the provider streams incrementally
+
+**This gates the whole plan.** ADR 0012 deferred concept streaming partly because nobody verified Gemini emits usable incremental output through our stack. Confirm it before writing production code. Nothing here ships.
+
+**Files:**
+- Create (throwaway, deleted in Step 4): `backend/spike_stream.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a written finding that pins which events carry text and whether tool events interleave. Task 2 depends on the answer.
+
+- [ ] **Step 1: Write the spike script**
+
+```python
+# backend/spike_stream.py  — THROWAWAY. Deleted at the end of this task.
+import asyncio
+
+from agents import ORCHESTRATOR_LIMITS
+from agents.chat_tutor import agent_for_mode
+from agents.deps import SaplingDeps
+
+
+async def main():
+    agent = agent_for_mode("expository")
+    deps = SaplingDeps(
+        user_id="spike-user",
+        course_id=None,
+        supabase=None,
+        request_id="spike",
+        session_id=None,
+    )
+    counts: dict[str, int] = {}
+    first_text_event: str | None = None
+    async for event in agent.run_stream_events(
+        "Explain what an eigenvalue is in two sentences.",
+        deps=deps,
+        usage_limits=ORCHESTRATOR_LIMITS,
+    ):
+        name = type(event).__name__
+        counts[name] = counts.get(name, 0) + 1
+        # Which event class first carries text?
+        if first_text_event is None:
+            delta = getattr(getattr(event, "delta", None), "content_delta", None)
+            part = getattr(getattr(event, "part", None), "content", None)
+            if delta or part:
+                first_text_event = f"{name} -> {(delta or part)!r}"
+    print("EVENT COUNTS:", counts)
+    print("FIRST TEXT FROM:", first_text_event)
+
+
+asyncio.run(main())
+```
+
+- [ ] **Step 2: Run it against a real key**
+
+Run from `backend/`:
+
+```bash
+venv/bin/python spike_stream.py
+```
+
+Expected: a `PartDeltaEvent` count well above 1 (proving incremental text, not one blob), and `FIRST TEXT FROM: PartStartEvent -> '...'`.
+
+- [ ] **Step 3: Record the finding**
+
+**If `PartDeltaEvent` count is > 1:** the gate is closed — proceed. Append the observed counts to the spec's Risks section, replacing the "spike could fail" hypothetical with the measured result.
+
+**If it is 0 or 1** (one blob, no incremental deltas): **stop and report to Andres before continuing.** #70's premise does not hold on this provider/version, and the plan needs rescoping. Write the finding to `docs/attempts/2026-07-16-gemini-incremental-streaming.md` per the `log-attempt` convention.
+
+- [ ] **Step 4: Delete the spike and commit the finding**
+
+```bash
+rm backend/spike_stream.py
+git add docs/superpowers/specs/2026-07-16-streaming-design.md
+git commit -m "docs(spec): record streaming spike results — close ADR-0012 gate"
+```
+
+---
+
+### Task 2: Extend the SaplingEvent vocabulary
+
+**Files:**
+- Modify: `backend/services/agent_events.py:15` (the `SaplingEventType` Literal)
+- Test: `backend/tests/test_agent_events.py` (create if absent)
+
+**Interfaces:**
+- Consumes: existing `SaplingEvent`, `sapling_event_to_sse`.
+- Produces: `SaplingEventType` now accepts `"token" | "graph_update" | "done"`. Task 3 constructs these.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/test_agent_events.py
+import json
+
+from services.agent_events import SaplingEvent, sapling_event_to_sse
+
+
+def test_token_event_serializes_to_sse():
+    ev = SaplingEvent(type="token", step="reply", message="", data={"delta": "Hi"})
+    wire = sapling_event_to_sse(ev)
+    assert wire["event"] == "token"
+    assert json.loads(wire["data"])["data"]["delta"] == "Hi"
+
+
+def test_graph_update_and_done_types_accepted():
+    for t in ("graph_update", "done"):
+        assert SaplingEvent(type=t, step="reply", message="").type == t
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `venv/bin/python -m pytest tests/test_agent_events.py -q`
+Expected: FAIL — pydantic `ValidationError`, `"token"` is not a permitted `SaplingEventType`.
+
+- [ ] **Step 3: Extend the Literal**
+
+In `backend/services/agent_events.py`, replace line 15:
+
+```python
+SaplingEventType = Literal["status", "progress", "result", "error"]
+```
+
+with:
+
+```python
+# "status"/"progress"/"result" are the document-pipeline vocabulary (ADR 0006).
+# "token"/"graph_update"/"done" extend it for chat streams; "error" is shared.
+SaplingEventType = Literal[
+    "status", "progress", "result", "error", "token", "graph_update", "done"
+]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `venv/bin/python -m pytest tests/test_agent_events.py -q && ruff check .`
+Expected: 2 passed, ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/agent_events.py backend/tests/test_agent_events.py
+git commit -m "feat(events): extend SaplingEvent vocabulary with token/graph_update/done (#70)"
+```
+
+---
+
+### Task 3: `services/chat_stream.py` — the generator
+
+The heart of the change. Everything it does is proven by Task 4's tests against a fake stream; no live LLM.
+
+**Files:**
+- Create: `backend/services/chat_stream.py`
+
+**Interfaces:**
+- Consumes: `SaplingEvent` (Task 2); `SaplingDeps` (`agents/deps.py`) — specifically `deps.graph_updates: list` and `deps.mastery_changes: list`, which `agents/tools/graph.py` appends to at `:117` (`{"new_nodes": [...]}`), `:169` (`{"updated_nodes": [...]}`), and `:171` (mastery changes).
+- Produces:
+  - `async def stream_agent_turn(*, agent, user_message, run_kwargs, deps, on_complete, legacy_fallback) -> AsyncIterator[SaplingEvent]`
+  - `def merge_graph_updates(updates: list[dict]) -> dict`
+  Task 5 (routes) calls both.
+
+**Pydantic AI 1.89.1 event shapes** (verified by inspection — do not guess):
+
+| Event class | Fields | Carries | Emit a `token`? |
+|---|---|---|---|
+| `PartStartEvent` | `index, part, previous_part_kind, event_kind` | **the first text chunk**, at `event.part.content` | **yes** |
+| `PartDeltaEvent` | `index, delta, event_kind` | subsequent text at `event.delta.content_delta` | **yes** |
+| `PartEndEvent` | `index, part, next_part_kind, event_kind` | **the FULL assembled text** at `event.part.content` | **NO — would duplicate the reply** |
+| `FinalResultEvent` | `tool_name, tool_call_id, event_kind` | no text | no |
+| `FunctionToolCallEvent` | `part, args_valid, event_kind` | tool name at `event.part.tool_name` | no (emit `progress`) |
+| `FunctionToolResultEvent` | `result, content, event_kind` | tool finished — **check deps here** | no (maybe `graph_update`) |
+| `AgentRunResultEvent` | `result, event_kind` | final output at `event.result.output` | no (feeds `done`) |
+
+> **Two traps, both observed live against `gemini-2.5-pro` on 2026-07-16 (Task 1's spike), both regression-tested in Task 4:**
+> 1. The reply's first chunk arrives on `PartStartEvent`, **not** `PartDeltaEvent`. Handling only deltas drops the opening — for a two-sentence answer the spike saw the entire first sentence arrive this way.
+> 2. `PartEndEvent` carries the **complete assembled reply** on the same `part.content` attribute `PartStartEvent` uses. Reading `part.content` without checking the class emits the whole reply a second time (`"hello world"` → `"hello worldhello world"`).
+>
+> This is why `_text_from` dispatches on class name instead of duck-typing attributes.
+
+- [ ] **Step 1: Write the module**
+
+```python
+# backend/services/chat_stream.py
+"""Translate a Pydantic AI chat run into Sapling SSE events.
+
+The single seam for streaming chat turns (ADR 0006 vocabulary). Iterates
+`agent.run_stream_events()` — the only API that yields BOTH text deltas and
+mid-run tool events in one pass — and emits:
+
+    status:start -> token* -> (progress:<tool> -> graph_update)* -> done
+
+Graph deltas are READ from `deps.graph_updates` / `deps.mastery_changes`,
+which the graph tools populate as they write through
+`graph_service.apply_graph_update` (ADR 0004). This module never writes the
+graph and never persists a message: persistence is the route's, via
+`on_complete`.
+
+Exactly one of `on_complete` / `legacy_fallback` runs per turn — see
+`stream_agent_turn` for the rungs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, AsyncIterator, Awaitable, Callable
+
+from services.agent_events import SaplingEvent
+
+logger = logging.getLogger(__name__)
+
+
+def merge_graph_updates(updates: list[dict]) -> dict:
+    """Merge tool-emitted payloads into one {key: [items]} dict.
+
+    Mirrors the merge in `routes.learn._chat_via_agent` verbatim: keys
+    concatenate (setdefault + extend), never clobber.
+    """
+    merged: dict = {}
+    for gu in updates:
+        for key, items in gu.items():
+            merged.setdefault(key, []).extend(items)
+    return merged
+
+
+def _text_from(event: Any) -> str | None:
+    """Extract a NEW text chunk from a stream event, or None.
+
+    Dispatches on class name, which matters more than it looks (all three
+    shapes below were observed live against gemini-2.5-pro on 2026-07-16):
+
+      PartStartEvent  -> part.content        the reply's FIRST chunk
+      PartDeltaEvent  -> delta.content_delta each subsequent chunk
+      PartEndEvent    -> part.content        the FULL assembled text — SKIP
+
+    Reading `part.content` generically would emit the whole reply a second
+    time when PartEndEvent lands ("hello world" -> "hello worldhello
+    world"). Reading only deltas would drop the opening chunk. Both are
+    regression-tested.
+    """
+    cls_name = type(event).__name__
+
+    if cls_name == "PartDeltaEvent":
+        delta = getattr(getattr(event, "delta", None), "content_delta", None)
+        return delta if isinstance(delta, str) and delta else None
+
+    if cls_name == "PartStartEvent":
+        content = getattr(getattr(event, "part", None), "content", None)
+        return content if isinstance(content, str) and content else None
+
+    # PartEndEvent / FinalResultEvent / tool + result events carry no NEW text.
+    return None
+
+
+def _tool_name_from(event: Any) -> str | None:
+    for path in ("part.tool_name", "tool_name", "result.tool_name"):
+        obj: Any = event
+        try:
+            for attr in path.split("."):
+                obj = getattr(obj, attr)
+            if isinstance(obj, str):
+                return obj
+        except AttributeError:
+            continue
+    return None
+
+
+async def stream_agent_turn(
+    *,
+    agent: Any,
+    user_message: str,
+    run_kwargs: dict,
+    deps: Any,
+    on_complete: Callable[[str, dict, list], dict | None],
+    legacy_fallback: Callable[[], Awaitable[dict]] | None = None,
+    request_id: str = "",
+) -> AsyncIterator[SaplingEvent]:
+    """Stream one agent turn as SaplingEvents.
+
+    on_complete(reply, merged_graph_update, mastery_changes) -> extra `done`
+    data. It persists; it is called exactly once, after the run completes and
+    BEFORE `done` is yielded, so a mid-generation disconnect (which cancels
+    this generator at its current yield) persists nothing.
+
+    legacy_fallback() -> awaitable returning the route's pre-agent result,
+    used ONLY when the agent fails before emitting any text (Rung 1). It is
+    async because the routes' legacy paths are (`_legacy_chat`). It owns its
+    own persistence, so on_complete is NOT called on that branch — calling
+    both double-writes.
+    """
+    yield SaplingEvent(type="status", step="start", message="Starting.")
+
+    chunks: list[str] = []
+    final_output: str | None = None
+    # High-water marks: how much of deps.* we have already emitted.
+    graph_hw = 0
+    mastery_hw = 0
+
+    try:
+        async for event in agent.run_stream_events(user_message, **run_kwargs):
+            text = _text_from(event)
+            if text:
+                chunks.append(text)
+                yield SaplingEvent(
+                    type="token", step="reply", message="", data={"delta": text}
+                )
+                continue
+
+            cls_name = type(event).__name__
+
+            if cls_name == "FunctionToolCallEvent":
+                tool = _tool_name_from(event) or "tool"
+                yield SaplingEvent(
+                    type="progress", step=tool, message=f"Calling {tool}."
+                )
+                continue
+
+            if cls_name == "FunctionToolResultEvent":
+                # A graph tool may have just written. Emit only what is new.
+                new_nodes = merge_graph_updates(deps.graph_updates[graph_hw:])
+                new_mastery = deps.mastery_changes[mastery_hw:]
+                graph_hw = len(deps.graph_updates)
+                mastery_hw = len(deps.mastery_changes)
+                if new_nodes or new_mastery:
+                    yield SaplingEvent(
+                        type="graph_update",
+                        step="graph",
+                        message="Knowledge graph updated.",
+                        data={"nodes": new_nodes, "mastery_changes": new_mastery},
+                    )
+                continue
+
+            if cls_name == "AgentRunResultEvent":
+                output = getattr(getattr(event, "result", None), "output", None)
+                if isinstance(output, str):
+                    final_output = output
+
+    # Catches UsageLimitExceeded / UnexpectedModelBehavior (both Exception
+    # subclasses) and anything else the model or a tool raises. Deliberately
+    # NOT BaseException: asyncio.CancelledError must propagate so a client
+    # disconnect stays a cancellation — never a "fallback to legacy".
+    except Exception as exc:
+        if chunks:
+            # Rung 2: text already shown. Never silently re-run — the user
+            # would see the reply restart. Terminal error; persist nothing.
+            logger.warning("Chat stream failed mid-generation", exc_info=exc)
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor was interrupted. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+
+        # Rung 1: nothing shown yet — degrade to the route's legacy path.
+        logger.warning("Chat agent failed before first token; using legacy", exc_info=exc)
+        if legacy_fallback is None:
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor is unavailable. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+        try:
+            legacy = await legacy_fallback()
+        except Exception:
+            logger.exception("Legacy fallback also failed")
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor is unavailable. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+        # legacy_fallback persisted its own rows; do NOT call on_complete.
+        yield SaplingEvent(
+            type="token", step="reply", message="",
+            data={"delta": legacy.get("reply", "")},
+        )
+        yield SaplingEvent(
+            type="done", step="reply", message="Complete.", data=legacy
+        )
+        return
+
+    reply = final_output if final_output is not None else "".join(chunks)
+    merged = merge_graph_updates(deps.graph_updates)
+    mastery = list(deps.mastery_changes)
+
+    extra = on_complete(reply, merged, mastery) or {}
+
+    yield SaplingEvent(
+        type="done",
+        step="reply",
+        message="Complete.",
+        data={
+            "reply": reply,
+            "graph_update": merged,
+            "mastery_changes": mastery,
+            **extra,
+        },
+    )
+```
+
+- [ ] **Step 2: Verify it imports and lints**
+
+Run from `backend/`:
+
+```bash
+venv/bin/python -c "from services.chat_stream import stream_agent_turn, merge_graph_updates; print('ok')" && ruff check services/chat_stream.py
+```
+
+Expected: `ok`, ruff clean. (Behavior is proven in Task 4 — this step only catches syntax/import errors.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/services/chat_stream.py
+git commit -m "feat(chat): add stream_agent_turn — Pydantic AI run → SaplingEvents (#70, #74)"
+```
+
+---
+
+### Task 4: Test `stream_agent_turn`
+
+**Files:**
+- Create: `backend/tests/test_chat_stream.py`
+
+**Interfaces:**
+- Consumes: `stream_agent_turn`, `merge_graph_updates` (Task 3).
+- Produces: nothing consumed downstream.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# backend/tests/test_chat_stream.py
+"""Unit tests for services/chat_stream.py against a fake event stream.
+
+No live LLM: FakeAgent yields stand-ins whose CLASS NAMES and attribute
+shapes match Pydantic AI 1.89.1 (verified by inspection), which is all
+stream_agent_turn dispatches on.
+"""
+import pytest
+
+from agents.deps import SaplingDeps
+from services.chat_stream import merge_graph_updates, stream_agent_turn
+
+
+# ── Fakes mirroring pydantic_ai event shapes ──────────────────────────────
+
+class TextPartDelta:
+    def __init__(self, content_delta):
+        self.content_delta = content_delta
+
+
+class PartDeltaEvent:
+    def __init__(self, content_delta):
+        self.delta = TextPartDelta(content_delta)
+
+
+class _TextPart:
+    def __init__(self, content):
+        self.content = content
+
+
+class PartStartEvent:
+    """First text chunk arrives here — NOT as a delta."""
+    def __init__(self, content):
+        self.part = _TextPart(content)
+
+
+class PartEndEvent:
+    """Carries the FULL assembled text on the same `.part.content`
+    attribute PartStartEvent uses. Must NOT produce a token."""
+    def __init__(self, content):
+        self.part = _TextPart(content)
+
+
+class _ToolPart:
+    def __init__(self, tool_name):
+        self.tool_name = tool_name
+
+
+class FunctionToolCallEvent:
+    def __init__(self, tool_name):
+        self.part = _ToolPart(tool_name)
+
+
+class FunctionToolResultEvent:
+    def __init__(self, on_fire=None):
+        # Simulates the tool having written to deps during its execution.
+        if on_fire:
+            on_fire()
+
+
+class _Result:
+    def __init__(self, output):
+        self.output = output
+
+
+class AgentRunResultEvent:
+    def __init__(self, output):
+        self.result = _Result(output)
+
+
+class FakeAgent:
+    def __init__(self, events, raise_after=None):
+        self._events = events
+        self._raise_after = raise_after
+
+    async def run_stream_events(self, user_message, **kwargs):
+        for i, ev in enumerate(self._events):
+            if self._raise_after is not None and i == self._raise_after:
+                raise RuntimeError("model blew up")
+            yield ev
+
+
+def make_deps():
+    return SaplingDeps(
+        user_id="u1", course_id="c1", supabase=None,
+        request_id="r1", session_id="s1",
+    )
+
+
+async def collect(agent, deps, on_complete, legacy_fallback=None):
+    events = []
+    async for ev in stream_agent_turn(
+        agent=agent, user_message="hi", run_kwargs={}, deps=deps,
+        on_complete=on_complete, legacy_fallback=legacy_fallback,
+        request_id="r1",
+    ):
+        events.append(ev)
+    return events
+
+
+# ── merge ─────────────────────────────────────────────────────────────────
+
+def test_merge_concatenates_and_never_clobbers():
+    merged = merge_graph_updates(
+        [{"new_nodes": [{"n": 1}]}, {"new_nodes": [{"n": 2}]}, {"updated_nodes": [{"n": 3}]}]
+    )
+    assert merged == {"new_nodes": [{"n": 1}, {"n": 2}], "updated_nodes": [{"n": 3}]}
+
+
+# ── happy path ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_first_chunk_from_part_start_is_not_dropped():
+    """PartStartEvent carries the reply's FIRST chunk. Regression: handling
+    only PartDeltaEvent silently truncates the opening."""
+    agent = FakeAgent([
+        PartStartEvent("Hello "),
+        PartDeltaEvent("world"),
+        AgentRunResultEvent("Hello world"),
+    ])
+    saved = {}
+    events = await collect(agent, make_deps(), lambda r, g, m: saved.update(reply=r) or {})
+    tokens = [e.data["delta"] for e in events if e.type == "token"]
+    assert tokens == ["Hello ", "world"]
+    assert saved["reply"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_part_end_event_does_not_duplicate_the_reply():
+    """PartEndEvent carries the FULL assembled text on .part.content — the
+    same attribute PartStartEvent uses for the FIRST chunk. Emitting a token
+    for it duplicates the whole reply in the user's bubble.
+
+    Regression: a duck-typed `getattr(event.part, 'content')` reader turns
+    "hello world" into "hello worldhello world". Observed live in Task 1's
+    spike."""
+    agent = FakeAgent([
+        PartStartEvent("hello "),
+        PartDeltaEvent("world"),
+        PartEndEvent("hello world"),      # full text — must be ignored
+        AgentRunResultEvent("hello world"),
+    ])
+    events = await collect(agent, make_deps(), lambda r, g, m: {})
+    tokens = [e.data["delta"] for e in events if e.type == "token"]
+    assert tokens == ["hello ", "world"], "PartEndEvent must not re-emit the reply"
+    assert "".join(tokens) == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_event_order_and_single_persistence():
+    agent = FakeAgent([
+        PartStartEvent("Hi"),
+        AgentRunResultEvent("Hi"),
+    ])
+    calls = []
+    events = await collect(agent, make_deps(), lambda r, g, m: calls.append(r) or {"extra": 1})
+    assert [e.type for e in events] == ["status", "token", "done"]
+    assert calls == ["Hi"], "on_complete must fire exactly once"
+    done = events[-1]
+    assert done.data["reply"] == "Hi"
+    assert done.data["extra"] == 1, "on_complete's return merges into done"
+
+
+@pytest.mark.asyncio
+async def test_graph_update_emitted_once_per_new_write():
+    """High-water mark: an already-emitted delta must not re-emit on the
+    next tool result."""
+    deps = make_deps()
+
+    def first_write():
+        deps.graph_updates.append({"new_nodes": [{"name": "Eigenvalues"}]})
+        deps.mastery_changes.append({"concept": "Eigenvalues", "before": 0.1, "after": 0.6})
+
+    agent = FakeAgent([
+        FunctionToolCallEvent("update_mastery_tool"),
+        FunctionToolResultEvent(on_fire=first_write),
+        PartStartEvent("Done."),
+        FunctionToolCallEvent("search_course_materials_tool"),
+        FunctionToolResultEvent(),          # writes nothing new
+        AgentRunResultEvent("Done."),
+    ])
+    events = await collect(agent, deps, lambda r, g, m: {})
+    graph_events = [e for e in events if e.type == "graph_update"]
+    assert len(graph_events) == 1, "second tool result added nothing — must not re-emit"
+    assert graph_events[0].data["nodes"] == {"new_nodes": [{"name": "Eigenvalues"}]}
+    assert graph_events[0].data["mastery_changes"][0]["after"] == 0.6
+    assert [e.type for e in events].index("graph_update") < [e.type for e in events].index("done")
+
+
+# ── failure rungs ─────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_rung1_failure_before_any_token_uses_legacy_and_skips_on_complete():
+    agent = FakeAgent([PartStartEvent("x")], raise_after=0)
+    on_complete_calls = []
+
+    async def fake_legacy():
+        # async because the real routes' legacy paths are (_legacy_chat)
+        return {"reply": "legacy reply", "graph_update": {}, "mastery_changes": []}
+
+    events = await collect(
+        agent, make_deps(),
+        on_complete=lambda r, g, m: on_complete_calls.append(r),
+        legacy_fallback=fake_legacy,
+    )
+    assert [e.type for e in events] == ["status", "token", "done"]
+    assert events[1].data["delta"] == "legacy reply"
+    assert events[-1].data["reply"] == "legacy reply"
+    assert on_complete_calls == [], "legacy owns persistence — on_complete must NOT run"
+
+
+@pytest.mark.asyncio
+async def test_rung2_failure_after_tokens_errors_and_persists_nothing():
+    agent = FakeAgent([PartStartEvent("Half a th"), PartDeltaEvent("ought")], raise_after=1)
+    on_complete_calls = []
+    legacy_calls = []
+
+    async def fake_legacy():
+        legacy_calls.append(1)
+        return {"reply": "nope"}
+
+    events = await collect(
+        agent, make_deps(),
+        on_complete=lambda r, g, m: on_complete_calls.append(r),
+        legacy_fallback=fake_legacy,
+    )
+    assert events[-1].type == "error"
+    assert events[-1].data["request_id"] == "r1"
+    assert on_complete_calls == [], "nothing may persist after a mid-stream failure"
+    assert legacy_calls == [], "never silently re-run once text was shown"
+
+
+@pytest.mark.asyncio
+async def test_cancel_mid_stream_persists_nothing():
+    """Client disconnect cancels the generator at its current yield."""
+    agent = FakeAgent([PartStartEvent("a"), PartDeltaEvent("b"), AgentRunResultEvent("ab")])
+    on_complete_calls = []
+    gen = stream_agent_turn(
+        agent=agent, user_message="hi", run_kwargs={}, deps=make_deps(),
+        on_complete=lambda r, g, m: on_complete_calls.append(r), request_id="r1",
+    )
+    await gen.__anext__()   # status
+    await gen.__anext__()   # first token
+    await gen.aclose()      # disconnect
+    assert on_complete_calls == [], "a partial reply must never persist"
+```
+
+- [ ] **Step 2: Run to verify they fail meaningfully**
+
+Run: `venv/bin/python -m pytest tests/test_chat_stream.py -q`
+Expected: all pass if Task 3 is correct. **If `test_first_chunk_from_part_start_is_not_dropped` fails**, `_text_from` is not reading `part.content` — fix Task 3's helper, do not weaken the test.
+
+If `pytest-asyncio` errors on the `@pytest.mark.asyncio` marks, check `pytest.ini`/`pyproject` for `asyncio_mode`; if it is `auto`, drop the marks.
+
+- [ ] **Step 3: Run the full suite for regressions**
+
+Run: `venv/bin/python -m pytest tests/ -q 2>&1 | tail -5 && ruff check .`
+Expected: no NEW failures. Known pre-existing on clean main: 2 `storage_service`, 1 OCR event-loop flake.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/test_chat_stream.py
+git commit -m "test(chat): cover stream_agent_turn ordering, deltas, and fallback rungs (#70, #74)"
+```
+
+---
+
+### Task 5: Wire the two stream routes
+
+**Files:**
+- Modify: `backend/routes/learn.py` — extract `_prepare_chat_run()` from `_chat_via_agent` (currently `:501-601`); add two routes after `chat()` (`:658-714`).
+- Test: `backend/tests/test_learn_stream_routes.py` (create)
+
+**Interfaces:**
+- Consumes: `stream_agent_turn`, `merge_graph_updates` (Task 3).
+- Produces: `POST /api/learn/chat/stream`, `POST /api/learn/start-session/stream`.
+
+- [ ] **Step 1: Extract `_prepare_chat_run` and keep `_chat_via_agent` on it**
+
+The context assembly currently inside `_chat_via_agent` (`learn.py:530-581`: deps, catalog chunk, RAG, shared-context constraint, model override, model settings) must be shared verbatim by both paths — not copy-pasted. Add above `_chat_via_agent`:
+
+```python
+def _prepare_chat_run(
+    *,
+    user_id: str,
+    session_id: str,
+    course_id: str,
+    mode: str,
+    user_message: str,
+    message_history: list,
+    use_shared_context: bool,
+    request_id: str,
+    model_pref: str | None = None,
+) -> tuple:
+    """Build (agent, assembled_message, run_kwargs, deps) for a chat turn.
+
+    Shared verbatim by the JSON path (`_chat_via_agent`) and the streaming
+    route so prompt assembly never forks. Extracted from `_chat_via_agent`;
+    behavior is unchanged.
+    """
+    agent = agent_for_mode(mode)
+
+    deps = SaplingDeps(
+        user_id=user_id,
+        course_id=course_id or None,
+        supabase=None,
+        request_id=request_id,
+        session_id=session_id,
+    )
+
+    bu_code = _get_course_info(course_id).get("course_code") if course_id else None
+    context_blocks: list[str] = []
+    if bu_code:
+        catalog_text = _get_catalog_chunk(bu_code)
+        if catalog_text:
+            context_blocks.append("COURSE CATALOG INFO (official BU course data):\n\n" + catalog_text)
+
+        from services.rag_service import retrieve_chunks, format_rag_context
+        rag_chunks = retrieve_chunks(user_message, course_id=bu_code, k=5)
+        rag_block = format_rag_context(rag_chunks)
+        if rag_block:
+            context_blocks.append(rag_block)
+
+    if context_blocks:
+        user_message = "\n\n".join(context_blocks) + "\n\n[STUDENT QUESTION]\n" + user_message
+
+    if not use_shared_context:
+        user_message = (
+            user_message
+            + "\n\n[Constraint: do not call any class-aggregate tool — "
+            "student opted out of shared context.]"
+        )
+
+    model_override = _resolve_model_pref(model_pref)
+    run_kwargs: dict = {
+        "deps": deps,
+        "message_history": message_history,
+        "usage_limits": ORCHESTRATOR_LIMITS,
+    }
+    if model_override is not None:
+        run_kwargs["model"] = model_override
+    if model_pref != "fast":
+        run_kwargs["model_settings"] = _build_pro_model_settings()
+
+    return agent, user_message, run_kwargs, deps
+```
+
+Then replace the body of `_chat_via_agent` from `agent = agent_for_mode(mode)` through the `run_kwargs` construction with:
+
+```python
+    agent, user_message, run_kwargs, deps = _prepare_chat_run(
+        user_id=user_id,
+        session_id=session_id,
+        course_id=course_id,
+        mode=mode,
+        user_message=user_message,
+        message_history=message_history,
+        use_shared_context=use_shared_context,
+        request_id=request_id,
+        model_pref=model_pref,
+    )
+```
+
+Leave the rest of `_chat_via_agent` (the `await agent.run(...)`, merge, and return) exactly as it is.
+
+- [ ] **Step 2: Verify the JSON path still passes**
+
+Run: `venv/bin/python -m pytest tests/test_learn_routes.py tests/test_chat_context_tools.py -q`
+Expected: PASS — a pure extraction must not change behavior.
+
+- [ ] **Step 3: Add the imports and the two routes**
+
+Add to the imports at the top of `learn.py`:
+
+```python
+from sse_starlette.sse import EventSourceResponse
+
+from services.agent_events import sapling_event_to_sse
+from services.chat_stream import stream_agent_turn
+```
+
+Add after `chat()` (i.e. after `learn.py:714`):
+
+```python
+@router.post("/chat/stream")
+async def chat_stream(body: ChatBody, request: Request):
+    """SSE token-streaming chat turn (#70) with live graph deltas (#74).
+
+    The JSON /chat route stays the non-streaming fallback (ADR 0001). No DBOS
+    wrap here — stream routes are deliberately outside durable execution
+    (ADR 0011); retries are client-driven and idempotent via X-Request-ID.
+    """
+    require_self(body.user_id, request)
+    _consume_pending(body.session_id, body.user_id)
+
+    request_id = (
+        getattr(request.state, "request_id", None)
+        or current_request_id()
+        or str(uuid.uuid4())
+    )
+
+    offering_id = _get_session_offering_id(body.session_id)
+    course_id = offering_course_id(offering_id) if offering_id else ""
+    # Load prior turns BEFORE the new user row is written, so history is
+    # conversation state up to (not including) this turn.
+    message_history = _load_message_history(body.session_id)
+
+    agent, assembled, run_kwargs, deps = _prepare_chat_run(
+        user_id=body.user_id,
+        session_id=body.session_id,
+        course_id=course_id,
+        mode=body.mode,
+        user_message=body.message,
+        message_history=message_history,
+        use_shared_context=body.use_shared_context,
+        request_id=request_id,
+        model_pref=body.model_pref,
+    )
+
+    def _persist(reply: str, graph_update: dict, mastery_changes: list) -> dict:
+        # Mirrors chat()'s ordering: user row, then assistant row. Runs only
+        # after the agent run completes, so a disconnect mid-generation
+        # persists nothing. Encryption happens inside save_message.
+        save_message(body.session_id, "user", body.message)
+        save_message(body.session_id, "assistant", reply, graph_update or None)
+        return {}
+
+    async def _legacy() -> dict:
+        # Rung 1 only (agent failed before any token). _legacy_chat persists
+        # its own user + assistant rows, so _persist must not also run —
+        # stream_agent_turn enforces that exclusivity.
+        return await _legacy_chat(body, request)
+
+    async def event_stream():
+        async for ev in stream_agent_turn(
+            agent=agent,
+            user_message=assembled,
+            run_kwargs=run_kwargs,
+            deps=deps,
+            on_complete=_persist,
+            legacy_fallback=_legacy,
+            request_id=request_id,
+        ):
+            yield sapling_event_to_sse(ev)
+
+    return EventSourceResponse(
+        event_stream(), headers={"X-Request-ID": request_id}
+    )
+```
+
+- [ ] **Step 4: Verify the chat stream route end to end at the unit level**
+
+Run: `venv/bin/python -m pytest tests/test_chat_stream.py -q && ruff check routes/learn.py services/chat_stream.py`
+Expected: PASS, ruff clean. (Route tests land in Step 6.)
+
+- [ ] **Step 5: Add the start-session stream route**
+
+```python
+@router.post("/start-session/stream")
+async def start_session_stream(body: StartSessionBody, request: Request):
+    """Streamed session opener — closes ADR-0015's start_session TODO by
+    running chat_tutor_agent instead of call_gemini_multiturn, and removes a
+    legacy call site on the primary path (#152/#151).
+
+    The JSON /start-session route is unchanged and remains the fallback.
+    PENDING_SESSIONS lazy materialization is preserved exactly: the row is
+    still written on first chat, by _consume_pending.
+    """
+    require_self(body.user_id, request)
+    request_id = (
+        getattr(request.state, "request_id", None)
+        or current_request_id()
+        or str(uuid.uuid4())
+    )
+    session_id = str(uuid.uuid4())
+
+    course_id = body.course_id or _get_course_id_for_topic(body.topic, body.user_id)
+    offering_id = resolve_offering(course_id, create=True) if course_id else ""
+
+    user_message = (
+        f"Student wants to learn about: {body.topic}\n\n"
+        "Begin the session with a warm greeting and your first question or explanation."
+    )
+
+    agent, assembled, run_kwargs, deps = _prepare_chat_run(
+        user_id=body.user_id,
+        session_id=session_id,
+        course_id=course_id,
+        mode=body.mode,
+        user_message=user_message,
+        message_history=[],
+        use_shared_context=body.use_shared_context,
+        request_id=request_id,
+        model_pref=body.model_pref,
+    )
+
+    def _stash(reply: str, graph_update: dict, mastery_changes: list) -> dict:
+        # Same lazy contract as the JSON route: nothing hits `sessions` until
+        # the first chat turn calls _consume_pending.
+        PENDING_SESSIONS[session_id] = {
+            "user_id": body.user_id,
+            "mode": body.mode,
+            "topic": body.topic,
+            "course_id": course_id,
+            "offering_id": offering_id,
+            "use_shared_context": body.use_shared_context,
+            "assistant_reply": reply,
+            "graph_update": graph_update,
+        }
+        return {"session_id": session_id, "graph_state": get_graph(body.user_id)}
+
+    async def event_stream():
+        async for ev in stream_agent_turn(
+            agent=agent,
+            user_message=assembled,
+            run_kwargs=run_kwargs,
+            deps=deps,
+            on_complete=_stash,
+            legacy_fallback=None,
+            request_id=request_id,
+        ):
+            yield sapling_event_to_sse(ev)
+
+    return EventSourceResponse(
+        event_stream(), headers={"X-Request-ID": request_id}
+    )
+```
+
+> `legacy_fallback=None` here is deliberate: the JSON `/start-session` remains reachable, and the client's Rung-3 fallback covers this route. A `None` fallback yields a terminal `error`, which the client handles.
+
+- [ ] **Step 6: Write route tests**
+
+```python
+# backend/tests/test_learn_stream_routes.py
+"""Route-level tests for the SSE chat streams."""
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def _sse_events(text: str) -> list[str]:
+    """Event names from a raw SSE body."""
+    return [
+        line.split("event:", 1)[1].strip()
+        for line in text.splitlines()
+        if line.startswith("event:")
+    ]
+
+
+class TestChatStream:
+    def test_streams_tokens_then_done(self):
+        async def fake_stream(**kwargs):
+            from services.agent_events import SaplingEvent
+            yield SaplingEvent(type="status", step="start", message="Starting.")
+            yield SaplingEvent(type="token", step="reply", message="", data={"delta": "Hi"})
+            kwargs["on_complete"]("Hi", {}, [])
+            yield SaplingEvent(type="done", step="reply", message="Complete.",
+                               data={"reply": "Hi", "graph_update": {}, "mastery_changes": []})
+
+        saved = []
+        with patch("routes.learn.stream_agent_turn", fake_stream), \
+             patch("routes.learn._prepare_chat_run",
+                   return_value=(MagicMock(), "msg", {}, MagicMock())), \
+             patch("routes.learn._consume_pending"), \
+             patch("routes.learn._get_session_offering_id", return_value="off-1"), \
+             patch("routes.learn.offering_course_id", return_value="c1"), \
+             patch("routes.learn._load_message_history", return_value=[]), \
+             patch("routes.learn.save_message", side_effect=lambda *a, **k: saved.append(a)):
+            r = client.post("/api/learn/chat/stream", json={
+                "session_id": "s1", "user_id": "u1", "message": "hello", "mode": "socratic",
+            })
+
+        assert r.status_code == 200
+        assert "text/event-stream" in r.headers["content-type"]
+        assert _sse_events(r.text) == ["status", "token", "done"]
+        assert [a[1] for a in saved] == ["user", "assistant"], "user row persists before assistant"
+
+    def test_requires_self(self):
+        """The guard must run BEFORE any streaming work starts.
+
+        Note the strict assertions: an earlier draft wrapped this in
+        try/except Exception: pass, which swallowed the AssertionError and
+        made the test pass even when auth was bypassed entirely.
+        """
+        from fastapi import HTTPException
+
+        with patch("routes.learn.require_self",
+                   side_effect=HTTPException(status_code=403, detail="forbidden")) as guard, \
+             patch("routes.learn._consume_pending"), \
+             patch("routes.learn._prepare_chat_run") as prep:
+            r = client.post("/api/learn/chat/stream", json={
+                "session_id": "s1", "user_id": "someone-else",
+                "message": "hi", "mode": "socratic",
+            })
+
+        assert r.status_code == 403
+        guard.assert_called_once()
+        prep.assert_not_called(), "auth must gate before any agent setup"
+
+
+class TestStartSessionStream:
+    def test_stashes_pending_session_and_does_not_write_db(self):
+        async def fake_stream(**kwargs):
+            from services.agent_events import SaplingEvent
+            extra = kwargs["on_complete"]("Welcome!", {}, [])
+            yield SaplingEvent(type="done", step="reply", message="Complete.",
+                               data={"reply": "Welcome!", **extra})
+
+        from routes.learn import PENDING_SESSIONS
+        PENDING_SESSIONS.clear()
+
+        with patch("routes.learn.stream_agent_turn", fake_stream), \
+             patch("routes.learn._prepare_chat_run",
+                   return_value=(MagicMock(), "msg", {}, MagicMock())), \
+             patch("routes.learn._get_course_id_for_topic", return_value="c1"), \
+             patch("routes.learn.resolve_offering", return_value="off-1"), \
+             patch("routes.learn.get_graph", return_value={"nodes": []}), \
+             patch("routes.learn.table") as tbl:
+            r = client.post("/api/learn/start-session/stream", json={
+                "user_id": "u1", "topic": "Eigenvalues", "mode": "socratic",
+            })
+
+        assert r.status_code == 200
+        assert len(PENDING_SESSIONS) == 1, "session must be stashed, not written"
+        stashed = next(iter(PENDING_SESSIONS.values()))
+        assert stashed["assistant_reply"] == "Welcome!"
+        assert stashed["topic"] == "Eigenvalues"
+        tbl.assert_not_called()
+```
+
+- [ ] **Step 7: Run the tests**
+
+Run: `venv/bin/python -m pytest tests/test_learn_stream_routes.py -q`
+Expected: PASS. If TestClient blocks on the stream, confirm the route returns `EventSourceResponse` (TestClient buffers SSE bodies fine; an infinite generator would hang — these fakes are finite).
+
+- [ ] **Step 8: Full suite + lint, then commit**
+
+```bash
+venv/bin/python -m pytest tests/ -q 2>&1 | tail -5
+ruff check .
+git add backend/routes/learn.py backend/services/chat_stream.py backend/tests/test_learn_stream_routes.py backend/tests/test_chat_stream.py
+git commit -m "feat(learn): SSE streaming routes for chat + start-session (#70, #74)"
+```
+
+---
+
+### Task 6: `streamSSE` stall guard
+
+**Files:**
+- Modify: `frontend/src/lib/sse.ts:29-40`
+- Test: `frontend/src/lib/sse.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: existing `streamSSE(url, init)`.
+- Produces: `streamSSE(url, init, opts?: { idleTimeoutMs?: number })`. Task 7 passes `{ idleTimeoutMs: 45000 }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/lib/sse.test.ts`:
+
+```ts
+it('rejects when no event arrives within idleTimeoutMs', async () => {
+  const stalledBody = new ReadableStream({
+    start() { /* never enqueues, never closes */ },
+  });
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(stalledBody, { status: 200 }) as never,
+  );
+
+  const iterate = async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _e of streamSSE('/x', {}, { idleTimeoutMs: 20 })) { /* drain */ }
+  };
+  await expect(iterate()).rejects.toThrow(/stalled/i);
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run from `frontend/`: `npx vitest run src/lib/sse.test.ts`
+Expected: FAIL — the test times out or errors on the unexpected third argument.
+
+- [ ] **Step 3: Implement the guard**
+
+In `frontend/src/lib/sse.ts`, change the signature and the read loop:
+
+```ts
+export async function* streamSSE<T = unknown>(
+  url: string,
+  init: RequestInit,
+  opts: { idleTimeoutMs?: number } = {},
+): AsyncGenerator<SSEEvent<T>> {
+  const res = await fetch(url, init);
+  // ... unchanged through `const reader = res.body.getReader();`
+```
+
+Then wrap each `reader.read()`:
+
+```ts
+      // A stalled stream (proxy dropped it, backend wedged) otherwise hangs
+      // the composer forever with no error. Race each read against a timer.
+      const { value, done } = opts.idleTimeoutMs
+        ? await Promise.race([
+            reader.read(),
+            new Promise<never>((_, reject) =>
+              setTimeout(
+                () => reject(new Error('Stream stalled — no data received.')),
+                opts.idleTimeoutMs,
+              ),
+            ),
+          ])
+        : await reader.read();
+```
+
+The existing `finally { await reader.cancel(); reader.releaseLock(); }` already releases the reader when the race rejects.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run src/lib/sse.test.ts && npm run typecheck`
+Expected: PASS, including the pre-existing sse tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/sse.ts frontend/src/lib/sse.test.ts
+git commit -m "feat(sse): add optional idleTimeoutMs stall guard to streamSSE (#70)"
+```
+
+---
+
+### Task 7: `streamChat()` consumer
+
+**Files:**
+- Modify: `frontend/src/lib/api.ts` (add near `sendChat`, `:112-130`)
+- Test: `frontend/src/lib/api.stream.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `streamSSE` with `idleTimeoutMs` (Task 6).
+- Produces:
+  ```ts
+  type GraphDelta = { nodes: Record<string, unknown[]>; mastery_changes: MasteryChange[] };
+  type ChatResult = { reply: string; graph_update: any; mastery_changes: any[]; session_id?: string; graph_state?: any };
+  streamChat(sessionId, userId, message, mode, useSharedContext, modelPref, handlers): Promise<ChatResult>
+  ```
+  Task 9 (Learn.tsx) calls it.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/src/lib/api.stream.test.ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+function sseBody(blocks: string[]): ReadableStream {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(c) {
+      for (const b of blocks) c.enqueue(enc.encode(b));
+      c.close();
+    },
+  });
+}
+
+const ev = (name: string, data: unknown) =>
+  `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('streamChat', () => {
+  it('accumulates tokens, surfaces graph deltas, resolves on done', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([
+          ev('status', { type: 'status', step: 'start', message: '' }),
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'Hel' } }),
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'lo' } }),
+          ev('graph_update', {
+            type: 'graph_update', step: 'graph', message: '',
+            data: { nodes: { new_nodes: [{ name: 'Eigen' }] }, mastery_changes: [] },
+          }),
+          ev('done', {
+            type: 'done', step: 'reply', message: '',
+            data: { reply: 'Hello', graph_update: {}, mastery_changes: [] },
+          }),
+        ]),
+        { status: 200 },
+      ) as never,
+    );
+
+    const { streamChat } = await import('./api');
+    const tokens: string[] = [];
+    const deltas: unknown[] = [];
+    const result = await streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, {
+      onToken: (t) => tokens.push(t),
+      onGraphUpdate: (d) => deltas.push(d),
+    });
+
+    expect(tokens).toEqual(['Hel', 'lo']);
+    expect(deltas).toHaveLength(1);
+    expect(result.reply).toBe('Hello');
+  });
+
+  it('rejects on a mid-stream error event', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'Half' } }),
+          ev('error', { type: 'error', step: 'reply', message: 'Interrupted.', data: { request_id: 'r1' } }),
+        ]),
+        { status: 200 },
+      ) as never,
+    );
+    const { streamChat } = await import('./api');
+    await expect(
+      streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, { onToken: () => {} }),
+    ).rejects.toThrow(/interrupted/i);
+  });
+
+  it('rejects when the stream never sends done', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'x' } })]),
+        { status: 200 },
+      ) as never,
+    );
+    const { streamChat } = await import('./api');
+    await expect(
+      streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, { onToken: () => {} }),
+    ).rejects.toThrow(/without a done/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/lib/api.stream.test.ts`
+Expected: FAIL — `streamChat` is not exported.
+
+- [ ] **Step 3: Implement**
+
+Add to `frontend/src/lib/api.ts` below `sendChat`:
+
+```ts
+export interface MasteryChange { concept: string; before: number; after: number }
+
+export interface GraphDelta {
+  nodes: Record<string, Array<Record<string, unknown>>>;
+  mastery_changes: MasteryChange[];
+}
+
+export interface ChatResult {
+  reply: string;
+  graph_update: any;
+  mastery_changes: MasteryChange[];
+  session_id?: string;
+  graph_state?: any;
+}
+
+interface StreamEvent {
+  type: string;
+  step: string;
+  message: string;
+  data?: Record<string, any> | null;
+}
+
+export interface StreamChatHandlers {
+  onToken?: (delta: string) => void;
+  onGraphUpdate?: (delta: GraphDelta) => void;
+  signal?: AbortSignal;
+}
+
+const STREAM_IDLE_MS = 45_000;
+
+async function consumeChatStream(
+  path: string,
+  payload: Record<string, unknown>,
+  { onToken, onGraphUpdate, signal }: StreamChatHandlers,
+): Promise<ChatResult> {
+  const { streamSSE } = await import('./sse');
+  let result: ChatResult | null = null;
+
+  for await (const e of streamSSE<StreamEvent>(
+    `${API_URL}${path}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      credentials: 'include',
+      signal,
+    },
+    { idleTimeoutMs: STREAM_IDLE_MS },
+  )) {
+    const ev = e.data;
+    if (ev.type === 'token') onToken?.(String(ev.data?.delta ?? ''));
+    else if (ev.type === 'graph_update') onGraphUpdate?.(ev.data as unknown as GraphDelta);
+    else if (ev.type === 'error') throw new Error(ev.message || 'The tutor was interrupted.');
+    else if (ev.type === 'done') result = ev.data as unknown as ChatResult;
+  }
+
+  if (!result) throw new Error('Chat stream ended without a done event.');
+  return result;
+}
+
+export const streamChat = (
+  sessionId: string,
+  userId: string,
+  message: string,
+  mode: string,
+  useSharedContext = true,
+  modelPref?: ModelPref,
+  handlers: StreamChatHandlers = {},
+) =>
+  consumeChatStream(
+    '/api/learn/chat/stream',
+    {
+      session_id: sessionId,
+      user_id: userId,
+      message,
+      mode,
+      use_shared_context: useSharedContext,
+      ...(modelPref ? { model_pref: modelPref } : {}),
+    },
+    handlers,
+  );
+
+export const startSessionStream = (
+  userId: string,
+  topic: string,
+  mode: string,
+  useSharedContext = true,
+  courseId?: string,
+  modelPref?: ModelPref,
+  handlers: StreamChatHandlers = {},
+) =>
+  consumeChatStream(
+    '/api/learn/start-session/stream',
+    {
+      user_id: userId,
+      topic,
+      mode,
+      use_shared_context: useSharedContext,
+      course_id: courseId,
+      ...(modelPref ? { model_pref: modelPref } : {}),
+    },
+    handlers,
+  );
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run src/lib/api.stream.test.ts && npm run typecheck`
+Expected: 3 passed, typecheck clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/api.ts frontend/src/lib/api.stream.test.ts
+git commit -m "feat(api): add streamChat/startSessionStream SSE consumers (#70, #74)"
+```
+
+---
+
+### Task 8: ChatPanel streaming bubble
+
+**Files:**
+- Modify: `frontend/src/components/ChatPanel.tsx`
+
+**Interfaces:**
+- Consumes: nothing new from earlier tasks directly — Learn.tsx (Task 9) drives it via props.
+- Produces: `ChatPanel` accepts `streamingText?: string | null` and `onStop?: () => void`. Task 9 passes both.
+
+Read the file first — its existing message/props shape decides the exact edit.
+
+- [ ] **Step 1: Add the props and render the live bubble**
+
+Add to the component's props interface:
+
+```ts
+  /** Assistant text arriving token-by-token; null when not streaming.
+   *  Rendered as a live bubble below the settled messages, then replaced by
+   *  the real message once the `done` event lands. */
+  streamingText?: string | null;
+  /** Abort the in-flight turn. Shown only while streaming. */
+  onStop?: () => void;
+```
+
+Render after the settled-message list, before the composer, following the file's existing assistant-bubble markup (reuse `MarkdownChat` exactly as settled messages do — do not fork the renderer):
+
+```tsx
+{streamingText !== null && streamingText !== undefined && (
+  <div className="chat-bubble chat-bubble--assistant" aria-live="polite">
+    {streamingText === ''
+      ? <TypingIndicator />
+      : <MarkdownChat>{streamingText}</MarkdownChat>}
+  </div>
+)}
+```
+
+If no `TypingIndicator` exists in the codebase, use the file's existing loading affordance rather than inventing one.
+
+- [ ] **Step 2: Disable the composer and show Stop while streaming**
+
+Where the send button/composer disabled state is computed, include `streamingText !== null && streamingText !== undefined`. Render the Stop control next to send when streaming:
+
+```tsx
+{onStop && streamingText !== null && streamingText !== undefined && (
+  <button type="button" className="btn btn--sm" onClick={onStop}>Stop</button>
+)}
+```
+
+- [ ] **Step 3: Verify**
+
+Run from `frontend/`: `npm run typecheck && npx eslint src/components/ChatPanel.tsx`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/ChatPanel.tsx
+git commit -m "feat(chat): streaming assistant bubble + stop control (#70)"
+```
+
+---
+
+### Task 9: Wire Learn.tsx — stream, reduce deltas, fall back
+
+**Files:**
+- Modify: `frontend/src/components/screens/Learn.tsx` (the send handler at `:300` calls `sendChat` today; `graphNodes` state at `:128,147`)
+
+**Interfaces:**
+- Consumes: `streamChat`, `GraphDelta`, `ChatResult` (Task 7); `ChatPanel`'s `streamingText` / `onStop` (Task 8).
+- Produces: end-user behavior. Terminal task.
+
+- [ ] **Step 1: Add streaming state and the graph reducer**
+
+```tsx
+  const [streamingText, setStreamingText] = React.useState<string | null>(null);
+  const streamAbort = React.useRef<AbortController | null>(null);
+
+  // Upsert streamed graph deltas into graphNodes so the Progress card's
+  // existing useMemo recomputes — no refetch, no extra round-trip (#74).
+  const applyGraphDelta = React.useCallback((delta: GraphDelta) => {
+    const incoming = Object.values(delta.nodes ?? {}).flat() as Array<Record<string, any>>;
+    if (!incoming.length) return;
+    setGraphNodes((prev) => {
+      const byId = new Map(prev.map((n) => [n.id, n]));
+      for (const node of incoming) {
+        const id = node.id ?? node.node_id;
+        if (!id) continue;
+        const existing = byId.get(id);
+        byId.set(id, existing ? { ...existing, ...node } : (node as any));
+      }
+      return Array.from(byId.values());
+    });
+  }, []);
+```
+
+Import `streamChat` and the types alongside the existing `sendChat` import.
+
+- [ ] **Step 2: Stream the turn, with the Rung-3 fallback**
+
+Replace the `const res = await sendChat(...)` call at `:300` with:
+
+```tsx
+      const controller = new AbortController();
+      streamAbort.current = controller;
+      setStreamingText('');
+      let sawToken = false;
+      let res: ChatResult;
+      try {
+        res = await streamChat(sessionId, userId, userText, mode, sharedCtx, modelPref, {
+          onToken: (delta) => {
+            sawToken = true;
+            setStreamingText((t) => (t ?? '') + delta);
+          },
+          onGraphUpdate: applyGraphDelta,
+          signal: controller.signal,
+        });
+      } catch (err) {
+        if (controller.signal.aborted) throw err;   // user pressed Stop
+        if (sawToken) throw err;                    // Rung 2: interrupted, surface it
+        // Rung 3: the stream never produced text — retry non-streaming.
+        res = await sendChat(sessionId, userId, userText, mode, sharedCtx, modelPref);
+      } finally {
+        setStreamingText(null);
+        streamAbort.current = null;
+      }
+```
+
+The existing code after this point — appending the assistant message from `res.reply`, handling `res.mastery_changes` — is unchanged, because `done` returns the same shape the JSON route does.
+
+- [ ] **Step 3: Wire Stop and unmount cleanup**
+
+Pass to `<ChatPanel>`: `streamingText={streamingText}` and `onStop={() => streamAbort.current?.abort()}`.
+
+Add the cleanup effect (guards the #131/#133 leaked-stream class):
+
+```tsx
+  React.useEffect(() => () => streamAbort.current?.abort(), []);
+```
+
+- [ ] **Step 4: Verify**
+
+Run from `frontend/`: `npm run typecheck && npx eslint src/components/screens/Learn.tsx && npx vitest run`
+Expected: all clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/screens/Learn.tsx
+git commit -m "feat(learn): stream tutor replies with live graph deltas (#70, #74)"
+```
+
+- [ ] **Step 6: Manual e2e smoke (required before the PR)**
+
+Run the backend (`venv/bin/python main.py`) and frontend (`npm run dev`), then verify each:
+
+1. A tutor turn renders text progressively — not one blob at the end.
+2. When the tutor moves mastery, the Progress card updates **mid-turn**, with no refetch in the Network tab.
+3. Stop mid-generation halts the text; the message does not appear in history after a reload.
+4. Kill the backend mid-generation → the bubble shows interrupted; after restart+reload, **no phantom partial message** in history.
+5. Point the frontend at a backend with the stream route disabled (or return 500 from it) → the turn still completes via the JSON fallback.
+
+Record the results in the PR body. If #2 fails, check `deps.graph_updates` is actually populated at tool-result time — that is the #74 acceptance.
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+git push -u origin feat/streaming-tutor
+gh pr create --base main \
+  --title "feat(learn): stream tutor replies over SSE with live graph deltas (#70, #74)" \
+  --body "Implements docs/superpowers/specs/2026-07-16-streaming-design.md.
+
+Closes #70
+Closes #74
+
+Also: migrates start_session onto chat_tutor_agent (closes ADR-0015's TODO, removes a legacy call_gemini_multiturn site from the primary path — progress on #152/#151).
+
+## Verification
+<paste the Step 6 smoke results>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** every spec section maps to a task — event vocabulary → 2; `chat_stream.py` incl. high-water marks, persistence contract, cancellation → 3, 4; `_prepare_chat_run` extraction, both routes, start-session `PENDING_SESSIONS` contract → 5; stall timeout → 6; consumer → 7; bubble states → 8; reducer, rollout with fallback, e2e smoke → 9. The ADR-0012 gate → 1.
+
+**Known gaps, deliberately left to the implementer:**
+- Task 8's exact JSX depends on `ChatPanel.tsx`'s current markup, which the task says to read first. The props contract is pinned; the markup is not.
+- The `failed/stopped` bubble state from the spec is implemented as "clear the streaming bubble and surface the error through Learn's existing error handling" rather than a bespoke interrupted-bubble UI. If the spec's "keep the partial text, mark it interrupted" affordance is wanted verbatim, it needs a follow-up task once ChatPanel's error surface is known.
+
+**Type consistency:** `stream_agent_turn`'s signature is identical across Tasks 3, 4, and 5 — `legacy_fallback` is `Callable[[], Awaitable[dict]] | None` everywhere, awaited in the module, async in the tests, and satisfied by `_legacy_chat` in the route. `GraphDelta` / `ChatResult` are defined in Task 7 and consumed with matching shapes in Task 9. `merge_graph_updates` is named identically throughout.
+
+**Verified against the installed stack, not assumed:** pydantic-ai is 1.89.1 in `backend/venv`; `Agent.run_stream_events` exists and yields both text and tool events; the event dataclass fields in Task 3's table came from `dataclasses.fields()` inspection. `requirements.txt` pins only `>=0.0.20`, so if a future bump changes these class names, `_text_from` / `_tool_name_from` degrade to returning `None` (silent truncation) rather than raising — Task 4's `test_first_chunk_from_part_start_is_not_dropped` is the canary.

--- a/docs/superpowers/specs/2026-07-16-streaming-design.md
+++ b/docs/superpowers/specs/2026-07-16-streaming-design.md
@@ -1,0 +1,298 @@
+# Streaming the tutor: SSE token streaming + live graph deltas
+
+**Date:** 2026-07-16
+**Owner:** Andres (AndresL230)
+**Issues:** #70 (streaming text in Learn), #74 (live progress card via SSE graph deltas)
+**Also advances:** #152 / #151 (retire `gemini_service`), ADR-0015's `start_session` follow-up TODO
+**Status:** design approved, ready for implementation plan
+
+## Problem
+
+The tutor chat is request/response. `POST /api/learn/chat` runs the model to completion and
+returns one JSON dict, so the student watches a spinner for the whole multi-second generation.
+`POST /api/learn/start-session` is worse: it blocks on the legacy `call_gemini_multiturn` while
+the model composes a greeting against a full system prompt, and that spinner opens every session.
+
+Meanwhile the Learn page's Progress card reads `graphNodes` fetched once at bootstrap. The tutor
+mutates mastery mid-session through `apply_graph_update`, but the card only reflects it after a
+page reload, so it feels stale exactly when the student is making progress.
+
+SSE plumbing already exists and is proven on the document-upload path. This design wires the same
+mechanism into chat, and — because both issues need the same terminal event — implements #70 and
+#74 together.
+
+## Scope
+
+**In scope**
+
+- SSE token streaming for `/api/learn/chat` (#70).
+- Live `graph_update` deltas on that same stream (#74).
+- A shared streaming seam (`services/chat_stream.py`) that both chat routes use, so a third
+  surface (notes chat) is a drop-in later.
+- Migrating `start_session` onto `chat_tutor_agent` and streaming its greeting.
+- One frontend consumer (`streamChat`) built on the existing `streamSSE`, plus the stall timeout
+  that `sse.ts` lacks today.
+
+**Out of scope**
+
+- `/action` and `/mode-switch` (#70 non-goals; they stay legacy).
+- Notes chat, quiz generation, study-guide streaming — the foundation makes them follow-ups.
+- Streaming tool-call *progress* to the UI beyond the graph deltas #74 asks for.
+- Reworking mastery computation or the agent tool surface.
+- Resumable streams / two-phase upload (ADR 0010's deferred design).
+- Retrofitting the document-upload pipeline. Its events are unchanged.
+
+## Constraints (from the vault — these bind the design)
+
+| Source | Constraint |
+|---|---|
+| ADR 0006 | SSE runs on `sse-starlette` + the `SaplingEvent` schema + `map_to_sapling_event`. New event types **extend** that vocabulary; we do not adopt another protocol. Frontend consumption goes through `streamSSE` — no second parser. |
+| ADR 0004 | All graph mutations flow through `graph_service.apply_graph_update`. Streamed deltas must be *sourced from* the tools' writes, never a parallel write path. |
+| ADR 0015 + CLAUDE.md | Encryption boundary: `_load_message_history` decrypts on read, `save_message` encrypts on write. The agent never sees ciphertext, and a token stream must not create a second, unencrypted persistence path. |
+| ADR 0001 / 0015 | Legacy fallback survives. `_legacy_chat` stays callable and correct; the rollback contract is that the JSON routes still work untouched. |
+| ADR 0011 | **Do not** wrap SSE stream routes in DBOS workflows — the asymmetry is deliberate. Retry safety comes from client retries + `X-Request-ID` idempotency. |
+| ADR 0009 | Every stream stamps `X-Request-ID`; error payloads carry it for Logfire correlation. |
+| ADR 0008 | Model choice stays in `agents/_providers.py` task slots + `SAPLING_MODEL_*` overrides. No hardcoded model in the stream module. |
+| `docs/attempts/2026-05-03-vault-gap-prompts-13-14.md` | FastAPI `BackgroundTasks` **does not fire** for streaming responses. Post-stream work uses `asyncio.create_task(asyncio.to_thread(...))`. |
+| ADR 0012 | Its empirical gate is still unanswered: nobody has verified that our Gemini + Pydantic AI versions emit usable incremental deltas via `run_stream`. **This design opens with a spike to close that gate.** |
+
+## Architecture
+
+One shared generator, two thin routes, unchanged JSON endpoints beneath as fallback.
+
+```
+Learn.tsx / ChatPanel          ← token / graph_update / done / error (SSE)
+  └─ api.ts streamChat()       ← wraps lib/sse.ts streamSSE (+ idle timeout)
+       └─ POST /api/learn/chat/stream · /api/learn/start-session/stream
+            └─ routes/learn.py (thin: auth, history load, context assembly)
+                 └─ services/chat_stream.py  ← NEW: run_stream → SaplingEvents
+                      └─ chat_tutor_agent (agent_for_mode)
+                           └─ apply_graph_update_tool / update_mastery_tool → deps
+```
+
+Routes stay thin: `require_self`, history load, RAG/catalog/constraint assembly (all unchanged
+from today), then hand an async generator to `EventSourceResponse`.
+
+### Event vocabulary
+
+Three new `SaplingEventType` members. Every event keeps the existing
+`{type, step, message, data}` envelope, so one parser and one switch serve every stream. The
+per-token envelope overhead (~40 bytes) is deliberate: uniformity beats terseness at chat volume.
+
+| type | status | `data` payload | meaning |
+|---|---|---|---|
+| `status` / `progress` / `result` / `error` | existing | unchanged | upload vocabulary, untouched; chat streams reuse `status:start`, `progress:<tool>`, and `error` |
+| **`token`** | new | `{"delta": "..."}`, `step="reply"` | one text delta; client appends to the live bubble |
+| **`graph_update`** | new | `{"nodes": {"new_nodes": [{concept_name, initial_mastery}], "updated_nodes": [{concept_name, mastery_delta}]}, "mastery_changes": [{concept, before, after}]}` | emitted after a graph tool result (#74); client matches by **concept name** — see the correction below |
+| **`done`** | new | `{"reply", "graph_update", "mastery_changes", "session_id"?}` | terminal; canonical reply reconciles token drift. Same dict the JSON route returns today |
+
+### Turn timeline
+
+1. Client `POST`s; stream opens; `X-Request-ID` stamped.
+2. `status:start`.
+3. `token` × N.
+4. `progress:update_mastery` when a graph tool fires.
+5. `graph_update` — the Progress card moves live.
+6. `token` × N (rest of the reply).
+7. Run completes → **persist**: `save_message(user)` then `save_message(assistant, graph_update)`,
+   through the existing encrypting boundary, in today's order.
+8. `done`.
+
+### Persistence contract
+
+Messages persist exactly when the agent run completes (step 7), **before** `done` is emitted —
+`done` delivery is best-effort. Consequences, stated explicitly:
+
+- Disconnect **during** generation: the generator is cancelled at its current `yield`,
+  `on_complete` never runs, nothing persists. The student resends. No partial replies in history.
+- Disconnect **after** completion but before `done` lands: the turn is saved; a history refetch
+  recovers it. No double-write, because persistence is keyed to run completion, not to delivery.
+
+## Backend
+
+### `services/chat_stream.py`
+
+```python
+async def stream_agent_turn(
+    *,
+    agent,                # agent_for_mode(mode)
+    user_message: str,    # already RAG/context/constraint-assembled
+    run_kwargs: dict,     # deps, message_history, usage_limits, model, model_settings
+    deps: SaplingDeps,    # watched for graph-tool accumulation
+    on_complete,          # (reply, merged_graph_update, mastery_changes) -> dict | None
+                          #   persists + returns extra `done` data
+    legacy_fallback,      # () -> dict | None — the route's own pre-agent path,
+                          #   used only by Rung 1; owns its persistence
+) -> AsyncIterator[SaplingEvent]
+```
+
+- **Context assembly stays in `learn.py`.** Today's `_chat_via_agent` splits into
+  `_prepare_chat_run()` — RAG retrieval, catalog block, shared-context constraint, model-pref
+  resolution — shared verbatim by the JSON and stream paths, and the run itself. No duplicated
+  prompt logic.
+- **Token deltas:** iterate the Pydantic AI stream (exact API pinned by the spike), yield `token`
+  events. This extends the `map_to_sapling_event` mapper family rather than replacing it; the
+  mapper keeps dispatching on `type(event).__name__` so version churn stays absorbed there.
+- **Graph deltas:** after each tool-result event, diff `deps.graph_updates` / `deps.mastery_changes`
+  against a high-water mark; yield one `graph_update` per new accumulation. The data originates
+  from `apply_graph_update` via the tools (ADR 0004).
+- **Completion:** build the same `{reply, graph_update, mastery_changes}` dict `_chat_via_agent`
+  returns today (including the `setdefault(...).extend(...)` merge of `deps.graph_updates`), call
+  `on_complete` (the route's persistence closure), yield `done`.
+- **Cancellation:** client disconnect cancels the generator at its current `yield`; `on_complete`
+  hasn't run, so nothing persists. No `BackgroundTasks`.
+- **No DBOS wrap** (ADR 0011).
+
+### Routes
+
+`POST /api/learn/chat/stream` and `POST /api/learn/start-session/stream`, both
+`EventSourceResponse`, both `require_self`-gated, both stamping `X-Request-ID`.
+
+`start_session` migrates onto `chat_tutor_agent`:
+
+- Same prompt assembly; `agent_for_mode(mode)`; greeting streams through `stream_agent_turn`.
+- Graph writes happen in-band via tools (and their deltas ride the stream) instead of via
+  `<graph_update>`-tag parsing.
+- `on_complete` stashes `PENDING_SESSIONS[session_id]` — the lazy-materialization contract and
+  `_consume_pending` are untouched.
+- `done` carries `{session_id, reply, graph_update, mastery_changes, graph_state}`.
+
+The JSON `/start-session` and `/chat` stay exactly as they are (ADR 0001/0015 rollback contract).
+
+### Fallback ladder
+
+1. **Agent fails before the first token** (`UsageLimitExceeded`, `UnexpectedModelBehavior`, any
+   exception) → run the route's legacy path *inside* the stream and emit its reply as a single
+   `token` plus a normal `done`. The client cannot tell the difference.
+
+   Each route supplies its own legacy callable, since the two differ: `/chat/stream` falls back to
+   `_legacy_chat` (which persists its own user + assistant rows); `/start-session/stream` falls
+   back to the existing `start_session` body (`call_gemini_multiturn` → `extract_graph_update` →
+   `apply_graph_update` → stash `PENDING_SESSIONS`).
+
+   **When Rung 1 fires, `on_complete` must not run** — the legacy callable already owns its
+   persistence, and calling both would double-write. `stream_agent_turn` therefore treats the
+   legacy callable and `on_complete` as mutually exclusive branches: exactly one runs per turn.
+2. **Failure mid-stream** (tokens already sent) → terminal `error` event carrying `request_id`;
+   persist nothing; client marks the bubble interrupted and offers Retry. No silent auto-retry
+   once text has been shown.
+3. **Stream fails to open** (HTTP/network/proxy) → `streamChat` throws before any event; Learn
+   transparently retries the turn via non-streaming `sendChat`, which keeps its own agent→legacy
+   ladder.
+
+## Frontend
+
+### `api.ts`
+
+```ts
+streamChat(sessionId, userId, message, mode, useSharedContext, modelPref, {
+  onToken:       (delta: string) => void,
+  onGraphUpdate: (u: GraphDelta) => void,
+  signal:        AbortSignal,
+}): Promise<ChatResult>   // resolves on `done`; rejects on `error`, stall, or open failure
+```
+
+- Built on the existing `streamSSE`, which gains one optional `idleTimeoutMs` (default 45s): no
+  event within the window aborts the reader and rejects. That is the streaming half of #192; the
+  error-classification half stays in #192.
+- `IS_LOCAL_MODE` never opens a stream — today's mock `sendChat` path is preserved.
+- `startSessionStream` mirrors the shape and resolves with the session payload.
+
+### `ChatPanel` — assistant bubble states
+
+| state | behavior |
+|---|---|
+| **waiting** | stream open, no token yet: typing indicator; composer disabled; Stop visible |
+| **streaming** | text grows per token through `MarkdownChat`; re-renders batched via `requestAnimationFrame` (one paint per frame, not per token) |
+| **final** | on `done`, swap to the canonical `reply`; re-enable composer |
+| **failed / stopped** | mid-stream `error` or user Stop: keep the partial text visually, mark it interrupted, offer Retry (nothing was persisted, so Retry re-sends the turn) |
+
+Cleanup: unmount and session-switch abort the in-flight reader through the same `AbortSignal`,
+guarding the #131/#133 leaked-stream bug class at one seam.
+
+### `Learn.tsx` — graph reducer (#74)
+
+`onGraphUpdate` upserts into `graphNodes`, and the Progress card recomputes through its existing
+`useMemo` — zero extra HTTP round-trips per turn, which is #74's acceptance criterion.
+`mastery_changes` accumulate in session state for the end-of-session summary, matching what the
+JSON path returns today.
+
+> **CORRECTION (2026-07-16, found during implementation — this design was wrong).**
+> This spec originally specified "upsert by node id" against a payload of
+> `{id, name, course_id, mastery_score, mastery_tier}`. **That payload does not exist.** The graph
+> tools (`backend/agents/tools/graph.py`) append `{"new_nodes": [{concept_name, initial_mastery}]}`
+> and `{"updated_nodes": [{concept_name, mastery_delta}]}` — there is **no node id** and **no
+> absolute mastery score** anywhere in them. Only the sibling `mastery_changes` array carries
+> authoritative absolute values, as `{concept, before, after}`.
+>
+> The shipped reducer therefore:
+> - **matches by concept name** (case/whitespace-normalized, mirroring the backend's
+>   `_normalize_concept`), keeping an id path only for forward compatibility;
+> - treats **`mastery_changes` as the authority** for score updates — `mastery_delta` has no safe
+>   client-side baseline to apply it against;
+> - inserts unknown concepts as a `stream-<slug>` placeholder, resolving color/subject/course and
+>   an edge to the subject root from the same `cardCourseId` the manual `addConcept` path uses
+>   (a placeholder without those renders black and orphaned in the 3D rail);
+> - ignores `new_edges` / `recommended_next` — the `GraphUpdate` type declares them, but only the
+>   legacy fallback path ever populates them.
+>
+> Consequence worth knowing: a turn that only *adds* concepts (`new_nodes`) moves no score, because
+> no `mastery_changes` are emitted. Only `update_mastery_tool` on an existing concept moves the
+> Progress card.
+
+### Rollout
+
+Default-on with automatic fallback. No feature flag: the fallback ladder is the safety mechanism,
+staging exists for pre-prod verification, and a flag would leave a cleanup chore behind.
+
+## Testing
+
+| Layer | Tool | What it proves |
+|---|---|---|
+| **Spike (first)** | throwaway script against a staging key | ADR-0012's gate: our Pydantic AI + Gemini versions really do emit incremental text deltas and mid-run tool events via `run_stream`. Pins which API the module uses. **Everything downstream depends on this.** |
+| chat_stream unit | pytest + fake agent stream | event ordering (`start` → `token` → `graph_update` → `done`); persistence fires exactly once, after completion; cancel-before-completion persists nothing; Rung-1 fallback emits the legacy reply as one token; graph-delta high-water-mark diffing (no re-emission) |
+| route | pytest + httpx, conftest mock Supabase | SSE wire format parses; `require_self` enforced on both stream routes; start-session stashes `PENDING_SESSIONS`; JSON routes behave identically to before |
+| frontend unit | vitest (following `sse.test.ts`) | `streamChat` token accumulation, `done` resolution, mid-stream error rejection, stall timeout; reducer upsert for both existing and new nodes |
+| e2e smoke | staging, manual checklist | a real tutor turn streams; the Progress card moves mid-turn; Stop works; killing the backend mid-turn yields a failed bubble and **no phantom message** in history |
+
+## Risks
+
+- ~~**The spike could fail**~~ — **RESOLVED 2026-07-16. ADR-0012's gate is closed.** Measured
+  against `gemini-2.5-pro` via `Agent.run_stream_events`, prompt "Explain what an eigenvalue is in
+  two sentences":
+
+  ```
+  EVENT COUNTS: {'PartStartEvent': 1, 'FinalResultEvent': 1, 'PartDeltaEvent': 2,
+                 'PartEndEvent': 1, 'AgentRunResultEvent': 1}
+  FIRST TEXT FROM: PartStartEvent -> 'An eigenvalue is the special number that tells you how much a'
+  ```
+
+  Text is genuinely incremental (multiple deltas, not one blob), so #70's premise holds. The spike
+  also caught two carrier traps that would have shipped as bugs, now encoded in the plan and
+  regression-tested:
+
+  1. The reply's **first** chunk arrives on `PartStartEvent`, not `PartDeltaEvent` — handling only
+     deltas drops the opening (here, the whole first sentence).
+  2. `PartEndEvent` carries the **full assembled reply** on the same `part.content` attribute —
+     emitting a token for it duplicates the entire reply (`"hello world"` → `"hello worldhello
+     world"`, reproduced live).
+
+  Hence `_text_from` dispatches on class name rather than duck-typing attributes.
+
+  Note the granularity is coarse (~4 chunks for two sentences), so the win is "text appears in
+  stages within ~1s" rather than a per-word typewriter. That is still a large improvement over a
+  multi-second spinner, but it is worth confirming against a long reply during the Task 9 smoke.
+- **Token-render cost** — a long reply re-rendering Markdown per token could jank. Mitigation:
+  rAF batching, measured during the e2e smoke.
+- **`learn.py` churn overlaps other work** — the file is active. Mitigation: land the spike and
+  `chat_stream.py` first (additive), then the route changes in a focused diff.
+
+## Acceptance
+
+- #70: a tutor turn renders tokens as they arrive; Stop aborts cleanly; nothing partial persists;
+  the legacy path still serves a correct turn when the agent trips.
+- #74: during a live session, a model-triggered graph update moves the Progress card with no page
+  reload and no extra REST round-trip.
+- `start_session` runs on `chat_tutor_agent`, streams its greeting, and keeps the
+  `PENDING_SESSIONS` contract intact.
+- The JSON `/chat` and `/start-session` routes remain byte-compatible for non-streaming clients.

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -124,7 +124,7 @@
   },
   "src/lib/api.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 25
+      "count": 26
     }
   },
   "src/lib/useLayoutPref.ts": {

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -32,6 +32,13 @@ interface ChatPanelProps {
   // Optional seed for the input. Bump `draftSeedKey` to apply.
   draftSeed?: string;
   draftSeedKey?: number;
+  /** Assistant text arriving token-by-token; null/undefined = not streaming.
+   *  Empty string = stream open but no token yet (shows the typing affordance).
+   *  Rendered as a live bubble below the settled messages, then replaced by
+   *  the real message once the `done` event lands. */
+  streamingText?: string | null;
+  /** Abort the in-flight turn. Shown only while streaming. */
+  onStop?: () => void;
 }
 
 export function ChatPanel({
@@ -43,14 +50,17 @@ export function ChatPanel({
   header,
   draftSeed,
   draftSeedKey,
+  streamingText,
+  onStop,
 }: ChatPanelProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const isStreaming = streamingText !== null && streamingText !== undefined;
 
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
-  }, [messages]);
+  }, [messages, streamingText]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 0 }}>
@@ -73,15 +83,32 @@ export function ChatPanel({
         }}
       >
         {messages.map(m => <Message key={m.id} m={m} />)}
+        {streamingText !== null && streamingText !== undefined && (
+          // Reuse Message/MarkdownChat exactly as settled assistant messages
+          // do, so a streaming reply never styles differently from a
+          // finished one. The `loading` flag reuses the same "Thinking…"
+          // affordance Learn.tsx already shows for in-flight assistant
+          // turns (see ChatMsg loading: true) rather than inventing a new
+          // typing indicator. The scroll container above already declares
+          // role="log" aria-live="polite" aria-relevant="additions", so this
+          // bubble's appearance is announced without a second, nested
+          // aria-live region on the bubble itself.
+          <Message
+            key="streaming"
+            m={{ id: "streaming", role: "assistant", content: streamingText, loading: streamingText === "" }}
+          />
+        )}
       </div>
 
       <ChatInputBar
         onSend={onSend}
         onAction={onAction}
-        disabled={disabled}
+        disabled={disabled || isStreaming}
         placeholder={placeholder}
         draftSeed={draftSeed}
         draftSeedKey={draftSeedKey}
+        streaming={isStreaming}
+        onStop={onStop}
       />
     </div>
   );
@@ -94,6 +121,8 @@ interface ChatInputBarProps {
   placeholder: string;
   draftSeed?: string;
   draftSeedKey?: number;
+  streaming?: boolean;
+  onStop?: () => void;
 }
 
 const ChatInputBar = React.memo(function ChatInputBar({
@@ -103,6 +132,8 @@ const ChatInputBar = React.memo(function ChatInputBar({
   placeholder,
   draftSeed,
   draftSeedKey,
+  streaming,
+  onStop,
 }: ChatInputBarProps) {
   const [text, setText] = useState<string>(draftSeed ?? "");
 
@@ -182,6 +213,16 @@ const ChatInputBar = React.memo(function ChatInputBar({
           }}
           rows={1}
         />
+        {streaming && onStop && (
+          <button
+            data-testid="tutor-stop"
+            className="btn btn--sm"
+            onClick={onStop}
+            aria-label="Stop response"
+          >
+            Stop
+          </button>
+        )}
         <button
           data-testid="tutor-send"
           className="btn btn--primary btn--sm"

--- a/frontend/src/components/screens/Learn.applyGraphDelta.test.ts
+++ b/frontend/src/components/screens/Learn.applyGraphDelta.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { applyGraphDeltaAssembly } from './Learn';
+import type { GraphDelta } from '@/lib/api';
+import type { GraphEdge, GraphNode } from '@/lib/data';
+
+/**
+ * Fix pass 3 (task-9): covers `applyGraphDelta`'s CALL SITE, not just its
+ * already-extracted helpers.
+ *
+ * Learn.graph.test.ts (fix pass 2) proved `mergeGraphDelta`,
+ * `deltaPlaceholderEdges`, and `mergeGraphEdges` are individually correct,
+ * but two of its tests drove a hand-written `applyDelta` helper that
+ * *mirrored* the real `applyGraphDelta` assembly rather than calling it —
+ * its own comment admitted as much. A reviewer proved this was a real gap:
+ * you could revert `applyGraphDelta` to the old broken "thread a value out
+ * of a functional updater, then read it synchronously right after" shape
+ * and all of fix pass 2's tests would still pass, because none of them
+ * called the real assembly. Those two tests (and the mirror) were removed;
+ * see the NOTE at the top of Learn.graph.test.ts.
+ *
+ * This file exercises `applyGraphDeltaAssembly` — the actual body of
+ * `applyGraphDelta`'s useCallback, extracted to a standalone exported
+ * function that takes `setGraphNodes`/`setGraphEdges` as parameters so it
+ * is callable outside React (see Learn.tsx). `LearnInner` calls this exact
+ * function with its real `setGraphNodes`/`setGraphEdges` state setters — no
+ * second copy of the assembly logic exists anywhere.
+ *
+ * The fake setters below never invoke the updater function they are given
+ * — they only *capture* it, then `flush` applies it later against a chosen
+ * `prev`. This matches real React precisely: a functional `setState`
+ * updater is never guaranteed to run synchronously at the call site (per
+ * the comment on `applyGraphDeltaAssembly` in Learn.tsx, streaming
+ * guarantees deferral by keeping the fiber's lanes non-empty via the
+ * per-token `setStreamingText` calls). Modeling "always deferred" is the
+ * correct worst case to test against, since that's what actually happens
+ * during a real stream.
+ *
+ * Revert-proof (see task-9-report.md, "Fix pass 3" section, for the actual
+ * command output): temporarily replacing `applyGraphDeltaAssembly`'s body
+ * in Learn.tsx with the broken shape —
+ *
+ *   let newEdges: GraphEdge[] = [];
+ *   setGraphNodes(prev => {
+ *     newEdges = deltaPlaceholderEdges(prev, delta, courseId);
+ *     return mergeGraphDelta(prev, delta, courseId);
+ *   });
+ *   if (newEdges.length) setGraphEdges(prev => mergeGraphEdges(prev, newEdges));
+ *
+ * — makes every test below fail: our fakes never run the nodes updater
+ * inline, so `newEdges` is still `[]` at the `if` check, `setGraphEdges` is
+ * never called at all, and `edges.flush` (never captured) returns `prev`
+ * unchanged.
+ */
+
+const root = (courseId: string): GraphNode => ({
+  id: `root-${courseId}`,
+  name: `${courseId} root`,
+  subject: `${courseId} subject`,
+  color: '#123456',
+  is_subject_root: true,
+  mastery_tier: 'mastered',
+  mastery_score: 1,
+  course_id: courseId,
+});
+
+const newNodeDelta = (concept: string): GraphDelta => ({
+  nodes: { new_nodes: [{ concept_name: concept, initial_mastery: 0.2 }] },
+  mastery_changes: [],
+});
+
+// A fake React-style functional-updater setter: `set` only *records* the
+// updater it's given — it never invokes it — exactly matching real React's
+// contract (the updater runs later, during render, not synchronously at the
+// call site). `flush` applies the captured updater to `prev` to simulate
+// that eventual render; if `set` was never called, `flush` returns `prev`
+// unchanged — the observable behavior when a buggy call site skips the
+// setState call entirely (the broken shape's actual failure mode).
+function fakeSetter<T>() {
+  let captured: ((prev: T) => T) | null = null;
+  const set = (updater: (prev: T) => T) => { captured = updater; };
+  const flush = (prev: T): T => (captured ? captured(prev) : prev);
+  return { set, flush };
+}
+
+describe('applyGraphDeltaAssembly — the real applyGraphDelta call site (task-9 fix pass 3)', () => {
+  it('a new streamed concept yields both the placeholder node and its root edge', () => {
+    const nodes = fakeSetter<GraphNode[]>();
+    const edges = fakeSetter<GraphEdge[]>();
+    const snapshot = [root('math')];
+
+    applyGraphDeltaAssembly(newNodeDelta('Eigenvalues'), 'math', snapshot, nodes.set, edges.set);
+
+    const nextNodes = nodes.flush(snapshot);
+    const nextEdges = edges.flush([]);
+
+    const placeholder = nextNodes.find(n => n.id === 'stream-eigenvalues');
+    expect(placeholder).toBeDefined();
+    expect(placeholder?.course_id).toBe('math');
+
+    expect(nextEdges).toContainEqual({ source: 'root-math', target: 'stream-eigenvalues', strength: 0.4 });
+    expect(nextEdges).toHaveLength(1);
+  });
+
+  it('applying the same delta twice (two full call+flush cycles) yields exactly one edge', () => {
+    const delta = newNodeDelta('Eigenvalues');
+    const snapshot0 = [root('math')];
+
+    const nodes1 = fakeSetter<GraphNode[]>();
+    const edges1 = fakeSetter<GraphEdge[]>();
+    applyGraphDeltaAssembly(delta, 'math', snapshot0, nodes1.set, edges1.set);
+    const nodesAfter1 = nodes1.flush(snapshot0);
+    const edgesAfter1 = edges1.flush([]);
+
+    // Second cycle: the render-scope `graphNodes` closure is now
+    // `nodesAfter1`, exactly like the real component's next call to
+    // `applyGraphDelta` after the first delta's render has committed.
+    const nodes2 = fakeSetter<GraphNode[]>();
+    const edges2 = fakeSetter<GraphEdge[]>();
+    applyGraphDeltaAssembly(delta, 'math', nodesAfter1, nodes2.set, edges2.set);
+    const nodesAfter2 = nodes2.flush(nodesAfter1);
+    const edgesAfter2 = edges2.flush(edgesAfter1);
+
+    expect(edgesAfter2.filter(e => e.target === 'stream-eigenvalues')).toHaveLength(1);
+    expect(nodesAfter2.filter(n => n.id === 'stream-eigenvalues')).toHaveLength(1);
+  });
+
+  it('the edge is computed eagerly, not threaded out of the nodes updater: it lands even when the nodes updater is never flushed', () => {
+    const nodes = fakeSetter<GraphNode[]>();
+    const edges = fakeSetter<GraphEdge[]>();
+    const snapshot = [root('math')];
+
+    applyGraphDeltaAssembly(newNodeDelta('Eigenvalues'), 'math', snapshot, nodes.set, edges.set);
+
+    // Deliberately never flush `nodes` — proves the edge computation does
+    // not depend on the nodes updater having run. The broken shape can
+    // never pass this: it computes edges *inside* the nodes updater and
+    // only calls setGraphEdges if that (unflushed) value already looks
+    // non-empty at the synchronous call site, so it never calls setGraphEdges
+    // at all here, and `edges.flush` is a no-op returning `[]` unchanged.
+    const nextEdges = edges.flush([]);
+    expect(nextEdges).toContainEqual({ source: 'root-math', target: 'stream-eigenvalues', strength: 0.4 });
+  });
+});

--- a/frontend/src/components/screens/Learn.graph.test.ts
+++ b/frontend/src/components/screens/Learn.graph.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { deltaPlaceholderEdges, mergeGraphDelta, mergeGraphEdges, resolveCardCourseId } from './Learn';
+import type { GraphDelta } from '@/lib/api';
+import type { GraphEdge, GraphNode } from '@/lib/data';
+
+/**
+ * Fix-pass-2 findings (task-9):
+ *
+ * Finding A: streamed placeholder edges were silently dropped, non-
+ * deterministically, because `applyGraphDelta` read a value out of a
+ * `setGraphNodes` functional updater immediately after calling it — but React
+ * doesn't run that updater synchronously except in a bailout that streaming
+ * almost never hits. The fix makes `graphNodes` and `graphEdges` two
+ * independent, idempotent updates instead: `mergeGraphDelta` (nodes) and
+ * `deltaPlaceholderEdges` + `mergeGraphEdges` (edges) never read each other's
+ * result — each is a pure function of its own arguments. This file exercises
+ * that pipeline directly (no timers, no React rendering, no bailout to rely
+ * on) and proves the edge survives, and survives being applied twice.
+ *
+ * Finding B: the streamed-placeholder course fallback was computed but never
+ * actually used — the previous "fix" was a no-op because `...patch` was
+ * spread after the courseId, so it always evaluated to the same value the
+ * unfixed code produced. `resolveCardCourseId` is the real, stronger
+ * resolution (mirrors `addConcept`'s `cardCourseId`); this file proves it
+ * actually differs from the naive `selectedCourseId`-only fallback, and that
+ * `mergeGraphDelta` actually uses whatever fallback it's given.
+ *
+ * NOTE (fix pass 3, task-9): this file used to also assert end-to-end
+ * "applies a delta and gets a placeholder + edge" behavior via a
+ * hand-written `applyDelta` helper that *mirrored* `applyGraphDelta`'s
+ * shape rather than calling it. A reviewer proved that mirror was a gap: you
+ * could revert the real `applyGraphDelta` to a broken value-threaded-out-of-
+ * an-updater shape and every test in this file would still pass, because
+ * none of them called the real assembly. Those two tests (and the mirror)
+ * were removed in favor of Learn.applyGraphDelta.test.ts, which exercises
+ * the real exported `applyGraphDeltaAssembly` and strictly covers the same
+ * ground (placeholder + edge creation, idempotency across two applications)
+ * plus the revert-proof property this file never had. The helper-level
+ * tests below (`mergeGraphEdges`, `deltaPlaceholderEdges`,
+ * `resolveCardCourseId`, `mergeGraphDelta` used directly) are untouched —
+ * they test real exported functions, not a mirror, and remain valid.
+ */
+
+const root = (courseId: string): GraphNode => ({
+  id: `root-${courseId}`,
+  name: `${courseId} root`,
+  subject: `${courseId} subject`,
+  color: '#123456',
+  is_subject_root: true,
+  mastery_tier: 'mastered',
+  mastery_score: 1,
+  course_id: courseId,
+});
+
+const newNodeDelta = (concept: string): GraphDelta => ({
+  nodes: { new_nodes: [{ concept_name: concept, initial_mastery: 0.2 }] },
+  mastery_changes: [],
+});
+
+describe('Finding A — streamed placeholder edges (task-9 fix pass 2)', () => {
+  it('mergeGraphEdges is pure: calling it twice with the identical (prev, additions) — exactly what React 18 Strict Mode does to a dev updater — returns the same result both times', () => {
+    const additions: GraphEdge[] = [{ source: 'root-math', target: 'stream-eigenvalues', strength: 0.4 }];
+    const firstInvocation = mergeGraphEdges([], additions);
+    const secondInvocation = mergeGraphEdges([], additions); // same prev, same additions — the double-invoke case
+
+    expect(firstInvocation).toEqual(secondInvocation);
+    expect(firstInvocation).toHaveLength(1);
+  });
+
+  it('never re-adds an edge that is already present in graphEdges', () => {
+    const already: GraphEdge[] = [{ source: 'root-math', target: 'stream-eigenvalues', strength: 0.4 }];
+    const candidates: GraphEdge[] = [{ source: 'root-math', target: 'stream-eigenvalues', strength: 0.4 }];
+    expect(mergeGraphEdges(already, candidates)).toBe(already); // same reference: no-op, not just equal
+  });
+
+  it('does not synthesize an edge for a concept that already exists as a real node', () => {
+    const known: GraphNode = {
+      id: 'real-eigen',
+      name: 'Eigenvalues',
+      subject: 'math subject',
+      color: '#abcdef',
+      mastery_tier: 'learning',
+      mastery_score: 0.5,
+      course_id: 'math',
+    };
+    const nodes = [root('math'), known];
+    const edges = deltaPlaceholderEdges(nodes, newNodeDelta('Eigenvalues'), 'math');
+    expect(edges).toHaveLength(0);
+  });
+
+  it('adds no edge when no subject root exists for the resolved course (matches prior behavior)', () => {
+    const edges = deltaPlaceholderEdges([], newNodeDelta('Eigenvalues'), 'math');
+    expect(edges).toHaveLength(0);
+  });
+});
+
+describe('Finding B — placeholder course fallback (task-9 fix pass 2)', () => {
+  it('resolveCardCourseId prefers the focused node\'s own course over selectedCourseId', () => {
+    const topicNode: GraphNode = {
+      id: 'n1',
+      name: 'Some concept',
+      subject: 'chem subject',
+      color: '#000',
+      mastery_tier: 'learning',
+      mastery_score: 0.4,
+      course_id: 'chem',
+    };
+    expect(resolveCardCourseId(topicNode, 'bio')).toBe('chem');
+  });
+
+  it('resolveCardCourseId falls back to selectedCourseId when the focused node has no course', () => {
+    expect(resolveCardCourseId(undefined, 'bio')).toBe('bio');
+  });
+
+  it('resolveCardCourseId falls back to null when nothing resolves (keeps prior behavior for the "" case)', () => {
+    expect(resolveCardCourseId(undefined, '')).toBeNull();
+  });
+
+  it('mergeGraphDelta actually uses the fallback it is given — a stronger fallback changes the placeholder\'s course_id', () => {
+    const nodesFallback = mergeGraphDelta([root('chem')], newNodeDelta('Enzymes'), 'chem');
+    const placeholder = nodesFallback.find(n => n.id === 'stream-enzymes');
+    expect(placeholder?.course_id).toBe('chem');
+  });
+});

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -21,7 +21,9 @@ import { useIsMobile } from "@/lib/useIsMobile";
 import { useUser } from "@/context/UserContext";
 import {
   startSession,
+  startSessionStream,
   sendChat,
+  streamChat,
   getSessions,
   resumeSession,
   deleteSession,
@@ -36,6 +38,8 @@ import {
   type Session,
   type SessionSummaryData,
   type EnrolledCourse,
+  type ChatResult,
+  type GraphDelta,
 } from "@/lib/api";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
 import { apiToGraphNode, type GraphNode, type GraphEdge } from "@/lib/data";
@@ -75,6 +79,222 @@ function normalizeMode(input: string | null): Mode {
   return (VALID_MODES as string[]).includes(input) ? (input as Mode) : "socratic";
 }
 
+// Mirrors backend/config.py::get_mastery_tier so a streamed delta classifies
+// mastery the same way a full graph refetch would.
+function tierForScore(score: number): GraphNode["mastery_tier"] {
+  if (score >= 0.75) return "mastered";
+  if (score >= 0.45) return "learning";
+  if (score >= 0.1) return "struggling";
+  return "unexplored";
+}
+
+const normalizeConceptName = (s: string) => s.trim().toLowerCase().replace(/\s+/g, " ");
+
+// Shared, defensive identity extraction for a single raw graph_update node
+// entry: matched by `id`/`node_id` when present (future-proofing against a
+// payload shape change), otherwise by normalized concept name. Used by both
+// `mergeGraphDelta` and `deltaPlaceholderEdges` so their notions of "is this
+// concept already known" can't drift apart.
+function rawNodeIdentity(raw: Record<string, unknown>): { id?: string; name?: string } {
+  const id = typeof raw.id === "string" ? raw.id : typeof raw.node_id === "string" ? raw.node_id : undefined;
+  const name = typeof raw.concept_name === "string" ? raw.concept_name : typeof raw.name === "string" ? raw.name : undefined;
+  return { id, name };
+}
+
+// Upsert a streamed `graph_update` event into `graphNodes` so the knowledge-map
+// rail's "In this branch" / "Elsewhere in course" panels recompute through
+// their existing useMemo — no refetch, no extra HTTP round-trip (#74).
+//
+// NOTE on the real payload shape: `delta.nodes` is NOT the flat
+// {id, name, course_id, mastery_score, mastery_tier}[] the streaming-design
+// spec sketches. It's a dict keyed by which graph tool wrote
+// (backend/agents/tools/graph.py via services/chat_stream.py
+// merge_graph_updates): `new_nodes` entries are {concept_name,
+// initial_mastery}; `updated_nodes` entries are {concept_name,
+// mastery_delta, reason, event_type}. Neither carries an `id` or an
+// absolute post-update score. `delta.mastery_changes` ({concept, before,
+// after}) IS authoritative for an existing node's new score, so it drives
+// merges for updates; `nodes` entries are read defensively via
+// `rawNodeIdentity` — and any fields we don't recognize are ignored rather
+// than crashing.
+//
+// Pure function of its arguments only — no component state is read. It does
+// NOT compute placeholder edges; see `deltaPlaceholderEdges` below, which
+// `applyGraphDelta` runs as a second, independent, idempotent update instead
+// of threading a value out of this one. Exported for Learn.graph.test.ts.
+export function mergeGraphDelta(
+  prev: GraphNode[],
+  delta: GraphDelta,
+  fallbackCourseId: string,
+): GraphNode[] {
+  const rawNodes = Object.values(delta.nodes ?? {}).flat() as Array<Record<string, unknown>>;
+  const rawMasteryChanges = delta.mastery_changes ?? [];
+  if (!rawNodes.length && !rawMasteryChanges.length) return prev;
+
+  const byId = new Map(prev.map(n => [n.id, n] as const));
+  const byName = new Map(prev.map(n => [normalizeConceptName(n.name), n] as const));
+
+  const upsert = (existing: GraphNode | undefined, name: string, patch: Partial<GraphNode>) => {
+    if (existing) {
+      const merged: GraphNode = { ...existing, ...patch };
+      byId.set(existing.id, merged);
+      byName.set(normalizeConceptName(existing.name), merged);
+      return;
+    }
+    // Unknown concept: insert a placeholder so it's visible immediately; a
+    // later full graph refetch (session end / next visit) reconciles the
+    // real id. The raw payload carries no course_id, so anchor it to the
+    // session's active course when there is one. Mirrors `addConcept`
+    // (~:892): resolve color + subject from the course's subject-root node
+    // instead of a hardcoded `var(--…)` (the 3D rail can't resolve CSS
+    // custom properties — lib/data.ts:78-79 — so that rendered black). The
+    // root-anchoring edge is added separately by `deltaPlaceholderEdges`,
+    // not here.
+    const id = `stream-${normalizeConceptName(name)}`;
+    const already = byId.get(id);
+    const courseId = (typeof patch.course_id === "string" ? patch.course_id : undefined) ?? fallbackCourseId;
+    const root = prev.find(n => n.is_subject_root && n.course_id === courseId);
+    const placeholder: GraphNode = already
+      ? { ...already, ...patch }
+      : {
+          id,
+          name,
+          subject: root?.subject ?? "",
+          color: root?.color ?? "var(--c-sage)",
+          mastery_tier: "unexplored",
+          mastery_score: 0,
+          course_id: courseId,
+          ...patch,
+        };
+    byId.set(id, placeholder);
+    byName.set(normalizeConceptName(name), placeholder);
+  };
+
+  for (const raw of rawNodes) {
+    const { id, name } = rawNodeIdentity(raw);
+    if (!id && !name) continue;
+    const existing = id ? byId.get(id) : byName.get(normalizeConceptName(name as string));
+    const patch: Partial<GraphNode> = {};
+    const score = typeof raw.mastery_score === "number"
+      ? raw.mastery_score
+      : (!existing && typeof raw.initial_mastery === "number") ? raw.initial_mastery : undefined;
+    if (score !== undefined) {
+      patch.mastery_score = score;
+      patch.mastery_tier = tierForScore(score);
+    }
+    if (typeof raw.mastery_tier === "string") patch.mastery_tier = raw.mastery_tier as GraphNode["mastery_tier"];
+    if (typeof raw.course_id === "string") patch.course_id = raw.course_id;
+    upsert(existing, name ?? (id as string), patch);
+  }
+
+  for (const mc of rawMasteryChanges) {
+    const existing = byName.get(normalizeConceptName(mc.concept));
+    if (!existing) continue; // bare mastery_changes entries carry no id/course to synthesize a new node from
+    upsert(existing, mc.concept, { mastery_score: mc.after, mastery_tier: tierForScore(mc.after) });
+  }
+
+  return Array.from(byId.values());
+}
+
+function edgeKey(e: GraphEdge): string {
+  return `${e.source}\u0000${e.target}`;
+}
+
+// The root→placeholder edges a streamed `graph_update` implies, computed
+// against `nodes` — the caller's current `graphNodes` snapshot — rather than
+// against `mergeGraphDelta`'s `prev`: the two run as independent updates
+// (see `applyGraphDelta`), so this can't reach into the other's in-flight
+// result, and doesn't need to. A concept only gets a synthetic edge when it
+// has no existing id/name match in `nodes`, mirroring `mergeGraphDelta`'s
+// "unknown concept" branch; an already-known concept is updated in place by
+// `mergeGraphDelta` and never gets a new edge here. Pure and side-effect
+// free. Exported for Learn.graph.test.ts.
+export function deltaPlaceholderEdges(
+  nodes: GraphNode[],
+  delta: GraphDelta,
+  fallbackCourseId: string,
+): GraphEdge[] {
+  const rawNodes = Object.values(delta.nodes ?? {}).flat() as Array<Record<string, unknown>>;
+  if (!rawNodes.length) return [];
+
+  const byId = new Map(nodes.map(n => [n.id, n] as const));
+  const byName = new Map(nodes.map(n => [normalizeConceptName(n.name), n] as const));
+  const edges: GraphEdge[] = [];
+
+  for (const raw of rawNodes) {
+    const { id, name } = rawNodeIdentity(raw);
+    if (!id && !name) continue;
+    const existing = id ? byId.get(id) : byName.get(normalizeConceptName(name as string));
+    if (existing) continue;
+
+    const courseId = (typeof raw.course_id === "string" ? raw.course_id : undefined) ?? fallbackCourseId;
+    const root = nodes.find(n => n.is_subject_root && n.course_id === courseId);
+    if (!root) continue;
+
+    const label = (name ?? id) as string;
+    edges.push({ source: root.id, target: `stream-${normalizeConceptName(label)}`, strength: 0.4 });
+  }
+  return edges;
+}
+
+// Idempotent edge append: dedupes `additions` against `prev` AND against
+// each other by source+target, so calling this twice with identical inputs —
+// React 18 Strict Mode's dev double-invocation of a setState updater, or the
+// same `graph_update` replayed — leaves `prev` unchanged the second time.
+// Never mutates `prev`. Exported for Learn.graph.test.ts.
+export function mergeGraphEdges(prev: GraphEdge[], additions: GraphEdge[]): GraphEdge[] {
+  if (!additions.length) return prev;
+  const seen = new Set(prev.map(edgeKey));
+  const next: GraphEdge[] = [];
+  for (const e of additions) {
+    const key = edgeKey(e);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    next.push(e);
+  }
+  return next.length ? [...prev, ...next] : prev;
+}
+
+// Course resolution for a rail-focused node: prefer the node's own course,
+// fall back to the course picker's selection, else null. Used both for the
+// rail's focus card (`cardCourseId` in LearnInner) and, via that same value,
+// for the streamed-placeholder course fallback in `applyGraphDelta` — so a
+// streamed node lands in the same course bucket a manually-added one would
+// (Finding B). Exported for Learn.graph.test.ts.
+export function resolveCardCourseId(
+  topicNode: GraphNode | undefined,
+  selectedCourseId: string,
+): string | null {
+  return topicNode?.course_id || selectedCourseId || null;
+}
+
+// The actual call-site assembly `applyGraphDelta` (LearnInner, below) runs on
+// every streamed `graph_update`. Extracted to a standalone, exported function
+// — rather than left inline in the `useCallback` body — specifically so
+// Learn.applyGraphDelta.test.ts can invoke the REAL assembly with fake
+// `setGraphNodes`/`setGraphEdges` and prove the shape below is what actually
+// runs, instead of testing a hand-written mirror of it (fix pass 2's gap).
+//
+// `edges` MUST be computed before either setter is called: it is a plain,
+// eager read of `graphNodesSnapshot` (the caller's current `graphNodes`), not
+// a value threaded out of the `setGraphNodes` updater. That distinction is
+// the entire fix — see the big comment on `applyGraphDelta` for why reading
+// a value out of a functional updater immediately after calling it is
+// unsound (React never runs it synchronously at the call site).
+// `setGraphNodes`/`setGraphEdges` are typed to only the functional-updater
+// overload because that's the only form this call site ever uses.
+export function applyGraphDeltaAssembly(
+  delta: GraphDelta,
+  courseId: string,
+  graphNodesSnapshot: GraphNode[],
+  setGraphNodes: (updater: (prev: GraphNode[]) => GraphNode[]) => void,
+  setGraphEdges: (updater: (prev: GraphEdge[]) => GraphEdge[]) => void,
+): void {
+  const edges = deltaPlaceholderEdges(graphNodesSnapshot, delta, courseId);
+  setGraphNodes(prev => mergeGraphDelta(prev, delta, courseId));
+  setGraphEdges(prev => mergeGraphEdges(prev, edges));
+}
+
 export function Learn() {
   return (
     <Suspense fallback={<div style={{ padding: 40, color: "var(--text-dim)" }}>Loading…</div>}>
@@ -106,6 +326,11 @@ function LearnInner() {
   const [messages, setMessages] = useState<ChatMsg[]>([]);
   const [sending, setSending] = useState(false);
   const [starting, setStarting] = useState(false);
+  // Assistant text arriving token-by-token for the in-flight turn; null =
+  // not streaming, '' = stream open but no token yet, non-empty = live text.
+  // Passed straight through to ChatPanel's `streamingText` prop.
+  const [streamingText, setStreamingText] = useState<string | null>(null);
+  const streamAbort = useRef<AbortController | null>(null);
 
   const [recentSessions, setRecentSessions] = useState<Session[]>([]);
   const [courses, setCourses] = useState<EnrolledCourse[]>([]);
@@ -114,11 +339,70 @@ function LearnInner() {
   const [graphEdges, setGraphEdges] = useState<GraphEdge[]>([]);
 
   // The rail's focused node — independent of the active session's topic, so
-  // clicking around the map explores without touching the chat. Null means the
-  // focus follows the current session topic. `lastNodeClickRef` powers the
-  // double-click-to-switch shortcut.
+  // clicking around the map explores without touching the chat. Null means
+  // the focus follows the current session topic. `lastNodeClickRef` powers
+  // the double-click-to-switch shortcut. Declared here — ahead of the rest
+  // of the rail state below — because `applyGraphDelta`'s course resolution
+  // needs `cardCourseId`, which is derived from it.
   const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
   const lastNodeClickRef = useRef<{ id: string; t: number } | null>(null);
+
+  const suggestParam = searchParams.get("suggest");
+  const highlightId = useMemo(() => {
+    // Pre-revamp Learn honored ?suggest=<concept> from the Dashboard
+    // "Learn next" suggestion; restore that here, falling back to the
+    // current topic if no suggestion is active.
+    const suggestMatch = suggestParam
+      ? graphNodes.find(n => n.name.toLowerCase() === suggestParam.trim().toLowerCase())
+      : null;
+    if (suggestMatch) return suggestMatch.id;
+    return graphNodes.find(n => n.name.toLowerCase() === topic.trim().toLowerCase())?.id;
+  }, [suggestParam, graphNodes, topic]);
+
+  // The rail focus: an explicitly-clicked node when present, otherwise the
+  // node for the active session topic. Drives the graph highlight, focus
+  // card, "In this branch", and "Elsewhere".
+  const activeFocusId = focusedNodeId ?? highlightId;
+  const topicNode = useMemo(
+    () => graphNodes.find(n => n.id === activeFocusId),
+    [graphNodes, activeFocusId],
+  );
+
+  // Course resolution shared by the rail's focus card, `addConcept` (~:892
+  // below), and the streamed-placeholder fallback right below: prefer the
+  // focused concept's own course, fall back to the course picker. Extracted
+  // to a top-level function (rather than an inline expression) so it's
+  // directly testable — see Learn.graph.test.ts.
+  const cardCourseId = resolveCardCourseId(topicNode, selectedCourseId);
+
+  // Streamed graph_update handler (#74) — see mergeGraphDelta above for why
+  // the match key falls back to concept name. The course fallback is
+  // `cardCourseId`, the same resolution `addConcept` uses for a manually-
+  // added node, so a streamed placeholder lands in the same course bucket;
+  // when nothing resolves at all it falls back to `selectedCourseId`, same
+  // as before.
+  //
+  // The actual assembly lives in `applyGraphDeltaAssembly` (top-level,
+  // exported, above) — nodes and edges are two independent, idempotent
+  // functional updates there, NOT one updater's result threaded into the
+  // other. `setGraphNodes`'s updater runs against the true, always-current
+  // `prev`. `setGraphEdges`'s updater applies edges computed eagerly against
+  // the render-scope `graphNodes` snapshot passed in here — safe because
+  // subject-root nodes never change mid-stream, and any staleness in the "is
+  // this concept already known" check only produces a redundant candidate,
+  // which `mergeGraphEdges` dedupes by source+target rather than an
+  // incorrect edge. Both updaters are pure functions of their arguments, so
+  // calling either twice with the same input — React 18 Strict Mode's dev
+  // double-invocation, or the same delta arriving twice — produces the same
+  // result. No timing assumption, nothing smuggled out.
+  const applyGraphDelta = useCallback(
+    (delta: GraphDelta) => {
+      const courseId = cardCourseId ?? selectedCourseId;
+      applyGraphDeltaAssembly(delta, courseId, graphNodes, setGraphNodes, setGraphEdges);
+    },
+    [cardCourseId, selectedCourseId, graphNodes],
+  );
+
   // Inline "add concept" composer state for the knowledge-map rail.
   const [addingConcept, setAddingConcept] = useState(false);
   const [newConceptName, setNewConceptName] = useState("");
@@ -214,23 +498,76 @@ function LearnInner() {
   // Begins a fresh tutor session on `t`. Shared by the entry-screen Start
   // button and the knowledge-map switch flow. Clears any map focus so the rail
   // snaps back to following the (new) active topic.
+  //
+  // Streams the greeting over startSessionStream, mirroring `send`'s
+  // three-rung fallback ladder verbatim (see the big comment on `send`,
+  // above `send`'s definition, for the full rationale):
+  //   Rung 3 (stream never produced text) -> retry transparently via the
+  //     non-streaming JSON startSession; the user never sees an error.
+  //   Rung 2 (rejected AFTER tokens appeared) -> surface the error via the
+  //     same toast path this handler already used for JSON failures. Never
+  //     silently re-run.
+  //   Stop pressed -> distinguished via the AbortController's signal.aborted;
+  //     intentional, not an error, no fallback. No session exists yet on
+  //     this path (session_id is only set on success below), so aborting
+  //     just drops back to the entry screen once `starting` clears.
+  //
+  // Like `send`, no loading placeholder goes into `messages` up front — the
+  // greeting renders through ChatPanel's `streamingText` bubble instead, so
+  // it appears progressively rather than after a spinner (#70's premise,
+  // extended to session start).
+  //
+  // Field-name note: the JSON route returns `initial_message`; the stream's
+  // `done` event returns `reply` (ChatResult). Both are normalized into
+  // `replyText` below so the rest of this function doesn't care which path
+  // served the turn.
   const beginSession = async (t: string) => {
     const topicName = t.trim();
     if (!topicName || !userId) return;
     setFocusedNodeId(null);
     setTopic(topicName);
     setTopicDraft(topicName);
-    setMessages([{ id: msgId(), role: "assistant", content: "", loading: true }]);
+    setMessages([]);
     setStarting(true);
+    setStreamingText("");
+    const controller = new AbortController();
+    streamAbort.current = controller;
+    let sawToken = false;
     try {
-      const res = await startSession(userId, topicName, mode, selectedCourseId || undefined, sharedCtx, modelPref);
-      setSessionId(res.session_id);
-      setMessages([{ id: msgId(), role: "assistant", content: res.initial_message || "Let's begin." }]);
+      let newSessionId: string;
+      let replyText: string;
+      try {
+        const res = await startSessionStream(userId, topicName, mode, sharedCtx, selectedCourseId || undefined, modelPref, {
+          onToken: (delta) => {
+            sawToken = true;
+            setStreamingText(prev => (prev ?? "") + delta);
+          },
+          onGraphUpdate: applyGraphDelta,
+          signal: controller.signal,
+        });
+        if (!res.session_id) throw new Error("Session stream completed without a session_id.");
+        newSessionId = res.session_id;
+        replyText = res.reply || "Let's begin.";
+      } catch (err) {
+        if (controller.signal.aborted) { setMessages([]); return; } // Stop pressed — intentional, not an error.
+        if (sawToken) throw err; // Rung 2: interrupted after producing text — surface it, don't retry.
+        // Rung 3: the stream never produced text — retry transparently via
+        // the non-streaming JSON route. Clear streamingText first so
+        // ChatPanel drops the Stop affordance for this leg (mirrors `send`).
+        setStreamingText(null);
+        const res = await startSession(userId, topicName, mode, selectedCourseId || undefined, sharedCtx, modelPref);
+        newSessionId = res.session_id;
+        replyText = res.initial_message || "Let's begin.";
+      }
+      setSessionId(newSessionId);
+      setMessages([{ id: msgId(), role: "assistant", content: replyText }]);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Couldn't start session.");
       setMessages([]);
     } finally {
       setStarting(false);
+      setStreamingText(null);
+      if (streamAbort.current === controller) streamAbort.current = null;
     }
   };
 
@@ -287,31 +624,76 @@ function LearnInner() {
     }
   }, [userId, toast]);
 
+  // Sends one turn over the SSE stream, with a three-rung fallback ladder:
+  //   Rung 3 (stream never produced text) -> retry transparently via the
+  //     non-streaming sendChat; the user never sees an error.
+  //   Rung 2 (rejected AFTER tokens appeared) -> surface the error through
+  //     the same error-message path the old non-streaming send() used. Never
+  //     silently re-run: the user already saw partial text, and nothing was
+  //     persisted server-side, so re-running would restart the reply.
+  //   Stop pressed -> distinguished via the AbortController's signal.aborted;
+  //     intentional, not an error, no fallback, no message appended (nothing
+  //     was persisted, so the partial bubble just disappears).
+  //
+  // Unlike the old handler, no loading placeholder is pushed into `messages`
+  // up front — ChatPanel renders the in-flight turn itself via streamingText
+  // (a placeholder there would double up with that live bubble). The real
+  // assistant message is appended once, after the turn resolves one way or
+  // another.
   const send = useCallback(async (userText: string) => {
     if (!userText.trim() || !sessionId || !userId) return;
-    setMessages(m => [
-      ...m,
-      { id: msgId(), role: "user", content: userText },
-      { id: msgId(), role: "assistant", content: "", loading: true },
-    ]);
+    setMessages(m => [...m, { id: msgId(), role: "user", content: userText }]);
     setSending(true);
+    setStreamingText("");
+    const controller = new AbortController();
+    streamAbort.current = controller;
+    let sawToken = false;
     try {
-      const res = await sendChat(sessionId, userId, userText, mode, sharedCtx, modelPref);
-      setMessages(m => {
-        const next = [...m];
-        next[next.length - 1] = { id: next[next.length - 1].id, role: "assistant", content: res.reply || "" };
-        return next;
-      });
+      let res: ChatResult;
+      try {
+        res = await streamChat(sessionId, userId, userText, mode, sharedCtx, modelPref, {
+          onToken: (delta) => {
+            sawToken = true;
+            setStreamingText(t => (t ?? "") + delta);
+          },
+          onGraphUpdate: applyGraphDelta,
+          signal: controller.signal,
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return; // Stop pressed — intentional, not an error.
+        if (sawToken) throw err; // Rung 2: interrupted after producing text — surface it, don't retry.
+        // Rung 3: the stream never produced text — retry transparently via the
+        // non-streaming JSON route. `sendChat`/`fetchJSON` (lib/api.ts) take
+        // no AbortSignal, and plumbing one through is out of scope for this
+        // fix — so the fallback request itself cannot actually be cancelled.
+        // Clear streamingText to null *before* issuing it so ChatPanel drops
+        // both the Stop button and the "Thinking…" bubble for this leg,
+        // rather than offering a Stop affordance that would abort an
+        // already-detached controller while the JSON call keeps running
+        // server-side regardless. `sending` stays true, so the input is
+        // still disabled — the turn just no longer looks interruptible,
+        // which is now the truth.
+        setStreamingText(null);
+        res = await sendChat(sessionId, userId, userText, mode, sharedCtx, modelPref);
+      }
+      setMessages(m => [...m, { id: msgId(), role: "assistant", content: res.reply || "" }]);
     } catch (err) {
-      setMessages(m => {
-        const next = [...m];
-        next[next.length - 1] = { id: next[next.length - 1].id, role: "assistant", content: `Error: ${err instanceof Error ? err.message : "unknown"}` };
-        return next;
-      });
+      setMessages(m => [...m, { id: msgId(), role: "assistant", content: `Error: ${err instanceof Error ? err.message : "unknown"}` }]);
     } finally {
       setSending(false);
+      setStreamingText(null);
+      if (streamAbort.current === controller) streamAbort.current = null;
     }
-  }, [sessionId, userId, mode, sharedCtx, modelPref]);
+  }, [sessionId, userId, mode, sharedCtx, modelPref, applyGraphDelta]);
+
+  // Abort any in-flight stream when the active session changes (including to
+  // none) and on unmount — guards the #131/#133 leaked-stream bug class. A
+  // plain unmount-only effect would miss the "switched sessions mid-stream"
+  // case, so this keys on sessionId: its cleanup fires both when sessionId
+  // changes and when the component unmounts.
+  useEffect(() => {
+    return () => streamAbort.current?.abort();
+  }, [sessionId]);
 
   const handleAction = async (action: "hint" | "confused" | "skip") => {
     if (!sessionId || !userId) return;
@@ -404,18 +786,6 @@ function LearnInner() {
 
   const modeOptions = useMemo(() => MODES.map(m => ({ value: m.id, label: m.name, description: m.tip })), []);
 
-  const suggestParam = searchParams.get("suggest");
-  const highlightId = useMemo(() => {
-    // Pre-revamp Learn honored ?suggest=<concept> from the Dashboard
-    // "Learn next" suggestion; restore that here, falling back to the
-    // current topic if no suggestion is active.
-    const suggestMatch = suggestParam
-      ? graphNodes.find(n => n.name.toLowerCase() === suggestParam.trim().toLowerCase())
-      : null;
-    if (suggestMatch) return suggestMatch.id;
-    return graphNodes.find(n => n.name.toLowerCase() === topic.trim().toLowerCase())?.id;
-  }, [suggestParam, graphNodes, topic]);
-
   // Jump the chat to `name`: resume an existing session on that concept if one
   // exists, otherwise start a fresh one. Both paths clear the map focus so the
   // rail follows the now-active session.
@@ -487,15 +857,6 @@ function LearnInner() {
     }
   };
 
-  // The rail focus: an explicitly-clicked node when present, otherwise the
-  // node for the active session topic. Drives the graph highlight, focus card,
-  // "In this branch", and "Elsewhere".
-  const activeFocusId = focusedNodeId ?? highlightId;
-  const topicNode = useMemo(
-    () => graphNodes.find(n => n.id === activeFocusId),
-    [graphNodes, activeFocusId],
-  );
-
   const neighborIds = useMemo(() => {
     if (!topicNode) return new Set<string>();
     const ids = new Set<string>();
@@ -506,7 +867,6 @@ function LearnInner() {
     return ids;
   }, [topicNode, graphEdges]);
 
-  const cardCourseId = topicNode?.course_id || selectedCourseId || null;
   const cardCourse = useMemo(
     () => courses.find(c => c.course_id === cardCourseId) ?? null,
     [courses, cardCourseId],
@@ -785,6 +1145,8 @@ function LearnInner() {
               onSend={send}
               onAction={handleAction}
               disabled={sending || starting}
+              streamingText={streamingText}
+              onStop={() => streamAbort.current?.abort()}
             />
           </div>
         )}

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -530,6 +530,10 @@ function LearnInner() {
     setMessages([]);
     setStarting(true);
     setStreamingText("");
+    // A stream may already be in flight (e.g. a graph-node click starting a
+    // new session while a reply streams) — abort it first so two streams
+    // never interleave writes into the same streamingText/messages state.
+    streamAbort.current?.abort();
     const controller = new AbortController();
     streamAbort.current = controller;
     let sawToken = false;
@@ -645,6 +649,10 @@ function LearnInner() {
     setMessages(m => [...m, { id: msgId(), role: "user", content: userText }]);
     setSending(true);
     setStreamingText("");
+    // A stream may already be in flight (e.g. a graph-node click starting a
+    // new session while a reply streams) — abort it first so two streams
+    // never interleave writes into the same streamingText/messages state.
+    streamAbort.current?.abort();
     const controller = new AbortController();
     streamAbort.current = controller;
     let sawToken = false;

--- a/frontend/src/lib/api.stream.test.ts
+++ b/frontend/src/lib/api.stream.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+function sseBody(blocks: string[]): ReadableStream {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(c) {
+      for (const b of blocks) c.enqueue(enc.encode(b));
+      c.close();
+    },
+  });
+}
+
+const ev = (name: string, data: unknown) =>
+  `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('streamChat', () => {
+  it('accumulates tokens, surfaces graph deltas, resolves on done', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([
+          ev('status', { type: 'status', step: 'start', message: '' }),
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'Hel' } }),
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'lo' } }),
+          ev('graph_update', {
+            type: 'graph_update', step: 'graph', message: '',
+            data: { nodes: { new_nodes: [{ name: 'Eigen' }] }, mastery_changes: [] },
+          }),
+          ev('done', {
+            type: 'done', step: 'reply', message: '',
+            data: { reply: 'Hello', graph_update: {}, mastery_changes: [] },
+          }),
+        ]),
+        { status: 200 },
+      ) as never,
+    );
+
+    const { streamChat } = await import('./api');
+    const tokens: string[] = [];
+    const deltas: unknown[] = [];
+    const result = await streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, {
+      onToken: (t) => tokens.push(t),
+      onGraphUpdate: (d) => deltas.push(d),
+    });
+
+    expect(tokens).toEqual(['Hel', 'lo']);
+    expect(deltas).toHaveLength(1);
+    expect(result.reply).toBe('Hello');
+  });
+
+  it('rejects on a mid-stream error event', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'Half' } }),
+          ev('error', { type: 'error', step: 'reply', message: 'Interrupted.', data: { request_id: 'r1' } }),
+        ]),
+        { status: 200 },
+      ) as never,
+    );
+    const { streamChat } = await import('./api');
+    await expect(
+      streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, { onToken: () => {} }),
+    ).rejects.toThrow(/interrupted/i);
+  });
+
+  it('preserves request_id from a mid-stream error event on the thrown Error', async () => {
+    // ADR 0009: the backend deliberately includes request_id on error events
+    // for Logfire correlation. Losing it on the frontend throw makes a
+    // user-reported error untraceable — assert it survives as a property
+    // AND stays visible in the (still-readable) message.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'Half' } }),
+          ev('error', { type: 'error', step: 'reply', message: 'Interrupted.', data: { request_id: 'trace-abc12345' } }),
+        ]),
+        { status: 200 },
+      ) as never,
+    );
+    const { streamChat } = await import('./api');
+    let caught: unknown;
+    try {
+      await streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, { onToken: () => {} });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as { requestId?: string }).requestId).toBe('trace-abc12345');
+    expect((caught as Error).message).toMatch(/interrupted/i);
+    expect((caught as Error).message).toContain('trace-abc');
+  });
+
+  it('rejects when the stream never sends done', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'x' } })]),
+        { status: 200 },
+      ) as never,
+    );
+    const { streamChat } = await import('./api');
+    await expect(
+      streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, { onToken: () => {} }),
+    ).rejects.toThrow(/without a done/i);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   ExtractedSyllabusCategory,
   AllowlistEmail, AchievementTrigger, AdminAuditEntry, AnalyticsOverview, PaginatedUsers,
   Note, LinkedConcept,
+  GraphUpdate, MasteryChange,
 } from '@/lib/types';
 
 export const API_URL = '';
@@ -167,6 +168,130 @@ export const sendChat = (
       ...(modelPref ? { model_pref: modelPref } : {}),
     }),
   });
+
+export interface GraphDelta {
+  nodes: Record<string, Array<Record<string, unknown>>>;
+  mastery_changes: MasteryChange[];
+}
+
+export interface ChatResult {
+  reply: string;
+  graph_update: GraphUpdate;
+  mastery_changes: MasteryChange[];
+  session_id?: string;
+  graph_state?: any;
+}
+
+interface StreamEvent {
+  type: string;
+  step: string;
+  message: string;
+  data?: Record<string, unknown> | null;
+}
+
+// Thrown from consumeChatStream on a mid-stream `error` event. Carries the
+// backend's `request_id` (ADR 0009, stamped for Logfire correlation) as a
+// property — not just baked into the message string — so a caller that
+// wants to display or copy it (see DocumentUploadModal's "Reference:"
+// pattern) doesn't have to re-parse the message text for it.
+export class ChatStreamError extends Error {
+  requestId?: string;
+  constructor(message: string, requestId?: string) {
+    // Keep the full id here (correlation needs an exact match); a caller
+    // that wants a short display form truncates it itself, same as
+    // DocumentUploadModal's "Reference: {id.slice(0, 8)}…" pattern.
+    super(requestId ? `${message} (ref: ${requestId})` : message);
+    this.name = 'ChatStreamError';
+    this.requestId = requestId;
+  }
+}
+
+export interface StreamChatHandlers {
+  onToken?: (delta: string) => void;
+  onGraphUpdate?: (delta: GraphDelta) => void;
+  signal?: AbortSignal;
+}
+
+const STREAM_IDLE_MS = 45_000;
+
+async function consumeChatStream(
+  path: string,
+  payload: Record<string, unknown>,
+  { onToken, onGraphUpdate, signal }: StreamChatHandlers,
+): Promise<ChatResult> {
+  const { streamSSE } = await import('./sse');
+  let result: ChatResult | null = null;
+
+  for await (const e of streamSSE<StreamEvent>(
+    `${API_URL}${path}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      credentials: 'include',
+      signal,
+    },
+    { idleTimeoutMs: STREAM_IDLE_MS },
+  )) {
+    const ev = e.data;
+    if (ev.type === 'token') onToken?.(String(ev.data?.delta ?? ''));
+    else if (ev.type === 'graph_update') onGraphUpdate?.(ev.data as unknown as GraphDelta);
+    else if (ev.type === 'error') {
+      const requestId = typeof ev.data?.request_id === 'string' ? ev.data.request_id : undefined;
+      throw new ChatStreamError(ev.message || 'The tutor was interrupted.', requestId);
+    }
+    else if (ev.type === 'done') result = ev.data as unknown as ChatResult;
+  }
+
+  if (!result) throw new Error('Chat stream ended without a done event.');
+  return result;
+}
+
+export const streamChat = (
+  sessionId: string,
+  userId: string,
+  message: string,
+  mode: string,
+  useSharedContext = true,
+  modelPref?: ModelPref,
+  handlers: StreamChatHandlers = {},
+): Promise<ChatResult> => {
+  return consumeChatStream(
+    '/api/learn/chat/stream',
+    {
+      session_id: sessionId,
+      user_id: userId,
+      message,
+      mode,
+      use_shared_context: useSharedContext,
+      ...(modelPref ? { model_pref: modelPref } : {}),
+    },
+    handlers,
+  );
+};
+
+export const startSessionStream = (
+  userId: string,
+  topic: string,
+  mode: string,
+  useSharedContext = true,
+  courseId?: string,
+  modelPref?: ModelPref,
+  handlers: StreamChatHandlers = {},
+): Promise<ChatResult> => {
+  return consumeChatStream(
+    '/api/learn/start-session/stream',
+    {
+      user_id: userId,
+      topic,
+      mode,
+      use_shared_context: useSharedContext,
+      course_id: courseId,
+      ...(modelPref ? { model_pref: modelPref } : {}),
+    },
+    handlers,
+  );
+};
 
 export interface SessionSummaryData {
   concepts_covered: string[];

--- a/frontend/src/lib/sse.test.ts
+++ b/frontend/src/lib/sse.test.ts
@@ -171,4 +171,41 @@ describe('streamSSE', () => {
     expect(events[0]).toEqual({ event: 'a', data: { i: 1 } });
     expect(events[1]).toEqual({ event: 'b', data: { i: 2 } });
   });
+
+  it('rejects when no event arrives within idleTimeoutMs', async () => {
+    const stalledBody = new ReadableStream({
+      start() { /* never enqueues, never closes */ },
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(stalledBody, { status: 200 }) as never,
+    );
+
+    const iterate = async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _e of streamSSE('/x', {}, { idleTimeoutMs: 20 })) { /* drain */ }
+    };
+    await expect(iterate()).rejects.toThrow(/stalled/i);
+  });
+
+  it('clears the idle-timeout timer on every successful read (no leaked timers on the happy path)', async () => {
+    vi.useFakeTimers();
+    try {
+      const payload =
+        'event: progress\ndata: {"step":1}\n\n' +
+        'event: progress\ndata: {"step":2}\n\n' +
+        'event: progress\ndata: {"step":3}\n\n';
+      mockFetchResponse(makeStreamingResponse([payload]));
+
+      const events = await collect(
+        streamSSE<{ step: number }>('/x', { method: 'POST' }, { idleTimeoutMs: 45000 }),
+      );
+
+      expect(events).toHaveLength(3);
+      // Every reader.read() races a setTimeout when idleTimeoutMs is set.
+      // If the winning read doesn't clear its timer, this stays > 0.
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -25,10 +25,13 @@ export type SSEEvent<T = unknown> = {
  *
  * Throws on non-2xx responses or missing body. The generator completes
  * naturally when the server closes the connection.
+ *
+ * If opts.idleTimeoutMs is set, rejects if no data arrives within that time.
  */
 export async function* streamSSE<T = unknown>(
   url: string,
   init: RequestInit,
+  opts: { idleTimeoutMs?: number } = {},
 ): AsyncGenerator<SSEEvent<T>> {
   const res = await fetch(url, init);
   if (!res.ok) {
@@ -45,7 +48,12 @@ export async function* streamSSE<T = unknown>(
 
   try {
     while (true) {
-      const { value, done } = await reader.read();
+      // A stalled stream (proxy dropped it, backend wedged) otherwise hangs
+      // the composer forever with no error. Race each read against a timer,
+      // clearing the timer once the race settles so it never lingers.
+      const { value, done } = opts.idleTimeoutMs
+        ? await readWithTimeout(reader, opts.idleTimeoutMs)
+        : await reader.read();
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
 
@@ -68,6 +76,31 @@ export async function* streamSSE<T = unknown>(
   } finally {
     await reader.cancel().catch(() => { /* already closed */ });
     reader.releaseLock();
+  }
+}
+
+/**
+ * Race a single reader.read() against an idle timeout, clearing the timer
+ * on every path (read wins, read throws, or the timer itself fires) so no
+ * timer is ever left pending once the race settles.
+ */
+async function readWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  idleTimeoutMs: number,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error("Stream stalled — no data received.")),
+          idleTimeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
## Summary

Streams tutor replies over SSE with live graph deltas (#70, #74). Rebased 2026-07-29 onto current main as a single rework commit (the branch had drifted 148 commits).

**What lands:**
- `services/chat_stream.py` — `stream_agent_turn`, the single streaming seam: `status:start → token* → (progress:<tool> → graph_update)* → done`, with the rung ladder (Rung 1 pre-token failure → route's legacy fallback; Rung 2 mid-stream → terminal error event, no silent re-run; `on_complete` XOR `legacy_fallback` — persistence happens exactly once).
- `services/agent_events.py` — chat event vocabulary (`token`/`graph_update`/`done`) extending the ADR-0006 document-pipeline shapes.
- `POST /api/learn/chat/stream` + `POST /api/learn/start-session/stream` (`EventSourceResponse`, `X-Request-ID` echo); JSON routes unchanged as fallbacks. start-session's agent-path migration closes ADR-0015's TODO on the streamed lane.
- Frontend: `sse.ts` parser, `api.ts` stream consumers, `Learn.tsx`/`ChatPanel` live-token rendering + Stop button (`tutor-stop` testid), `applyGraphDelta` for in-stream graph updates.
- **Function-mode seam now serves streamed runs**: `_function_model_for` gained a `stream_function` that replays the registered handler's `ModelResponse` as deltas — E2E `E2E_*` constants stay byte-identical across JSON and SSE lanes (2 new seam tests).
- ADR `docs/decisions/0020-streaming-tutor-interrupt-retry.md`.

**Dropped from the original branch** (superseded by `_LoopSafeGoogleModel`, #453): `fresh_google_model`/`fresh_model_for`, `_fresh_stream_model`, all per-call `model=` overrides — the streamed routes now inherit the agent's own model, which also keeps the `SAPLING_MODEL_MODE` seam in the streaming path.

## Testing
- backend: 1198 passed, 27 skipped; ruff clean.
- frontend: 221 vitest, tsc clean, eslint 0 errors.
- Full local e2e cycle (function-mode stack, lock-serialized): pending below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)