### PR TITLE
fix(rag): content-hash chunk ids — dedup identical uploads per course

### DIFF
--- a/backend/scripts/dedupe_course_chunks.py
+++ b/backend/scripts/dedupe_course_chunks.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+One-time dedupe: migrate course_chunks document rows to content-hash ids.
+
+Chunk ids used to be sha256(doc_id::index::text), so the same lecture
+slides uploaded by N students stored N copies of every chunk.
+services/rag_service.py::chunk_id now scopes ids to
+sha256(course_id::text); this script rewrites existing rows to that
+scheme and collapses duplicates. Catalog rows (category=catalog) use
+their own id scheme and are untouched.
+
+For each group of rows sharing chunk_id(course_id, chunk_text), the
+winner is the first row that already has an embedding (avoids
+re-embedding); its metadata (doc_id/uploader_id/chunk_index) carries
+over, matching the last-writer-wins contract in rag_service.
+
+Dry-run by default. Run from backend/:
+    python scripts/dedupe_course_chunks.py            # preview
+    python scripts/dedupe_course_chunks.py --apply    # rewrite rows
+
+Reads .env; for staging run under `dotenv -f .env.staging run -- ...`.
+"""
+import argparse
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+BASE = Path(__file__).parent.parent
+load_dotenv(BASE / ".env")
+sys.path.insert(0, str(BASE))
+
+from db.connection import table  # noqa: E402
+from services.rag_service import chunk_id  # noqa: E402
+
+PAGE_SIZE = 1000
+UPSERT_BATCH = 200
+DELETE_BATCH = 50
+
+COLUMNS = (
+    "id,course_id,doc_id,uploader_id,chunk_index,chunk_text,chunk_hash,"
+    "embedding,category,semester,section_id,school"
+)
+
+
+def fetch_document_rows() -> list[dict]:
+    rows: list[dict] = []
+    offset = 0
+    while True:
+        page, total = table("course_chunks").select_with_count(
+            COLUMNS,
+            filters={"category": "eq.document"},
+            order="id.asc",
+            limit=PAGE_SIZE,
+            offset=offset,
+        )
+        rows.extend(page)
+        offset += len(page)
+        if not page or offset >= total:
+            return rows
+
+
+def plan_migration(rows: list[dict]) -> tuple[list[dict], list[str]]:
+    """Group rows by content-hash id; return (records to upsert, ids to delete)."""
+    groups: dict[str, list[dict]] = {}
+    for row in rows:
+        groups.setdefault(chunk_id(row["course_id"], row["chunk_text"]), []).append(row)
+
+    upserts: list[dict] = []
+    deletes: list[str] = []
+    for new_id, members in groups.items():
+        winner = next((m for m in members if m.get("embedding")), members[0])
+        if winner["id"] != new_id:
+            upserts.append({**winner, "id": new_id, "chunk_hash": new_id})
+        deletes.extend(m["id"] for m in members if m["id"] != new_id)
+    return upserts, deletes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Collapse duplicate course_chunks rows onto content-hash ids."
+    )
+    parser.add_argument("--apply", action="store_true", help="Write changes (default: preview).")
+    args = parser.parse_args()
+
+    rows = fetch_document_rows()
+    upserts, deletes = plan_migration(rows)
+    unique = len(rows) - len(deletes)
+    print(
+        f"{len(rows)} document rows -> {unique} unique chunks "
+        f"({len(deletes)} duplicate/legacy-id rows to remove, {len(upserts)} rows to rewrite)."
+    )
+
+    if not args.apply:
+        print("Dry run — re-run with --apply to write.")
+        return
+
+    # Upsert winners under their new ids first, then delete stale ids, so an
+    # interrupted run never leaves a chunk with no surviving row.
+    db = table("course_chunks")
+    for i in range(0, len(upserts), UPSERT_BATCH):
+        db.upsert(upserts[i : i + UPSERT_BATCH], on_conflict="id")
+    for i in range(0, len(deletes), DELETE_BATCH):
+        batch = deletes[i : i + DELETE_BATCH]
+        db.delete(filters={"id": f"in.({','.join(batch)})"})
+    print(f"Done: rewrote {len(upserts)} rows, deleted {len(deletes)}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/dedupe_course_chunks.py
+++ b/backend/scripts/dedupe_course_chunks.py
@@ -10,9 +10,12 @@ scheme and collapses duplicates. Catalog rows (category=catalog) use
 their own id scheme and are untouched.
 
 For each group of rows sharing chunk_id(course_id, chunk_text), the
-winner is the first row that already has an embedding (avoids
-re-embedding); its metadata (doc_id/uploader_id/chunk_index) carries
-over, matching the last-writer-wins contract in rag_service.
+winner is the first row (id-ascending) that already has an embedding
+(avoids re-embedding); its metadata (doc_id/uploader_id/chunk_index)
+carries over. Which legacy row's metadata survives is arbitrary — no
+timestamp is consulted — and that is fine: rag_service documents these
+columns as non-load-bearing metadata (retrieval reads only course_id +
+chunk_text), so the only invariant that matters is keeping an embedding.
 
 Dry-run by default. Run from backend/:
     python scripts/dedupe_course_chunks.py            # preview

--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -127,15 +127,22 @@ def retrieve_chunks(
 
 
 def chunk_id(course_code: str, chunk_text: str) -> str:
-    """Content-addressed chunk id, scoped per course.
+    """Content-addressed chunk id, scoped per course and per row kind.
 
     Identical text in the same course maps to one row no matter which
     document or uploader supplied it, so N students uploading the same
     slides dedup to one embedding instead of N. doc_id/uploader_id/
     chunk_index on the row are last-writer-wins metadata; retrieval only
     reads course_id + chunk_text.
+
+    The literal "document" segment keeps this keyspace DISJOINT from
+    catalog rows: scripts/ingest_catalog.py ids category=catalog rows as
+    sha256(course::text) in the SAME course_chunks table (on_conflict=id),
+    so an un-namespaced hash would let a document chunk whose text
+    byte-matches a catalog chunk silently overwrite the catalog row and
+    flip its category — dropping it from every category=eq.catalog reader.
     """
-    return hashlib.sha256(f"{course_code}::{chunk_text}".encode()).hexdigest()
+    return hashlib.sha256(f"{course_code}::document::{chunk_text}".encode()).hexdigest()
 
 
 def index_document_chunks(

--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -126,6 +126,18 @@ def retrieve_chunks(
         return []
 
 
+def chunk_id(course_code: str, chunk_text: str) -> str:
+    """Content-addressed chunk id, scoped per course.
+
+    Identical text in the same course maps to one row no matter which
+    document or uploader supplied it, so N students uploading the same
+    slides dedup to one embedding instead of N. doc_id/uploader_id/
+    chunk_index on the row are last-writer-wins metadata; retrieval only
+    reads course_id + chunk_text.
+    """
+    return hashlib.sha256(f"{course_code}::{chunk_text}".encode()).hexdigest()
+
+
 def index_document_chunks(
     course_code: str,
     doc_id: str,
@@ -134,18 +146,22 @@ def index_document_chunks(
 ) -> int:
     """Embed and upsert document chunks to course_chunks.
 
-    Returns the number of chunks upserted. Uses RETRIEVAL_DOCUMENT task
-    type for all embeddings. Upsert is idempotent — re-indexing the same
-    doc_id produces the same chunk IDs and merges cleanly.
+    Returns the number of unique chunks upserted. Uses RETRIEVAL_DOCUMENT
+    task type for all embeddings. Chunk ids are content-addressed per
+    course (see chunk_id), so re-uploads of the same content merge instead
+    of duplicating rows. Repeated text within one document is deduped
+    before upsert — Postgres rejects an upsert payload that hits the same
+    row twice.
     """
     if not chunks:
         return 0
 
-    records = []
+    records_by_id: dict[str, dict] = {}
     for i, chunk_text in enumerate(chunks):
-        raw = f"{doc_id}::{i}::{chunk_text}"
-        cid = hashlib.sha256(raw.encode()).hexdigest()
-        records.append({
+        cid = chunk_id(course_code, chunk_text)
+        if cid in records_by_id:
+            continue
+        records_by_id[cid] = {
             "id":          cid,
             "course_id":   course_code,
             "doc_id":      doc_id,
@@ -158,7 +174,9 @@ def index_document_chunks(
             "semester":    "current",
             "section_id":  None,
             "school":      "",
-        })
+        }
+
+    records = list(records_by_id.values())
 
     # Embed in batches of 50 (API limit)
     BATCH = 50

--- a/backend/tests/test_dedupe_course_chunks.py
+++ b/backend/tests/test_dedupe_course_chunks.py
@@ -1,0 +1,78 @@
+"""Tests for scripts.dedupe_course_chunks.plan_migration — the pure
+regrouping logic of the one-time content-hash id migration."""
+from services.rag_service import chunk_id
+
+
+def _row(rid, course, text, embedding=None, doc="doc-1"):
+    return {
+        "id": rid,
+        "course_id": course,
+        "doc_id": doc,
+        "uploader_id": "user-1",
+        "chunk_index": 0,
+        "chunk_text": text,
+        "chunk_hash": rid,
+        "embedding": embedding,
+        "category": "document",
+        "semester": "current",
+        "section_id": None,
+        "school": "",
+    }
+
+
+def test_duplicate_rows_collapse_to_one_content_hash_row():
+    """Two legacy rows with identical text in the same course become one
+    upsert under the content-hash id and two deletes of the legacy ids."""
+    from scripts.dedupe_course_chunks import plan_migration
+
+    rows = [
+        _row("legacy-a", "CAS CS 330", "memoization basics", embedding="[0.1,0.2]"),
+        _row("legacy-b", "CAS CS 330", "memoization basics", doc="doc-2"),
+    ]
+    upserts, deletes = plan_migration(rows)
+
+    new_id = chunk_id("CAS CS 330", "memoization basics")
+    assert [u["id"] for u in upserts] == [new_id]
+    assert upserts[0]["chunk_hash"] == new_id
+    assert sorted(deletes) == ["legacy-a", "legacy-b"]
+
+
+def test_winner_is_a_row_that_already_has_an_embedding():
+    """The surviving row must reuse an existing embedding rather than
+    leaving the merged chunk unembedded."""
+    from scripts.dedupe_course_chunks import plan_migration
+
+    rows = [
+        _row("legacy-a", "CAS CS 330", "graph traversal", embedding=None),
+        _row("legacy-b", "CAS CS 330", "graph traversal", embedding="[0.3,0.4]", doc="doc-2"),
+    ]
+    upserts, _ = plan_migration(rows)
+
+    assert upserts[0]["embedding"] == "[0.3,0.4]"
+    assert upserts[0]["doc_id"] == "doc-2"
+
+
+def test_rows_already_on_content_hash_ids_are_untouched():
+    """Idempotency: a second run over already-migrated data plans no writes."""
+    from scripts.dedupe_course_chunks import plan_migration
+
+    cid = chunk_id("CAS CS 330", "sorting algorithms")
+    rows = [_row(cid, "CAS CS 330", "sorting algorithms", embedding="[0.5]")]
+    upserts, deletes = plan_migration(rows)
+
+    assert upserts == []
+    assert deletes == []
+
+
+def test_same_text_across_courses_stays_separate():
+    from scripts.dedupe_course_chunks import plan_migration
+
+    rows = [
+        _row("legacy-a", "CAS CS 330", "big-O notation"),
+        _row("legacy-b", "CAS CS 111", "big-O notation"),
+    ]
+    upserts, deletes = plan_migration(rows)
+
+    assert len(upserts) == 2
+    assert len({u["id"] for u in upserts}) == 2
+    assert sorted(deletes) == ["legacy-a", "legacy-b"]

--- a/backend/tests/test_rag_service.py
+++ b/backend/tests/test_rag_service.py
@@ -311,3 +311,18 @@ def test_index_document_chunks_never_reaches_transport_in_function_mode(monkeypa
     captured = capsys.readouterr()
     assert "unstubbed LLM egress" not in captured.out
     assert "SAPLING_MODEL_MODE" in captured.out
+
+
+def test_document_chunk_ids_never_collide_with_catalog_ids():
+    """Document and catalog rows share the course_chunks table and its
+    on_conflict=id upsert. The document id keyspace is namespaced with a
+    literal "document" segment so a document chunk whose text byte-matches a
+    catalog chunk (same course) can never overwrite the catalog row and flip
+    its category out from under the category=eq.catalog readers."""
+    from scripts.ingest_catalog import chunk_id as catalog_chunk_id
+    from services.rag_service import chunk_id as document_chunk_id
+
+    course, text = "CAS CS 132", "This course covers matrices and vector spaces."
+    assert document_chunk_id(course, text) != catalog_chunk_id(course, text)
+    # Still content-addressed within the document keyspace.
+    assert document_chunk_id(course, text) == document_chunk_id(course, text)

--- a/backend/tests/test_rag_service.py
+++ b/backend/tests/test_rag_service.py
@@ -128,6 +128,68 @@ def test_index_document_chunks_empty_returns_zero(mock_client):
     mock_client.models.embed_content.assert_not_called()
 
 
+@patch("services.rag_service._client")
+def test_chunk_ids_are_content_addressed_per_course(mock_client):
+    """Identical chunk text in the same course must map to the same chunk id
+    regardless of which document or uploader supplied it — 200 students
+    uploading the same lecture slides should produce one row per unique
+    chunk, not 200 copies of every embedding."""
+    mock_client.models.embed_content.return_value = _make_embedding_response([[0.2] * 768])
+    with patch("services.rag_service.table") as mock_table:
+        mock_table.return_value.upsert.return_value = []
+        from services.rag_service import index_document_chunks
+
+        index_document_chunks("CAS CS 330", "doc-a", "user-1", ["memoization basics"])
+        id_from_doc_a = mock_table.return_value.upsert.call_args[0][0][0]["id"]
+
+        index_document_chunks("CAS CS 330", "doc-b", "user-2", ["memoization basics"])
+        id_from_doc_b = mock_table.return_value.upsert.call_args[0][0][0]["id"]
+
+    assert id_from_doc_a == id_from_doc_b
+
+
+@patch("services.rag_service._client")
+def test_chunk_ids_differ_across_courses(mock_client):
+    """The dedup scope is per-course: the same text indexed under two
+    different course codes must NOT collide, or one course's doc_id/metadata
+    would clobber the other's."""
+    mock_client.models.embed_content.return_value = _make_embedding_response([[0.2] * 768])
+    with patch("services.rag_service.table") as mock_table:
+        mock_table.return_value.upsert.return_value = []
+        from services.rag_service import index_document_chunks
+
+        index_document_chunks("CAS CS 330", "doc-a", "user-1", ["memoization basics"])
+        id_cs330 = mock_table.return_value.upsert.call_args[0][0][0]["id"]
+
+        index_document_chunks("CAS CS 111", "doc-a", "user-1", ["memoization basics"])
+        id_cs111 = mock_table.return_value.upsert.call_args[0][0][0]["id"]
+
+    assert id_cs330 != id_cs111
+
+
+@patch("services.rag_service._client")
+def test_duplicate_chunks_within_one_document_are_deduped(mock_client):
+    """A document repeating the same text (boilerplate headers/footers) must
+    not emit duplicate ids in a single upsert payload — Postgres rejects
+    ON CONFLICT DO UPDATE hitting the same row twice in one statement."""
+    mock_client.models.embed_content.return_value = _make_embedding_response([[0.2] * 768] * 2)
+    with patch("services.rag_service.table") as mock_table:
+        mock_table.return_value.upsert.return_value = []
+        from services.rag_service import index_document_chunks
+
+        count = index_document_chunks(
+            "CAS CS 330",
+            "doc-a",
+            "user-1",
+            ["Page header boilerplate", "actual content", "Page header boilerplate"],
+        )
+        records = mock_table.return_value.upsert.call_args[0][0]
+
+    ids = [r["id"] for r in records]
+    assert len(ids) == len(set(ids)) == 2
+    assert count == 2
+
+
 @patch("services.rag_service._embed_documents_batch")
 def test_index_document_chunks_handles_embedding_failure(mock_embed):
     """Test that embedding failures are caught and records are still upserted with embedding=None."""


### PR DESCRIPTION
## Problem

`course_chunks` ids were `sha256(doc_id::index::text)`, so identical content uploaded by different students (or the same doc re-uploaded) stored a full copy of every chunk **and its embedding** per upload. A popular course with shared slides multiplies chunk storage by enrollment count.

## Fix

- **`rag_service.chunk_id`** (new): ids are now `sha256(course_id::chunk_text)` — content-addressed, scoped per course. Identical text in the same course merges to one row regardless of document or uploader; the same text in *different* courses stays separate.
- `doc_id` / `uploader_id` / `chunk_index` become last-writer-wins metadata. Safe because nothing reads, filters, or deletes by them: the `match_course_chunks` RPC returns only `course_id`/`chunk_text`/`similarity`, and no code path deletes `course_chunks` by `doc_id`.
- **In-batch dedup** in `index_document_chunks`: a document repeating the same text (boilerplate headers) would otherwise put duplicate keys in one upsert payload, which Postgres rejects (`ON CONFLICT DO UPDATE cannot affect row a second time`).
- **`scripts/dedupe_course_chunks.py`**: one-time, idempotent, dry-run-by-default migration for existing rows — groups legacy rows by content-hash id, keeps a row that already has an embedding (no re-embedding cost), upserts winners **before** deleting stale ids so an interrupted run never drops a chunk. Catalog rows (`category=catalog`, own id scheme via `ingest_catalog.py`) are untouched.

## Not covered

- Cross-course dedup (same textbook chapter in two courses) — intentional: rows carry per-course metadata, and retrieval filters by course.
- `backfill_document_chunks.py`'s `_already_indexed` check keys on `doc_id`; under dedup a doc whose chunks were claimed by another doc's rows may re-index and flip `doc_id` — harmless churn, ids are stable.

## Testing

- 3 new tests in `test_rag_service.py` (same text + course collides, different courses don't, in-batch dedup) and 4 in `test_dedupe_course_chunks.py` (collapse, embedding-preferring winner, idempotency, cross-course separation) — all written first and watched fail (TDD).
- Full backend suite: **963 passed, 1 skipped**; the `test_ocr_pipeline.py::test_save_to_db` error is the pre-existing live-Supabase/event-loop artifact documented in ADR 0016 (reproduces identically with the change stashed).
- `ruff check` clean on all touched files.

## Deploy note

After merge, run `python scripts/dedupe_course_chunks.py` (dry-run), review counts, then `--apply` — once per environment (`dotenv -f .env.staging run -- ...` for staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved document indexing by identifying identical content within each course and avoiding duplicate entries.
  * Preserved separate entries for identical content across different courses.
  * Added a migration utility to consolidate existing duplicate document chunks, with a preview mode before changes are applied.

* **Bug Fixes**
  * Prevented repeated indexing of the same content from creating redundant records.
  * Preserved existing embeddings when consolidating duplicate chunks.

* **Tests**
  * Added coverage for deduplication, course scoping, migration behavior, and idempotent indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->