### PR TITLE
fix(frontend): make DEPLOY_ENV the single source of truth for env config

### DIFF
--- a/backend/scripts/dedupe_course_chunks.py
+++ b/backend/scripts/dedupe_course_chunks.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+One-time dedupe: migrate course_chunks document rows to content-hash ids.
+
+Chunk ids used to be sha256(doc_id::index::text), so the same lecture
+slides uploaded by N students stored N copies of every chunk.
+services/rag_service.py::chunk_id now scopes ids to
+sha256(course_id::text); this script rewrites existing rows to that
+scheme and collapses duplicates. Catalog rows (category=catalog) use
+their own id scheme and are untouched.
+
+For each group of rows sharing chunk_id(course_id, chunk_text), the
+winner is the first row that already has an embedding (avoids
+re-embedding); its metadata (doc_id/uploader_id/chunk_index) carries
+over, matching the last-writer-wins contract in rag_service.
+
+Dry-run by default. Run from backend/:
+    python scripts/dedupe_course_chunks.py            # preview
+    python scripts/dedupe_course_chunks.py --apply    # rewrite rows
+
+Reads .env; for staging run under `dotenv -f .env.staging run -- ...`.
+"""
+import argparse
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+BASE = Path(__file__).parent.parent
+load_dotenv(BASE / ".env")
+sys.path.insert(0, str(BASE))
+
+from db.connection import table  # noqa: E402
+from services.rag_service import chunk_id  # noqa: E402
+
+PAGE_SIZE = 1000
+UPSERT_BATCH = 200
+DELETE_BATCH = 50
+
+COLUMNS = (
+    "id,course_id,doc_id,uploader_id,chunk_index,chunk_text,chunk_hash,"
+    "embedding,category,semester,section_id,school"
+)
+
+
+def fetch_document_rows() -> list[dict]:
+    rows: list[dict] = []
+    offset = 0
+    while True:
+        page, total = table("course_chunks").select_with_count(
+            COLUMNS,
+            filters={"category": "eq.document"},
+            order="id.asc",
+            limit=PAGE_SIZE,
+            offset=offset,
+        )
+        rows.extend(page)
+        offset += len(page)
+        if not page or offset >= total:
+            return rows
+
+
+def plan_migration(rows: list[dict]) -> tuple[list[dict], list[str]]:
+    """Group rows by content-hash id; return (records to upsert, ids to delete)."""
+    groups: dict[str, list[dict]] = {}
+    for row in rows:
+        groups.setdefault(chunk_id(row["course_id"], row["chunk_text"]), []).append(row)
+
+    upserts: list[dict] = []
+    deletes: list[str] = []
+    for new_id, members in groups.items():
+        winner = next((m for m in members if m.get("embedding")), members[0])
+        if winner["id"] != new_id:
+            upserts.append({**winner, "id": new_id, "chunk_hash": new_id})
+        deletes.extend(m["id"] for m in members if m["id"] != new_id)
+    return upserts, deletes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Collapse duplicate course_chunks rows onto content-hash ids."
+    )
+    parser.add_argument("--apply", action="store_true", help="Write changes (default: preview).")
+    args = parser.parse_args()
+
+    rows = fetch_document_rows()
+    upserts, deletes = plan_migration(rows)
+    unique = len(rows) - len(deletes)
+    print(
+        f"{len(rows)} document rows -> {unique} unique chunks "
+        f"({len(deletes)} duplicate/legacy-id rows to remove, {len(upserts)} rows to rewrite)."
+    )
+
+    if not args.apply:
+        print("Dry run — re-run with --apply to write.")
+        return
+
+    # Upsert winners under their new ids first, then delete stale ids, so an
+    # interrupted run never leaves a chunk with no surviving row.
+    db = table("course_chunks")
+    for i in range(0, len(upserts), UPSERT_BATCH):
+        db.upsert(upserts[i : i + UPSERT_BATCH], on_conflict="id")
+    for i in range(0, len(deletes), DELETE_BATCH):
+        batch = deletes[i : i + DELETE_BATCH]
+        db.delete(filters={"id": f"in.({','.join(batch)})"})
+    print(f"Done: rewrote {len(upserts)} rows, deleted {len(deletes)}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -85,6 +85,18 @@ def retrieve_chunks(
         return []
 
 
+def chunk_id(course_code: str, chunk_text: str) -> str:
+    """Content-addressed chunk id, scoped per course.
+
+    Identical text in the same course maps to one row no matter which
+    document or uploader supplied it, so N students uploading the same
+    slides dedup to one embedding instead of N. doc_id/uploader_id/
+    chunk_index on the row are last-writer-wins metadata; retrieval only
+    reads course_id + chunk_text.
+    """
+    return hashlib.sha256(f"{course_code}::{chunk_text}".encode()).hexdigest()
+
+
 def index_document_chunks(
     course_code: str,
     doc_id: str,
@@ -93,18 +105,22 @@ def index_document_chunks(
 ) -> int:
     """Embed and upsert document chunks to course_chunks.
 
-    Returns the number of chunks upserted. Uses RETRIEVAL_DOCUMENT task
-    type for all embeddings. Upsert is idempotent — re-indexing the same
-    doc_id produces the same chunk IDs and merges cleanly.
+    Returns the number of unique chunks upserted. Uses RETRIEVAL_DOCUMENT
+    task type for all embeddings. Chunk ids are content-addressed per
+    course (see chunk_id), so re-uploads of the same content merge instead
+    of duplicating rows. Repeated text within one document is deduped
+    before upsert — Postgres rejects an upsert payload that hits the same
+    row twice.
     """
     if not chunks:
         return 0
 
-    records = []
+    records_by_id: dict[str, dict] = {}
     for i, chunk_text in enumerate(chunks):
-        raw = f"{doc_id}::{i}::{chunk_text}"
-        cid = hashlib.sha256(raw.encode()).hexdigest()
-        records.append({
+        cid = chunk_id(course_code, chunk_text)
+        if cid in records_by_id:
+            continue
+        records_by_id[cid] = {
             "id":          cid,
             "course_id":   course_code,
             "doc_id":      doc_id,
@@ -117,7 +133,9 @@ def index_document_chunks(
             "semester":    "current",
             "section_id":  None,
             "school":      "",
-        })
+        }
+
+    records = list(records_by_id.values())
 
     # Embed in batches of 50 (API limit)
     BATCH = 50

--- a/backend/tests/test_dedupe_course_chunks.py
+++ b/backend/tests/test_dedupe_course_chunks.py
@@ -1,0 +1,78 @@
+"""Tests for scripts.dedupe_course_chunks.plan_migration — the pure
+regrouping logic of the one-time content-hash id migration."""
+from services.rag_service import chunk_id
+
+
+def _row(rid, course, text, embedding=None, doc="doc-1"):
+    return {
+        "id": rid,
+        "course_id": course,
+        "doc_id": doc,
+        "uploader_id": "user-1",
+        "chunk_index": 0,
+        "chunk_text": text,
+        "chunk_hash": rid,
+        "embedding": embedding,
+        "category": "document",
+        "semester": "current",
+        "section_id": None,
+        "school": "",
+    }
+
+
+def test_duplicate_rows_collapse_to_one_content_hash_row():
+    """Two legacy rows with identical text in the same course become one
+    upsert under the content-hash id and two deletes of the legacy ids."""
+    from scripts.dedupe_course_chunks import plan_migration
+
+    rows = [
+        _row("legacy-a", "CAS CS 330", "memoization basics", embedding="[0.1,0.2]"),
+        _row("legacy-b", "CAS CS 330", "memoization basics", doc="doc-2"),
+    ]
+    upserts, deletes = plan_migration(rows)
+
+    new_id = chunk_id("CAS CS 330", "memoization basics")
+    assert [u["id"] for u in upserts] == [new_id]
+    assert upserts[0]["chunk_hash"] == new_id
+    assert sorted(deletes) == ["legacy-a", "legacy-b"]
+
+
+def test_winner_is_a_row_that_already_has_an_embedding():
+    """The surviving row must reuse an existing embedding rather than
+    leaving the merged chunk unembedded."""
+    from scripts.dedupe_course_chunks import plan_migration
+
+    rows = [
+        _row("legacy-a", "CAS CS 330", "graph traversal", embedding=None),
+        _row("legacy-b", "CAS CS 330", "graph traversal", embedding="[0.3,0.4]", doc="doc-2"),
+    ]
+    upserts, _ = plan_migration(rows)
+
+    assert upserts[0]["embedding"] == "[0.3,0.4]"
+    assert upserts[0]["doc_id"] == "doc-2"
+
+
+def test_rows_already_on_content_hash_ids_are_untouched():
+    """Idempotency: a second run over already-migrated data plans no writes."""
+    from scripts.dedupe_course_chunks import plan_migration
+
+    cid = chunk_id("CAS CS 330", "sorting algorithms")
+    rows = [_row(cid, "CAS CS 330", "sorting algorithms", embedding="[0.5]")]
+    upserts, deletes = plan_migration(rows)
+
+    assert upserts == []
+    assert deletes == []
+
+
+def test_same_text_across_courses_stays_separate():
+    from scripts.dedupe_course_chunks import plan_migration
+
+    rows = [
+        _row("legacy-a", "CAS CS 330", "big-O notation"),
+        _row("legacy-b", "CAS CS 111", "big-O notation"),
+    ]
+    upserts, deletes = plan_migration(rows)
+
+    assert len(upserts) == 2
+    assert len({u["id"] for u in upserts}) == 2
+    assert sorted(deletes) == ["legacy-a", "legacy-b"]

--- a/backend/tests/test_rag_service.py
+++ b/backend/tests/test_rag_service.py
@@ -81,6 +81,68 @@ def test_index_document_chunks_empty_returns_zero(mock_client):
     mock_client.models.embed_content.assert_not_called()
 
 
+@patch("services.rag_service._client")
+def test_chunk_ids_are_content_addressed_per_course(mock_client):
+    """Identical chunk text in the same course must map to the same chunk id
+    regardless of which document or uploader supplied it — 200 students
+    uploading the same lecture slides should produce one row per unique
+    chunk, not 200 copies of every embedding."""
+    mock_client.models.embed_content.return_value = _make_embedding_response([[0.2] * 768])
+    with patch("services.rag_service.table") as mock_table:
+        mock_table.return_value.upsert.return_value = []
+        from services.rag_service import index_document_chunks
+
+        index_document_chunks("CAS CS 330", "doc-a", "user-1", ["memoization basics"])
+        id_from_doc_a = mock_table.return_value.upsert.call_args[0][0][0]["id"]
+
+        index_document_chunks("CAS CS 330", "doc-b", "user-2", ["memoization basics"])
+        id_from_doc_b = mock_table.return_value.upsert.call_args[0][0][0]["id"]
+
+    assert id_from_doc_a == id_from_doc_b
+
+
+@patch("services.rag_service._client")
+def test_chunk_ids_differ_across_courses(mock_client):
+    """The dedup scope is per-course: the same text indexed under two
+    different course codes must NOT collide, or one course's doc_id/metadata
+    would clobber the other's."""
+    mock_client.models.embed_content.return_value = _make_embedding_response([[0.2] * 768])
+    with patch("services.rag_service.table") as mock_table:
+        mock_table.return_value.upsert.return_value = []
+        from services.rag_service import index_document_chunks
+
+        index_document_chunks("CAS CS 330", "doc-a", "user-1", ["memoization basics"])
+        id_cs330 = mock_table.return_value.upsert.call_args[0][0][0]["id"]
+
+        index_document_chunks("CAS CS 111", "doc-a", "user-1", ["memoization basics"])
+        id_cs111 = mock_table.return_value.upsert.call_args[0][0][0]["id"]
+
+    assert id_cs330 != id_cs111
+
+
+@patch("services.rag_service._client")
+def test_duplicate_chunks_within_one_document_are_deduped(mock_client):
+    """A document repeating the same text (boilerplate headers/footers) must
+    not emit duplicate ids in a single upsert payload — Postgres rejects
+    ON CONFLICT DO UPDATE hitting the same row twice in one statement."""
+    mock_client.models.embed_content.return_value = _make_embedding_response([[0.2] * 768] * 2)
+    with patch("services.rag_service.table") as mock_table:
+        mock_table.return_value.upsert.return_value = []
+        from services.rag_service import index_document_chunks
+
+        count = index_document_chunks(
+            "CAS CS 330",
+            "doc-a",
+            "user-1",
+            ["Page header boilerplate", "actual content", "Page header boilerplate"],
+        )
+        records = mock_table.return_value.upsert.call_args[0][0]
+
+    ids = [r["id"] for r in records]
+    assert len(ids) == len(set(ids)) == 2
+    assert count == 2
+
+
 @patch("services.rag_service._embed_documents_batch")
 def test_index_document_chunks_handles_embedding_failure(mock_embed):
     """Test that embedding failures are caught and records are still upserted with embedding=None."""

--- a/docs/decisions/0020-deploy-env-single-source-of-truth.md
+++ b/docs/decisions/0020-deploy-env-single-source-of-truth.md
@@ -64,15 +64,33 @@ with the explicit vars kept as backward-compatible fallbacks.
 ## Operational follow-up (required, not code)
 
 The code change does **not** fix the currently-broken deployment — only a
-redeploy does. On the Cloudflare **Workers Builds** for each environment:
+redeploy does. Each environment is a separate Cloudflare **Workers Build** with
+two *distinct* fields — a **Build command** and a **Deploy command** — that must
+never be conflated:
 
-- Set `DEPLOY_ENV` as a **build** variable (`staging` / `production`).
-  `wrangler.toml [vars]` are runtime-only; the `/api` rewrite and `NEXT_PUBLIC_*`
-  inlining bake at build time (see [0018](0018-session-token-lifecycle.md)).
-- Staging's deploy command must be `npx wrangler deploy --env staging`.
+- **Build command** — MUST stay `npm run cf:build` (`opennextjs-cloudflare
+  build`). This is the step that compiles the app into `.open-next/worker.js`,
+  the `main` entry `wrangler.toml` deploys. **Never overwrite the build command
+  with a `wrangler deploy` / `wrangler versions upload` line.** A deploy command
+  in the build field skips the OpenNext build entirely, `.open-next/` is never
+  produced, and every build fails with `ERROR Could not find compiled Open Next
+  config, did you run the build command?` — this is exactly what took the
+  `frontend-staging` build down for ~16 builds starting 2026-07-20, when the
+  build field was replaced with `npx wrangler deploy --env staging` while wiring
+  up `DEPLOY_ENV` below.
+- **Deploy command** — leave it as the already-green `npx wrangler versions
+  upload`; it was never the problem. The staging environment
+  (`[env.staging]` → the `frontend-staging` worker) is selected by the staging
+  Workers Build's own deploy config / `--env staging` on the *deploy* step — it
+  does **not** belong in the build command.
+- Set `DEPLOY_ENV` as a **build** variable (`staging` / `production`). This is a
+  *variable*, set in the Build variables panel — not a command. `wrangler.toml
+  [vars]` are runtime-only; the `/api` rewrite and `NEXT_PUBLIC_*` inlining bake
+  at build time (see [0018](0018-session-token-lifecycle.md)).
 - Confirm `staging.saplinglearn.com` routes to the `frontend-staging` worker,
   not `frontend`.
-- Verify: `curl -sSI https://staging.saplinglearn.com/dashboard` must show
+- Verify the build is green again, then:
+  `curl -sSI https://staging.saplinglearn.com/dashboard` must show
   `Location: https://api.staging.saplinglearn.com/api/auth/google`.
 
 ## Note

--- a/docs/decisions/0020-deploy-env-single-source-of-truth.md
+++ b/docs/decisions/0020-deploy-env-single-source-of-truth.md
@@ -1,0 +1,84 @@
+# 0020 — DEPLOY_ENV as the single source of truth for frontend environment config
+
+**Status:** accepted · **Relates to:** #190, [0018](0018-session-token-lifecycle.md)
+
+## Symptom
+
+Login on `staging.saplinglearn.com` bounced to `/?error=session_expired` with
+nothing in the browser console.
+
+## Root cause
+
+The error is a **middleware** redirect (`frontend/src/middleware.ts`), not a
+backend one — the backend fails to `/auth?error=…`, only the middleware redirects
+to `/?error=…`, and it's a server-side 307 so nothing reaches the console.
+
+The worker serving `staging.saplinglearn.com` was running with the **production**
+config: probing `GET https://staging.saplinglearn.com/dashboard` (no cookie)
+returned `307 → https://api.saplinglearn.com/api/auth/google` — the *prod*
+backend, not `api.staging.saplinglearn.com`. So the `[env.staging]` overrides in
+`wrangler.toml` were not in effect (deployed without `--env staging`, or the
+custom-domain route was bound to the prod `frontend` worker instead of
+`frontend-staging`).
+
+Consequence: staging's login round-tripped through the prod backend, which signs
+the handoff token with prod's `SESSION_SECRET` and redirects to prod's
+`FRONTEND_URL`. The `sapling_session` cookie that came back was prod-signed and
+scoped to `.saplinglearn.com` (a parent-domain cookie, so it *also* reaches
+`staging.saplinglearn.com`). Staging's middleware then verified it with staging's
+`SESSION_SECRET` → HMAC mismatch → `middleware.ts:56` → `session_expired`. The
+staging backend itself was healthy the whole time (clean `401 {"detail":"Not
+authenticated"}`, its own OAuth client).
+
+This is the mirror image of the footgun `deployGuard.ts` was built for (#190,
+"staging config on the prod worker"). That guard's check that catches an
+internally-consistent-but-wrong-target build only arms when `DEPLOY_ENV` is set —
+and it wasn't set on either Workers Build, so it slept.
+
+## Decision
+
+Make `DEPLOY_ENV` the single knob that drives every environment-specific value,
+with the explicit vars kept as backward-compatible fallbacks.
+
+- `deployGuard.ts` gains pure, unit-tested helpers:
+  - `resolveFrontendEnv(env)` — when `DEPLOY_ENV` names a known env, derive
+    `apiUrl`/`cookieDomain` from `FRONTEND_ENVS` (cannot drift or half-set);
+    otherwise fall back to `BACKEND_URL` → `NEXT_PUBLIC_API_URL` and
+    `COOKIE_DOMAIN`, preserving docker/local behaviour.
+  - `expectedEnvForHost(host)` / `detectHostConfigMismatch(host, apiUrl)` —
+    map the canonical hosts to their env and flag a worker serving one env's
+    host while wired to another's backend (returns null for previews/localhost).
+- `middleware.ts` derives `API_URL` via `resolveFrontendEnv` and, on a protected
+  route, calls `detectHostConfigMismatch`. On mismatch it logs a loud server
+  error and redirects with a **distinct** `env_misconfig` code instead of the
+  misleading `session_expired`. This is the runtime defence-in-depth for what the
+  build-time guard cannot see (a consistent build shipped to the wrong worker).
+- `app/api/auth/session/route.ts` derives the cookie `Domain` from
+  `resolveFrontendEnv`, so a staging build cannot mint a `.saplinglearn.com`
+  cookie that leaks into prod.
+- `next.config.ts` derives the build-time `BACKEND_URL` (the `/api` rewrite) and
+  the inlined `NEXT_PUBLIC_API_URL`/`COOKIE_DOMAIN` from `DEPLOY_ENV`.
+- `wrangler.toml` sets `DEPLOY_ENV = "production"` in `[vars]` and
+  `DEPLOY_ENV = "staging"` in `[env.staging.vars]`.
+
+## Operational follow-up (required, not code)
+
+The code change does **not** fix the currently-broken deployment — only a
+redeploy does. On the Cloudflare **Workers Builds** for each environment:
+
+- Set `DEPLOY_ENV` as a **build** variable (`staging` / `production`).
+  `wrangler.toml [vars]` are runtime-only; the `/api` rewrite and `NEXT_PUBLIC_*`
+  inlining bake at build time (see [0018](0018-session-token-lifecycle.md)).
+- Staging's deploy command must be `npx wrangler deploy --env staging`.
+- Confirm `staging.saplinglearn.com` routes to the `frontend-staging` worker,
+  not `frontend`.
+- Verify: `curl -sSI https://staging.saplinglearn.com/dashboard` must show
+  `Location: https://api.staging.saplinglearn.com/api/auth/google`.
+
+## Note
+
+The repo's `vitest` runner currently crashes at startup on Node 20.12.1
+(`util.styleText` receives an array of styles, which needs Node ≥ 20.16/22).
+The new pure helpers were verified via `tsx` + `tsc --noEmit`; the vitest specs
+are added and will run in CI on a supported Node. Bumping the local Node /
+pinning an engines range is a separate cleanup.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,7 +2,21 @@ import type { NextConfig } from "next";
 // The dev-mode OpenNext hook lets `next dev` continue to work locally
 // against Cloudflare bindings (R2/KV/env vars). Safe no-op in prod builds.
 import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
-import { checkFrontendDeployEnv } from "./src/lib/deployGuard";
+import { checkFrontendDeployEnv, resolveFrontendEnv } from "./src/lib/deployGuard";
+
+// DEPLOY_ENV is the single knob: when a Workers Build sets DEPLOY_ENV=staging|
+// production, the build-time BACKEND_URL (the /api rewrite target) and the
+// inlined NEXT_PUBLIC_API_URL / COOKIE_DOMAIN are DERIVED from FRONTEND_ENVS so
+// they cannot be half-set or point at the wrong environment. Setting these on
+// process.env before Next reads them keeps NEXT_PUBLIC_* inlining consistent.
+// When DEPLOY_ENV is unset we leave the explicit vars alone (local/docker, or a
+// legacy build that sets BACKEND_URL directly).
+const RESOLVED = resolveFrontendEnv(process.env);
+if (RESOLVED.derived) {
+  process.env.BACKEND_URL = RESOLVED.apiUrl;
+  process.env.NEXT_PUBLIC_API_URL = RESOLVED.apiUrl;
+  if (RESOLVED.cookieDomain) process.env.COOKIE_DOMAIN = RESOLVED.cookieDomain;
+}
 
 // .trim() defends against a stray leading/trailing space in the build
 // variable: an untrimmed " https://..." makes the /api rewrite destination

--- a/frontend/src/app/api/auth/session/route.ts
+++ b/frontend/src/app/api/auth/session/route.ts
@@ -1,12 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { signSession, SESSION_MAX_AGE } from '@/lib/sessionToken';
 import { sanitizeCookieDomain } from '@/lib/cookieDomain';
+import { resolveFrontendEnv } from '@/lib/deployGuard';
 
 const SESSION_SECRET = process.env.SESSION_SECRET;
 // #190: validate COOKIE_DOMAIN instead of trusting env verbatim — an
 // overly-broad value would scope the session cookie across unrelated
 // subdomains. An invalid value degrades to a host-only cookie.
-const COOKIE_DOMAIN = sanitizeCookieDomain(process.env.COOKIE_DOMAIN);
+//
+// The domain is derived from DEPLOY_ENV (single source of truth) so the cookie
+// is always scoped to the deployed environment — a staging build can't mint a
+// `.saplinglearn.com` cookie that leaks into prod. Falls back to the explicit
+// COOKIE_DOMAIN env when DEPLOY_ENV is unset (docker/local).
+const COOKIE_DOMAIN = sanitizeCookieDomain(
+  resolveFrontendEnv(process.env as Record<string, string | undefined>).cookieDomain,
+);
 
 /**
  * CSRF defense beyond SameSite=Lax (#190): reject cross-origin requests to the

--- a/frontend/src/components/SignInModal.tsx
+++ b/frontend/src/components/SignInModal.tsx
@@ -14,6 +14,7 @@ const ERROR_COPY: Record<string, string> = {
   google_not_configured: "Google sign-in is not configured on the server. Please contact support.",
   signin_failed: "Sign-in failed. Please try again.",
   session_expired: "Your session has expired. Please sign in again.",
+  env_misconfig: "This environment is misconfigured and can't sign you in. Please contact support.",
   revoked: "Your access has been revoked.",
   oauth_denied: "Sign-in was cancelled.",
   unknown: "Something went wrong. Please try again.",

--- a/frontend/src/lib/deployGuard.test.ts
+++ b/frontend/src/lib/deployGuard.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { checkFrontendDeployEnv } from './deployGuard';
+import {
+  checkFrontendDeployEnv,
+  resolveFrontendEnv,
+  expectedEnvForHost,
+  detectHostConfigMismatch,
+  FRONTEND_ENVS,
+} from './deployGuard';
 
 const PROD = {
   NEXT_PUBLIC_API_URL: 'https://api.saplinglearn.com',
@@ -58,5 +64,129 @@ describe('checkFrontendDeployEnv', () => {
         DEPLOY_ENV: 'production',
       }),
     ).toEqual([]);
+  });
+});
+
+describe('resolveFrontendEnv', () => {
+  it('derives all values from DEPLOY_ENV=staging (single source of truth)', () => {
+    const r = resolveFrontendEnv({ DEPLOY_ENV: 'staging' });
+    expect(r).toEqual({
+      env: 'staging',
+      apiUrl: FRONTEND_ENVS.staging.apiUrl,
+      cookieDomain: FRONTEND_ENVS.staging.cookieDomain,
+      derived: true,
+    });
+  });
+
+  it('derives from DEPLOY_ENV=production even if explicit vars point elsewhere', () => {
+    // DEPLOY_ENV wins: a stray staging BACKEND_URL cannot leak through.
+    const r = resolveFrontendEnv({
+      DEPLOY_ENV: 'production',
+      BACKEND_URL: 'https://api.staging.saplinglearn.com',
+      COOKIE_DOMAIN: '.staging.saplinglearn.com',
+    });
+    expect(r.env).toBe('production');
+    expect(r.apiUrl).toBe(FRONTEND_ENVS.production.apiUrl);
+    expect(r.cookieDomain).toBe(FRONTEND_ENVS.production.cookieDomain);
+    expect(r.derived).toBe(true);
+  });
+
+  it('tolerates case/whitespace in DEPLOY_ENV', () => {
+    expect(resolveFrontendEnv({ DEPLOY_ENV: '  Staging ' }).env).toBe('staging');
+  });
+
+  it('falls back to explicit vars when DEPLOY_ENV is unset (backward compatible)', () => {
+    const r = resolveFrontendEnv({
+      BACKEND_URL: 'https://api.staging.saplinglearn.com',
+      NEXT_PUBLIC_API_URL: 'https://ignored.example.com',
+      COOKIE_DOMAIN: '.staging.saplinglearn.com',
+    });
+    expect(r).toEqual({
+      env: null,
+      apiUrl: 'https://api.staging.saplinglearn.com', // BACKEND_URL preferred over NEXT_PUBLIC_API_URL
+      cookieDomain: '.staging.saplinglearn.com',
+      derived: false,
+    });
+  });
+
+  it('falls back to NEXT_PUBLIC_API_URL when BACKEND_URL is absent', () => {
+    const r = resolveFrontendEnv({ NEXT_PUBLIC_API_URL: 'http://backend:5000' });
+    expect(r.apiUrl).toBe('http://backend:5000');
+    expect(r.derived).toBe(false);
+  });
+
+  it('ignores an unknown DEPLOY_ENV and falls back to explicit vars', () => {
+    const r = resolveFrontendEnv({ DEPLOY_ENV: 'prod', BACKEND_URL: 'https://api.saplinglearn.com' });
+    expect(r.env).toBeNull();
+    expect(r.apiUrl).toBe('https://api.saplinglearn.com');
+    expect(r.derived).toBe(false);
+  });
+
+  it('is empty (no backend) when nothing is configured', () => {
+    expect(resolveFrontendEnv({})).toEqual({
+      env: null,
+      apiUrl: '',
+      cookieDomain: undefined,
+      derived: false,
+    });
+  });
+});
+
+describe('expectedEnvForHost', () => {
+  it('maps the staging host and its subdomains to staging', () => {
+    expect(expectedEnvForHost('staging.saplinglearn.com')).toBe('staging');
+    expect(expectedEnvForHost('api.staging.saplinglearn.com')).toBe('staging');
+  });
+
+  it('maps the apex/www/app prod hosts to production', () => {
+    expect(expectedEnvForHost('saplinglearn.com')).toBe('production');
+    expect(expectedEnvForHost('www.saplinglearn.com')).toBe('production');
+    expect(expectedEnvForHost('app.saplinglearn.com')).toBe('production');
+  });
+
+  it('strips a port and is case-insensitive', () => {
+    expect(expectedEnvForHost('STAGING.saplinglearn.com:443')).toBe('staging');
+  });
+
+  it('returns null for previews / localhost / unknown hosts (no judgment)', () => {
+    expect(expectedEnvForHost('foo.workers.dev')).toBeNull();
+    expect(expectedEnvForHost('localhost')).toBeNull();
+    expect(expectedEnvForHost('')).toBeNull();
+    expect(expectedEnvForHost(undefined)).toBeNull();
+  });
+});
+
+describe('detectHostConfigMismatch', () => {
+  it('flags the exact bug: staging host wired to the prod backend', () => {
+    const msg = detectHostConfigMismatch(
+      'staging.saplinglearn.com',
+      'https://api.saplinglearn.com',
+    );
+    expect(msg).toMatch(/staging/);
+    expect(msg).toMatch(/production/);
+  });
+
+  it('flags a prod host wired to the staging backend', () => {
+    expect(
+      detectHostConfigMismatch('www.saplinglearn.com', 'https://api.staging.saplinglearn.com'),
+    ).not.toBeNull();
+  });
+
+  it('passes when the host and backend agree', () => {
+    expect(
+      detectHostConfigMismatch('staging.saplinglearn.com', 'https://api.staging.saplinglearn.com'),
+    ).toBeNull();
+    expect(
+      detectHostConfigMismatch('www.saplinglearn.com', 'https://api.saplinglearn.com'),
+    ).toBeNull();
+  });
+
+  it('does not judge preview hosts or non-canonical backends', () => {
+    expect(
+      detectHostConfigMismatch('foo.workers.dev', 'https://api.saplinglearn.com'),
+    ).toBeNull();
+    expect(
+      detectHostConfigMismatch('staging.saplinglearn.com', 'http://backend:5000'),
+    ).toBeNull();
   });
 });

--- a/frontend/src/lib/deployGuard.ts
+++ b/frontend/src/lib/deployGuard.ts
@@ -47,6 +47,81 @@ function classify(
   return null;
 }
 
+/** The build- and run-time frontend config, resolved from a single knob. */
+export interface ResolvedFrontendEnv {
+  /** The environment we resolved to, or null (unknown / local / preview). */
+  env: FrontendEnv | null;
+  /** Backend origin (used for BACKEND_URL and NEXT_PUBLIC_API_URL). */
+  apiUrl: string;
+  /** Cookie `Domain` attribute, or undefined for a host-only cookie. */
+  cookieDomain: string | undefined;
+  /** True when values came from DEPLOY_ENV, not explicit env vars. */
+  derived: boolean;
+}
+
+/**
+ * Resolve the effective frontend config from an env bag.
+ *
+ * `DEPLOY_ENV` is the single source of truth: when it names a known environment
+ * the API origin and cookie domain are DERIVED from `FRONTEND_ENVS`, so they
+ * cannot drift, be half-set, or be leaked from a stray explicit var. When
+ * `DEPLOY_ENV` is unset (local/dev, docker, or a legacy build that sets the
+ * vars explicitly) this falls back to the explicit env vars — preserving prior
+ * behaviour, including the middleware's `BACKEND_URL`-before-`NEXT_PUBLIC_API_URL`
+ * preference (BACKEND_URL is the server-reachable origin; see middleware.ts).
+ */
+export function resolveFrontendEnv(env: EnvSource): ResolvedFrontendEnv {
+  const deployEnv = (env.DEPLOY_ENV ?? '').trim().toLowerCase();
+  if (deployEnv && deployEnv in FRONTEND_ENVS) {
+    const c = FRONTEND_ENVS[deployEnv as FrontendEnv];
+    return { env: deployEnv as FrontendEnv, apiUrl: c.apiUrl, cookieDomain: c.cookieDomain, derived: true };
+  }
+  return {
+    env: null,
+    apiUrl: (env.BACKEND_URL ?? '').trim() || (env.NEXT_PUBLIC_API_URL ?? '').trim(),
+    cookieDomain: (env.COOKIE_DOMAIN ?? '').trim() || undefined,
+    derived: false,
+  };
+}
+
+/**
+ * Best-effort: which environment SHOULD serve this request host? Returns null
+ * for hosts we don't recognise (preview `*.workers.dev`, localhost, custom
+ * domains) — the guard must not judge those.
+ */
+export function expectedEnvForHost(host: string | undefined | null): FrontendEnv | null {
+  const h = (host ?? '').trim().toLowerCase().split(':')[0];
+  if (!h) return null;
+  if (h === 'staging.saplinglearn.com' || h.endsWith('.staging.saplinglearn.com')) return 'staging';
+  if (h === 'saplinglearn.com' || h === 'www.saplinglearn.com' || h === 'app.saplinglearn.com') {
+    return 'production';
+  }
+  return null;
+}
+
+/**
+ * Detect a host/backend mismatch: the worker is serving a host that belongs to
+ * one environment but is wired to another environment's backend (the exact
+ * failure behind staging's `session_expired` — a prod-config worker answering
+ * `staging.saplinglearn.com`). Returns a human-readable reason, or null when
+ * consistent or indeterminable. Runtime defence-in-depth for what the
+ * build-time guard cannot see (an internally-consistent build shipped to the
+ * wrong worker/route).
+ */
+export function detectHostConfigMismatch(
+  host: string | undefined | null,
+  effectiveApiUrl: string,
+): string | null {
+  const expected = expectedEnvForHost(host);
+  if (!expected) return null;
+  const configured = classify(effectiveApiUrl, 'apiUrl');
+  if (!configured || configured === expected) return null;
+  return (
+    `host ${host} expects the ${expected} backend (${FRONTEND_ENVS[expected].apiUrl}) ` +
+    `but is wired to the ${configured} backend (${effectiveApiUrl})`
+  );
+}
+
 /**
  * Check the frontend deploy variables. Returns a list of problems (empty = OK).
  * Pure — takes an env bag so it is unit-testable.

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { verifySession } from '@/lib/sessionToken'
+import { resolveFrontendEnv, detectHostConfigMismatch } from '@/lib/deployGuard'
 
 // Every route in the (shell) group is gated here. #189: /profile/[userId]
 // was the one shell route missing from both this list and config.matcher, so
@@ -22,9 +23,13 @@ const PROTECTED = [
 // no-op there; the NEXT_PUBLIC_API_URL fallback keeps any env that only sets
 // that one working. .trim() mirrors next.config.ts's defense against a stray
 // space in a deploy variable.
-const API_URL =
-  (process.env.BACKEND_URL ?? '').trim() ||
-  (process.env.NEXT_PUBLIC_API_URL ?? '').trim()
+//
+// DEPLOY_ENV is the single source of truth: when set (wrangler.toml `[vars]` /
+// `[env.staging.vars]`) the backend origin is derived from FRONTEND_ENVS so it
+// cannot drift from the deployed environment. When unset (docker/local) it
+// falls back to BACKEND_URL, then NEXT_PUBLIC_API_URL — the original behaviour.
+const RESOLVED = resolveFrontendEnv(process.env as Record<string, string | undefined>)
+const API_URL = RESOLVED.apiUrl
 
 function googleAuthRedirect() {
   if (!API_URL) return null
@@ -48,6 +53,23 @@ export async function middleware(request: NextRequest) {
 
   const isProtected = PROTECTED.some(p => pathname.startsWith(p))
   if (!isProtected) return NextResponse.next()
+
+  // Defence-in-depth for the "wrong environment on this worker" deploy footgun:
+  // if the host we're serving belongs to one environment (e.g. staging.*) but
+  // API_URL points at another's backend (e.g. prod api.*), sign-in silently
+  // fails — the backend can't validate a session cookie signed with the other
+  // env's SESSION_SECRET, which surfaced as a mystery `session_expired` on
+  // staging. Fail with a distinct, greppable code and a loud server log instead.
+  const mismatch = detectHostConfigMismatch(request.nextUrl.hostname, API_URL)
+  if (mismatch) {
+    console.error(
+      `[sapling] deploy misconfiguration: ${mismatch}. This worker is serving the ` +
+        'wrong environment — redeploy with the correct DEPLOY_ENV build variable and ' +
+        '`wrangler deploy --env <env>`, and confirm the custom-domain route binding. ' +
+        'See docs/decisions/0018-session-token-lifecycle.md.',
+    )
+    return redirectToSignin(request, 'env_misconfig')
+  }
 
   const token = request.cookies.get('sapling_session')?.value
   if (!token) return redirectToSignin(request)

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -2,7 +2,15 @@
 #
 # Cloudflare Workers config for the Next.js frontend (OpenNext adapter).
 # Deploy locally: `cd frontend && npm run cf:deploy`.
-# CI on Workers Builds: set build command to `npm run cf:build`.
+#
+# Cloudflare Workers Builds has TWO separate fields — keep them distinct:
+#   * Build command  -> `npm run cf:build`  (opennextjs-cloudflare build;
+#                        compiles `.open-next/worker.js`, the `main` below).
+#   * Deploy command -> `npx wrangler versions upload` (staging adds `--env
+#                        staging` here / via its own config — never in Build).
+# NEVER put a `wrangler deploy`/`versions upload` command in the Build field:
+# it skips the OpenNext build, so nothing produces `.open-next/` and the deploy
+# fails with "Could not find compiled Open Next config" (see ADR 0020).
 
 name = "frontend"
 main = ".open-next/worker.js"

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -13,7 +13,14 @@ compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
 binding = "ASSETS"
 directory = ".open-next/assets"
 
+# DEPLOY_ENV is the single source of truth (see src/lib/deployGuard.ts): the
+# middleware derives the backend origin and the session route derives the cookie
+# domain from it at runtime. NEXT_PUBLIC_API_URL/BACKEND_URL/COOKIE_DOMAIN below
+# are kept as explicit fallbacks. IMPORTANT: these `[vars]` are RUNTIME-only —
+# the /api rewrite and NEXT_PUBLIC_* inlining are baked at BUILD time, so the
+# staging Workers Build must ALSO set DEPLOY_ENV=staging as a build variable.
 [vars]
+DEPLOY_ENV = "production"
 NEXT_PUBLIC_API_URL = "https://api.saplinglearn.com"
 BACKEND_URL = "https://api.saplinglearn.com"
 COOKIE_DOMAIN = ".saplinglearn.com"
@@ -28,6 +35,7 @@ enabled = true
 name = "frontend-staging"
 
 [env.staging.vars]
+DEPLOY_ENV = "staging"
 NEXT_PUBLIC_API_URL = "https://api.staging.saplinglearn.com"
 BACKEND_URL = "https://api.staging.saplinglearn.com"
 COOKIE_DOMAIN = ".staging.saplinglearn.com"


### PR DESCRIPTION
## Why

Login on **staging.saplinglearn.com** bounced to `/?error=session_expired` with nothing in the browser console.

Root cause (verified by probing staging): the worker serving `staging.saplinglearn.com` was running with **production** config — `GET https://staging.saplinglearn.com/dashboard` (no cookie) returned `307 → https://api.saplinglearn.com/api/auth/google` (the *prod* backend, not `api.staging.saplinglearn.com`). So the `[env.staging]` overrides weren't in effect.

Consequence: staging's login round-tripped through the prod backend, which signs the handoff token with prod's `SESSION_SECRET` and redirects to prod's `FRONTEND_URL`. The `sapling_session` cookie that came back was prod-signed and scoped to `.saplinglearn.com` (a parent-domain cookie, so it also reaches `staging.saplinglearn.com`). Staging's middleware then verified it with staging's `SESSION_SECRET` → HMAC mismatch → `middleware.ts:56` → `session_expired`. The staging backend was healthy throughout.

This is the mirror of the footgun `deployGuard.ts` was built for (#190). The guard's check that catches a consistent-but-wrong-target build only arms when `DEPLOY_ENV` is set — and it wasn't set on either Workers Build, so it slept.

## What changed

`DEPLOY_ENV` becomes the single knob driving every environment-specific value, with the explicit vars kept as backward-compatible fallbacks.

- **`deployGuard.ts`** — `resolveFrontendEnv` (derive `apiUrl`/`cookieDomain` from `FRONTEND_ENVS` when `DEPLOY_ENV` is set; else fall back to explicit vars), plus `expectedEnvForHost` / `detectHostConfigMismatch`. Pure + unit-tested.
- **`middleware.ts`** — derive `API_URL` via the resolver; on a protected route, flag a host/backend mismatch with a loud server log + a distinct **`env_misconfig`** code instead of the misleading `session_expired`.
- **`app/api/auth/session/route.ts`** — cookie `Domain` derived from the resolver (a staging build can't mint a `.saplinglearn.com` cookie).
- **`next.config.ts`** — build-time `BACKEND_URL`/`NEXT_PUBLIC_API_URL`/`COOKIE_DOMAIN` derived from `DEPLOY_ENV`.
- **`wrangler.toml`** — `DEPLOY_ENV` set for `[vars]` (production) and `[env.staging.vars]` (staging).
- **`SignInModal.tsx`** — user copy for `env_misconfig`.
- **ADR `0020`** — root cause + required deploy follow-up.

## Verification

- `tsc --noEmit` → exit 0.
- `eslint` on changed files → 0 errors (one pre-existing `<img>` warning).
- New pure-function logic verified via `tsx` (all assertions pass). `vitest` currently crashes at startup on local Node 20.12.1 (`rolldown` → `util.styleText` array form needs Node ≥ 20.16/22) — pre-existing and unrelated; CI on a supported Node will run the added specs.

## ⚠️ Required deploy follow-up (this PR does NOT fix the running deployment)

Only a staging redeploy clears the live error:

1. Set `DEPLOY_ENV` as a **build** variable on each Workers Build — `staging` / `production`.
2. Staging deploy command must be `npx wrangler deploy --env staging`.
3. Confirm `staging.saplinglearn.com` routes to the **`frontend-staging`** worker, not `frontend`.
4. Verify: `curl -sSI https://staging.saplinglearn.com/dashboard` should show `Location: https://api.staging.saplinglearn.com/api/auth/google`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Course content indexing now uses content-addressed chunk IDs and avoids duplicate chunks within indexing runs.
  * Deployment environment configuration now drives API routing and session cookie domain behavior more consistently.

* **Bug Fixes**
  * Added runtime detection for frontend/back-end configuration mismatches to prevent staging/production session issues.
  * When misconfigured, users are redirected to sign in with clearer “environment misconfiguration” messaging.

* **Chores**
  * Added a one-time migration tool to safely deduplicate existing course chunk records, with a preview mode before applying changes.

* **Tests**
  * Expanded coverage for deduplication planning and deploy environment derivation/mismatch detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->