### PR TITLE
fix(agents): fresh google client for run_agent_sync agent routes (part of #354)

### DIFF
--- a/backend/agents/_run.py
+++ b/backend/agents/_run.py
@@ -21,7 +21,29 @@ T = TypeVar("T")
 def run_agent_sync(coro: Coroutine[Any, Any, T]) -> T:
     """Run an agent coroutine to completion from synchronous code.
 
-    Must be called from a thread with no running event loop (the case for
-    FastAPI sync handlers and direct unit-test calls under TestClient).
+    Intended for FastAPI sync ``def`` handlers, which FastAPI runs in a worker
+    thread with no event loop — there ``asyncio.run`` drives the agent.
+
+    Some sync helpers are ALSO reached from *async* handlers via a sync call
+    chain (e.g. ``build_system_prompt`` -> ``get_course_context`` -> here, from
+    the async legacy chat / start-session paths). A loop is already running on
+    that thread, so ``asyncio.run`` can't be used and — critically — we must not
+    block the event loop on an LLM round-trip. The old code let ``asyncio.run``
+    raise and leaked a "coroutine 'run' was never awaited" warning. Instead,
+    close ``coro`` (no warning) and raise a clear error so the (already
+    ``try/except``-guarded) caller degrades gracefully; the async path should
+    ``await`` the agent directly rather than route through this seam.
     """
-    return asyncio.run(coro)
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No loop on this thread: the sanctioned synchronous seam.
+        return asyncio.run(coro)
+    # A loop is already running: we can't drive the coroutine here without
+    # blocking it. Close it to avoid a "never awaited" warning, then signal
+    # the misuse clearly for the caller to handle.
+    coro.close()
+    raise RuntimeError(
+        "run_agent_sync() was called from a running event loop; async callers "
+        "must await the agent directly."
+    )

--- a/backend/routes/graph.py
+++ b/backend/routes/graph.py
@@ -14,6 +14,7 @@ from services.graph_service import (
 )
 from services.request_context import current_request_id
 from agents import WORKER_LIMITS
+from agents._providers import fresh_model_for
 from agents._run import run_agent_sync
 from agents.deps import SaplingDeps
 from agents.concept_describe import concept_describe_agent, build_message
@@ -134,6 +135,11 @@ def describe_concept(user_id: str, body: ConceptDescriptionBody, request: Reques
                 build_message(concept, course_label),
                 deps=deps,
                 usage_limits=WORKER_LIMITS,
+                # Fresh client: run_agent_sync drives this on a throwaway
+                # per-request loop, and the shared client's pooled connection
+                # outlives the loop that opened it -> "Event loop is closed" on
+                # the next call in a reused worker thread. See fresh_model_for.
+                model=fresh_model_for("concept_describe"),
             )
         )
     except (AgentRunError, httpx.HTTPError, ValidationError) as e:

--- a/backend/services/course_context_service.py
+++ b/backend/services/course_context_service.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 from functools import lru_cache
 
 from db.connection import table
+from agents._providers import fresh_model_for
 from agents._run import run_agent_sync
 from agents.course_summary import course_summary_agent
 
@@ -52,7 +53,12 @@ def _generate_summary_with_gemini(
     )
 
     try:
-        result = run_agent_sync(course_summary_agent.run(user_message))
+        # Fresh client: run_agent_sync drives this on a throwaway per-request
+        # loop; the shared client's pooled connection would outlive it and trip
+        # "Event loop is closed" on reuse. See fresh_model_for.
+        result = run_agent_sync(
+            course_summary_agent.run(user_message, model=fresh_model_for("course_summary"))
+        )
         return result.output.summary
     except Exception:
         # Fallback summary if the agent fails

--- a/backend/tests/test_run_agent_sync_loop.py
+++ b/backend/tests/test_run_agent_sync_loop.py
@@ -1,0 +1,49 @@
+# backend/tests/test_run_agent_sync_loop.py
+"""Regression: run_agent_sync's loop handling + fresh-client agent runs.
+
+The module-level google client is unsafe across event loops: a connection it
+pooled on one loop trips `RuntimeError: Event loop is closed` when reused after
+that loop is gone. `run_agent_sync` drives agents on throwaway per-request
+loops (`asyncio.run`), so agents run through it must use a FRESH client, and it
+must never (a) blindly `asyncio.run` from inside a running loop or (b) leak the
+coroutine it was handed.
+"""
+import asyncio
+import inspect
+
+import pytest
+
+from agents._providers import _provider, fresh_model_for, model_name_for
+from agents._run import run_agent_sync
+
+
+def test_runs_coroutine_when_no_loop():
+    async def work():
+        return 7
+
+    assert run_agent_sync(work()) == 7
+
+
+def test_from_running_loop_raises_and_closes_coro():
+    """Called from an async context it must not asyncio.run (that would raise
+    opaquely) nor leak the coroutine (a "never awaited" warning); it closes the
+    coroutine and raises a clear error the caller can degrade on."""
+    async def scenario():
+        async def agent_call():
+            return 1
+
+        coro = agent_call()
+        with pytest.raises(RuntimeError, match="running event loop"):
+            run_agent_sync(coro)
+        # Closed, not abandoned — so no "coroutine was never awaited" warning.
+        assert inspect.getcoroutinestate(coro) == inspect.CORO_CLOSED
+
+    asyncio.run(scenario())
+
+
+def test_fresh_model_for_uses_a_fresh_provider():
+    m = fresh_model_for("concept_describe")
+    assert m.provider is not _provider
+    assert m.model_name == model_name_for("concept_describe")
+    # Distinct client each call — no cross-loop connection reuse.
+    assert fresh_model_for("concept_describe").provider is not m.provider


### PR DESCRIPTION
Part of #354. Stacked on #349 (`feat/streaming-tutor`) — merge that first.

## Root cause

Same one as #349's streaming crash: the module-level shared `google.genai` client (`agents/_providers.py::_provider`) is **unsafe across event loops**. Its httpx pool caches connections bound to the loop that opened them; reusing/closing one on a different (or already-closed) loop trips `RuntimeError: Event loop is closed`.

`run_agent_sync()` drives agents on throwaway per-request loops (`asyncio.run`) inside FastAPI's reused sync-handler threadpool threads — so the 2nd call in a thread trips over the 1st call's stale connection.

**Reproduced on `main`:** `POST /api/graph/{user_id}/concept-description` returns a flaky `500 / 200 / 500` on repeat calls (surfaced as React errors in the Learn knowledge-map).

## What this does

- `concept_describe` (`routes/graph.py`) and `course_summary` (`services/course_context_service.py`) now run on a fresh client via `model=fresh_model_for(...)`.
- `run_agent_sync` hardened: when misused from a running event loop it now closes the coroutine (kills the "coroutine was never awaited" warning) and raises a clear error the caller degrades on — instead of blocking the loop or leaking.
- Adds `tests/test_run_agent_sync_loop.py`.

The `fresh_google_model` / `fresh_model_for` / `model_name_for` helpers land in #349.

## Verification

- `POST /api/graph/{u}/concept-description` × 5 in a row → **200 every time** (was 500/200/500 on `main`); 0 `Event loop is closed` in logs.
- Streaming (#349) still reaches `done` with graph deltas; non-streaming `/chat` unaffected.
- `161 passed` across the affected suites (learn, graph, quiz, social, study_guide, course_context, streaming, run_agent_sync).

## Not in this PR (remaining #354 scope)

The same one-line fresh-client fix still needs applying to the other sync-handler agent routes: `study_guide.py:104`, `social.py:142`, `documents.py:245`, `quiz.py:459`, `flashcard_import_service.py:249`, `main.py:222`. Tracked in #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
