### PR TITLE
fix(agents): guard run_agent_sync against running event loops (#354 follow-up)

### DIFF
--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -95,6 +95,12 @@ _DEFAULTS: dict[AgentTask, str] = {
 }
 
 
+# The admin `/api/gemini-test` connectivity probe has no `_DEFAULTS` task of
+# its own; it just needs the cheapest round-trip. Pinned here so probe sites
+# (agents/health.py) can't drift from each other.
+HEALTH_PROBE_MODEL = "gemini-2.5-flash-lite"
+
+
 def _new_provider() -> GoogleProvider:
     """A fresh `GoogleProvider` (fresh `google.genai` client + httpx connection
     pool). CI and import-time tools don't have GEMINI_API_KEY set; the dummy

--- a/backend/agents/_run.py
+++ b/backend/agents/_run.py
@@ -25,8 +25,9 @@ def run_agent_sync(coro: Coroutine[Any, Any, T]) -> T:
     thread with no event loop — there ``asyncio.run`` drives the agent.
 
     Some sync helpers are ALSO reached from *async* handlers via a sync call
-    chain (e.g. ``build_system_prompt`` -> ``get_course_context`` -> here, from
-    the async legacy chat / start-session paths). A loop is already running on
+    chain (e.g. ``_legacy_chat`` -> ``apply_graph_update`` ->
+    ``update_course_context`` -> ``_generate_summary_with_gemini`` -> here,
+    and the same shape from the async upload pipeline). A loop is already running on
     that thread, so ``asyncio.run`` can't be used and — critically — we must not
     block the event loop on an LLM round-trip. The old code let ``asyncio.run``
     raise and leaked a "coroutine 'run' was never awaited" warning. Instead,

--- a/backend/agents/_run.py
+++ b/backend/agents/_run.py
@@ -21,7 +21,29 @@ T = TypeVar("T")
 def run_agent_sync(coro: Coroutine[Any, Any, T]) -> T:
     """Run an agent coroutine to completion from synchronous code.
 
-    Must be called from a thread with no running event loop (the case for
-    FastAPI sync handlers and direct unit-test calls under TestClient).
+    Intended for FastAPI sync ``def`` handlers, which FastAPI runs in a worker
+    thread with no event loop — there ``asyncio.run`` drives the agent.
+
+    Some sync helpers are ALSO reached from *async* handlers via a sync call
+    chain (e.g. ``build_system_prompt`` -> ``get_course_context`` -> here, from
+    the async legacy chat / start-session paths). A loop is already running on
+    that thread, so ``asyncio.run`` can't be used and — critically — we must not
+    block the event loop on an LLM round-trip. The old code let ``asyncio.run``
+    raise and leaked a "coroutine 'run' was never awaited" warning. Instead,
+    close ``coro`` (no warning) and raise a clear error so the (already
+    ``try/except``-guarded) caller degrades gracefully; the async path should
+    ``await`` the agent directly rather than route through this seam.
     """
-    return asyncio.run(coro)
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No loop on this thread: the sanctioned synchronous seam.
+        return asyncio.run(coro)
+    # A loop is already running: we can't drive the coroutine here without
+    # blocking it. Close it to avoid a "never awaited" warning, then signal
+    # the misuse clearly for the caller to handle.
+    coro.close()
+    raise RuntimeError(
+        "run_agent_sync() was called from a running event loop; async callers "
+        "must await the agent directly."
+    )

--- a/backend/agents/health.py
+++ b/backend/agents/health.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 from pydantic_ai import Agent
 
-from agents._providers import google_model
+from agents._providers import HEALTH_PROBE_MODEL, google_model
 
 
 # Cheapest model on the shared provider; the probe only needs a round-trip.
 health_probe_agent = Agent[None, str](
-    model=google_model("gemini-2.5-flash-lite"),
+    model=google_model(HEALTH_PROBE_MODEL),
     output_type=str,
     system_prompt="You are a connectivity probe. Reply with exactly the text the user asks for.",
     metadata={"agent": "health_probe"},

--- a/backend/tests/test_run_agent_sync_loop.py
+++ b/backend/tests/test_run_agent_sync_loop.py
@@ -3,7 +3,8 @@
 
 `run_agent_sync` drives agents via ``asyncio.run`` from sync route handlers.
 Called from a thread that already has a running loop (an async handler's sync
-call chain, e.g. build_system_prompt -> get_course_context), it must never
+call chain, e.g. _legacy_chat -> apply_graph_update -> update_course_context
+-> _generate_summary_with_gemini), it must never
 (a) blindly ``asyncio.run`` — that raises opaquely — nor (b) leak the
 coroutine it was handed (a "never awaited" warning). Cross-loop client safety
 itself lives in `_LoopSafeGoogleModel` (see test_loop_safe_google_model.py).

--- a/backend/tests/test_run_agent_sync_loop.py
+++ b/backend/tests/test_run_agent_sync_loop.py
@@ -1,0 +1,40 @@
+# backend/tests/test_run_agent_sync_loop.py
+"""Regression: run_agent_sync's event-loop handling.
+
+`run_agent_sync` drives agents via ``asyncio.run`` from sync route handlers.
+Called from a thread that already has a running loop (an async handler's sync
+call chain, e.g. build_system_prompt -> get_course_context), it must never
+(a) blindly ``asyncio.run`` — that raises opaquely — nor (b) leak the
+coroutine it was handed (a "never awaited" warning). Cross-loop client safety
+itself lives in `_LoopSafeGoogleModel` (see test_loop_safe_google_model.py).
+"""
+import asyncio
+import inspect
+
+import pytest
+
+from agents._run import run_agent_sync
+
+
+def test_runs_coroutine_when_no_loop():
+    async def work():
+        return 7
+
+    assert run_agent_sync(work()) == 7
+
+
+def test_from_running_loop_raises_and_closes_coro():
+    """Called from an async context it must not asyncio.run (that would raise
+    opaquely) nor leak the coroutine (a "never awaited" warning); it closes the
+    coroutine and raises a clear error the caller can degrade on."""
+    async def scenario():
+        async def agent_call():
+            return 1
+
+        coro = agent_call()
+        with pytest.raises(RuntimeError, match="running event loop"):
+            run_agent_sync(coro)
+        # Closed, not abandoned — so no "coroutine was never awaited" warning.
+        assert inspect.getcoroutinestate(coro) == inspect.CORO_CLOSED
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

Reworked 2026-07-29: the original fresh-client sweep + subject_root dedup were superseded on main by the #447–#454 batch (`_LoopSafeGoogleModel` in #453 solved cross-loop client safety properly; the #355 dedup landed with its own regression test). This PR now carries only the piece main still lacks:

- **`run_agent_sync` running-loop guard** — called from an async handler's sync call chain (e.g. `build_system_prompt` → `get_course_context`), it used to let `asyncio.run` raise opaquely and leak a "coroutine was never awaited" warning. Now it closes the coroutine and raises a clear `RuntimeError` the try/except-guarded callers degrade on.
- **`HEALTH_PROBE_MODEL`** constant in `agents/_providers.py`, used by `agents/health.py`, so probe sites can't drift.
- Regression tests for both loop paths (`tests/test_run_agent_sync_loop.py`).

The streaming-tutor interrupt/retry ADR that was on this branch moves to #349 (main's 0019 slot is now taken by the SAPLING_MODEL_MODE seam ADR).

## Testing

- `pytest tests/ -q`: 1181 passed, 27 skipped.
- `ruff check .`: clean (one pre-existing hit in an untracked local ops script only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent execution errors when synchronous calls are made from an asynchronous context, with clearer guidance to use asynchronous execution.
  - Prevented coroutine cleanup warnings in unsupported execution scenarios.
  - Kept the connectivity health check aligned with the configured model.

- **Tests**
  - Added regression coverage for synchronous execution and active event-loop handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->