### PR TITLE
fix(limits): retry_after ceiling capped at window — deterministic on coarse timers (#346)

### DIFF
--- a/backend/services/flashcard_import_service.py
+++ b/backend/services/flashcard_import_service.py
@@ -93,10 +93,12 @@ def check_rate_limit(user_id: str) -> int | None:
     bucket = [t for t in _rate_state.get(user_id, []) if now - t < _RATE_WINDOW_SEC]
     if len(bucket) >= _RATE_LIMIT:
         # Seconds until the oldest call in the window ages out (freeing a slot),
-        # rounded up. ceil keeps a sub-second remainder from reporting 0, and —
+        # rounded up. ceil keeps a sub-second remainder from reporting 0 and —
         # unlike the old `int(...) + 1` — never overshoots to 61 when the calls
-        # land in the same clock tick (elapsed == 0). Always in [1, _RATE_WINDOW_SEC].
-        retry = math.ceil(_RATE_WINDOW_SEC - (now - bucket[0]))
+        # land in the same clock tick (elapsed == 0). The min() cap additionally
+        # pins the ceiling when `now` reads BEFORE bucket[0] (NTP step / coarse
+        # Windows timers, #346), so the result is always in [1, _RATE_WINDOW_SEC].
+        retry = min(_RATE_WINDOW_SEC, math.ceil(_RATE_WINDOW_SEC - (now - bucket[0])))
         _rate_state[user_id] = bucket
         return retry
     bucket.append(now)

--- a/backend/services/request_limits.py
+++ b/backend/services/request_limits.py
@@ -4,6 +4,7 @@ Factored for reuse across CPU/cost-heavy endpoints (OCR extraction, LLM). The
 flashcard import service has an older copy of the same sliding-window limiter
 (`services/flashcard_import_service.check_rate_limit`) that can migrate here.
 """
+import math
 import time
 
 from fastapi import HTTPException, UploadFile
@@ -23,7 +24,10 @@ def check_rate_limit(key: str, *, limit: int, window_sec: int) -> int | None:
     now = time.time()
     bucket = [t for t in _rate_state.get(key, []) if now - t < window_sec]
     if len(bucket) >= limit:
-        retry = int(window_sec - (now - bucket[0])) + 1
+        # Ceiling of the remaining window, capped at window_sec: on coarse
+        # timers (Windows, ~15.6ms tick) `now` can equal `bucket[0]` exactly,
+        # and int(remaining) + 1 would overshoot to window_sec + 1 (#346).
+        retry = min(window_sec, math.ceil(window_sec - (now - bucket[0])))
         _rate_state[key] = bucket
         return retry
     bucket.append(now)

--- a/backend/services/request_limits.py
+++ b/backend/services/request_limits.py
@@ -27,6 +27,8 @@ def check_rate_limit(key: str, *, limit: int, window_sec: int) -> int | None:
         # Ceiling of the remaining window, capped at window_sec: on coarse
         # timers (Windows, ~15.6ms tick) `now` can equal `bucket[0]` exactly,
         # and int(remaining) + 1 would overshoot to window_sec + 1 (#346).
+        # The min() cap additionally pins the ceiling when `now` reads BEFORE
+        # bucket[0] (NTP backward step) — ceil alone would exceed the window.
         retry = min(window_sec, math.ceil(window_sec - (now - bucket[0])))
         _rate_state[key] = bucket
         return retry

--- a/backend/tests/test_flashcard_import_service.py
+++ b/backend/tests/test_flashcard_import_service.py
@@ -447,3 +447,17 @@ class TestGenerateFlashcards:
         assert "- BFS" in sent
         # Free-text context branch.
         assert "Focus on the midterm review session." in sent
+
+
+class TestRateLimitClockSkew:
+    def test_retry_capped_when_clock_steps_backward(self, monkeypatch):
+        # NTP can step time.time() BACKWARD between calls: now < bucket[0]
+        # makes the remaining window exceed the 60s window, and bare ceil()
+        # would report an impossible retry hint. The min() cap is load-bearing
+        # exactly here (#346).
+        now = [1000.0]
+        monkeypatch.setattr(svc.time, "time", lambda: now[0])
+        for _ in range(5):
+            svc.check_rate_limit("u-skew")
+        now[0] = 998.5  # clock stepped back 1.5s
+        assert svc.check_rate_limit("u-skew") == 60

--- a/backend/tests/test_flashcard_import_service.py
+++ b/backend/tests/test_flashcard_import_service.py
@@ -90,6 +90,23 @@ class TestRateLimit:
         now[0] = 1061.0  # past 60-second window
         assert svc.check_rate_limit("u1") is None
 
+    def test_retry_capped_at_window_on_coincident_timestamps(self, monkeypatch):
+        # Windows' coarse timer (~15.6ms tick) reliably lands a tight loop of
+        # calls on the identical time.time() value, so elapsed == 0.0 exactly
+        # and the retry hint must still stay within (0, window] (#346).
+        monkeypatch.setattr(svc.time, "time", lambda: 1000.0)
+        for _ in range(5):
+            svc.check_rate_limit("u1")
+        assert svc.check_rate_limit("u1") == 60
+
+    def test_retry_uses_ceiling_of_remaining_window(self, monkeypatch):
+        now = [1000.0]
+        monkeypatch.setattr(svc.time, "time", lambda: now[0])
+        for _ in range(5):
+            svc.check_rate_limit("u1")
+        now[0] = 1059.5  # 0.5s of the window left -> ceil to 1
+        assert svc.check_rate_limit("u1") == 1
+
 
 # ── parse_xlsx ───────────────────────────────────────────────────────────────
 

--- a/backend/tests/test_request_limits.py
+++ b/backend/tests/test_request_limits.py
@@ -51,3 +51,15 @@ class TestCheckRateLimit:
             request_limits.check_rate_limit("k", limit=3, window_sec=60)
         now[0] = 1059.5  # 0.5s of the window left -> ceil to 1
         assert request_limits.check_rate_limit("k", limit=3, window_sec=60) == 1
+
+    def test_retry_capped_when_clock_steps_backward(self, monkeypatch):
+        # NTP can step time.time() BACKWARD between calls: now < bucket[0]
+        # makes the remaining window exceed window_sec, and bare ceil() would
+        # report an impossible retry hint (e.g. 61+s for a 60s window). The
+        # min() cap is load-bearing exactly here (#346).
+        now = [1000.0]
+        monkeypatch.setattr(request_limits.time, "time", lambda: now[0])
+        for _ in range(3):
+            request_limits.check_rate_limit("k", limit=3, window_sec=60)
+        now[0] = 998.5  # clock stepped back 1.5s
+        assert request_limits.check_rate_limit("k", limit=3, window_sec=60) == 60

--- a/backend/tests/test_request_limits.py
+++ b/backend/tests/test_request_limits.py
@@ -1,0 +1,53 @@
+"""Unit tests for the shared sliding-window limiter in services/request_limits.
+
+The consumer-level behavior (OCR extraction, Gradescope routes) is covered in
+test_extract_auth_bounds.py / test_gradescope.py; these pin the limiter's own
+contract, especially the retry-hint bounds from #346.
+"""
+import services.request_limits as request_limits
+
+
+class TestCheckRateLimit:
+    def setup_method(self):
+        request_limits._rate_state.clear()
+
+    def test_allows_up_to_limit(self):
+        for _ in range(3):
+            assert request_limits.check_rate_limit("k", limit=3, window_sec=60) is None
+
+    def test_over_limit_returns_retry(self):
+        for _ in range(3):
+            request_limits.check_rate_limit("k", limit=3, window_sec=60)
+        retry = request_limits.check_rate_limit("k", limit=3, window_sec=60)
+        assert retry is not None
+        assert 0 < retry <= 60
+
+    def test_keys_are_isolated(self):
+        for _ in range(3):
+            request_limits.check_rate_limit("k1", limit=3, window_sec=60)
+        assert request_limits.check_rate_limit("k2", limit=3, window_sec=60) is None
+
+    def test_resets_after_window(self, monkeypatch):
+        now = [1000.0]
+        monkeypatch.setattr(request_limits.time, "time", lambda: now[0])
+        for _ in range(3):
+            request_limits.check_rate_limit("k", limit=3, window_sec=60)
+        now[0] = 1061.0
+        assert request_limits.check_rate_limit("k", limit=3, window_sec=60) is None
+
+    def test_retry_capped_at_window_on_coincident_timestamps(self, monkeypatch):
+        # Windows' coarse timer (~15.6ms tick) reliably lands a tight loop of
+        # calls on the identical time.time() value, so elapsed == 0.0 exactly
+        # and the retry hint must still stay within (0, window] (#346).
+        monkeypatch.setattr(request_limits.time, "time", lambda: 1000.0)
+        for _ in range(3):
+            request_limits.check_rate_limit("k", limit=3, window_sec=60)
+        assert request_limits.check_rate_limit("k", limit=3, window_sec=60) == 60
+
+    def test_retry_uses_ceiling_of_remaining_window(self, monkeypatch):
+        now = [1000.0]
+        monkeypatch.setattr(request_limits.time, "time", lambda: now[0])
+        for _ in range(3):
+            request_limits.check_rate_limit("k", limit=3, window_sec=60)
+        now[0] = 1059.5  # 0.5s of the window left -> ceil to 1
+        assert request_limits.check_rate_limit("k", limit=3, window_sec=60) == 1


### PR DESCRIPTION
## Problem

`check_rate_limit` computes the retry hint as `int(window - elapsed) + 1` — a broken ceiling. When the rate-limited call shares an identical `time.time()` value with the first call in the window, `elapsed == 0.0` exactly and the hint overshoots to **window + 1** (61s for a 60s window). On Windows this happens reliably (the timer ticks every ~15.6 ms, so a tight loop of 6 calls lands on one tick), which:

- violates the `(0, window]` contract callers surface as `Retry-After`, and
- makes `TestRateLimit::test_sixth_call_returns_retry_after` fail out-of-the-box for every Windows contributor (`assert 61 <= 60`). Linux CI passes only by accident — elapsed there is tiny-but-nonzero, so `int(59.999…) + 1 == 60`.

## Fix

True ceiling semantics, clamped at the window, in **both** copies of the limiter:

```python
retry = min(window_sec, math.ceil(window_sec - (now - bucket[0])))
```

- `services/request_limits.py` (shared limiter behind OCR extraction + Gradescope routes)
- `services/flashcard_import_service.py` (older twin the shared module's docstring notes should eventually migrate)

The clamp also guards the pathological `elapsed < 0` case (clock steps backward between calls).

## Tests (TDD — written first, verified failing)

- `test_retry_capped_at_window_on_coincident_timestamps` (both limiters): freezes `time.time` so `elapsed == 0.0` exactly — deterministic reproduction of the Windows failure on every platform; pins `retry == 60`. **Failed (61) before the fix, passes after.**
- `test_retry_uses_ceiling_of_remaining_window` (both limiters): 0.5s remaining → `retry == 1`, pinning ceiling semantics against a regression to plain truncation.
- New `tests/test_request_limits.py` also covers the shared limiter's base contract (allow-up-to-limit, over-limit hint bounds, key isolation, window reset), which previously had no direct unit tests.

## Verification

- Affected suites (`test_flashcard_import_service`, `test_request_limits`, `test_extract_auth_bounds`, `test_gradescope`): **72/72 passed** — on the Windows machine where the suite was previously red.
- `ruff check` clean on all touched files.

Supersedes #347 (same clamp idea, but closed without regression tests; this PR adds the deterministic frozen-time coverage the issue asked for).

Fixes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rate-limit retry guidance so displayed wait times remain within the configured limit window.
  - Corrected rounding for fractional remaining wait times, providing more accurate retry estimates.
  - Ensured edge cases, including coincident timestamps and near-expired windows, return valid retry values.

- **Tests**
  - Added coverage for rate-limit boundaries, timing behavior, key isolation, and window resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->