### PR TITLE
Batch: social-directory scoping (#342), auth stub promotion (#285), CodeRabbit on integration branches (#343)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit reviews ONLY the repository default branch (main) unless other base
+# branches are listed explicitly. Without this file, every PR targeting a
+# long-lived integration branch got "Review skipped: reviews are disabled for
+# this base branch" — and because the PR otherwise looks normal and CI goes
+# green, the absence of a review reads as "nothing to flag" rather than
+# "never looked" (#343).
+#
+# That matters most for `production`: main -> production promotion PRs (e.g.
+# #305, #314) are the last gate before prod, and they were never machine
+# reviewed. The promotion PR is a merge of already-reviewed-looking commits, so
+# it gets no fresh line-by-line review on the way in either.
+#
+# `staging` is listed defensively. The branch does not exist right now (it was
+# deleted 2026-07-15, after #334 merged and #337 closed), but it was a real
+# long-lived integration branch and this config should already cover it if it
+# is ever recreated.
+#
+# Patterns are regex and are anchored on purpose: an unanchored `staging` would
+# also match feature branches such as `docs/staging-environment-plan`.
+language: en-US
+reviews:
+  auto_review:
+    base_branches:
+      - ^production$
+      - ^staging$

--- a/backend/db/migrations/0031_profile_visibility_school.sql
+++ b/backend/db/migrations/0031_profile_visibility_school.sql
@@ -1,0 +1,20 @@
+-- 0031: allow the 'school' profile-visibility tier
+--
+-- The Settings UI has always offered three visibility tiers
+-- (public / school / private, frontend Settings.tsx), but user_settings only
+-- permitted ('public','private') (0001 baseline, re-declared in 0005). Selecting
+-- "school" therefore hit the CHECK constraint and 500'd, so the tier was
+-- unreachable. #342 makes it load-bearing: the school directory
+-- (GET /api/social/students) is now scoped to the viewer's school and honors
+-- this setting, so 'school' has to be a storable value.
+--
+-- The baseline CHECK is an inline column constraint, so Postgres auto-named it
+-- user_settings_profile_visibility_check. Drop it (if present) and re-add a
+-- widened, explicitly-named constraint.
+
+ALTER TABLE user_settings
+    DROP CONSTRAINT IF EXISTS user_settings_profile_visibility_check;
+
+ALTER TABLE user_settings
+    ADD CONSTRAINT user_settings_profile_visibility_check
+    CHECK (profile_visibility IN ('public', 'school', 'private'));

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -451,14 +451,32 @@ def google_callback(request: Request, code: str = Query(...), state: str = Query
         user_id = f"user_{google_id}"
         is_approved = False
         from datetime import datetime as _dt, timezone as _tz
-        table("users").insert({
+        # Upsert, not insert (#285). `user_id` is deterministic, so a *stub* row
+        # can already occupy this id: `graph_service.ensure_user_exists` inserts
+        # {id, streak_count} with a NULL google_id for any authenticated request,
+        # and the HMAC-signed `sapling_session` cookie outlives a row delete — so
+        # a stale tab can create one for an account that no longer exists. The
+        # lookup above is by google_id, which NULL never matches, so we land here
+        # and a blind INSERT collided on users_pkey -> 409 -> unhandled -> a
+        # permanent sign-in 500 loop.
+        #
+        # on_conflict MUST be the primary key: `google_id` is UNIQUE and would be
+        # valid PostgREST, but the stub's google_id is NULL and NULLs never
+        # conflict, so it would not resolve this. merge-duplicates fills the
+        # stub's NULL auth columns in, promoting it to a real user.
+        table("users").upsert({
             "id": user_id,
             "email": encrypt_if_present(email),
             "google_id": google_id,
             "auth_provider": "google",
             "last_sign_in_at": _dt.now(_tz.utc).isoformat(),
-        })
-        table("user_profiles").insert({"user_id": user_id, **profile_fields})
+        }, on_conflict="id")
+        # Same hazard: user_profiles.user_id is the PK (0024), and a stub that
+        # reached onboarding already has a row here (onboarding.py upserts it).
+        table("user_profiles").upsert(
+            {"user_id": user_id, **profile_fields},
+            on_conflict="user_id",
+        )
 
     # Store OAuth tokens (calendar access included)
     # expires_at is TIMESTAMPTZ after migration 0024 — pass None (not "") when

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -380,6 +380,16 @@ def update_settings(user_id: str, body: UpdateSettingsBody, request: Request):
     incoming = body.model_dump(exclude_none=True)
     updates = {k: v for k, v in incoming.items() if k in ALLOWED}
 
+    # Validate profile_visibility against its DB CHECK enum (0031 widened it to
+    # include 'school'). Without this, an out-of-enum value reaches PostgREST as
+    # a raw CHECK violation → unhandled 500; a clean 400 is the honest response.
+    if "profile_visibility" in updates and updates["profile_visibility"] not in (
+        "public",
+        "school",
+        "private",
+    ):
+        raise HTTPException(status_code=400, detail="Invalid profile_visibility")
+
     if updates:
         updates["updated_at"] = datetime.now(timezone.utc).isoformat()
         table("user_settings").update(updates, filters={"user_id": f"eq.{user_id}"})

--- a/backend/routes/social.py
+++ b/backend/routes/social.py
@@ -14,6 +14,7 @@ from services.auth_guard import require_self, get_session_user_id
 from services.encryption import encrypt_if_present, decrypt_if_present
 from services.profiles import get_display_name, get_display_names
 from services.graph_service import get_graph
+from services import academics
 from services.matching_service import find_study_matches
 from services.request_context import current_request_id
 from services.social_cache_service import get_cached_summary, save_summary, invalidate as invalidate_summary
@@ -436,21 +437,61 @@ def toggle_reaction(room_id: str, message_id: str, body: ToggleReactionBody, req
 
 @router.get("/students")
 def get_students(request: Request):
-    """Return a lightweight profile for every user in the DB."""
+    """A lightweight directory of students who share the viewer's school.
+
+    Scoped for #342. Before this, the endpoint returned a profile for *every*
+    user in the DB to any authenticated caller — the `user_id` was bound and
+    never used, so it authenticated without authorizing. Two boundaries now
+    apply:
+
+    - **School scope**: only users enrolled at the same school as the viewer
+      (via ``academics.school_peer_user_ids``). An empty scope (viewer not
+      enrolled / course carries no school) yields an empty directory — fail
+      closed, mirroring the enrollment-scoping pattern in ``calendar.py``.
+    - **profile_visibility**: users who set their profile to ``private`` opt out
+      of the directory entirely. ``public`` and ``school`` are both listed (the
+      endpoint is already school-scoped, so they're equivalent here).
+
+    The payload is deliberately lightweight — name, streak, course names — and
+    carries **no mastery data**: per-concept mastery is academic-performance
+    information that belongs on the profile page (which already gates detail on
+    profile_visibility), not in a browsable directory.
+    """
     user_id = get_session_user_id(request)
-    users = table("users").select("id,streak_count")
+
+    peer_ids = academics.school_peer_user_ids(user_id)
+    if not peer_ids:
+        return {"students": []}
+    peer_list = sorted(peer_ids)
+
+    # Honor profile_visibility: drop 'private' users from the listing. Users with
+    # no settings row default to 'public' (the column default), so they stay.
+    settings_rows = table("user_settings").select(
+        "user_id,profile_visibility",
+        filters={"user_id": f"in.({','.join(peer_list)})"},
+    ) or []
+    hidden = {
+        s["user_id"] for s in settings_rows if s.get("profile_visibility") == "private"
+    }
+    visible_ids = [uid for uid in peer_list if uid not in hidden]
+    if not visible_ids:
+        return {"students": []}
+
+    users = table("users").select(
+        "id,streak_count", filters={"id": f"in.({','.join(visible_ids)})"}
+    ) or []
     # Display names live on user_profiles (0024); resolve in bulk and decrypt.
     name_map = get_display_names([u["id"] for u in users])
-    # A user's courses now resolve through the enrollment chain
+
+    # A user's courses resolve through the enrollment chain
     # (enrollments → course_offerings → courses); the abstract `courses` catalog
     # no longer carries a per-user row. Read the offering's abstract course name
     # via the embedded join and dedup, since one abstract course may have several
     # offerings (per term/section) the user is enrolled in.
     enrollment_rows = table("enrollments").select(
-        "user_id,course_offerings(courses(course_name))"
-    )
-    nodes_rows = table("graph_nodes").select("user_id,mastery_tier,concept_name,mastery_score")
-
+        "user_id,course_offerings(courses(course_name))",
+        filters={"user_id": f"in.({','.join(visible_ids)})"},
+    ) or []
     courses_by_user: dict = defaultdict(set)
     for e in enrollment_rows:
         offering = e.get("course_offerings") or {}
@@ -459,33 +500,12 @@ def get_students(request: Request):
         if course_name:
             courses_by_user[e["user_id"]].add(course_name)
 
-    mastery_by_user: dict = defaultdict(
-        lambda: {"mastered": 0, "learning": 0, "struggling": 0, "unexplored": 0, "total": 0}
-    )
-    top_concepts_by_user: dict = defaultdict(list)
-    for n in nodes_rows:
-        uid = n["user_id"]
-        tier = n["mastery_tier"]
-        mastery_by_user[uid]["total"] += 1
-        if tier in mastery_by_user[uid]:
-            mastery_by_user[uid][tier] += 1
-        if tier == "mastered":
-            top_concepts_by_user[uid].append((n.get("mastery_score", 0), n["concept_name"]))
-
-    # Sort each user's mastered concepts by score desc, keep top 4
-    for uid in top_concepts_by_user:
-        top_concepts_by_user[uid] = [
-            name for _, name in sorted(top_concepts_by_user[uid], reverse=True)[:4]
-        ]
-
     students = [
         {
             "user_id": u["id"],
             "name": name_map.get(u["id"], ""),
             "streak": u.get("streak_count") or 0,
             "courses": sorted(courses_by_user[u["id"]]),
-            "stats": dict(mastery_by_user[u["id"]]),
-            "top_concepts": top_concepts_by_user[u["id"]],
         }
         for u in users
     ]

--- a/backend/services/academics.py
+++ b/backend/services/academics.py
@@ -171,6 +171,97 @@ def user_enrollment_ids(user_id: str) -> list[dict]:
     ) or []
 
 
+def school_peer_user_ids(user_id: str) -> set[str]:
+    """The set of user_ids who share a school with ``user_id`` (includes them).
+
+    A user's school(s) are derived from the abstract courses behind their
+    enrollments (``enrollments`` → ``course_offerings.course_id`` →
+    ``courses.school_id``); peers are everyone enrolled in any offering of any
+    course at those schools. Backs the #342 school-scoped directory.
+
+    Multi-step reads (rather than PostgREST embedded filters) per this module's
+    house style. Deliberately **not** cached: enrollments mutate and this is a
+    visibility boundary, so a stale set would leak or hide users. Each step
+    short-circuits on an empty set — both to skip work and to avoid the
+    degenerate ``in.()`` filter that ``','.join(set())`` would produce.
+    """
+    if not user_id:
+        return set()
+
+    # 1. the viewer's own offerings
+    my_offerings = {
+        e["offering_id"] for e in user_enrollment_ids(user_id) if e.get("offering_id")
+    }
+    if not my_offerings:
+        return set()
+
+    # 2. offerings → abstract course ids
+    my_course_ids = {
+        r["course_id"]
+        for r in (
+            table("course_offerings").select(
+                "course_id", filters={"id": f"in.({','.join(my_offerings)})"}
+            )
+            or []
+        )
+        if r.get("course_id")
+    }
+    if not my_course_ids:
+        return set()
+
+    # 3. courses → the viewer's school ids
+    school_ids = {
+        r["school_id"]
+        for r in (
+            table("courses").select(
+                "school_id", filters={"id": f"in.({','.join(my_course_ids)})"}
+            )
+            or []
+        )
+        if r.get("school_id")
+    }
+    if not school_ids:
+        return set()
+
+    # 4. school ids → every course at those schools
+    school_course_ids = {
+        r["id"]
+        for r in (
+            table("courses").select(
+                "id", filters={"school_id": f"in.({','.join(school_ids)})"}
+            )
+            or []
+        )
+    }
+    if not school_course_ids:
+        return set()
+
+    # 5. those courses → every offering
+    school_offering_ids = {
+        r["id"]
+        for r in (
+            table("course_offerings").select(
+                "id", filters={"course_id": f"in.({','.join(school_course_ids)})"}
+            )
+            or []
+        )
+    }
+    if not school_offering_ids:
+        return set()
+
+    # 6. those offerings → every enrolled user
+    return {
+        r["user_id"]
+        for r in (
+            table("enrollments").select(
+                "user_id", filters={"offering_id": f"in.({','.join(school_offering_ids)})"}
+            )
+            or []
+        )
+        if r.get("user_id")
+    }
+
+
 def enrollment_id_for(user_id: str, course_id: str, *, create: bool = False) -> str | None:
     """Resolve (user, abstract course) → the user's current-term enrollment id.
 

--- a/backend/tests/test_auth_stub_promotion.py
+++ b/backend/tests/test_auth_stub_promotion.py
@@ -1,0 +1,206 @@
+"""
+Regression tests for #285 — Google sign-in 500s when a *stub* users row exists.
+
+A stub row (`{"id": ..., "streak_count": 0}`, `google_id` NULL) is created by
+`services.graph_service.ensure_user_exists`, which `get_graph` calls for any
+authenticated request. Because the `sapling_session` cookie is HMAC-signed and
+survives a DB row delete, a still-"logged in" tab can create a stub for an
+account that no longer exists.
+
+The callback looked users up by `google_id` ONLY, so the stub (google_id NULL)
+was invisible to it. Control fell through to a blind INSERT on the deterministic
+id `user_{google_id}` — the stub's own id — and collided on `users_pkey`:
+
+    HTTP 409: {"code":"23505","message":"duplicate key value violates unique
+               constraint \"users_pkey\""}
+
+`connection.py`'s `raise_for_status()` turned that into an unhandled exception →
+`main.py`'s handler → an opaque 500, permanently, for that account.
+
+These tests drive the REAL `/google/callback` route (only the Google network hops
+are mocked) and pin all three provisioning outcomes:
+
+  (a) a stub exists      -> promoted in place; sign-in succeeds
+  (b) a brand-new user   -> still provisioned
+  (c) a full user exists -> still takes the UPDATE path (id preserved)
+
+The fence: the mocked `users`/`user_profiles` tables raise the production 409 on
+`.insert(...)`. The fixed code never blind-inserts, so any regression to `insert`
+fails these tests with the exact error from the bug report rather than silently.
+"""
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import routes.auth as auth_module
+
+# Mount ONLY the auth router — main.py pulls in logfire and the full stack.
+_app = FastAPI()
+_app.include_router(auth_module.router, prefix="/api/auth")
+
+GOOGLE_ID = "108451234567890123456"
+USER_ID = f"user_{GOOGLE_ID}"
+EMAIL = "student@bu.edu"
+
+
+def _pkey_409(*_args, **_kwargs):
+    """Raise the exact PostgREST error #285 reported, the way connection.py does."""
+    request = httpx.Request("POST", "https://example.supabase.co/rest/v1/users")
+    response = httpx.Response(
+        409,
+        json={
+            "code": "23505",
+            "details": f"Key (id)=({USER_ID}) already exists.",
+            "message": 'duplicate key value violates unique constraint "users_pkey"',
+        },
+        request=request,
+    )
+    raise httpx.HTTPStatusError("409 Conflict", request=request, response=response)
+
+
+def _mock_table_factory(users_rows):
+    """Per-table mocks. `users.select` returns `users_rows` (the google_id lookup).
+
+    `.insert` raises the production 409 on the two tables the callback writes, so
+    a blind insert can never pass silently.
+    """
+    mocks: dict = {}
+
+    def factory(name):
+        if name not in mocks:
+            m = MagicMock(name=f"table:{name}")
+            m.select.return_value = []
+            m.insert.return_value = []
+            m.update.return_value = []
+            m.upsert.return_value = []
+            mocks[name] = m
+        return mocks[name]
+
+    factory("users").select.return_value = users_rows
+    factory("users").insert.side_effect = _pkey_409
+    factory("user_profiles").insert.side_effect = _pkey_409
+    return factory, mocks
+
+
+@pytest.fixture
+def drive_callback(monkeypatch):
+    """Drive the real callback past the two Google network hops."""
+    monkeypatch.setattr(auth_module, "SESSION_SECRET", "test-secret-key")
+    monkeypatch.setattr(auth_module, "GOOGLE_AVAILABLE", True)
+
+    creds = MagicMock(token="access-tok", refresh_token="refresh-tok", expiry=None)
+    flow = MagicMock(credentials=creds)
+    fake_flow_cls = MagicMock()
+    fake_flow_cls.from_client_config.return_value = flow
+    monkeypatch.setattr(auth_module, "Flow", fake_flow_cls, raising=False)
+
+    userinfo = MagicMock()
+    userinfo.raise_for_status.return_value = None
+    userinfo.json.return_value = {
+        "id": GOOGLE_ID,
+        "email": EMAIL,
+        "name": "Ada Lovelace",
+        "picture": "https://example.com/a.png",
+    }
+    # auth.py does `import httpx` inside the function, so patch the module attr.
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: userinfo)
+
+    def _drive(users_rows):
+        factory, mocks = _mock_table_factory(users_rows)
+        monkeypatch.setattr(auth_module, "table", factory)
+
+        nonce = "nonce-abc"
+        cookie = auth_module._encode_oauth_cookie(
+            {"n": nonce, "cv": "verifier", "popup_id": None}
+        )
+        state = auth_module._encode_state({"action": "signin", "n": nonce})
+        client = TestClient(_app)
+        client.cookies.set(auth_module.OAUTH_STATE_COOKIE, cookie)
+        response = client.get(
+            f"/api/auth/google/callback?code=auth-code&state={state}",
+            follow_redirects=False,
+        )
+        return response, mocks
+
+    return _drive
+
+
+class TestStubUserPromotion:
+    """(a) A stub row must be adopted, not collided with."""
+
+    def test_stub_signin_succeeds_and_does_not_500(self, drive_callback):
+        # The stub is invisible to a google_id lookup -> select returns [].
+        response, _ = drive_callback(users_rows=[])
+        # Before the fix this raised HTTPStatusError(409) -> 500.
+        assert response.status_code in (302, 307), (
+            f"expected a redirect, got {response.status_code} — the 409 escaped"
+        )
+
+    def test_stub_is_promoted_via_upsert_on_id_not_insert(self, drive_callback):
+        _, mocks = drive_callback(users_rows=[])
+
+        mocks["users"].insert.assert_not_called()
+        mocks["users"].upsert.assert_called_once()
+
+        payload = mocks["users"].upsert.call_args.args[0]
+        kwargs = mocks["users"].upsert.call_args.kwargs
+        # on_conflict MUST target the primary key. `google_id` would not resolve
+        # #285: the stub's google_id is NULL and NULLs never conflict.
+        assert kwargs.get("on_conflict", "id") == "id"
+        assert payload["id"] == USER_ID
+        assert payload["google_id"] == GOOGLE_ID, "the stub's NULL google_id must be filled in"
+        assert payload["auth_provider"] == "google"
+        assert "last_sign_in_at" in payload
+
+    def test_profile_row_is_also_upserted(self, drive_callback):
+        """A stub that completed onboarding already has a user_profiles row
+        (user_id is the PK), so that insert 409s too."""
+        _, mocks = drive_callback(users_rows=[])
+
+        mocks["user_profiles"].insert.assert_not_called()
+        mocks["user_profiles"].upsert.assert_called_once()
+        assert mocks["user_profiles"].upsert.call_args.kwargs.get("on_conflict") == "user_id"
+        assert mocks["user_profiles"].upsert.call_args.args[0]["user_id"] == USER_ID
+
+    def test_unapproved_new_user_still_gated_to_pending(self, drive_callback):
+        """Promotion must not smuggle anyone past the approval gate."""
+        response, _ = drive_callback(users_rows=[])
+        assert "/pending" in response.headers["location"]
+
+
+class TestBrandNewUser:
+    """(b) The no-stub path must still provision a user."""
+
+    def test_new_user_row_is_created(self, drive_callback):
+        response, mocks = drive_callback(users_rows=[])
+        assert response.status_code in (302, 307)
+        mocks["users"].upsert.assert_called_once()
+        assert mocks["users"].upsert.call_args.args[0]["id"] == USER_ID
+
+
+class TestExistingUserUnchanged:
+    """(c) A fully-provisioned user must still take the UPDATE path."""
+
+    def test_existing_user_updates_and_keeps_its_own_id(self, drive_callback):
+        # A legacy row whose id is NOT `user_{google_id}` — the reason the two
+        # branches must stay separate rather than collapsing into one upsert
+        # keyed on the derived id.
+        legacy_id = "legacy-uuid-0001"
+        response, mocks = drive_callback(
+            users_rows=[{"id": legacy_id, "is_approved": True}]
+        )
+
+        assert response.status_code in (302, 307)
+        mocks["users"].update.assert_called_once()
+        assert mocks["users"].update.call_args.kwargs["filters"] == {"id": f"eq.{legacy_id}"}
+        mocks["users"].upsert.assert_not_called()
+        mocks["users"].insert.assert_not_called()
+
+    def test_approved_user_is_not_sent_to_pending(self, drive_callback):
+        response, _ = drive_callback(
+            users_rows=[{"id": USER_ID, "is_approved": True}]
+        )
+        assert "/pending" not in response.headers["location"]

--- a/backend/tests/test_profile_routes.py
+++ b/backend/tests/test_profile_routes.py
@@ -236,6 +236,47 @@ class TestGetSettings:
         assert r.json()["theme"] == "light"
 
 
+# ── PATCH /api/profile/{user_id}/settings ──────────────────────────────────
+
+class TestUpdateSettingsVisibility:
+    """profile_visibility is validated in-route against its DB CHECK enum (0031),
+    so a bad value returns 400 rather than reaching PostgREST as a raw CHECK
+    violation → 500 (#342)."""
+
+    def _tables(self):
+        captured = {}
+
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "user_settings":
+                m.select.return_value = [{"user_id": USER_ID, "profile_visibility": "public"}]
+                m.update.side_effect = lambda data, filters: captured.update({"data": data}) or [{}]
+            else:
+                m.select.return_value = []
+            return m
+
+        return table_side_effect, captured
+
+    def test_school_tier_is_accepted(self):
+        table_side_effect, captured = self._tables()
+        with _mock_self(), patch("routes.profile.table", side_effect=table_side_effect):
+            r = client.patch(
+                f"/api/profile/{USER_ID}/settings", json={"profile_visibility": "school"}
+            )
+        assert r.status_code == 200
+        assert captured["data"]["profile_visibility"] == "school"
+
+    def test_invalid_visibility_is_rejected_400(self):
+        table_side_effect, captured = self._tables()
+        with _mock_self(), patch("routes.profile.table", side_effect=table_side_effect):
+            r = client.patch(
+                f"/api/profile/{USER_ID}/settings", json={"profile_visibility": "friends"}
+            )
+        assert r.status_code == 400
+        # And nothing was written — the bad value never reached the DB.
+        assert "data" not in captured
+
+
 # ── POST /api/profile/{user_id}/equip ──────────────────────────────────────
 
 class TestEquipCosmetic:

--- a/backend/tests/test_social_students.py
+++ b/backend/tests/test_social_students.py
@@ -1,147 +1,312 @@
 """
-Unit tests for GET /api/social/students (routes/social.py::get_students).
+Tests for GET /api/social/students (routes/social.py::get_students) and the
+school-scoping helper that backs it (services/academics.py::school_peer_user_ids).
 
-After the academics split (migration 0020) the abstract `courses` table no
-longer has a `user_id` column or per-enrollment rows. A user's courses are now
-resolved through the enrollment chain:
+#342 turned this endpoint from "return a profile for every user in the DB" into
+a school-scoped, visibility-respecting directory with a mastery-free payload.
+These tests pin all three:
 
-    enrollments(user_id) -> course_offerings(course_id) -> courses(course_name)
+  - scope:      only users sharing the viewer's school are returned;
+  - visibility: users with profile_visibility == 'private' are dropped;
+  - payload:    rows carry name/streak/courses only — no mastery data.
 
-These tests pin the new offering-aware resolution and the (unchanged) response
-shape of the endpoint.
+The route mocks are deliberately filter-aware: the `users`/`enrollments` mocks
+return only rows matching the `in.(...)` filter the route builds, so a route
+that forgot to scope its reads would fail these tests rather than pass on a mock
+that ignores filters.
 """
 from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 
+import routes.social as social
 from main import app
+from services import academics
 
 client = TestClient(app)
 
 
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _parse_in(filters: dict | None, col: str) -> set[str]:
+    """Parse a PostgREST ``{col: 'in.(a,b,c)'}`` filter into a set of ids."""
+    if not filters or col not in filters:
+        return set()
+    raw = filters[col]
+    assert raw.startswith("in.("), f"expected an in.() filter, got {raw!r}"
+    inner = raw[len("in.(") : -1]
+    return set(p for p in inner.split(",") if p)
+
+
+def _route_tables(settings_rows, all_users, all_enrollments):
+    """Factory + captured per-table mocks for the route's `table()` calls.
+
+    `users` and `enrollments` are filter-aware — they return only rows whose id
+    matches the route's `in.(...)` filter, so the scoping the route applies is
+    reflected in the output (and any missing filter would raise in _parse_in).
+    """
+    mocks: dict = {}
+
+    def factory(name):
+        if name in mocks:
+            return mocks[name]
+        m = MagicMock(name=f"table:{name}")
+        if name == "user_settings":
+            m.select.return_value = settings_rows
+        elif name == "users":
+            def _users_select(cols=None, filters=None, **kw):
+                ids = _parse_in(filters, "id")
+                return [u for u in all_users if u["id"] in ids]
+            m.select.side_effect = _users_select
+        elif name == "enrollments":
+            def _enr_select(cols=None, filters=None, **kw):
+                ids = _parse_in(filters, "user_id")
+                return [e for e in all_enrollments if e["user_id"] in ids]
+            m.select.side_effect = _enr_select
+        else:
+            m.select.return_value = []
+        mocks[name] = m
+        return m
+
+    return factory, mocks
+
+
 def _enrollment(user_id: str, course_name: str) -> dict:
-    """An enrollments row with the PostgREST embedded course-offering -> course join."""
+    """An enrollments row with the PostgREST embedded course-offering → course join."""
     return {
         "user_id": user_id,
         "course_offerings": {"courses": {"course_name": course_name}},
     }
 
 
-def _table_factory(users, enrollment_rows, node_rows):
-    def table_side_effect(name):
-        m = MagicMock()
-        if name == "users":
-            m.select.return_value = users
-        elif name == "enrollments":
-            m.select.return_value = enrollment_rows
-        elif name == "graph_nodes":
-            m.select.return_value = node_rows
-        else:
-            m.select.return_value = []
+# ── route: scope ────────────────────────────────────────────────────────────
+
+
+class TestSchoolScope:
+    def test_only_school_peers_are_returned(self):
+        peers = {"user_andres", "user_maya", "user_sam"}
+        all_users = [
+            {"id": "user_andres", "streak_count": 3},
+            {"id": "user_maya", "streak_count": 9},
+            {"id": "user_sam", "streak_count": 5},
+            # A user outside the viewer's school — must NOT appear even though the
+            # `users` table physically contains them.
+            {"id": "user_outsider", "streak_count": 99},
+        ]
+        factory, mocks = _route_tables(
+            settings_rows=[],
+            all_users=all_users,
+            all_enrollments=[
+                _enrollment("user_maya", "Calculus II"),
+                _enrollment("user_sam", "Algorithms"),
+            ],
+        )
+        with patch.object(social.academics, "school_peer_user_ids", return_value=peers), \
+             patch.object(social, "table", factory), \
+             patch.object(social, "get_display_names", return_value={
+                 "user_andres": "Andres", "user_maya": "Maya", "user_sam": "Sam",
+             }):
+            r = client.get("/api/social/students")
+
+        assert r.status_code == 200
+        ids = {s["user_id"] for s in r.json()["students"]}
+        assert ids == peers
+        assert "user_outsider" not in ids
+        # The users read was scoped to exactly the school peers.
+        assert _parse_in(mocks["users"].select.call_args.kwargs["filters"], "id") == peers
+
+    def test_empty_scope_returns_empty_and_reads_nothing_else(self):
+        factory, _ = _route_tables([], [], [])
+        tbl = MagicMock(side_effect=factory)  # wrap so we can assert it isn't called
+        with patch.object(social.academics, "school_peer_user_ids", return_value=set()), \
+             patch.object(social, "table", tbl), \
+             patch.object(social, "get_display_names") as names:
+            r = client.get("/api/social/students")
+
+        assert r.status_code == 200
+        assert r.json() == {"students": []}
+        # Fail closed: no user_settings/users/enrollments reads, no name decrypt.
+        tbl.assert_not_called()
+        names.assert_not_called()
+
+
+# ── route: visibility ──────────────────────────────────────────────────────
+
+
+class TestProfileVisibility:
+    def test_private_users_are_excluded(self):
+        peers = {"user_andres", "user_maya", "user_priya"}
+        all_users = [
+            {"id": "user_andres", "streak_count": 3},
+            {"id": "user_maya", "streak_count": 9},
+            {"id": "user_priya", "streak_count": 14},
+        ]
+        factory, mocks = _route_tables(
+            settings_rows=[{"user_id": "user_priya", "profile_visibility": "private"}],
+            all_users=all_users,
+            all_enrollments=[],
+        )
+        with patch.object(social.academics, "school_peer_user_ids", return_value=peers), \
+             patch.object(social, "table", factory), \
+             patch.object(social, "get_display_names", return_value={
+                 "user_andres": "Andres", "user_maya": "Maya", "user_priya": "Priya",
+             }):
+            r = client.get("/api/social/students")
+
+        ids = {s["user_id"] for s in r.json()["students"]}
+        assert ids == {"user_andres", "user_maya"}
+        assert "user_priya" not in ids
+        # The users read excluded the private user up front.
+        assert "user_priya" not in _parse_in(
+            mocks["users"].select.call_args.kwargs["filters"], "id"
+        )
+
+    def test_public_and_school_tiers_are_both_listed(self):
+        peers = {"user_pub", "user_sch"}
+        factory, _ = _route_tables(
+            settings_rows=[
+                {"user_id": "user_pub", "profile_visibility": "public"},
+                {"user_id": "user_sch", "profile_visibility": "school"},
+            ],
+            all_users=[
+                {"id": "user_pub", "streak_count": 1},
+                {"id": "user_sch", "streak_count": 2},
+            ],
+            all_enrollments=[],
+        )
+        with patch.object(social.academics, "school_peer_user_ids", return_value=peers), \
+             patch.object(social, "table", factory), \
+             patch.object(social, "get_display_names", return_value={
+                 "user_pub": "Pub", "user_sch": "Sch",
+             }):
+            r = client.get("/api/social/students")
+
+        assert {s["user_id"] for s in r.json()["students"]} == peers
+
+    def test_missing_settings_row_defaults_to_listed(self):
+        # A peer with no user_settings row keeps the column default ('public').
+        peers = {"user_nosettings"}
+        factory, _ = _route_tables(
+            settings_rows=[],
+            all_users=[{"id": "user_nosettings", "streak_count": 0}],
+            all_enrollments=[],
+        )
+        with patch.object(social.academics, "school_peer_user_ids", return_value=peers), \
+             patch.object(social, "table", factory), \
+             patch.object(social, "get_display_names", return_value={"user_nosettings": "Nemo"}):
+            r = client.get("/api/social/students")
+
+        assert {s["user_id"] for s in r.json()["students"]} == peers
+
+    def test_all_peers_private_returns_empty(self):
+        peers = {"user_a", "user_b"}
+        factory, _ = _route_tables(
+            settings_rows=[
+                {"user_id": "user_a", "profile_visibility": "private"},
+                {"user_id": "user_b", "profile_visibility": "private"},
+            ],
+            all_users=[{"id": "user_a", "streak_count": 0}, {"id": "user_b", "streak_count": 0}],
+            all_enrollments=[],
+        )
+        with patch.object(social.academics, "school_peer_user_ids", return_value=peers), \
+             patch.object(social, "table", factory), \
+             patch.object(social, "get_display_names") as names:
+            r = client.get("/api/social/students")
+
+        assert r.json() == {"students": []}
+        names.assert_not_called()
+
+
+# ── route: payload ─────────────────────────────────────────────────────────
+
+
+class TestPayloadShape:
+    def test_no_mastery_fields_and_courses_deduped(self):
+        peers = {"user_maya"}
+        factory, _ = _route_tables(
+            settings_rows=[],
+            all_users=[{"id": "user_maya", "streak_count": 9}],
+            # Same abstract course via two offerings → one deduped entry.
+            all_enrollments=[
+                _enrollment("user_maya", "Calculus II"),
+                _enrollment("user_maya", "Calculus II"),
+                _enrollment("user_maya", "Linear Algebra"),
+            ],
+        )
+        with patch.object(social.academics, "school_peer_user_ids", return_value=peers), \
+             patch.object(social, "table", factory), \
+             patch.object(social, "get_display_names", return_value={"user_maya": "Maya"}):
+            r = client.get("/api/social/students")
+
+        row = r.json()["students"][0]
+        assert set(row.keys()) == {"user_id", "name", "streak", "courses"}
+        assert "stats" not in row and "top_concepts" not in row
+        assert row["courses"] == ["Calculus II", "Linear Algebra"]
+        assert row["streak"] == 9
+        assert row["name"] == "Maya"
+
+    def test_never_reads_graph_nodes(self):
+        # Mastery is gone entirely — the route must not touch graph_nodes.
+        peers = {"user_maya"}
+        factory, mocks = _route_tables(
+            settings_rows=[], all_users=[{"id": "user_maya", "streak_count": 0}], all_enrollments=[]
+        )
+        with patch.object(social.academics, "school_peer_user_ids", return_value=peers), \
+             patch.object(social, "table", factory), \
+             patch.object(social, "get_display_names", return_value={"user_maya": "Maya"}):
+            client.get("/api/social/students")
+        assert "graph_nodes" not in mocks
+
+
+# ── helper: academics.school_peer_user_ids ─────────────────────────────────
+
+
+def _chain_tables(responses: dict):
+    """`table()` factory whose select() dispatches on (table_name, filter_col).
+
+    Distinguishes the two reads that hit the same table with different filters
+    (course_offerings by id vs by course_id; enrollments by user_id vs by
+    offering_id).
+    """
+    def factory(name):
+        m = MagicMock(name=f"table:{name}")
+        def _select(cols=None, filters=None, **kw):
+            fcol = next(iter(filters.keys())) if filters else None
+            return responses.get((name, fcol), [])
+        m.select.side_effect = _select
         return m
-
-    return table_side_effect
-
-
-def _names_for(users):
-    """Display names now live on user_profiles; the route resolves them via
-    services.profiles.get_display_names (patched here). Each fixture user's
-    `name` key stands in for that user's decrypted profile name."""
-    return {u["id"]: u["name"] for u in users}
+    return factory
 
 
-class TestGetStudents:
-    def test_courses_resolved_via_enrollments(self):
-        users = [{"id": "u1", "name": "Alice", "streak_count": 3}]
-        enrollments = [
-            _enrollment("u1", "Intro CS"),
-            _enrollment("u1", "Calculus I"),
-        ]
-        with patch(
-            "routes.social.table",
-            side_effect=_table_factory(users, enrollments, []),
-        ), patch("routes.social.get_display_names", return_value=_names_for(users)):
-            r = client.get("/api/social/students")
-
-        assert r.status_code == 200
-        students = r.json()["students"]
-        assert len(students) == 1
-        assert students[0]["user_id"] == "u1"
-        assert students[0]["courses"] == ["Calculus I", "Intro CS"]  # sorted
-
-    def test_courses_deduped_across_offerings(self):
-        # Same abstract course taught in two offerings -> appears once.
-        users = [{"id": "u1", "name": "Alice", "streak_count": 0}]
-        enrollments = [
-            _enrollment("u1", "Intro CS"),
-            _enrollment("u1", "Intro CS"),
-            _enrollment("u1", "Calculus I"),
-        ]
-        with patch(
-            "routes.social.table",
-            side_effect=_table_factory(users, enrollments, []),
-        ), patch("routes.social.get_display_names", return_value=_names_for(users)):
-            r = client.get("/api/social/students")
-
-        assert r.status_code == 200
-        courses = r.json()["students"][0]["courses"]
-        assert courses == ["Calculus I", "Intro CS"]
-
-    def test_courses_grouped_per_user(self):
-        users = [
-            {"id": "u1", "name": "Alice", "streak_count": 1},
-            {"id": "u2", "name": "Bob", "streak_count": 2},
-        ]
-        enrollments = [
-            _enrollment("u1", "Intro CS"),
-            _enrollment("u2", "Physics"),
-        ]
-        with patch(
-            "routes.social.table",
-            side_effect=_table_factory(users, enrollments, []),
-        ), patch("routes.social.get_display_names", return_value=_names_for(users)):
-            r = client.get("/api/social/students")
-
-        assert r.status_code == 200
-        by_id = {s["user_id"]: s for s in r.json()["students"]}
-        assert by_id["u1"]["courses"] == ["Intro CS"]
-        assert by_id["u2"]["courses"] == ["Physics"]
-
-    def test_no_enrollments_yields_empty_courses(self):
-        users = [{"id": "u1", "name": "Alice", "streak_count": 0}]
-        with patch(
-            "routes.social.table",
-            side_effect=_table_factory(users, [], []),
-        ), patch("routes.social.get_display_names", return_value=_names_for(users)):
-            r = client.get("/api/social/students")
-
-        assert r.status_code == 200
-        students = r.json()["students"]
-        assert len(students) == 1
-        assert students[0]["courses"] == []
-
-    def test_response_shape_preserved(self):
-        users = [{"id": "u1", "name": "Alice", "streak_count": 5}]
-        enrollments = [_enrollment("u1", "Intro CS")]
-        node_rows = [
-            {"user_id": "u1", "mastery_tier": "mastered",
-             "concept_name": "Loops", "mastery_score": 0.9},
-            {"user_id": "u1", "mastery_tier": "struggling",
-             "concept_name": "Recursion", "mastery_score": 0.2},
-        ]
-        with patch(
-            "routes.social.table",
-            side_effect=_table_factory(users, enrollments, node_rows),
-        ), patch("routes.social.get_display_names", return_value=_names_for(users)):
-            r = client.get("/api/social/students")
-
-        assert r.status_code == 200
-        student = r.json()["students"][0]
-        assert set(student.keys()) == {
-            "user_id", "name", "streak", "courses", "stats", "top_concepts"
+class TestSchoolPeerUserIds:
+    def test_traverses_enrollment_chain_to_school_peers(self):
+        responses = {
+            ("enrollments", "user_id"): [{"id": "e1", "offering_id": "off1"}],   # viewer's enrollments
+            ("course_offerings", "id"): [{"course_id": "c1"}],                    # off1 → course c1
+            ("courses", "id"): [{"school_id": "s1"}],                             # c1 → school s1
+            ("courses", "school_id"): [{"id": "c1"}, {"id": "c2"}],               # all courses at s1
+            ("course_offerings", "course_id"): [{"id": "off1"}, {"id": "off2"}],  # their offerings
+            ("enrollments", "offering_id"): [                                     # everyone enrolled
+                {"user_id": "user_v"}, {"user_id": "user_peer"}, {"user_id": "user_peer"},
+            ],
         }
-        assert student["streak"] == 5
-        assert student["top_concepts"] == ["Loops"]
-        assert student["stats"]["mastered"] == 1
-        assert student["stats"]["struggling"] == 1
-        assert student["stats"]["total"] == 2
+        with patch.object(academics, "table", _chain_tables(responses)):
+            assert academics.school_peer_user_ids("user_v") == {"user_v", "user_peer"}
+
+    def test_no_enrollments_returns_empty(self):
+        with patch.object(academics, "table", _chain_tables({("enrollments", "user_id"): []})):
+            assert academics.school_peer_user_ids("user_v") == set()
+
+    def test_course_without_school_fails_closed(self):
+        responses = {
+            ("enrollments", "user_id"): [{"id": "e1", "offering_id": "off1"}],
+            ("course_offerings", "id"): [{"course_id": "c1"}],
+            ("courses", "id"): [{"school_id": None}],  # no school → empty scope
+        }
+        with patch.object(academics, "table", _chain_tables(responses)):
+            assert academics.school_peer_user_ids("user_v") == set()
+
+    def test_empty_user_id_returns_empty(self):
+        with patch.object(academics, "table", _chain_tables({})):
+            assert academics.school_peer_user_ids("") == set()

--- a/frontend/src/components/screens/Social.tsx
+++ b/frontend/src/components/screens/Social.tsx
@@ -931,8 +931,7 @@ function SchoolDirectory() {
     if (!t) return students;
     return students.filter(s =>
       s.name.toLowerCase().includes(t) ||
-      s.courses.some(c => c.toLowerCase().includes(t)) ||
-      s.top_concepts.some(c => c.toLowerCase().includes(t))
+      s.courses.some(c => c.toLowerCase().includes(t))
     );
   }, [q, students]);
 
@@ -985,15 +984,8 @@ function SchoolDirectory() {
                       {s.courses.slice(0, 3).join(" · ")}
                     </div>
                   )}
-                  {s.top_concepts.length > 0 && (
-                    <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 6 }}>
-                      {s.top_concepts.slice(0, 3).map(c => (
-                        <span key={c} className="chip chip--accent">{c}</span>
-                      ))}
-                    </div>
-                  )}
                   <div style={{ fontSize: 10, color: "var(--text-muted)", marginTop: 6 }}>
-                    {s.stats.mastered}/{s.stats.total} concepts · {s.streak}d streak
+                    {s.streak}d streak
                   </div>
                 </div>
               </Link>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -380,8 +380,9 @@ export interface StudentRow {
   name: string;
   streak: number;
   courses: string[];
-  stats: { mastered: number; learning: number; struggling: number; unexplored: number; total: number };
-  top_concepts: string[];
+  // Per-concept mastery (stats/top_concepts) was removed from this endpoint in
+  // #342: it is academic-performance data that belongs on the profile page, not
+  // in a browsable directory. The directory is now name + courses + streak only.
 }
 
 export const getStudents = () =>

--- a/frontend/src/lib/localData.ts
+++ b/frontend/src/lib/localData.ts
@@ -349,11 +349,12 @@ const LOCAL_ROOM_ACTIVITY = [
   { id: 'act3', user_name: LOCAL_USER.name, activity_type: 'studied', concept_name: 'Integration by Parts', created_at: minutesAgo(400) },
 ];
 
+// Mastery (stats/top_concepts) dropped from the directory payload in #342.
 const LOCAL_STUDENTS = [
-  { user_id: 'peer-maya', name: 'Maya Chen', streak: 9, courses: ['Calculus II', 'Linear Algebra'], stats: { mastered: 6, learning: 3, struggling: 1, unexplored: 2, total: 12 }, top_concepts: ['Taylor Series', 'Polar Coordinates', 'Eigenvalues'] },
-  { user_id: 'peer-sam', name: 'Sam Rivera', streak: 5, courses: ['Data Structures', 'Algorithms'], stats: { mastered: 5, learning: 4, struggling: 2, unexplored: 1, total: 12 }, top_concepts: ['Graph Algorithms', 'Hash Maps', 'Sorting'] },
-  { user_id: 'peer-priya', name: 'Priya Patel', streak: 14, courses: ['Intro to Psychology', 'Statistics'], stats: { mastered: 8, learning: 2, struggling: 0, unexplored: 3, total: 13 }, top_concepts: ['Memory & Encoding', 'Hypothesis Testing'] },
-  { user_id: 'peer-jordan', name: 'Jordan Lee', streak: 2, courses: ['Data Structures'], stats: { mastered: 2, learning: 5, struggling: 3, unexplored: 4, total: 14 }, top_concepts: ['Binary Trees'] },
+  { user_id: 'peer-maya', name: 'Maya Chen', streak: 9, courses: ['Calculus II', 'Linear Algebra'] },
+  { user_id: 'peer-sam', name: 'Sam Rivera', streak: 5, courses: ['Data Structures', 'Algorithms'] },
+  { user_id: 'peer-priya', name: 'Priya Patel', streak: 14, courses: ['Intro to Psychology', 'Statistics'] },
+  { user_id: 'peer-jordan', name: 'Jordan Lee', streak: 2, courses: ['Data Structures'] },
 ];
 
 export function handleLocalRequest(path: string, options?: RequestInit): unknown {


### PR DESCRIPTION
Three independent fixes from the issue batch. Each is a self-contained commit; reviewable commit-by-commit.

Closes #342
Closes #285
Closes #343

---

## #342 — scope `/api/social/students` to the viewer's school *(security, P2)*

`get_students` returned a profile for **every user in the DB** — name, streak, courses, **and per-concept mastery** — to any authenticated caller. The session `user_id` was bound and never used, so the endpoint authenticated without authorizing.

**Decision (product call, confirmed):** scope to *school* + honor `profile_visibility`; trim mastery from the payload.

- **School scope** via a new bulk helper `academics.school_peer_user_ids(user_id)` — walks `enrollments → course_offerings.course_id → courses.school_id` and back to every user enrolled at those schools. Multi-step reads per the module's house style; **not cached** (mutable visibility boundary); **fails closed** on empty scope, mirroring the enrollment-scoping pattern in `calendar.py`.
- **Visibility:** `profile_visibility == 'private'` users are dropped from the listing. Migration `0031` widens the `user_settings` CHECK to allow the `'school'` tier the Settings UI has always offered but the DB rejected (a latent 500 on selecting it); `update_settings` now validates the value → **400** instead of a raw CHECK violation.
- **Payload trimmed** to `name/streak/courses`. The mastery histogram + top concepts are academic-performance data that belong on the profile page (already gated on `profile_visibility`), not a browsable directory. Frontend directory, `StudentRow` type, and local-mode fixture updated to match.

⚠️ **Deploy note — migration `0031` is applied per-environment, not by merge:**

- **Staging DB: already applied + verified** (2026-07-17). The staging project has a clean `schema_migrations` ledger; only `0031` was pending. Constraint is now `CHECK (profile_visibility = ANY (ARRAY['public','school','private']))`. Safe to have applied ahead of the code — it only removes the pre-existing `'school'` 500 in Settings.
- **Prod DB: NOT applied — do NOT run a plain `db.migrate` against prod.** Prod has **no `schema_migrations` ledger** (#317), so the runner would treat all 34 migrations as pending and try to re-run them from scratch. `--baseline` alone is also wrong (it would mark `0031` applied without running it). Correct sequence as part of the `main→production` promotion: **(1)** baseline `0001`–`0030` on prod so the already-present schema is recorded, **(2)** then apply only `0031` for real. This fixes the #317 gap for prod as a side effect and needs a human watching.

## #285 — promote stub users on sign-in instead of 409'ing *(auth)*

Sign-in 500'd whenever a **stub** `users` row existed (id set, `google_id` NULL — created by `graph_service.ensure_user_exists`, reachable after a row delete because the HMAC `sapling_session` cookie outlives it). The new-user branch looked up by `google_id` only (NULL never matches), fell through to a blind INSERT on the deterministic id `user_{google_id}`, and collided on `users_pkey` → unhandled 409 → permanent sign-in 500 loop.

- Both blind inserts (`users` **and** `user_profiles` — its `user_id` is also a PK and 409s for a stub that reached onboarding) become **upserts**.
- `on_conflict` is the **primary key, not `google_id`**: the stub's `google_id` is NULL and NULLs never conflict, so only an id-conflict resolves it; `merge-duplicates` fills the NULL auth columns in.
- The existing-user branch is untouched, so a legacy row whose id ≠ `user_{google_id}` keeps its id.
- Tests drive the **real** `/google/callback` with the mocked tables raising the exact production 409 on insert — a regression to a blind insert fails loudly.

## #343 — enable CodeRabbit on long-lived integration branches *(CI, P2)*

CodeRabbit reviews only the default branch unless base branches are listed, and the repo had **no `.coderabbit.yaml` at all** — so PRs targeting an integration branch got "Review skipped" while CI stayed green.

- Adds `.coderabbit.yaml` listing `^production$` and `^staging$` (anchored regex, validated against `schema.v2.json`).
- The gap that still matters is **`production`**: `main → production` promotion PRs (#305, #314) are the last gate before prod and were never machine-reviewed. `staging` is listed defensively (that branch was deleted 2026-07-15; no open PR currently targets a non-main base).

---

## Verification
- Backend: **966 passed**, only the 3 pre-existing failures on clean main (`test_storage_service` ×2, `test_ocr_pipeline` event-loop error). `ruff check` clean on all touched files.
- Frontend: `tsc --noEmit` clean, `eslint` clean on touched files, **88 vitest tests pass**.
- New tests: `test_auth_stub_promotion.py` (7), rewritten `test_social_students.py` (scope/visibility/payload + `school_peer_user_ids` traversal), `test_profile_routes.py` visibility-validation.

## Not included
- **#164** (dead `?resume=`/`?session=` Learn links) is intentionally **deferred**: it lives in `Learn.tsx`, which draft PR #349 rewrites (+408/−46), and #349 does **not** fix it. Doing it now guarantees a conflict and throwaway work; it should be a #349 follow-up. Details on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a school-scoped student directory that shows peers based on shared school enrollment.
  - Added profile visibility options: Public, School, and Private.
  - Directory entries now display student names, courses, and learning streaks.

- **Bug Fixes**
  - Improved Google sign-in for accounts with pre-existing records.
  - Invalid profile visibility values now return a clear validation error instead of a server error.
  - Private profiles are excluded from the school directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->