### PR TITLE
feat: semester-scoped learning + Courses & Semesters hub

### DIFF
--- a/backend/db/migrations/0036_offering_null_section_unique.sql
+++ b/backend/db/migrations/0036_offering_null_section_unique.sql
@@ -1,0 +1,15 @@
+-- 0036: close the NULL-section gap in course_offerings uniqueness.
+--
+-- 0020's course_offerings_unique is a plain UNIQUE (course_id, term_id, section).
+-- Plain UNIQUE treats NULLs as distinct, so two rows for the same
+-- (course_id, term_id) with section IS NULL — exactly the shape
+-- services/academics.py::resolve_offering(create=True) inserts — are BOTH
+-- allowed. Two concurrent add_course calls could therefore each create an
+-- offering for the same course+term and enroll against different rows,
+-- defeating the no-retake invariant. This partial unique index makes the
+-- NULL-section case unique too; sectioned rows stay governed by the existing
+-- constraint. resolve_offering catches the resulting insert conflict and
+-- re-selects the winner.
+CREATE UNIQUE INDEX IF NOT EXISTS course_offerings_course_term_nullsec_uniq
+    ON course_offerings (course_id, term_id)
+    WHERE section IS NULL;

--- a/backend/prompts/preamble.txt
+++ b/backend/prompts/preamble.txt
@@ -8,6 +8,14 @@ Current Knowledge Graph:
 Previous Session Summary (if exists):
 {last_session_summary}
 
+ACADEMIC INTEGRITY (non-negotiable):
+Your job is to build the student's understanding, never to do their graded work for them.
+- Never give the complete or final answer to a task the student is trying to submit — homework, a problem set, a graded assignment, a lab, an essay, or a take-home quiz/exam. Do not write their essay, carry a problem through to the final result they would turn in, or produce the exact code or numeric values they would submit.
+- Never reproduce verbatim solution text from the student's uploaded materials or from retrieved course context as "the answer."
+- Instead, teach them to reach it themselves: give hints, ask leading questions, break the problem into steps, check their reasoning, point out where they went wrong, and work through an ANALOGOUS example (different numbers or wording) when a demonstration would help.
+- You SHOULD still fully explain concepts, definitions, theorems, and general worked examples — the restriction is only on handing over the answer to the student's own graded task.
+- If the student pushes for the answer, or you are unsure whether something is a graded deliverable, guide rather than solve.
+
 FORMATTING & VISUALIZATION TOOLS:
 The student-facing reply is rendered with full Markdown + GFM, KaTeX math, and syntax-highlighted code. Use these tools ambitiously whenever a visualization clarifies the idea — do not default to plain prose when structure would teach better.
 

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -1147,7 +1147,7 @@ def _index_document_chunks(
     is persisted, so it never blocks the SSE stream.
     """
     import time
-    from services.chunker import chunk_document
+    from services.chunker import chunk_for_category
     from services.rag_service import index_document_chunks
     from services.encryption import encrypt_if_present
 
@@ -1160,7 +1160,7 @@ def _index_document_chunks(
         )
         bu_course_id = (rows[0].get("course_code") or course_id) if rows else course_id
 
-        chunks = chunk_document(extracted_text)
+        chunks = chunk_for_category(extracted_text, category)
         if not chunks:
             return
 

--- a/backend/routes/gradebook.py
+++ b/backend/routes/gradebook.py
@@ -39,23 +39,8 @@ router = APIRouter()
 
 
 # ── Enrollment resolution ────────────────────────────────────────────────────
-
-def _term_id_for_semester(semester: str | None) -> str | None:
-    """Map a `semester` query value to a term id.
-
-    `semester` is a term **label** (e.g. "Spring 2026"); fall back to treating
-    it as a term id directly. None → None (caller defaults to current term).
-    """
-    if not semester:
-        return None
-    rows = table("terms").select(
-        "id", filters={"label": f"eq.{semester}"}, limit=1
-    )
-    if rows:
-        return rows[0]["id"]
-    # Maybe the caller already passed a term id.
-    rows = table("terms").select("id", filters={"id": f"eq.{semester}"}, limit=1)
-    return rows[0]["id"] if rows else None
+# `semester` query values (term labels, with a term-id fallback) resolve via
+# the shared `academics.term_id_for_label` — one mapping across the API.
 
 
 def _resolve_enrollment(user_id: str, course_id: str, semester: str | None) -> dict | None:
@@ -72,7 +57,7 @@ def _resolve_enrollment(user_id: str, course_id: str, semester: str | None) -> d
     if not offering_ids:
         return None
 
-    target_term_id = _term_id_for_semester(semester)
+    target_term_id = academics.term_id_for_label(semester)
     if target_term_id is None and semester is None:
         cur = academics.current_term()
         target_term_id = cur["id"] if cur else None
@@ -203,7 +188,7 @@ def get_summary(request: Request, user_id: str = Query(...), semester: str = Que
     current grade + letter, plus the term GPA."""
     require_self(user_id, request)
 
-    term_id = _term_id_for_semester(semester)
+    term_id = academics.term_id_for_label(semester)
     if not term_id:
         return {"courses": [], "gpa": None, "semester": semester}
 
@@ -597,7 +582,7 @@ def get_gpa(request: Request, user_id: str = Query(...), semester: str | None = 
     """
     require_self(user_id, request)
 
-    term_id = _term_id_for_semester(semester) if semester else None
+    term_id = academics.term_id_for_label(semester) if semester else None
 
     enrollments = table("enrollments").select(
         "id,user_id,offering_id,letter_scale,curve_mode,curve_avg_target,curve_sd_delta",

--- a/backend/routes/graph.py
+++ b/backend/routes/graph.py
@@ -1,7 +1,7 @@
 import uuid
 
 import httpx
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, Query
 from pydantic import BaseModel, ValidationError
 from typing import Optional
 from pydantic_ai.exceptions import AgentRunError
@@ -24,15 +24,15 @@ router = APIRouter()
 
 
 @router.get("/{user_id}")
-def get_user_graph(user_id: str, request: Request):
+def get_user_graph(user_id: str, request: Request, semester: str | None = Query(None)):
     require_self(user_id, request)
-    return get_graph(user_id)
+    return get_graph(user_id, semester)
 
 
 @router.get("/{user_id}/recommendations")
-def get_user_recommendations(user_id: str, request: Request):
+def get_user_recommendations(user_id: str, request: Request, semester: str | None = Query(None)):
     require_self(user_id, request)
-    return {"recommendations": get_recommendations(user_id)}
+    return {"recommendations": get_recommendations(user_id, semester)}
 
 
 # ── Course endpoints ──────────────────────────────────────────────────────────
@@ -41,6 +41,9 @@ class AddCourseBody(BaseModel):
     course_id: str
     color: Optional[str] = None
     nickname: Optional[str] = None
+    # Semester label to enroll into (the active tab in the Courses & Semesters
+    # hub). Omitted → the backend falls back to the current term.
+    term: Optional[str] = None
 
 
 class UpdateCourseColorBody(BaseModel):
@@ -65,7 +68,7 @@ def list_courses(user_id: str, request: Request):
 @router.post("/{user_id}/courses")
 def create_course(user_id: str, body: AddCourseBody, request: Request):
     require_self(user_id, request)
-    result = add_course(user_id, body.course_id, body.color, body.nickname)
+    result = add_course(user_id, body.course_id, body.color, body.nickname, body.term)
     if "error" in result:
         raise HTTPException(status_code=404, detail=result["error"])
     return result

--- a/backend/scripts/backfill_document_chunks.py
+++ b/backend/scripts/backfill_document_chunks.py
@@ -39,7 +39,7 @@ load_dotenv(BASE / ".env.staging")
 sys.path.insert(0, str(BASE))
 
 from db.connection import table  # noqa: E402
-from services.chunker import chunk_document  # noqa: E402
+from services.chunker import chunk_for_category  # noqa: E402
 from services.rag_service import _embed_document, index_document_chunks  # noqa: E402
 from services.encryption import decrypt_if_present  # noqa: E402
 
@@ -76,7 +76,7 @@ def main() -> None:
         filters={"extracted_text": "is.null", "deleted_at": "is.null"},
     )
     docs = table("documents").select(
-        "id,file_name,user_id,offering_id,extracted_text",
+        "id,file_name,user_id,offering_id,extracted_text,category",
         filters={"extracted_text": "not.is.null", "deleted_at": "is.null"},
     )
 
@@ -117,7 +117,7 @@ def main() -> None:
             continue
 
         try:
-            chunks = chunk_document(extracted)
+            chunks = chunk_for_category(extracted, doc.get("category") or "other")
             if not chunks:
                 print("0 chunks (empty text)")
                 ok += 1

--- a/backend/services/academics.py
+++ b/backend/services/academics.py
@@ -50,6 +50,44 @@ def list_terms() -> list[dict]:
     ) or []
 
 
+def term_id_for_label(label: str | None) -> str | None:
+    """Resolve a semester **label** (e.g. "Spring 2026") to a term id.
+
+    Falls back to treating the value as a term id directly. ``None``/empty → None.
+    The canonical mapping for ``semester`` query values across the API —
+    ``routes/gradebook.py`` and the graph/recommendations scoping both use it.
+    """
+    if not label:
+        return None
+    rows = table("terms").select("id", filters={"label": f"eq.{label}"}, limit=1)
+    if rows:
+        return rows[0]["id"]
+    rows = table("terms").select("id", filters={"id": f"eq.{label}"}, limit=1)
+    return rows[0]["id"] if rows else None
+
+
+def user_course_ids_for_term(user_id: str, term_id: str) -> set[str]:
+    """The abstract ``course_id``s the user is enrolled in for a given term.
+
+    ``enrollments (user_id) → offering_id → course_offerings (term_id) → course_id``.
+    Multi-step reads (this module avoids PostgREST embedded filters); short-circuits
+    on empty sets. Deliberately **not** cached — enrollments mutate.
+    """
+    if not user_id or not term_id:
+        return set()
+    enr = table("enrollments").select(
+        "offering_id", filters={"user_id": f"eq.{user_id}"}
+    ) or []
+    off_ids = {e["offering_id"] for e in enr if e.get("offering_id")}
+    if not off_ids:
+        return set()
+    offs = table("course_offerings").select(
+        "course_id",
+        filters={"id": f"in.({','.join(off_ids)})", "term_id": f"eq.{term_id}"},
+    ) or []
+    return {o["course_id"] for o in offs if o.get("course_id")}
+
+
 def resolve_offering(
     course_id: str,
     term_id: str | None = None,

--- a/backend/services/academics.py
+++ b/backend/services/academics.py
@@ -20,6 +20,8 @@ import uuid
 from datetime import date
 from functools import lru_cache
 
+import httpx
+
 from db.connection import table
 
 
@@ -98,7 +100,10 @@ def resolve_offering(
 
     ``term_id`` defaults to the current term. If no matching offering exists:
     - ``create=True`` inserts one (NULL section) and returns its id, so a fresh
-      enrollment lands in the real current semester instead of a legacy term;
+      enrollment lands in the real current semester instead of a legacy term.
+      Race-safe: losing a concurrent create to the partial unique index
+      (migration 0036) re-selects and returns the winner's row instead of
+      surfacing the conflict;
     - ``create=False`` falls back to any existing offering of the course.
     Returns None only when the course has no offering and we can't/shouldn't make one.
     """
@@ -120,10 +125,26 @@ def resolve_offering(
 
     if create and term_id:
         new_id = str(uuid.uuid4())
-        table("course_offerings").insert(
-            {"id": new_id, "course_id": course_id, "term_id": term_id}
-        )
-        return new_id
+        try:
+            table("course_offerings").insert(
+                {"id": new_id, "course_id": course_id, "term_id": term_id}
+            )
+            return new_id
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 409:
+                raise
+            # Lost a create race: the NULL-section partial unique index (0036)
+            # rejected a second offering for (course, term). The winner's row
+            # exists now — return it.
+            rows = table("course_offerings").select(
+                "id",
+                filters={"course_id": f"eq.{course_id}", "term_id": f"eq.{term_id}"},
+                order="created_at.asc",
+                limit=1,
+            )
+            if rows:
+                return rows[0]["id"]
+            raise
 
     # No offering in the target term and not creating — fall back to any offering
     # of this course so reads still resolve to something sensible.

--- a/backend/services/chunker.py
+++ b/backend/services/chunker.py
@@ -7,6 +7,8 @@ over-long blocks at sentence boundaries.
 Target: 50–400 words per chunk.
 """
 
+import re
+
 _MIN_WORDS = 50
 _MAX_WORDS = 400
 
@@ -34,6 +36,97 @@ def _split_at_sentence(text: str, max_words: int) -> list[str]:
         chunks.append(candidate.strip())
         start += len(candidate.split())
     return [c for c in chunks if c.strip()]
+
+
+_PROSE_TARGET_WORDS = 200
+_PROSE_OVERLAP_WORDS = 40
+_PROSE_CATEGORIES = {"reading", "assignment", "study_guide"}
+
+# Split on whitespace that follows sentence-ending punctuation.
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
+
+
+def _split_sentences(text: str) -> list[str]:
+    """Split prose into sentences, collapsing all whitespace first.
+
+    Prose (essays, problem-set writeups) has sparse blank lines, so we
+    normalize newlines away and segment on sentence punctuation instead of
+    on blocks. Deterministic: fixed regex, no model calls.
+    """
+    normalized = " ".join(text.split())
+    if not normalized:
+        return []
+    return [s for s in _SENTENCE_BOUNDARY.split(normalized) if s]
+
+
+def chunk_prose(text: str) -> list[str]:
+    """Chunk continuous prose into overlapping sentence windows.
+
+    Packs sentences greedily into ~_PROSE_TARGET_WORDS windows, carries a
+    ~_PROSE_OVERLAP_WORDS overlap into the next window so ideas straddling a
+    boundary appear in both, hard-caps any window at _MAX_WORDS, and absorbs a
+    too-small trailing remainder into the final window. Deterministic.
+    """
+    if not text or not text.strip():
+        return []
+
+    sentences = _split_sentences(text)
+    if not sentences:
+        return []
+
+    counts = [_word_count(s) for s in sentences]
+    n = len(sentences)
+
+    # Whole document fits in one window -> single chunk.
+    if sum(counts) <= _PROSE_TARGET_WORDS:
+        return [" ".join(sentences)]
+
+    chunks: list[str] = []
+    start = 0
+    while start < n:
+        # Grow the window until we reach the word target (or run out).
+        end = start
+        words = 0
+        while end < n and words < _PROSE_TARGET_WORDS:
+            words += counts[end]
+            end += 1
+
+        # If the leftover tail is too small to stand alone, absorb it here
+        # rather than emit a sub-_MIN_WORDS chunk.
+        remaining = sum(counts[end:])
+        if 0 < remaining < _MIN_WORDS:
+            end = n
+
+        piece = " ".join(sentences[start:end])
+        if _word_count(piece) > _MAX_WORDS:
+            chunks.extend(_split_at_sentence(piece, _MAX_WORDS))
+        else:
+            chunks.append(piece)
+
+        if end >= n:
+            break
+
+        # Step back to create overlap for the next window. Guarantee forward
+        # progress: next window always starts at least one sentence past `start`.
+        overlap = 0
+        next_start = end
+        while next_start - 1 > start and overlap < _PROSE_OVERLAP_WORDS:
+            next_start -= 1
+            overlap += counts[next_start]
+        start = next_start
+
+    return [c for c in chunks if c.strip()]
+
+
+def chunk_for_category(text: str, category: str) -> list[str]:
+    """Route to the chunking strategy for a document's classified category.
+
+    Continuous-prose categories use the sentence-window chunker; structured
+    markdown (and any unrecognized category) uses the block chunker.
+    """
+    if category in _PROSE_CATEGORIES:
+        return chunk_prose(text)
+    return chunk_document(text)
 
 
 def chunk_document(text: str) -> list[str]:

--- a/backend/services/graph_service.py
+++ b/backend/services/graph_service.py
@@ -354,6 +354,14 @@ def add_course(
     up under the tab the user was viewing instead of being silently dropped into
     the date-derived current term. When omitted/unresolvable it falls back to the
     current term.
+
+    Single return contract: ``{course_id, already_existed, ...}`` —
+    ``already_existed=True`` carries ``term`` (the label the course is already
+    taken in; "" when unknown), ``already_existed=False`` means a fresh
+    enrollment was created — or ``{course_id, error}`` when the course/term
+    can't be resolved. The up-front no-retake check is the only
+    already-existed path: ``resolve_offering``'s conflict retry (migration
+    0036) makes a lost create race land on the winner's offering.
     """
     # Verify the abstract course exists in the catalog
     course_check = table("courses").select("id", filters={"id": f"eq.{course_id}"})
@@ -385,14 +393,6 @@ def add_course(
     offering_id = resolve_offering(course_id, term_id=term_id, create=True)
     if not offering_id:
         return {"course_id": course_id, "error": "No term available to enroll into"}
-
-    # Check if already enrolled in this offering
-    existing = table("enrollments").select(
-        "id",
-        filters={"user_id": f"eq.{user_id}", "offering_id": f"eq.{offering_id}"},
-    )
-    if existing:
-        return {"course_id": course_id, "already_existed": True}
 
     table("enrollments").insert({
         "id": str(uuid.uuid4()),

--- a/backend/services/graph_service.py
+++ b/backend/services/graph_service.py
@@ -141,15 +141,30 @@ def _compute_velocity(events: list) -> float:
     return round(positive_gain / days, 4)
 
 
-def get_graph(user_id: str) -> dict:
+def get_graph(user_id: str, semester: str | None = None) -> dict:
     ensure_user_exists(user_id)
-    
+
     # Get all enrolled courses for this user
     enrolled_courses = _user_enrolled_courses(user_id)
-    
+
+    # Optional semester scope (Path A): restrict to the courses the user is
+    # enrolled in for that term. `allowed_course_ids is None` means "all terms".
+    allowed_course_ids: set[str] | None = None
+    if semester:
+        from services.academics import term_id_for_label, user_course_ids_for_term
+        term_id = term_id_for_label(semester)
+        allowed_course_ids = (
+            user_course_ids_for_term(user_id, term_id) if term_id else set()
+        )
+        enrolled_courses = [
+            c for c in enrolled_courses if c.get("course_id") in allowed_course_ids
+        ]
+
     # Get all graph nodes for this user
     nodes_raw = table("graph_nodes").select("*", filters={"user_id": f"eq.{user_id}"})
     nodes = nodes_raw or []
+    if allowed_course_ids is not None:
+        nodes = [n for n in nodes if n.get("course_id") in allowed_course_ids]
     node_ids = {n["id"] for n in nodes}
 
     edges_raw = table("graph_edges").select("*", filters={"user_id": f"eq.{user_id}"})
@@ -321,20 +336,53 @@ def get_courses(user_id: str) -> list:
     return result
 
 
-def add_course(user_id: str, course_id: str, color: str | None = None, nickname: str | None = None) -> dict:
+def add_course(
+    user_id: str,
+    course_id: str,
+    color: str | None = None,
+    nickname: str | None = None,
+    term: str | None = None,
+) -> dict:
     """
     Enroll a user in a course. ``course_id`` is the abstract catalog course id;
-    the enrollment is created against the **current term's offering** of that
-    course (created if the catalog lacks one), so new enrollments land in the
-    real current semester.
+    the enrollment is created against an offering of that course (created if the
+    catalog lacks one).
+
+    ``term`` is an optional semester **label** (e.g. "Fall 2026") — the semester
+    the caller is enrolling into (the active tab in the Courses & Semesters hub).
+    When given and resolvable it picks that term's offering, so the course shows
+    up under the tab the user was viewing instead of being silently dropped into
+    the date-derived current term. When omitted/unresolvable it falls back to the
+    current term.
     """
     # Verify the abstract course exists in the catalog
     course_check = table("courses").select("id", filters={"id": f"eq.{course_id}"})
     if not course_check:
         return {"course_id": course_id, "error": "Course not found in catalog"}
 
-    from services.academics import resolve_offering
-    offering_id = resolve_offering(course_id, create=True)
+    from services.academics import (
+        resolve_offering,
+        user_offering_ids_for_course,
+        term_for_offering,
+        term_id_for_label,
+    )
+
+    # No-retake rule: a course already enrolled in ANY term can't be added again.
+    # (Broadens the old current-term-only check so cross-semester duplicates are
+    # rejected instead of silently creating a second enrollment.)
+    existing_offerings = user_offering_ids_for_course(user_id, course_id)
+    if existing_offerings:
+        existing_term = term_for_offering(existing_offerings[0]) or {}
+        return {
+            "course_id": course_id,
+            "already_existed": True,
+            "term": existing_term.get("label", ""),
+        }
+
+    # Resolve the requested semester label → term id. An unknown label yields
+    # None, which resolve_offering treats as "current term".
+    term_id = term_id_for_label(term) if term else None
+    offering_id = resolve_offering(course_id, term_id=term_id, create=True)
     if not offering_id:
         return {"course_id": course_id, "error": "No term available to enroll into"}
 
@@ -635,13 +683,23 @@ def apply_graph_update(user_id: str, graph_update: dict, course_id: str | None =
     return mastery_changes
 
 
-def get_recommendations(user_id: str) -> list:
+def get_recommendations(user_id: str, semester: str | None = None) -> list:
+    filters = {
+        "user_id": f"eq.{user_id}",
+        "mastery_tier": "in.(struggling,learning,unexplored)",
+    }
+    if semester:
+        from services.academics import term_id_for_label, user_course_ids_for_term
+        term_id = term_id_for_label(semester)
+        allowed = user_course_ids_for_term(user_id, term_id) if term_id else set()
+        # Unresolved label / no enrollment in that term → no recommendations.
+        if not allowed:
+            return []
+        filters["course_id"] = f"in.({','.join(allowed)})"
+
     rows = table("graph_nodes").select(
-        "concept_name,mastery_score,mastery_tier",
-        filters={
-            "user_id": f"eq.{user_id}",
-            "mastery_tier": "in.(struggling,learning,unexplored)",
-        },
+        "concept_name,mastery_score,mastery_tier,course_id",
+        filters=filters,
         order="mastery_score.asc",
         limit=5,
     )

--- a/backend/tests/test_academics.py
+++ b/backend/tests/test_academics.py
@@ -134,3 +134,46 @@ def test_term_for_offering():
     }
     with patch.object(ac, "table", side_effect=_factory(rows)):
         assert ac.term_for_offering("off-1")["label"] == "Fall 2026"
+
+
+# ── term_id_for_label ────────────────────────────────────────────────────────
+
+def test_term_id_for_label_resolves_by_label():
+    rows = {"terms": [{"id": "t-spring"}]}
+    with patch.object(ac, "table", side_effect=_factory(rows)):
+        assert ac.term_id_for_label("Spring 2026") == "t-spring"
+
+
+def test_term_id_for_label_falls_back_to_id():
+    # First select (by label) empty; second (by id) returns the row.
+    factory = _factory({}, select_seqs={"terms": [[], [{"id": "t-xyz"}]]})
+    with patch.object(ac, "table", side_effect=factory):
+        assert ac.term_id_for_label("t-xyz") == "t-xyz"
+
+
+def test_term_id_for_label_none_for_empty():
+    with patch.object(ac, "table", side_effect=_factory({})):
+        assert ac.term_id_for_label("") is None
+
+
+# ── user_course_ids_for_term ─────────────────────────────────────────────────
+
+def test_user_course_ids_for_term_intersects_enrollments_and_term():
+    rows = {
+        "enrollments": [{"offering_id": "off-1"}, {"offering_id": "off-2"}],
+        # course_offerings filtered by (id in off-1,off-2) AND term_id eq t-spring
+        "course_offerings": [{"course_id": "bio-101"}],
+    }
+    with patch.object(ac, "table", side_effect=_factory(rows)):
+        assert ac.user_course_ids_for_term("user_andres", "t-spring") == {"bio-101"}
+
+
+def test_user_course_ids_for_term_empty_when_no_enrollments():
+    with patch.object(ac, "table", side_effect=_factory({"enrollments": []})):
+        assert ac.user_course_ids_for_term("user_andres", "t-spring") == set()
+
+
+def test_user_course_ids_for_term_empty_args():
+    with patch.object(ac, "table", side_effect=_factory({})):
+        assert ac.user_course_ids_for_term("", "t") == set()
+        assert ac.user_course_ids_for_term("u", "") == set()

--- a/backend/tests/test_academics.py
+++ b/backend/tests/test_academics.py
@@ -7,6 +7,9 @@ MagicMock per table name, seeded with canned `.select()` rows and recording
 """
 from unittest.mock import MagicMock, patch
 
+import httpx
+import pytest
+
 import services.academics as ac
 
 
@@ -90,6 +93,55 @@ def test_resolve_offering_creates_when_missing_and_create_true():
     assert payload["course_id"] == "course-1"
     assert payload["term_id"] == "t1"
     assert payload["id"] == off_id
+
+
+def _conflict_error() -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "http://test/course_offerings")
+    return httpx.HTTPStatusError(
+        "conflict", request=req, response=httpx.Response(409, request=req)
+    )
+
+
+def test_resolve_offering_create_conflict_reselects_winner():
+    """Losing the create race to the 0036 partial unique index re-selects the
+    now-existing offering and returns it instead of raising."""
+    factory = _factory(
+        {"terms": [{"id": "t1", "sort_key": 1}]},
+        # pre-insert term lookup misses, post-conflict re-select finds the winner
+        select_seqs={"course_offerings": [[], [{"id": "off-winner"}]]},
+    )
+    cache: dict = {}
+
+    def make(name):
+        m = cache.get(name) or factory(name)
+        cache[name] = m
+        if name == "course_offerings":
+            m.insert.side_effect = _conflict_error()
+        return m
+
+    with patch.object(ac, "table", side_effect=make):
+        assert ac.resolve_offering("course-1", term_id="t1", create=True) == "off-winner"
+
+
+def test_resolve_offering_create_non_conflict_error_propagates():
+    """Only 409 means 'someone else created it' — other HTTP errors re-raise."""
+    req = httpx.Request("POST", "http://test/course_offerings")
+    err = httpx.HTTPStatusError(
+        "boom", request=req, response=httpx.Response(500, request=req)
+    )
+    factory = _factory({"terms": [{"id": "t1", "sort_key": 1}], "course_offerings": []})
+    cache: dict = {}
+
+    def make(name):
+        m = cache.get(name) or factory(name)
+        cache[name] = m
+        if name == "course_offerings":
+            m.insert.side_effect = err
+        return m
+
+    with patch.object(ac, "table", side_effect=make):
+        with pytest.raises(httpx.HTTPStatusError):
+            ac.resolve_offering("course-1", term_id="t1", create=True)
 
 
 def test_resolve_offering_no_create_falls_back_to_any_offering():

--- a/backend/tests/test_chunker.py
+++ b/backend/tests/test_chunker.py
@@ -1,4 +1,7 @@
-from services.chunker import chunk_document
+from services.chunker import chunk_document, chunk_prose, chunk_for_category
+
+_MAX_WORDS_BUFFER = 420   # _MAX_WORDS (400) + small slack for a boundary sentence
+_MIN_WORDS_FLOOR = 50     # matches chunker._MIN_WORDS
 
 
 def test_empty_returns_empty():
@@ -46,3 +49,82 @@ def test_no_empty_chunks():
     result = chunk_document(text)
     for chunk in result:
         assert chunk.strip() != ""
+
+
+def _prose(n):
+    """n distinct sentences, each 10 unique tokens + a period.
+
+    Every token is unique to its sentence, so any token shared between two
+    chunks proves a whole sentence overlaps them."""
+    return " ".join(
+        f"alpha{i} bravo{i} charlie{i} delta{i} echo{i} "
+        f"foxtrot{i} golf{i} hotel{i} india{i} juliet{i}."
+        for i in range(n)
+    )
+
+
+def test_prose_empty_returns_empty():
+    assert chunk_prose("") == []
+    assert chunk_prose("   ") == []
+
+
+def test_prose_short_text_is_single_chunk():
+    text = "Photosynthesis converts light into chemical energy. It happens in chloroplasts."
+    result = chunk_prose(text)
+    assert len(result) == 1
+    assert "photosynthesis" in result[0].lower()
+
+
+def test_prose_no_blank_lines_splits_into_multiple_chunks():
+    # ~600 words of continuous prose with NO double-newline boundaries.
+    result = chunk_prose(_prose(60))
+    assert len(result) >= 2
+
+
+def test_prose_chunks_respect_max_words():
+    for chunk in chunk_prose(_prose(60)):
+        assert len(chunk.split()) <= _MAX_WORDS_BUFFER
+
+
+def test_prose_adjacent_chunks_overlap():
+    chunks = chunk_prose(_prose(60))
+    assert len(chunks) >= 2
+    for a, b in zip(chunks, chunks[1:]):
+        shared = set(a.split()) & set(b.split())
+        assert shared, "expected at least one overlapping sentence between adjacent chunks"
+
+
+def test_prose_is_deterministic():
+    text = _prose(45)
+    assert chunk_prose(text) == chunk_prose(text)
+
+
+def test_prose_splits_oversized_sentence_at_max_words():
+    # A single sentence far exceeding _MAX_WORDS (400) must be hard-split so
+    # no resulting chunk exceeds the cap. Exercises the _split_at_sentence
+    # branch in chunk_prose, which the uniform _prose() fixture never reaches.
+    giant = " ".join(f"token{i}" for i in range(500)) + "."
+    result = chunk_prose(giant)
+    assert len(result) > 1
+    for chunk in result:
+        assert len(chunk.split()) <= 400
+
+
+def test_prose_no_tiny_trailing_chunk():
+    # 22 sentences (~220 words): the leftover after the first ~200-word window
+    # is small and must be absorbed, never emitted as a sub-50-word chunk.
+    # Without absorption, this count would yield a sub-50-word trailing chunk.
+    for chunk in chunk_prose(_prose(22)):
+        assert len(chunk.split()) >= _MIN_WORDS_FLOOR
+
+
+def test_dispatch_prose_categories_use_prose_chunker():
+    text = _prose(40)
+    for cat in ("reading", "assignment", "study_guide"):
+        assert chunk_for_category(text, cat) == chunk_prose(text)
+
+
+def test_dispatch_structured_categories_use_block_chunker():
+    text = "Block one about sorting.\n\nBlock two about graphs.\n\nBlock three about trees."
+    for cat in ("slides", "lecture_notes", "syllabus", "other", "unknown_value"):
+        assert chunk_for_category(text, cat) == chunk_document(text)

--- a/backend/tests/test_document_indexing.py
+++ b/backend/tests/test_document_indexing.py
@@ -8,9 +8,9 @@ resolution, chunking, the relevance gate, and the call into
 `services.rag_service.index_document_chunks`) was never actually
 exercised. These tests call it directly.
 
-`chunk_document` and `index_document_chunks` are imported *inside* the
+`chunk_for_category` and `index_document_chunks` are imported *inside* the
 function body (local imports), so they must be patched at their
-definition sites (`services.chunker.chunk_document`,
+definition sites (`services.chunker.chunk_for_category`,
 `services.rag_service.index_document_chunks`) rather than on
 `routes.documents`.
 """
@@ -51,7 +51,7 @@ class TestIndexDocumentChunks:
                     course_chunks_rows=[],  # no catalog embedding -> gate skipped
                 ),
             ),
-            patch("services.chunker.chunk_document", return_value=chunks) as mock_chunk,
+            patch("services.chunker.chunk_for_category", return_value=chunks) as mock_chunk,
             patch(
                 "services.rag_service.index_document_chunks", return_value=2
             ) as mock_index,
@@ -64,7 +64,7 @@ class TestIndexDocumentChunks:
                 category="lecture_notes",
             )
 
-        mock_chunk.assert_called_once_with("some extracted text")
+        mock_chunk.assert_called_once_with("some extracted text", "lecture_notes")
         mock_index.assert_called_once_with(
             course_code="BIO-101",
             doc_id="doc-1",
@@ -73,7 +73,7 @@ class TestIndexDocumentChunks:
         )
 
     def test_empty_chunks_short_circuits_before_indexing(self):
-        """chunk_document() returning [] (e.g. empty/garbage extracted text)
+        """chunk_for_category() returning [] (e.g. empty/garbage extracted text)
         must bail out before ever calling index_document_chunks."""
         with (
             patch(
@@ -83,7 +83,7 @@ class TestIndexDocumentChunks:
                     course_chunks_rows=[],
                 ),
             ),
-            patch("services.chunker.chunk_document", return_value=[]),
+            patch("services.chunker.chunk_for_category", return_value=[]),
             patch("services.rag_service.index_document_chunks") as mock_index,
         ):
             _index_document_chunks(
@@ -121,7 +121,7 @@ class TestIndexDocumentChunks:
                     course_chunks_rows=[{"embedding": [0.1] * 768}],  # catalog row present
                 ),
             ),
-            patch("services.chunker.chunk_document", return_value=["chunk one"]),
+            patch("services.chunker.chunk_for_category", return_value=["chunk one"]),
             patch("services.rag_service.index_document_chunks") as mock_index,
             caplog.at_level(logging.ERROR, logger="routes.documents"),
         ):
@@ -136,3 +136,30 @@ class TestIndexDocumentChunks:
         ctor.assert_not_called()
         mock_index.assert_not_called()
         assert "_index_document_chunks failed for doc doc-gate" in caplog.text
+
+    def test_category_is_passed_to_chunker(self):
+        """The document's category must reach the chunker so prose docs get
+        the prose strategy."""
+        with (
+            patch(
+                "routes.documents.table",
+                side_effect=_mock_table_for(
+                    courses_rows=[{"course_code": "ENG-201"}],
+                    course_chunks_rows=[],
+                ),
+            ),
+            patch(
+                "services.chunker.chunk_for_category",
+                return_value=["one chunk of prose"],
+            ) as mock_chunk,
+            patch("services.rag_service.index_document_chunks", return_value=1),
+        ):
+            _index_document_chunks(
+                doc_id="doc-3",
+                course_id="course-uuid-1",
+                user_id="user-1",
+                extracted_text="an essay body",
+                category="assignment",
+            )
+
+        mock_chunk.assert_called_once_with("an essay body", "assignment")

--- a/backend/tests/test_graph_service.py
+++ b/backend/tests/test_graph_service.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import pytest
 from unittest.mock import MagicMock, patch
 
+import services.graph_service as gs
 from services.graph_service import (
     get_graph,
     get_courses,
@@ -769,3 +770,252 @@ class TestGetRecommendations:
         with patch("services.graph_service.table", return_value=_simple_mock([])):
             result = get_recommendations("u1")
         assert result == []
+
+
+# ── get_graph semester scoping ─────────────────────────────────────────────────
+
+def test_get_graph_semester_filters_nodes_and_stats():
+    """With a semester, only that term's course nodes survive and stats recount."""
+    enrolled = [
+        {"id": "e1", "offering_id": "o1", "course_id": "bio-101",
+         "color": None, "nickname": None, "enrolled_at": "2026-01-01", "term": "Spring 2026",
+         "courses": {"course_code": "BIO-101", "course_name": "Biology", "department": "", "school": ""}},
+        {"id": "e2", "offering_id": "o2", "course_id": "psy-110",
+         "color": None, "nickname": None, "enrolled_at": "2025-09-01", "term": "Fall 2025",
+         "courses": {"course_code": "PSY-110", "course_name": "Psych", "department": "", "school": ""}},
+    ]
+    nodes = [
+        {"id": "n1", "course_id": "bio-101", "concept_name": "Cells",
+         "mastery_score": 0.4, "mastery_tier": "learning", "times_studied": 1},
+        {"id": "n2", "course_id": "psy-110", "concept_name": "Freud",
+         "mastery_score": 0.9, "mastery_tier": "mastered", "times_studied": 2},
+    ]
+
+    def fake_table(name):
+        from unittest.mock import MagicMock
+        m = MagicMock(name=f"table({name})")
+        m.select.return_value = {"graph_nodes": nodes, "graph_edges": [],
+                                 "node_mastery_events": [], "users": [{"streak_count": 3}]}.get(name, [])
+        return m
+
+    with patch.object(gs, "_user_enrolled_courses", return_value=enrolled), \
+         patch.object(gs, "ensure_user_exists", return_value=None), \
+         patch.object(gs, "table", side_effect=fake_table), \
+         patch("services.academics.term_id_for_label", return_value="t-spring"), \
+         patch("services.academics.user_course_ids_for_term", return_value={"bio-101"}):
+        out = gs.get_graph("user_andres", semester="Spring 2026")
+
+    concept_nodes = [n for n in out["nodes"] if not n.get("is_subject_root")]
+    assert {n["course_id"] for n in concept_nodes} == {"bio-101"}
+    assert out["stats"]["total_nodes"] == 1
+    assert out["stats"]["mastered"] == 0
+    # Only the Spring subject-root hub is built.
+    roots = [n for n in out["nodes"] if n.get("is_subject_root")]
+    assert {r["course_id"] for r in roots} == {"bio-101"}
+
+
+def test_get_graph_no_semester_returns_all():
+    enrolled = []
+    nodes = [
+        {"id": "n1", "course_id": "bio-101", "concept_name": "Cells",
+         "mastery_score": 0.4, "mastery_tier": "learning", "times_studied": 1},
+        {"id": "n2", "course_id": "psy-110", "concept_name": "Freud",
+         "mastery_score": 0.9, "mastery_tier": "mastered", "times_studied": 2},
+    ]
+
+    def fake_table(name):
+        from unittest.mock import MagicMock
+        m = MagicMock(name=f"table({name})")
+        m.select.return_value = {"graph_nodes": nodes, "graph_edges": [],
+                                 "node_mastery_events": [], "users": []}.get(name, [])
+        return m
+
+    with patch.object(gs, "_user_enrolled_courses", return_value=enrolled), \
+         patch.object(gs, "ensure_user_exists", return_value=None), \
+         patch.object(gs, "table", side_effect=fake_table):
+        out = gs.get_graph("user_andres")
+
+    assert out["stats"]["total_nodes"] == 2
+
+
+def test_get_recommendations_semester_builds_course_filter():
+    """When scoped, the DB query carries a course_id in.(...) filter and limit 5."""
+    captured = {}
+
+    def fake_table(name):
+        from unittest.mock import MagicMock
+        m = MagicMock(name=f"table({name})")
+        def _select(cols, filters=None, order=None, limit=None):
+            captured["filters"] = filters
+            captured["limit"] = limit
+            return [{"concept_name": "Cells", "mastery_score": 0.2,
+                     "mastery_tier": "struggling", "course_id": "bio-101"}]
+        m.select.side_effect = _select
+        return m
+
+    with patch.object(gs, "table", side_effect=fake_table), \
+         patch("services.academics.term_id_for_label", return_value="t-spring"), \
+         patch("services.academics.user_course_ids_for_term", return_value={"bio-101"}):
+        recs = gs.get_recommendations("user_andres", semester="Spring 2026")
+
+    assert captured["filters"]["course_id"] == "in.(bio-101)"
+    assert captured["limit"] == 5
+    assert [r["concept_name"] for r in recs] == ["Cells"]
+
+
+def test_get_recommendations_semester_empty_allowed_returns_empty():
+    """Unresolved term / no enrollment → [] without querying graph_nodes."""
+    def fake_table(name):
+        from unittest.mock import MagicMock
+        m = MagicMock(name=f"table({name})")
+        m.select.side_effect = AssertionError("must not query when no courses in term")
+        return m
+
+    with patch.object(gs, "table", side_effect=fake_table), \
+         patch("services.academics.term_id_for_label", return_value=None), \
+         patch("services.academics.user_course_ids_for_term", return_value=set()):
+        assert gs.get_recommendations("user_andres", semester="Nope 1999") == []
+
+
+def test_add_course_rejects_course_taken_in_any_term():
+    """A course the user already has in a *different* term can't be re-added."""
+    def fake_table(name):
+        from unittest.mock import MagicMock
+        m = MagicMock(name=f"table({name})")
+        m.select.return_value = [{"id": "bio-101"}] if name == "courses" else []
+        m.insert.side_effect = AssertionError("must not insert a duplicate enrollment")
+        return m
+
+    with patch.object(gs, "table", side_effect=fake_table), \
+         patch("services.academics.user_offering_ids_for_course", return_value=["off-old"]), \
+         patch("services.academics.term_for_offering", return_value={"label": "Fall 2025"}):
+        result = gs.add_course("user_andres", "bio-101")
+
+    assert result["already_existed"] is True
+    assert result["term"] == "Fall 2025"
+
+
+def test_add_course_enrolls_when_never_taken():
+    inserted = []
+
+    def fake_table(name):
+        from unittest.mock import MagicMock
+        m = MagicMock(name=f"table({name})")
+        m.select.return_value = [{"id": "bio-101"}] if name == "courses" else []
+        def _insert(data):
+            inserted.append((name, data))
+            return [data]
+        m.insert.side_effect = _insert
+        return m
+
+    with patch.object(gs, "table", side_effect=fake_table), \
+         patch("services.academics.user_offering_ids_for_course", return_value=[]), \
+         patch("services.academics.resolve_offering", return_value="off-new"), \
+         patch("services.course_context_service.update_course_context", return_value=None):
+        result = gs.add_course("user_andres", "bio-101")
+
+    assert result["already_existed"] is False
+    assert any(name == "enrollments" for name, _ in inserted)
+
+
+def test_graph_route_passes_semester_through():
+    from fastapi.testclient import TestClient
+    import routes.graph as graph_route
+    from main import app
+
+    captured = {}
+
+    def fake_get_graph(user_id, semester=None):
+        captured["user_id"] = user_id
+        captured["semester"] = semester
+        return {"nodes": [], "edges": [], "stats": {}}
+
+    with patch.object(graph_route, "get_graph", side_effect=fake_get_graph):
+        client = TestClient(app)
+        resp = client.get("/api/graph/user_andres?semester=Spring%202026")
+
+    assert resp.status_code == 200
+    assert captured == {"user_id": "user_andres", "semester": "Spring 2026"}
+
+
+def test_add_course_enrolls_into_requested_term():
+    """A term label picks THAT term's offering, not the date-derived current term.
+
+    Regression: the Courses & Semesters hub adds while a semester tab is active;
+    without threading the term through, every add landed in current_term and was
+    filtered out of the tab the user was viewing.
+    """
+    from unittest.mock import MagicMock
+
+    def fake_table(name):
+        m = MagicMock(name=f"table({name})")
+        m.select.return_value = [{"id": "bio-101"}] if name == "courses" else []
+        m.insert.side_effect = lambda data: [data]
+        return m
+
+    captured = {}
+
+    def fake_resolve(course_id, term_id=None, *, create=False):
+        captured["term_id"] = term_id
+        captured["create"] = create
+        return "off-fall"
+
+    with patch.object(gs, "table", side_effect=fake_table), \
+         patch("services.academics.user_offering_ids_for_course", return_value=[]), \
+         patch("services.academics.term_id_for_label", return_value="fall-2026"), \
+         patch("services.academics.resolve_offering", side_effect=fake_resolve), \
+         patch("services.course_context_service.update_course_context", return_value=None):
+        result = gs.add_course("user_andres", "bio-101", term="Fall 2026")
+
+    assert result["already_existed"] is False
+    assert captured["term_id"] == "fall-2026"
+    assert captured["create"] is True
+
+
+def test_add_course_no_term_falls_back_to_current_term():
+    """No term label → resolve_offering gets term_id=None (its current-term default)."""
+    from unittest.mock import MagicMock
+
+    def fake_table(name):
+        m = MagicMock(name=f"table({name})")
+        m.select.return_value = [{"id": "bio-101"}] if name == "courses" else []
+        m.insert.side_effect = lambda data: [data]
+        return m
+
+    captured = {}
+
+    def fake_resolve(course_id, term_id=None, *, create=False):
+        captured["term_id"] = term_id
+        return "off-current"
+
+    with patch.object(gs, "table", side_effect=fake_table), \
+         patch("services.academics.user_offering_ids_for_course", return_value=[]), \
+         patch("services.academics.resolve_offering", side_effect=fake_resolve), \
+         patch("services.course_context_service.update_course_context", return_value=None):
+        result = gs.add_course("user_andres", "bio-101")
+
+    assert result["already_existed"] is False
+    assert captured["term_id"] is None
+
+
+def test_create_course_route_passes_term_through():
+    from fastapi.testclient import TestClient
+    import routes.graph as graph_route
+    from main import app
+
+    captured = {}
+
+    def fake_add_course(user_id, course_id, color=None, nickname=None, term=None):
+        captured.update(user_id=user_id, course_id=course_id, term=term)
+        return {"course_id": course_id, "already_existed": False}
+
+    with patch.object(graph_route, "add_course", side_effect=fake_add_course), \
+         patch.object(graph_route, "require_self", return_value=None):
+        client = TestClient(app)
+        resp = client.post(
+            "/api/graph/user_andres/courses",
+            json={"course_id": "bio-101", "term": "Fall 2026"},
+        )
+
+    assert resp.status_code == 200
+    assert captured["term"] == "Fall 2026"

--- a/backend/tests/test_graph_service.py
+++ b/backend/tests/test_graph_service.py
@@ -376,9 +376,12 @@ class TestAddCourse:
         assert "course_id" not in inserted             # enrollments key on the offering
 
     def test_skips_insert_for_existing_course(self):
+        # The up-front no-retake check is the single already-existed path (the
+        # redundant per-offering enrollment check was removed): an enrollment in
+        # any offering of the course short-circuits before any term resolution.
         factory, mocks = _cached_mock_table({
             "courses": [{"id": "c1"}],
-            "enrollments": [{"id": "existing"}],       # already enrolled in this offering
+            "enrollments": [{"id": "existing", "offering_id": "off-1"}],
             "terms": [{"id": "t1", "sort_key": 1}],
             "course_offerings": [{"id": "off-1"}],
         })
@@ -387,6 +390,7 @@ class TestAddCourse:
             result = add_course("u1", "c1")
 
         assert result["already_existed"] is True
+        assert "term" in result  # single return contract: duplicate carries term
         mocks["enrollments"].insert.assert_not_called()
 
 

--- a/backend/tests/test_shared_course_context.py
+++ b/backend/tests/test_shared_course_context.py
@@ -468,6 +468,14 @@ class TestLearnHelpers(unittest.TestCase):
         self.assertNotIn("COURSE INTELLIGENCE", prompt)
         mock_ctx.assert_not_called()
 
+    def test_build_system_prompt_carries_academic_integrity_rule(self):
+        """The no-answers integrity rule must be present in every tutor
+        prompt regardless of mode or course context."""
+        from routes.learn import build_system_prompt
+        prompt = build_system_prompt("expository", "Alice", "{}")
+        self.assertIn("ACADEMIC INTEGRITY", prompt)
+        self.assertIn("never to do their graded work for them", prompt)
+
     @patch("routes.learn.table")
     @patch("services.course_context_service.get_course_context", return_value={})
     def test_build_system_prompt_course_id_but_empty_ctx(self, mock_ctx, mock_table):

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -230,6 +230,7 @@ never collide in the DOM.
 | --- | --- |
 | `dashboard-courses-key-toggle` | expand/collapse toggle of the "My courses" key overlay on the graph panel (default sidebar layout; the key starts collapsed) |
 | `dashboard-course-code` | a course row's code/name label inside the expanded key — repeated per course with **no suffix** (deliberate deviation from the suffix rule above: journeys select a row by seeded content, `getByTestId(…).filter({ hasText })`, so no per-row identity is exposed) |
+| `dashboard-courses-manage` | the cog inside the expanded key that opens the Courses & Semesters hub (the hub's own semester tabs are plain text buttons — journeys select them by role/name, e.g. "All semesters" / "Fall 2025") |
 
 ### `library`
 

--- a/docs/superpowers/plans/2026-07-20-per-type-document-chunking.md
+++ b/docs/superpowers/plans/2026-07-20-per-type-document-chunking.md
@@ -1,0 +1,471 @@
+# Per-type Document Chunking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route documents to different chunking strategies based on their classified `category` — a sentence-window "prose" chunker for continuous writing, the existing block chunker for structured markdown.
+
+**Architecture:** Add `chunk_prose(text)` and a `chunk_for_category(text, category)` dispatch to `services/chunker.py`. The dispatch sends `reading`/`assignment`/`study_guide` to `chunk_prose` and everything else to the unchanged `chunk_document`. The document ingest path and the backfill script already know each document's `category`; they call the dispatch instead of `chunk_document` directly.
+
+**Tech Stack:** Python 3, pytest. No new dependencies.
+
+## Global Constraints
+
+- Chunk boundaries MUST be deterministic — chunk IDs are derived from chunk text, so identical input must always produce identical chunks (no randomness, no model calls in the chunker). (ADR 0019)
+- Reuse the existing module-level constants `_MIN_WORDS = 50` and `_MAX_WORDS = 400` in `services/chunker.py`; do not redefine them.
+- `chunk_document` must remain behaviorally unchanged — structured categories keep today's output exactly.
+- All Supabase access goes through `db/connection.py::table()`.
+- Run all commands from `backend/`.
+
+## Prose category set (verbatim)
+
+```python
+_PROSE_CATEGORIES = {"reading", "assignment", "study_guide"}
+```
+Everything else (`syllabus`, `lecture_notes`, `slides`, `other`, and any unknown value) routes to `chunk_document`.
+
+## File Structure
+
+- `backend/services/chunker.py` — MODIFY. Add `_PROSE_TARGET_WORDS`, `_PROSE_OVERLAP_WORDS`, `_PROSE_CATEGORIES`, `_split_sentences`, `chunk_prose`, `chunk_for_category`. `chunk_document`, `_word_count`, `_split_at_sentence` unchanged.
+- `backend/tests/test_chunker.py` — MODIFY. Add prose + dispatch tests alongside the existing block tests.
+- `backend/routes/documents.py` — MODIFY (~lines 1061, 1074). Import and call `chunk_for_category` instead of `chunk_document`.
+- `backend/tests/test_document_indexing.py` — MODIFY. Update the two existing tests to patch `chunk_for_category`; add a dispatch-passthrough assertion.
+- `backend/scripts/backfill_document_chunks.py` — MODIFY (~lines 79, 120). Select `category` and route through `chunk_for_category`.
+
+---
+
+### Task 1: Prose chunker + category dispatch in `services/chunker.py`
+
+**Files:**
+- Modify: `backend/services/chunker.py`
+- Test: `backend/tests/test_chunker.py`
+
+**Interfaces:**
+- Consumes: existing `_word_count(text) -> int`, `_split_at_sentence(text, max_words) -> list[str]`, constants `_MIN_WORDS`, `_MAX_WORDS`.
+- Produces:
+  - `chunk_prose(text: str) -> list[str]`
+  - `chunk_for_category(text: str, category: str) -> list[str]`
+  - `_split_sentences(text: str) -> list[str]`
+  - constants `_PROSE_TARGET_WORDS = 200`, `_PROSE_OVERLAP_WORDS = 40`, `_PROSE_CATEGORIES = {"reading", "assignment", "study_guide"}`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/test_chunker.py`:
+
+```python
+from services.chunker import chunk_prose, chunk_for_category, chunk_document
+
+
+def _prose(n):
+    """n distinct sentences, each 10 unique tokens + a period.
+
+    Every token is unique to its sentence, so any token shared between two
+    chunks proves a whole sentence overlaps them."""
+    return " ".join(
+        f"alpha{i} bravo{i} charlie{i} delta{i} echo{i} "
+        f"foxtrot{i} golf{i} hotel{i} india{i} juliet{i}."
+        for i in range(n)
+    )
+
+
+def test_prose_empty_returns_empty():
+    assert chunk_prose("") == []
+    assert chunk_prose("   ") == []
+
+
+def test_prose_short_text_is_single_chunk():
+    text = "Photosynthesis converts light into chemical energy. It happens in chloroplasts."
+    result = chunk_prose(text)
+    assert len(result) == 1
+    assert "photosynthesis" in result[0].lower()
+
+
+def test_prose_no_blank_lines_splits_into_multiple_chunks():
+    # ~600 words of continuous prose with NO double-newline boundaries.
+    result = chunk_prose(_prose(60))
+    assert len(result) >= 2
+
+
+def test_prose_chunks_respect_max_words():
+    for chunk in chunk_prose(_prose(60)):
+        assert len(chunk.split()) <= _MAX_WORDS_BUFFER
+
+
+def test_prose_adjacent_chunks_overlap():
+    chunks = chunk_prose(_prose(60))
+    assert len(chunks) >= 2
+    for a, b in zip(chunks, chunks[1:]):
+        shared = set(a.split()) & set(b.split())
+        assert shared, "expected at least one overlapping sentence between adjacent chunks"
+
+
+def test_prose_is_deterministic():
+    text = _prose(45)
+    assert chunk_prose(text) == chunk_prose(text)
+
+
+def test_prose_no_tiny_trailing_chunk():
+    # 21 sentences (~210 words): the leftover after the first ~200-word window
+    # is small and must be absorbed, never emitted as a sub-50-word chunk.
+    for chunk in chunk_prose(_prose(21)):
+        assert len(chunk.split()) >= _MIN_WORDS_FLOOR
+
+
+def test_dispatch_prose_categories_use_prose_chunker():
+    text = _prose(40)
+    for cat in ("reading", "assignment", "study_guide"):
+        assert chunk_for_category(text, cat) == chunk_prose(text)
+
+
+def test_dispatch_structured_categories_use_block_chunker():
+    text = "Block one about sorting.\n\nBlock two about graphs.\n\nBlock three about trees."
+    for cat in ("slides", "lecture_notes", "syllabus", "other", "unknown_value"):
+        assert chunk_for_category(text, cat) == chunk_document(text)
+```
+
+Add these two constants near the top of `backend/tests/test_chunker.py` (below the imports) so the assertions read clearly:
+
+```python
+_MAX_WORDS_BUFFER = 420   # _MAX_WORDS (400) + small slack for a boundary sentence
+_MIN_WORDS_FLOOR = 50     # matches chunker._MIN_WORDS
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest tests/test_chunker.py -q`
+Expected: FAIL with `ImportError: cannot import name 'chunk_prose'` (and `chunk_for_category`).
+
+- [ ] **Step 3: Implement the prose chunker and dispatch**
+
+In `backend/services/chunker.py`, add `import re` at the top of the file (below the module docstring). Then add the following after `_split_at_sentence` (keep `chunk_document` where it is):
+
+```python
+_PROSE_TARGET_WORDS = 200
+_PROSE_OVERLAP_WORDS = 40
+_PROSE_CATEGORIES = {"reading", "assignment", "study_guide"}
+
+# Split on whitespace that follows sentence-ending punctuation.
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
+
+
+def _split_sentences(text: str) -> list[str]:
+    """Split prose into sentences, collapsing all whitespace first.
+
+    Prose (essays, problem-set writeups) has sparse blank lines, so we
+    normalize newlines away and segment on sentence punctuation instead of
+    on blocks. Deterministic: fixed regex, no model calls.
+    """
+    normalized = " ".join(text.split())
+    if not normalized:
+        return []
+    return [s for s in _SENTENCE_BOUNDARY.split(normalized) if s]
+
+
+def chunk_prose(text: str) -> list[str]:
+    """Chunk continuous prose into overlapping sentence windows.
+
+    Packs sentences greedily into ~_PROSE_TARGET_WORDS windows, carries a
+    ~_PROSE_OVERLAP_WORDS overlap into the next window so ideas straddling a
+    boundary appear in both, hard-caps any window at _MAX_WORDS, and absorbs a
+    too-small trailing remainder into the final window. Deterministic.
+    """
+    if not text or not text.strip():
+        return []
+
+    sentences = _split_sentences(text)
+    if not sentences:
+        return []
+
+    counts = [_word_count(s) for s in sentences]
+    n = len(sentences)
+
+    # Whole document fits in one window -> single chunk.
+    if sum(counts) <= _PROSE_TARGET_WORDS:
+        return [" ".join(sentences)]
+
+    chunks: list[str] = []
+    start = 0
+    while start < n:
+        # Grow the window until we reach the word target (or run out).
+        end = start
+        words = 0
+        while end < n and words < _PROSE_TARGET_WORDS:
+            words += counts[end]
+            end += 1
+
+        # If the leftover tail is too small to stand alone, absorb it here
+        # rather than emit a sub-_MIN_WORDS chunk.
+        remaining = sum(counts[end:])
+        if 0 < remaining < _MIN_WORDS:
+            end = n
+
+        piece = " ".join(sentences[start:end])
+        if _word_count(piece) > _MAX_WORDS:
+            chunks.extend(_split_at_sentence(piece, _MAX_WORDS))
+        else:
+            chunks.append(piece)
+
+        if end >= n:
+            break
+
+        # Step back to create overlap for the next window. Guarantee forward
+        # progress: next window always starts at least one sentence past `start`.
+        overlap = 0
+        next_start = end
+        while next_start - 1 > start and overlap < _PROSE_OVERLAP_WORDS:
+            next_start -= 1
+            overlap += counts[next_start]
+        start = next_start
+
+    return [c for c in chunks if c.strip()]
+
+
+def chunk_for_category(text: str, category: str) -> list[str]:
+    """Route to the chunking strategy for a document's classified category.
+
+    Continuous-prose categories use the sentence-window chunker; structured
+    markdown (and any unrecognized category) uses the block chunker.
+    """
+    if category in _PROSE_CATEGORIES:
+        return chunk_prose(text)
+    return chunk_document(text)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m pytest tests/test_chunker.py -q`
+Expected: PASS (all existing block tests plus the new prose/dispatch tests).
+
+- [ ] **Step 5: Lint**
+
+Run: `ruff check services/chunker.py tests/test_chunker.py`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/services/chunker.py backend/tests/test_chunker.py
+git commit -m "feat(rag): add prose chunker and per-category chunking dispatch"
+```
+
+---
+
+### Task 2: Route the ingest pipeline through `chunk_for_category`
+
+**Files:**
+- Modify: `backend/routes/documents.py` (import ~line 1061; call ~line 1074)
+- Test: `backend/tests/test_document_indexing.py`
+
+**Interfaces:**
+- Consumes: `services.chunker.chunk_for_category(text, category) -> list[str]` (Task 1).
+- Produces: no new public interface; `_index_document_chunks` now dispatches on the `category` it already receives.
+
+- [ ] **Step 1: Update the failing tests**
+
+In `backend/tests/test_document_indexing.py`, the two existing tests patch `services.chunker.chunk_document`; the code will now call `chunk_for_category`. Replace the patch target and the call assertion.
+
+In `test_happy_path_indexes_chunks_when_no_catalog_embedding`, change:
+
+```python
+            patch("services.chunker.chunk_document", return_value=chunks) as mock_chunk,
+```
+to:
+```python
+            patch("services.chunker.chunk_for_category", return_value=chunks) as mock_chunk,
+```
+
+and change the call assertion:
+
+```python
+        mock_chunk.assert_called_once_with("some extracted text")
+```
+to (the test passes `category="lecture_notes"`):
+```python
+        mock_chunk.assert_called_once_with("some extracted text", "lecture_notes")
+```
+
+In `test_empty_chunks_short_circuits_before_indexing`, change:
+
+```python
+            patch("services.chunker.chunk_document", return_value=[]),
+```
+to:
+```python
+            patch("services.chunker.chunk_for_category", return_value=[]),
+```
+
+Then add a new test to the `TestIndexDocumentChunks` class proving the category is threaded through:
+
+```python
+    def test_category_is_passed_to_chunker(self):
+        """The document's category must reach the chunker so prose docs get
+        the prose strategy."""
+        with (
+            patch(
+                "routes.documents.table",
+                side_effect=_mock_table_for(
+                    courses_rows=[{"course_code": "ENG-201"}],
+                    course_chunks_rows=[],
+                ),
+            ),
+            patch(
+                "services.chunker.chunk_for_category",
+                return_value=["one chunk of prose"],
+            ) as mock_chunk,
+            patch("services.rag_service.index_document_chunks", return_value=1),
+        ):
+            _index_document_chunks(
+                doc_id="doc-3",
+                course_id="course-uuid-1",
+                user_id="user-1",
+                extracted_text="an essay body",
+                category="assignment",
+            )
+
+        mock_chunk.assert_called_once_with("an essay body", "assignment")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python -m pytest tests/test_document_indexing.py -q`
+Expected: FAIL — the patched `chunk_for_category` isn't called yet (code still calls `chunk_document`), so `mock_chunk.assert_called_once_with(...)` fails / `AssertionError`.
+
+- [ ] **Step 3: Wire the dispatch into `_index_document_chunks`**
+
+In `backend/routes/documents.py`, change the local import (~line 1061):
+
+```python
+    from services.chunker import chunk_document
+```
+to:
+```python
+    from services.chunker import chunk_for_category
+```
+
+and change the call (~line 1074):
+
+```python
+        chunks = chunk_document(extracted_text)
+```
+to:
+```python
+        chunks = chunk_for_category(extracted_text, category)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `python -m pytest tests/test_document_indexing.py -q`
+Expected: PASS (all three tests in `TestIndexDocumentChunks`).
+
+- [ ] **Step 5: Lint**
+
+Run: `ruff check routes/documents.py tests/test_document_indexing.py`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/routes/documents.py backend/tests/test_document_indexing.py
+git commit -m "feat(rag): route document ingest through per-category chunker"
+```
+
+---
+
+### Task 3: Route the backfill script through `chunk_for_category`
+
+**Files:**
+- Modify: `backend/scripts/backfill_document_chunks.py` (import ~line 42; select ~line 79; call ~line 120)
+
+**Interfaces:**
+- Consumes: `services.chunker.chunk_for_category` (Task 1).
+- Produces: no new interface — the backfill now matches the live pipeline's per-category behavior instead of chunking every historical doc as a block.
+
+**Note:** `scripts/seed_quiz_fixture.py` intentionally keeps `chunk_document` — its fixtures are hand-authored structured markdown with `\n\n` block breaks, and `tests/test_seed_quiz_fixture.py` asserts `chunk_document` is called per-file. Do not change it.
+
+- [ ] **Step 1: Add `category` to the document query**
+
+In `backend/scripts/backfill_document_chunks.py`, change the select (~line 78):
+
+```python
+    docs = table("documents").select(
+        "id,file_name,user_id,offering_id,extracted_text",
+        filters={"extracted_text": "not.is.null", "deleted_at": "is.null"},
+    )
+```
+to:
+```python
+    docs = table("documents").select(
+        "id,file_name,user_id,offering_id,extracted_text,category",
+        filters={"extracted_text": "not.is.null", "deleted_at": "is.null"},
+    )
+```
+
+- [ ] **Step 2: Update the import**
+
+Change (~line 42):
+
+```python
+from services.chunker import chunk_document  # noqa: E402
+```
+to:
+```python
+from services.chunker import chunk_for_category  # noqa: E402
+```
+
+- [ ] **Step 3: Route the chunking call by category**
+
+Change (~line 120):
+
+```python
+            chunks = chunk_document(extracted)
+```
+to:
+```python
+            chunks = chunk_for_category(extracted, doc.get("category") or "other")
+```
+
+- [ ] **Step 4: Verify the script imports cleanly (no live DB needed)**
+
+Run: `python -c "import scripts.backfill_document_chunks"`
+Expected: no output, exit 0 (module imports without error).
+
+- [ ] **Step 5: Lint**
+
+Run: `ruff check scripts/backfill_document_chunks.py`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/scripts/backfill_document_chunks.py
+git commit -m "feat(rag): route chunk backfill through per-category chunker"
+```
+
+---
+
+### Task 4: Full-suite regression check
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the chunking-related suites together**
+
+Run: `python -m pytest tests/test_chunker.py tests/test_document_indexing.py tests/test_seed_quiz_fixture.py -q`
+Expected: PASS — including `test_seed_quiz_fixture.py`, confirming the untouched fixture path still calls `chunk_document` per file.
+
+- [ ] **Step 2: Run the broader RAG suite**
+
+Run: `python -m pytest tests/test_rag_service.py tests/test_document_indexing.py -q`
+Expected: PASS.
+
+---
+
+## Out of scope (do not implement here)
+
+- **Tutor answer-behavior rule** — the "never give a student the answer / never complete an assignment" instruction is a separate, system-prompt-only change (`PREAMBLE_TEMPLATE` in `routes/learn.py` and the quiz prompt in `backend/prompts/`). It does not depend on this work and is tracked in the design doc's separate note.
+- **Distinguishing assignment prompts from student solutions** — no classifier change.
+- **Re-indexing existing prose docs** — changing prose boundaries changes chunk IDs; stale rows are harmless (last-writer-wins metadata). Running `scripts/backfill_document_chunks.py` (Task 3) after deploy will refresh docs that were never indexed; a full re-index of already-indexed docs is optional and not part of this plan.
+
+## Self-Review
+
+- **Spec coverage:** dispatch (Tasks 1–3), prose chunker with overlap + determinism + cap + tiny-tail handling (Task 1), constants (Task 1), ingest wiring (Task 2), unchanged block path for structured/`other` (Task 1 dispatch test), testing (Tasks 1–4). The design's "separate note" and out-of-scope items are recorded above, not implemented. ✓
+- **Placeholders:** none — all code and commands are concrete. ✓
+- **Type consistency:** `chunk_prose(text: str) -> list[str]`, `chunk_for_category(text: str, category: str) -> list[str]`, `_split_sentences(text: str) -> list[str]` are used identically everywhere they appear. ✓

--- a/docs/superpowers/plans/2026-07-20-semester-scoped-learning.md
+++ b/docs/superpowers/plans/2026-07-20-semester-scoped-learning.md
@@ -1,0 +1,1025 @@
+# Semester-scoped learning + Courses & Semesters hub — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a settings-only semester switcher (a redesigned "Courses & Semesters" modal) that scopes the knowledge graph, Learn, Study, Quiz, and the Dashboard graph to a chosen term, and block re-adding a course already taken in any semester.
+
+**Architecture:** Path A — read-time filtering, **no schema change / no migration**. The graph stays keyed on the abstract `course_id`. A new `academics` resolver turns a term label into the set of course ids the user is enrolled in for that term; the graph/recommendations reads filter to that set when a `semester` param is present (absent = all terms, unchanged). The frontend holds the active semester in `localStorage` (mirrors `useLayoutPref`) and threads it through the learning surfaces. Enrolling is broadened to reject a course the user already has in *any* term (the no-retake rule).
+
+**Tech Stack:** Backend — FastAPI, Supabase via `db/connection.table()`, pytest with the mock-`table` factory from `tests/conftest.py`. Frontend — Next.js/React, Vitest + `@testing-library/react`.
+
+---
+
+## File Structure
+
+Backend:
+- Modify `backend/services/academics.py` — add `term_id_for_label`, `user_course_ids_for_term`.
+- Modify `backend/services/graph_service.py` — `get_graph(user_id, semester=None)`, `get_recommendations(user_id, semester=None)`, no-retake guard in `add_course`.
+- Modify `backend/routes/graph.py` — optional `semester` query param on the two GET routes.
+- Modify `backend/tests/test_academics.py`, `backend/tests/test_graph_service.py` — new tests.
+
+Frontend:
+- Modify `frontend/src/lib/api.ts` — `EnrolledCourse.term`; `semester` arg on `getGraph`/`getRecommendations`.
+- Create `frontend/src/lib/useActiveSemester.ts` — hook + `distinctTerms`/`resolveActiveSemester` helpers.
+- Create `frontend/src/lib/useActiveSemester.test.ts` — vitest unit test for the helpers.
+- Modify `frontend/src/components/ManageCoursesModal.tsx` — group by term, term tabs (set active semester), "Already taken · <term>" state, "Personal learning — Coming soon" row.
+- Modify `frontend/src/components/screens/Dashboard.tsx`, `Tree.tsx`, `Learn.tsx`, `Quiz.tsx` — thread the active semester.
+
+---
+
+## Task 1: Academics resolvers — `term_id_for_label` + `user_course_ids_for_term`
+
+**Files:**
+- Modify: `backend/services/academics.py` (add two functions after `list_terms`, around `:51`)
+- Test: `backend/tests/test_academics.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/tests/test_academics.py`:
+
+```python
+# ── term_id_for_label ────────────────────────────────────────────────────────
+
+def test_term_id_for_label_resolves_by_label():
+    rows = {"terms": [{"id": "t-spring"}]}
+    with patch.object(ac, "table", side_effect=_factory(rows)):
+        assert ac.term_id_for_label("Spring 2026") == "t-spring"
+
+
+def test_term_id_for_label_falls_back_to_id():
+    # First select (by label) empty; second (by id) returns the row.
+    factory = _factory({}, select_seqs={"terms": [[], [{"id": "t-xyz"}]]})
+    with patch.object(ac, "table", side_effect=factory):
+        assert ac.term_id_for_label("t-xyz") == "t-xyz"
+
+
+def test_term_id_for_label_none_for_empty():
+    with patch.object(ac, "table", side_effect=_factory({})):
+        assert ac.term_id_for_label("") is None
+
+
+# ── user_course_ids_for_term ─────────────────────────────────────────────────
+
+def test_user_course_ids_for_term_intersects_enrollments_and_term():
+    rows = {
+        "enrollments": [{"offering_id": "off-1"}, {"offering_id": "off-2"}],
+        # course_offerings filtered by (id in off-1,off-2) AND term_id eq t-spring
+        "course_offerings": [{"course_id": "bio-101"}],
+    }
+    with patch.object(ac, "table", side_effect=_factory(rows)):
+        assert ac.user_course_ids_for_term("user_andres", "t-spring") == {"bio-101"}
+
+
+def test_user_course_ids_for_term_empty_when_no_enrollments():
+    with patch.object(ac, "table", side_effect=_factory({"enrollments": []})):
+        assert ac.user_course_ids_for_term("user_andres", "t-spring") == set()
+
+
+def test_user_course_ids_for_term_empty_args():
+    with patch.object(ac, "table", side_effect=_factory({})):
+        assert ac.user_course_ids_for_term("", "t") == set()
+        assert ac.user_course_ids_for_term("u", "") == set()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_academics.py -k "term_id_for_label or user_course_ids_for_term" -v`
+Expected: FAIL with `AttributeError: module 'services.academics' has no attribute 'term_id_for_label'`.
+
+- [ ] **Step 3: Implement the two functions**
+
+In `backend/services/academics.py`, insert after `list_terms` (after `:51`):
+
+```python
+def term_id_for_label(label: str | None) -> str | None:
+    """Resolve a semester **label** (e.g. "Spring 2026") to a term id.
+
+    Falls back to treating the value as a term id directly. ``None``/empty → None.
+    Mirrors the mapping in ``routes/gradebook.py::_term_id_for_semester`` so the
+    ``semester`` query value resolves the same way across the API.
+    """
+    if not label:
+        return None
+    rows = table("terms").select("id", filters={"label": f"eq.{label}"}, limit=1)
+    if rows:
+        return rows[0]["id"]
+    rows = table("terms").select("id", filters={"id": f"eq.{label}"}, limit=1)
+    return rows[0]["id"] if rows else None
+
+
+def user_course_ids_for_term(user_id: str, term_id: str) -> set[str]:
+    """The abstract ``course_id``s the user is enrolled in for a given term.
+
+    ``enrollments (user_id) → offering_id → course_offerings (term_id) → course_id``.
+    Multi-step reads (this module avoids PostgREST embedded filters); short-circuits
+    on empty sets. Deliberately **not** cached — enrollments mutate.
+    """
+    if not user_id or not term_id:
+        return set()
+    enr = table("enrollments").select(
+        "offering_id", filters={"user_id": f"eq.{user_id}"}
+    ) or []
+    off_ids = {e["offering_id"] for e in enr if e.get("offering_id")}
+    if not off_ids:
+        return set()
+    offs = table("course_offerings").select(
+        "course_id",
+        filters={"id": f"in.({','.join(off_ids)})", "term_id": f"eq.{term_id}"},
+    ) or []
+    return {o["course_id"] for o in offs if o.get("course_id")}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/test_academics.py -k "term_id_for_label or user_course_ids_for_term" -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/academics.py backend/tests/test_academics.py
+git commit -m "feat(academics): term_id_for_label + user_course_ids_for_term resolvers"
+```
+
+---
+
+## Task 2: `get_graph(semester=)` filters nodes/edges/stats by term
+
+**Files:**
+- Modify: `backend/services/graph_service.py:144` (`get_graph`)
+- Test: `backend/tests/test_graph_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_graph_service.py` (add the imports at the top if missing: `from unittest.mock import patch` and `import services.graph_service as gs`):
+
+```python
+def test_get_graph_semester_filters_nodes_and_stats():
+    """With a semester, only that term's course nodes survive and stats recount."""
+    enrolled = [
+        {"id": "e1", "offering_id": "o1", "course_id": "bio-101",
+         "color": None, "nickname": None, "enrolled_at": "2026-01-01", "term": "Spring 2026",
+         "courses": {"course_code": "BIO-101", "course_name": "Biology", "department": "", "school": ""}},
+        {"id": "e2", "offering_id": "o2", "course_id": "psy-110",
+         "color": None, "nickname": None, "enrolled_at": "2025-09-01", "term": "Fall 2025",
+         "courses": {"course_code": "PSY-110", "course_name": "Psych", "department": "", "school": ""}},
+    ]
+    nodes = [
+        {"id": "n1", "course_id": "bio-101", "concept_name": "Cells",
+         "mastery_score": 0.4, "mastery_tier": "learning", "times_studied": 1},
+        {"id": "n2", "course_id": "psy-110", "concept_name": "Freud",
+         "mastery_score": 0.9, "mastery_tier": "mastered", "times_studied": 2},
+    ]
+
+    def fake_table(name):
+        from unittest.mock import MagicMock
+        m = MagicMock(name=f"table({name})")
+        m.select.return_value = {"graph_nodes": nodes, "graph_edges": [],
+                                 "node_mastery_events": [], "users": [{"streak_count": 3}]}.get(name, [])
+        return m
+
+    with patch.object(gs, "_user_enrolled_courses", return_value=enrolled), \
+         patch.object(gs, "ensure_user_exists", return_value=None), \
+         patch.object(gs, "table", side_effect=fake_table), \
+         patch("services.academics.term_id_for_label", return_value="t-spring"), \
+         patch("services.academics.user_course_ids_for_term", return_value={"bio-101"}):
+        out = gs.get_graph("user_andres", semester="Spring 2026")
+
+    concept_nodes = [n for n in out["nodes"] if not n.get("is_subject_root")]
+    assert {n["course_id"] for n in concept_nodes} == {"bio-101"}
+    assert out["stats"]["total_nodes"] == 1
+    assert out["stats"]["mastered"] == 0
+    # Only the Spring subject-root hub is built.
+    roots = [n for n in out["nodes"] if n.get("is_subject_root")]
+    assert {r["course_id"] for r in roots} == {"bio-101"}
+
+
+def test_get_graph_no_semester_returns_all():
+    enrolled = []
+    nodes = [
+        {"id": "n1", "course_id": "bio-101", "concept_name": "Cells",
+         "mastery_score": 0.4, "mastery_tier": "learning", "times_studied": 1},
+        {"id": "n2", "course_id": "psy-110", "concept_name": "Freud",
+         "mastery_score": 0.9, "mastery_tier": "mastered", "times_studied": 2},
+    ]
+
+    def fake_table(name):
+        from unittest.mock import MagicMock
+        m = MagicMock(name=f"table({name})")
+        m.select.return_value = {"graph_nodes": nodes, "graph_edges": [],
+                                 "node_mastery_events": [], "users": []}.get(name, [])
+        return m
+
+    with patch.object(gs, "_user_enrolled_courses", return_value=enrolled), \
+         patch.object(gs, "ensure_user_exists", return_value=None), \
+         patch.object(gs, "table", side_effect=fake_table):
+        out = gs.get_graph("user_andres")
+
+    assert out["stats"]["total_nodes"] == 2
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_graph_service.py -k "get_graph_semester or get_graph_no_semester" -v`
+Expected: FAIL — `get_graph()` got an unexpected keyword argument `semester`.
+
+- [ ] **Step 3: Implement the filter**
+
+In `backend/services/graph_service.py`, change the signature at `:144` and add the filter block:
+
+```python
+def get_graph(user_id: str, semester: str | None = None) -> dict:
+    ensure_user_exists(user_id)
+
+    # Get all enrolled courses for this user
+    enrolled_courses = _user_enrolled_courses(user_id)
+
+    # Optional semester scope (Path A): restrict to the courses the user is
+    # enrolled in for that term. `allowed_course_ids is None` means "all terms".
+    allowed_course_ids: set[str] | None = None
+    if semester:
+        from services.academics import term_id_for_label, user_course_ids_for_term
+        term_id = term_id_for_label(semester)
+        allowed_course_ids = (
+            user_course_ids_for_term(user_id, term_id) if term_id else set()
+        )
+        enrolled_courses = [
+            c for c in enrolled_courses if c.get("course_id") in allowed_course_ids
+        ]
+
+    # Get all graph nodes for this user
+    nodes_raw = table("graph_nodes").select("*", filters={"user_id": f"eq.{user_id}"})
+    nodes = nodes_raw or []
+    if allowed_course_ids is not None:
+        nodes = [n for n in nodes if n.get("course_id") in allowed_course_ids]
+    node_ids = {n["id"] for n in nodes}
+```
+
+This replaces the existing `:144-153` block (up to and including `node_ids = {n["id"] for n in nodes}`). Everything below is unchanged: edges already filter to `node_ids` (`:165`), stats count over `nodes` (`:190-193`), and subject roots build from `enrolled_courses` (`:234`) — all now operate on the filtered sets.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/test_graph_service.py -k "get_graph_semester or get_graph_no_semester" -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/graph_service.py backend/tests/test_graph_service.py
+git commit -m "feat(graph): scope get_graph to a semester's courses"
+```
+
+---
+
+## Task 3: `get_recommendations(semester=)` filters by term
+
+**Files:**
+- Modify: `backend/services/graph_service.py:629` (`get_recommendations`)
+- Test: `backend/tests/test_graph_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_graph_service.py`:
+
+```python
+def test_get_recommendations_semester_filters_by_course():
+    rows = [
+        {"concept_name": "Cells", "mastery_score": 0.2, "mastery_tier": "struggling", "course_id": "bio-101"},
+        {"concept_name": "Freud", "mastery_score": 0.3, "mastery_tier": "learning", "course_id": "psy-110"},
+    ]
+
+    def fake_table(name):
+        from unittest.mock import MagicMock
+        m = MagicMock(name=f"table({name})")
+        m.select.return_value = rows if name == "graph_nodes" else []
+        return m
+
+    with patch.object(gs, "table", side_effect=fake_table), \
+         patch("services.academics.term_id_for_label", return_value="t-spring"), \
+         patch("services.academics.user_course_ids_for_term", return_value={"bio-101"}):
+        recs = gs.get_recommendations("user_andres", semester="Spring 2026")
+
+    assert [r["concept_name"] for r in recs] == ["Cells"]
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_graph_service.py -k get_recommendations_semester -v`
+Expected: FAIL — unexpected keyword argument `semester`.
+
+- [ ] **Step 3: Implement the filter**
+
+Replace `get_recommendations` at `backend/services/graph_service.py:629`:
+
+```python
+def get_recommendations(user_id: str, semester: str | None = None) -> list:
+    allowed: set[str] | None = None
+    if semester:
+        from services.academics import term_id_for_label, user_course_ids_for_term
+        term_id = term_id_for_label(semester)
+        allowed = user_course_ids_for_term(user_id, term_id) if term_id else set()
+
+    rows = table("graph_nodes").select(
+        "concept_name,mastery_score,mastery_tier,course_id",
+        filters={
+            "user_id": f"eq.{user_id}",
+            "mastery_tier": "in.(struggling,learning,unexplored)",
+        },
+        order="mastery_score.asc",
+        # When scoping, over-fetch then trim after filtering so we still return up
+        # to 5 recommendations for the term.
+        limit=5 if allowed is None else 50,
+    )
+    if allowed is not None:
+        rows = [r for r in rows if r.get("course_id") in allowed][:5]
+    recs = []
+    for r in rows:
+        tier = r["mastery_tier"]
+        if tier == "unexplored":
+            reason = "You haven't studied this yet — a great place to start."
+        elif tier == "struggling":
+            reason = f"You're struggling here ({int(r['mastery_score']*100)}%) — focus here to improve."
+        else:
+            reason = f"You're making progress ({int(r['mastery_score']*100)}%) — keep going!"
+        recs.append({"concept_name": r["concept_name"], "reason": reason})
+    return recs
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/test_graph_service.py -k get_recommendations_semester -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/graph_service.py backend/tests/test_graph_service.py
+git commit -m "feat(graph): scope recommendations to a semester's courses"
+```
+
+---
+
+## Task 4: `add_course` no-retake guard (reject a course taken in any term)
+
+**Files:**
+- Modify: `backend/services/graph_service.py:315` (`add_course`)
+- Test: `backend/tests/test_graph_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_graph_service.py`:
+
+```python
+def test_add_course_rejects_course_taken_in_any_term():
+    """A course the user already has in a *different* term can't be re-added."""
+    def fake_table(name):
+        from unittest.mock import MagicMock
+        m = MagicMock(name=f"table({name})")
+        m.select.return_value = [{"id": "bio-101"}] if name == "courses" else []
+        m.insert.side_effect = AssertionError("must not insert a duplicate enrollment")
+        return m
+
+    with patch.object(gs, "table", side_effect=fake_table), \
+         patch("services.academics.user_offering_ids_for_course", return_value=["off-old"]), \
+         patch("services.academics.term_for_offering", return_value={"label": "Fall 2025"}):
+        result = gs.add_course("user_andres", "bio-101")
+
+    assert result["already_existed"] is True
+    assert result["term"] == "Fall 2025"
+
+
+def test_add_course_enrolls_when_never_taken():
+    inserted = []
+
+    def fake_table(name):
+        from unittest.mock import MagicMock
+        m = MagicMock(name=f"table({name})")
+        m.select.return_value = [{"id": "bio-101"}] if name == "courses" else []
+        def _insert(data):
+            inserted.append((name, data))
+            return [data]
+        m.insert.side_effect = _insert
+        return m
+
+    with patch.object(gs, "table", side_effect=fake_table), \
+         patch("services.academics.user_offering_ids_for_course", return_value=[]), \
+         patch("services.academics.resolve_offering", return_value="off-new"), \
+         patch("services.course_context_service.update_course_context", return_value=None):
+        result = gs.add_course("user_andres", "bio-101")
+
+    assert result["already_existed"] is False
+    assert any(name == "enrollments" for name, _ in inserted)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_graph_service.py -k "add_course_rejects or add_course_enrolls" -v`
+Expected: FAIL — the reject test currently creates a second enrollment (no `term` key / triggers the insert AssertionError).
+
+- [ ] **Step 3: Implement the guard**
+
+In `backend/services/graph_service.py`, edit `add_course` (`:322`). After the catalog-existence check and **before** `resolve_offering(...)`, insert the guard:
+
+```python
+    # Verify the abstract course exists in the catalog
+    course_check = table("courses").select("id", filters={"id": f"eq.{course_id}"})
+    if not course_check:
+        return {"course_id": course_id, "error": "Course not found in catalog"}
+
+    from services.academics import (
+        resolve_offering,
+        user_offering_ids_for_course,
+        term_for_offering,
+    )
+
+    # No-retake rule: a course already enrolled in ANY term can't be added again.
+    # (Broadens the old current-term-only check so cross-semester duplicates are
+    # rejected instead of silently creating a second enrollment.)
+    existing_offerings = user_offering_ids_for_course(user_id, course_id)
+    if existing_offerings:
+        term = term_for_offering(existing_offerings[0]) or {}
+        return {
+            "course_id": course_id,
+            "already_existed": True,
+            "term": term.get("label", ""),
+        }
+
+    offering_id = resolve_offering(course_id, create=True)
+    if not offering_id:
+        return {"course_id": course_id, "error": "No term available to enroll into"}
+```
+
+Leave the rest of `add_course` (the current-offering `existing` check at `:332-338`, the insert, the context refresh) unchanged — the `from services.academics import resolve_offering` line that used to sit at `:327` is now covered by the combined import above, so delete that now-duplicate import line.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/test_graph_service.py -k "add_course_rejects or add_course_enrolls" -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/graph_service.py backend/tests/test_graph_service.py
+git commit -m "feat(graph): reject re-adding a course taken in any term (no-retake)"
+```
+
+---
+
+## Task 5: Route wiring — `semester` query param on the two GET graph routes
+
+**Files:**
+- Modify: `backend/routes/graph.py:4` (import), `:24` (`get_user_graph`), `:30` (`get_user_recommendations`)
+- Test: `backend/tests/test_graph_service.py` (route-level via FastAPI TestClient)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_graph_service.py`:
+
+```python
+def test_graph_route_passes_semester_through():
+    from fastapi.testclient import TestClient
+    import routes.graph as graph_route
+    from main import app
+
+    captured = {}
+
+    def fake_get_graph(user_id, semester=None):
+        captured["user_id"] = user_id
+        captured["semester"] = semester
+        return {"nodes": [], "edges": [], "stats": {}}
+
+    with patch.object(graph_route, "get_graph", side_effect=fake_get_graph):
+        client = TestClient(app)
+        resp = client.get("/api/graph/user_andres?semester=Spring%202026")
+
+    assert resp.status_code == 200
+    assert captured == {"user_id": "user_andres", "semester": "Spring 2026"}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_graph_service.py -k graph_route_passes_semester -v`
+Expected: FAIL — `semester` is `None` (route ignores the query param).
+
+- [ ] **Step 3: Implement the route change**
+
+In `backend/routes/graph.py`, add `Query` to the fastapi import at `:4`:
+
+```python
+from fastapi import APIRouter, HTTPException, Request, Query
+```
+
+Replace `:24-33`:
+
+```python
+@router.get("/{user_id}")
+def get_user_graph(user_id: str, request: Request, semester: str | None = Query(None)):
+    require_self(user_id, request)
+    return get_graph(user_id, semester)
+
+
+@router.get("/{user_id}/recommendations")
+def get_user_recommendations(user_id: str, request: Request, semester: str | None = Query(None)):
+    require_self(user_id, request)
+    return {"recommendations": get_recommendations(user_id, semester)}
+```
+
+- [ ] **Step 4: Run the test to verify it passes, then the full backend suite**
+
+Run: `cd backend && python -m pytest tests/test_graph_service.py -k graph_route_passes_semester -v`
+Expected: PASS.
+Run: `cd backend && python -m pytest tests/ -q`
+Expected: all pass (no regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/routes/graph.py backend/tests/test_graph_service.py
+git commit -m "feat(graph): accept optional semester query param on graph + recommendations"
+```
+
+---
+
+## Task 6: API client — `EnrolledCourse.term` + `semester` on `getGraph`/`getRecommendations`
+
+**Files:**
+- Modify: `frontend/src/lib/api.ts:37-41` (`getGraph`, `getRecommendations`), `:43-54` (`EnrolledCourse`)
+
+- [ ] **Step 1: Add `term` to `EnrolledCourse`**
+
+In `frontend/src/lib/api.ts`, add a field to the `EnrolledCourse` interface (after `nickname`, `:51`):
+
+```typescript
+export interface EnrolledCourse {
+  enrollment_id: string;
+  course_id: string;
+  course_code: string;
+  course_name: string;
+  school: string;
+  department: string;
+  color: string | null;
+  nickname: string | null;
+  term: string;
+  node_count: number;
+  enrolled_at: string;
+}
+```
+
+- [ ] **Step 2: Thread `semester` through the two fetchers**
+
+Replace `:37-41`:
+
+```typescript
+// Graph
+export const getGraph = (userId: string, semester?: string) =>
+  fetchJSON<{ nodes: any[]; edges: any[]; stats: any }>(
+    `/api/graph/${userId}${semester ? `?semester=${encodeURIComponent(semester)}` : ""}`,
+  );
+
+export const getRecommendations = (userId: string, semester?: string) =>
+  fetchJSON<{ recommendations: any[] }>(
+    `/api/graph/${userId}/recommendations${semester ? `?semester=${encodeURIComponent(semester)}` : ""}`,
+  );
+```
+
+- [ ] **Step 3: Verify types compile**
+
+Run: `cd frontend && npm run typecheck`
+Expected: PASS (no type errors introduced; `term` is additive and existing callers still compile).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/lib/api.ts
+git commit -m "feat(api): EnrolledCourse.term + optional semester on graph fetchers"
+```
+
+---
+
+## Task 7: `useActiveSemester` hook + term helpers
+
+**Files:**
+- Create: `frontend/src/lib/useActiveSemester.ts`
+- Test: `frontend/src/lib/useActiveSemester.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/lib/useActiveSemester.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { distinctTerms, resolveActiveSemester } from "./useActiveSemester";
+
+const c = (term: string) => ({ term });
+
+describe("distinctTerms", () => {
+  it("dedups preserving first-seen order and drops blanks", () => {
+    expect(distinctTerms([c("Fall 2025"), c("Spring 2026"), c("Fall 2025"), c("")]))
+      .toEqual(["Fall 2025", "Spring 2026"]);
+  });
+});
+
+describe("resolveActiveSemester", () => {
+  it("keeps the active value when it is among the enrolled terms", () => {
+    expect(resolveActiveSemester("Fall 2025", [c("Fall 2025"), c("Spring 2026")]))
+      .toBe("Fall 2025");
+  });
+
+  it("defaults to the most-recently-enrolled term when active is unset/stale", () => {
+    // courses arrive enrolled_at ascending → last is most recent.
+    expect(resolveActiveSemester("", [c("Fall 2025"), c("Spring 2026")]))
+      .toBe("Spring 2026");
+    expect(resolveActiveSemester("Winter 1999", [c("Fall 2025"), c("Spring 2026")]))
+      .toBe("Spring 2026");
+  });
+
+  it("returns empty string when there are no terms", () => {
+    expect(resolveActiveSemester("", [])).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/lib/useActiveSemester.test.ts`
+Expected: FAIL — cannot resolve `./useActiveSemester`.
+
+- [ ] **Step 3: Implement the hook + helpers**
+
+Create `frontend/src/lib/useActiveSemester.ts`:
+
+```typescript
+"use client";
+
+import { useEffect, useState } from "react";
+
+export const ACTIVE_SEMESTER_STORAGE_KEY = "sapling_active_semester";
+const CHANGE_EVENT = "sapling-active-semester-change";
+
+/** Distinct term labels in first-seen order, dropping blanks. */
+export function distinctTerms(courses: { term: string }[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const c of courses) {
+    if (c.term && !seen.has(c.term)) {
+      seen.add(c.term);
+      out.push(c.term);
+    }
+  }
+  return out;
+}
+
+/**
+ * The semester to actually scope by: the stored `active` value when it is one
+ * of the user's enrolled terms, else the most-recently-enrolled term. Courses
+ * arrive `enrolled_at` ascending, so the last distinct term is the most recent.
+ * (Heuristic default; can be upgraded to term `sort_key` ordering later.)
+ */
+export function resolveActiveSemester(active: string, courses: { term: string }[]): string {
+  const terms = distinctTerms(courses);
+  if (active && terms.includes(active)) return active;
+  return terms.length ? terms[terms.length - 1] : "";
+}
+
+function read(): string {
+  if (typeof window === "undefined") return "";
+  return window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY) ?? "";
+}
+
+/** [activeSemester, setActiveSemester] — persisted to localStorage, cross-tab + same-tab reactive. */
+export function useActiveSemester(): [string, (v: string) => void] {
+  const [sem, setSem] = useState<string>("");
+
+  useEffect(() => {
+    setSem(read());
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === ACTIVE_SEMESTER_STORAGE_KEY) setSem(read());
+    };
+    const onCustom = () => setSem(read());
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(CHANGE_EVENT, onCustom);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(CHANGE_EVENT, onCustom);
+    };
+  }, []);
+
+  const update = (v: string) => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, v);
+    setSem(v);
+    window.dispatchEvent(new Event(CHANGE_EVENT));
+  };
+
+  return [sem, update];
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/lib/useActiveSemester.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/useActiveSemester.ts frontend/src/lib/useActiveSemester.test.ts
+git commit -m "feat(frontend): useActiveSemester hook + term-resolution helpers"
+```
+
+---
+
+## Task 8: Dashboard — scope graph, recommendations, and course panels to the active semester
+
+**Files:**
+- Modify: `frontend/src/components/screens/Dashboard.tsx` (imports; `load` at `:256-298`; `courseProgress` at `:326-344`; the `CoursesKey`/legacy panels' course source)
+
+- [ ] **Step 1: Import the hook + helper**
+
+Add to the imports block near `:11-13`:
+
+```typescript
+import { useActiveSemester, resolveActiveSemester } from "@/lib/useActiveSemester";
+```
+
+- [ ] **Step 2: Read the hook and default it once courses load**
+
+Inside `Dashboard()`, after `const { userId, userName, userReady } = useUser();` (`:192`), add:
+
+```typescript
+  const [activeSemester, setActiveSemester] = useActiveSemester();
+```
+
+In `load` (`:256`), pass the active semester to the scoped fetchers and write back a default when unset. Replace the `Promise.all` block (`:261-267`) and the `setCourses(cs)` line (`:268-269`):
+
+```typescript
+      const [graphRes, coursesRes, assignsRes, sessionsRes, recsRes] = await Promise.all([
+        getGraph(userId, activeSemester || undefined),
+        getCourses(userId),
+        getUpcomingAssignments(userId),
+        getSessions(userId, 10),
+        getRecommendations(userId, activeSemester || undefined).catch(() => ({ recommendations: [] })),
+      ]);
+      const cs = coursesRes.courses || [];
+      setCourses(cs);
+      // First run with no stored semester: default to the most-recent enrolled term.
+      if (!activeSemester) {
+        const def = resolveActiveSemester("", cs);
+        if (def) setActiveSemester(def);
+      }
+```
+
+Add `activeSemester` to the `load` dependency array (`:298`):
+
+```typescript
+  }, [userId, activeSemester]);
+```
+
+- [ ] **Step 3: Scope the dashboard's course panels to the active semester**
+
+The graph nodes are already server-scoped. Filter the course list the panels render so chips/progress match. Replace `courseProgress` (`:326`):
+
+```typescript
+  const scopedCourses = React.useMemo(
+    () => (activeSemester ? courses.filter((c) => c.term === activeSemester) : courses),
+    [courses, activeSemester],
+  );
+
+  const courseProgress = React.useMemo(() => {
+    return scopedCourses.map(c => {
+```
+
+...and change that memo's dependency array from `[courses, nodes]` (`:344`) to `[scopedCourses, nodes]`.
+
+Also update the graph-header course chips that read `courses.slice(0, 5)` (`:400`) to `scopedCourses.slice(0, 5)`, and the legacy header count `courses.length` (`:396`) to `scopedCourses.length`.
+
+Note: keep passing the **full** `courses` list to `<ManageCoursesModal ... courses={courses} />` (`:1039`) — the hub needs every term to group them.
+
+- [ ] **Step 4: Verify build + types**
+
+Run: `cd frontend && npm run typecheck && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/screens/Dashboard.tsx
+git commit -m "feat(dashboard): scope graph, recommendations, and course panels to active semester"
+```
+
+---
+
+## Task 9: Tree / Learn / Quiz — thread the active semester into their graph loads
+
+**Files:**
+- Modify: `frontend/src/components/screens/Tree.tsx:62-63`
+- Modify: `frontend/src/components/screens/Learn.tsx:154-155`
+- Modify: `frontend/src/components/screens/Quiz.tsx:39-40`
+
+- [ ] **Step 1: Tree — scope graph + course list**
+
+In `Tree.tsx`, add the import:
+
+```typescript
+import { useActiveSemester } from "@/lib/useActiveSemester";
+```
+
+Inside the component, add `const [activeSemester] = useActiveSemester();`. Change the graph fetch (`:62`) to `getGraph(userId, activeSemester || undefined)`, add `activeSemester` to that load effect's dependency array, and where the fetched courses are stored/used for the course rail, filter with `activeSemester ? courses.filter(c => c.term === activeSemester) : courses`.
+
+- [ ] **Step 2: Learn — scope graph + course picker**
+
+In `Learn.tsx`, add the import and `const [activeSemester] = useActiveSemester();`. Change the graph fetch (`:155`) to `getGraph(userId, activeSemester || undefined)`, add `activeSemester` to the load effect's deps, and filter the course-picker list (`filtered`, `:1378-1382`) to `activeSemester ? c.term === activeSemester : true` alongside the existing predicates.
+
+- [ ] **Step 3: Quiz — scope graph + course picker**
+
+In `Quiz.tsx`, add the import and `const [activeSemester] = useActiveSemester();`. Change the graph fetch (`:40`) to `getGraph(userId, activeSemester || undefined)`, add `activeSemester` to the deps, and filter its course list to the active term the same way.
+
+- [ ] **Step 4: Verify build + types**
+
+Run: `cd frontend && npm run typecheck && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/screens/Tree.tsx frontend/src/components/screens/Learn.tsx frontend/src/components/screens/Quiz.tsx
+git commit -m "feat(learn): scope Tree/Learn/Quiz to the active semester"
+```
+
+---
+
+## Task 10: "Courses & Semesters" hub — group by term, term tabs, no-retake messaging, Personal learning
+
+**Files:**
+- Modify: `frontend/src/components/ManageCoursesModal.tsx`
+
+- [ ] **Step 1: Import the hook/helpers and read the active semester**
+
+Add to the imports (after `:16`):
+
+```typescript
+import { useActiveSemester, distinctTerms, resolveActiveSemester } from "@/lib/useActiveSemester";
+```
+
+Inside `ManageCoursesModal(...)`, after `const toast = useToast();` (`:34`), add:
+
+```typescript
+  const [activeSemester, setActiveSemester] = useActiveSemester();
+  const terms = React.useMemo(() => distinctTerms(courses), [courses]);
+  const activeTerm = resolveActiveSemester(activeSemester, courses);
+```
+
+- [ ] **Step 2: Add the term-tab selector above the course list**
+
+Replace the header of the "Your courses" section (`:104`) so the tabs render above it:
+
+```tsx
+          <div className="label-micro" style={{ marginBottom: 8 }}>Semester</div>
+          {terms.length === 0 ? (
+            <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 16 }}>
+              No semesters yet — add a course below.
+            </div>
+          ) : (
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 16 }}>
+              {terms.map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setActiveSemester(t)}
+                  className="btn btn--sm"
+                  style={{
+                    background: t === activeTerm ? "var(--accent-soft)" : "var(--bg-panel)",
+                    color: t === activeTerm ? "var(--accent)" : "var(--text-dim)",
+                    border: "1px solid var(--border)",
+                  }}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          )}
+
+          <div className="label-micro" style={{ marginBottom: 8 }}>
+            {activeTerm ? `Courses · ${activeTerm}` : "Your courses"}
+          </div>
+```
+
+- [ ] **Step 3: Show only the active term's courses in the list**
+
+Replace the enrolled-course map (`:108-112`) so it renders the active term's courses:
+
+```tsx
+          <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 20 }}>
+            {courses.filter((c) => !activeTerm || c.term === activeTerm).length === 0 && (
+              <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
+                No courses in this semester yet.
+              </div>
+            )}
+            {courses
+              .filter((c) => !activeTerm || c.term === activeTerm)
+              .map((c) => (
+                <EnrolledRow key={c.course_id} userId={userId} course={c} onChanged={onChanged} />
+              ))}
+          </div>
+```
+
+- [ ] **Step 4: "Already taken · <term>" state in the add-search results**
+
+The dedup map already covers all terms (`enrolledIds`, `:65`). Build a course_id → term lookup and use it for the disabled label. After `const enrolledIds = ...` (`:65`), add:
+
+```typescript
+  const enrolledTermById = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of courses) m.set(c.course_id, c.term);
+    return m;
+  }, [courses]);
+```
+
+Replace the add-result button (`:148-158`):
+
+```tsx
+                  <button
+                    className="btn btn--sm"
+                    disabled={enrolled}
+                    onClick={() => handleAdd(c)}
+                    style={{
+                      opacity: enrolled ? 0.55 : 1,
+                      background: enrolled ? "var(--bg-subtle)" : undefined,
+                    }}
+                    title={enrolled ? "A course can only be taken once across semesters" : undefined}
+                  >
+                    {enrolled
+                      ? `Already taken${enrolledTermById.get(c.id) ? ` · ${enrolledTermById.get(c.id)}` : ""}`
+                      : <><Icon name="plus" size={12} /> Add</>}
+                  </button>
+```
+
+- [ ] **Step 5: "Personal learning — Coming soon" row + retitle the modal**
+
+Change the modal title (`:96`) from `My Courses` to `Courses & Semesters`. Before the closing `</div>` of the scroll body (after the add-results list, i.e. after `:162`), add:
+
+```tsx
+          <div style={{ borderTop: "1px solid var(--border)", marginTop: 20, paddingTop: 16 }}>
+            <button
+              className="btn btn--sm"
+              disabled
+              aria-disabled="true"
+              style={{ opacity: 0.5, cursor: "not-allowed" }}
+            >
+              <Icon name="sparkle" size={12} /> Personal learning
+            </button>
+            <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 6 }}>
+              Coming soon
+            </div>
+          </div>
+```
+
+- [ ] **Step 6: Retitle the dashboard entry point**
+
+In `frontend/src/components/screens/Dashboard.tsx`, change the legacy "Manage" button label (`:738`, currently `<Icon name="cog" .../> Manage`) to `<Icon name="cog" size={12} /> Courses & Semesters`. (The sidebar `CoursesKey` "Manage" is an icon-only button — leave its `title="Manage courses"` as-is, or update to "Courses & Semesters" for consistency.)
+
+- [ ] **Step 7: Verify build + types + lint**
+
+Run: `cd frontend && npm run typecheck && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 8: Manual smoke test**
+
+Run: `cd frontend && npm run dev` (backend running per `backend/` README). In the browser:
+- Open the dashboard → click "Courses & Semesters" → confirm term tabs appear, switching a tab changes which courses list and (after close/reload of the dashboard) scopes the graph.
+- In "Add a course", search a course you already took in another term → confirm the button reads "Already taken · <term>" and is disabled.
+- Confirm the "Personal learning" button is grayed out with "Coming soon" beneath it.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/components/ManageCoursesModal.tsx frontend/src/components/screens/Dashboard.tsx
+git commit -m "feat(courses): Courses & Semesters hub — term tabs, no-retake label, personal-learning placeholder"
+```
+
+---
+
+## Final verification
+
+- [ ] **Backend suite green**
+
+Run: `cd backend && python -m pytest tests/ -q`
+Expected: all pass.
+
+- [ ] **Backend lint**
+
+Run: `cd backend && ruff check .`
+Expected: no new violations.
+
+- [ ] **Frontend tests + typecheck + lint**
+
+Run: `cd frontend && npm run test && npm run typecheck && npm run lint`
+Expected: all pass.
+
+---
+
+## Notes / decisions carried from the spec
+
+- **Path A only.** No schema change, no migration, no re-keying of `graph_nodes`. Retakes are disallowed (Task 4), so a per-retake graph never arises.
+- **Default semester** is the most-recently-*enrolled* term (Task 7 `resolveActiveSemester`), a heuristic standing in for "current term"; upgrade to term `sort_key` ordering later if needed.
+- **Session/quiz-exam listing scoping** (mentioned in spec §1) is achieved via client-side course-picker filtering in Task 9 rather than new backend params — the pickers already read `getCourses`, which carries `term`. No separate endpoint changes needed.
+- **Out of scope:** Gradebook's existing `SemesterChips`; implementing "Personal learning".

--- a/docs/superpowers/specs/2026-07-20-per-type-document-chunking-design.md
+++ b/docs/superpowers/specs/2026-07-20-per-type-document-chunking-design.md
@@ -1,0 +1,100 @@
+# Per-type document chunking
+
+- Date: 2026-07-20
+- Status: proposed (design)
+- Related: `docs/decisions/0019-content-addressed-course-chunks-ids.md` (forward-references `[[0021-per-type-document-chunking]]`)
+
+## Problem
+
+The RAG pipeline uses a single chunker (`services/chunker.py::chunk_document`) for every
+document. It splits on double-newline block boundaries — the natural delimiter in Docling's
+markdown output — which works well for **structured** material (slides, lecture notes,
+syllabi) but poorly for **continuous prose**. A student's written problem-set work, an essay,
+or a dense reading has few blank-line boundaries, so the block splitter produces one giant
+block that then gets chopped at arbitrary sentence boundaries with no overlap — ideas land
+split across chunks and retrieval quality suffers.
+
+## Approach: strategy registry keyed on `category`
+
+The document classifier already emits a `category`
+(`syllabus | lecture_notes | slides | reading | assignment | study_guide | other`), and
+`routes/documents.py::_index_document_chunks` (line ~1074) already **receives** that category
+but currently ignores it, calling `chunk_document(text)` unconditionally. We wire the existing
+signal through instead of inventing a new one.
+
+`services/chunker.py` gains a dispatch:
+
+```python
+def chunk_for_category(text: str, category: str) -> list[str]:
+    if category in _PROSE_CATEGORIES:   # reading, assignment, study_guide
+        return chunk_prose(text)
+    return chunk_document(text)         # slides, lecture_notes, syllabus, other (unchanged)
+```
+
+- `_index_document_chunks` calls `chunk_for_category(extracted_text, category)` instead of
+  `chunk_document(extracted_text)`. No other call site changes.
+- `chunk_document` is untouched — structured material keeps its current, working behavior.
+
+## The prose chunker
+
+`chunk_prose(text)` windows over sentences instead of blocks:
+
+1. Segment `text` into sentences (extend the existing `". "`-boundary logic in
+   `_split_at_sentence`; handle `?`/`!` too).
+2. Greedily pack sentences into windows targeting **~200 words**, hard-capped at
+   `_MAX_WORDS` (400).
+3. Carry a **~40-word overlap** (the trailing whole sentences summing to ≈40 words) into the
+   start of the next window, so ideas that straddle a boundary appear in both neighbours.
+4. Drop a trailing window below `_MIN_WORDS` (50) by merging it into the previous window.
+
+**Determinism is a hard requirement** (per ADR 0019: chunk IDs are derived from chunk text, so
+boundaries must be reproducible). `chunk_prose` uses only fixed thresholds and greedy packing —
+no randomness, no model calls — so re-running on identical input yields identical chunks.
+
+## Constants
+
+Defined alongside the existing `_MIN_WORDS`/`_MAX_WORDS`:
+
+- `_PROSE_TARGET_WORDS = 200`
+- `_PROSE_OVERLAP_WORDS = 40`
+- `_PROSE_CATEGORIES = {"reading", "assignment", "study_guide"}`
+
+## Data flow (unchanged except the dispatch)
+
+```
+upload → classify (category) → extract text
+      → _index_document_chunks(category)
+            → chunk_for_category(text, category)   ← NEW dispatch
+            → embed batches → upsert course_chunks
+```
+
+## Testing
+
+- `tests/test_chunker.py`: add cases for `chunk_prose` — continuous prose with no `\n\n`
+  splits into ~200-word windows; overlap present between adjacent chunks; determinism (same
+  input → identical output across two calls); short prose stays a single chunk; `assignment`/
+  `reading`/`study_guide` route to prose while `slides`/`syllabus` route to the block chunker.
+- `tests/test_document_indexing.py`: assert `_index_document_chunks` dispatches on category.
+
+## Re-indexing note (for the plan, not this design)
+
+Changing prose boundaries changes chunk IDs, so previously-indexed prose documents will not
+collide with their new chunks. Existing rows are stale-but-harmless (last-writer-wins metadata);
+a backfill re-index (`scripts/backfill_document_chunks.py`) can refresh them. Whether to backfill
+now or let it happen on next upload is an implementation decision for the plan.
+
+## Separate, unrelated note: tutor answer-behavior
+
+The pedagogical rule — the tutor must **never give out answers or complete a student's
+assignment / problem set**, and should guide with hints and analogous examples instead — is a
+standing behavioral instruction in the tutor's system prompt (`PREAMBLE_TEMPLATE` in
+`routes/learn.py`), and equivalently in the quiz-generation prompt (`backend/prompts/`). It is
+**not** part of this chunking work and does not depend on it: the rule holds regardless of what
+is ingested or what RAG retrieves. Captured here only so it isn't lost; it can ship on its own.
+
+## Out of scope
+
+- The tutor answer-behavior rule above (separate, system-prompt-only change).
+- Distinguishing assignment prompts from student solutions (no classifier change).
+- The doc-scoped vs. content-addressed chunk-ID discrepancy between ADR 0019 and the current
+  `rag_service.index_document_chunks` — noted, but not addressed here.

--- a/docs/superpowers/specs/2026-07-20-semester-scoped-learning-design.md
+++ b/docs/superpowers/specs/2026-07-20-semester-scoped-learning-design.md
@@ -43,6 +43,16 @@ course already taken in any (incl. previous) semester cannot be added again, and
    The Dashboard graph respects the active semester so the setting has a visible
    effect on the home screen.
 
+> **Amendment (2026-07-29): default = All semesters, scoping is opt-in.** The
+> e2e lane vetoed auto-resolving a default term: the rich seed spans Fall 2025 /
+> Spring 2026 / Summer 2026 and 7 of 11 journeys failed because the auto-picked
+> term silently hid cross-term data (dashboard lost MATH210; the graph shrank to
+> 1 of 17 nodes). The empty stored value now IS the default and means "All
+> semesters" (every surface fetches/filters unscoped); nothing resolves a
+> default term on the user's behalf. Scoping starts only when the user picks a
+> term in the hub's tabs — the hub gains an explicit "All semesters" tab that
+> clears the stored value — and the persisted choice still scopes every surface.
+
 ## Design
 
 ### 1. Backend — term-scoped reads (`services/academics.py`, `routes/graph.py`)
@@ -137,7 +147,8 @@ Backend (pytest, mock Supabase/Gemini per `tests/conftest.py`):
 Frontend:
 
 - Hub groups enrolled courses by term and lists term tabs.
-- `useActiveSemester` persists across reloads and defaults to the current term.
+- `useActiveSemester` persists across reloads; empty = "All semesters" (the
+  default — see the amendment above; no auto-resolved term).
 - Selecting a term scopes the course list; scoped readers pass the `semester` param.
 - A prior-term course renders the disabled "Already taken · <term>" state.
 

--- a/docs/superpowers/specs/2026-07-20-semester-scoped-learning-design.md
+++ b/docs/superpowers/specs/2026-07-20-semester-scoped-learning-design.md
@@ -1,0 +1,150 @@
+# Semester-scoped learning + Courses & Semesters hub — design
+
+**Date:** 2026-07-20
+**Status:** Approved (pending spec review) → next: implementation plan
+**Owner:** full-stack (backend + frontend)
+
+## Problem
+
+A student's enrolled courses span multiple semesters (terms), but the learning
+surfaces give no way to organize or scope by semester:
+
+- The knowledge graph is keyed on the **abstract `course_id`** and is deliberately
+  cumulative across terms (`graph_nodes.course_id`; `graph_service.get_courses`
+  counts nodes per `course_id`). `GET /api/graph/{user_id}` returns **every**
+  term's nodes mixed into one graph.
+- `ManageCoursesModal` lists enrolled courses as one flat list
+  (`ManageCoursesModal.tsx:109`) with no hint that terms exist.
+- Tree / Learn / Study / Quiz all read `getCourses(userId)` (all terms) with no
+  term filter, so previous-semester courses are technically reachable but
+  undifferentiated.
+
+The user wants: (1) a way to switch the active semester and scope the learning
+experience to it, (2) enrolled courses organized by semester, (3) a rule that a
+course already taken in any (incl. previous) semester cannot be added again, and
+(4) a placeholder "Personal learning" entry marked "Coming soon".
+
+## Decisions (approved)
+
+1. **No retakes.** Each abstract course lives in exactly one semester for a user.
+   Re-adding a course already enrolled in any term is blocked. This makes each
+   course's graph effectively single-semester already.
+2. **Path A — filter by semester, no schema change.** Because of decision 1, we do
+   NOT re-key `graph_nodes` from `course_id` → `offering_id` and do NOT migrate
+   data. Semester scoping is a **read-time filter** on the existing graph. Purely
+   additive; omitting the filter preserves today's behavior.
+   - Explicitly out of scope: the earlier "separate graph per retake" idea. With
+     retakes blocked, each course has exactly one graph, scoped to its one term.
+3. **Settings-only hub.** The redesigned `ManageCoursesModal` ("Courses &
+   Semesters") is the single home for both **managing** courses and **switching**
+   the active study semester. No separate always-visible switcher for now (can be
+   added later if switching feels buried).
+4. **Active semester scopes Tree / Learn / Study / Quiz AND the Dashboard graph.**
+   The Dashboard graph respects the active semester so the setting has a visible
+   effect on the home screen.
+
+## Design
+
+### 1. Backend — term-scoped reads (`services/academics.py`, `routes/graph.py`)
+
+No data model changes. Add one resolver primitive and thread an optional
+`semester` param through the learning reads.
+
+**New helper — `services/academics.py`:**
+
+```
+user_course_ids_for_term(user_id: str, term_id: str) -> set[str]
+```
+
+Returns the abstract `course_id`s the user is enrolled in for that term:
+`enrollments (user_id) → offering_id → course_offerings (term_id) → course_id`.
+Multi-step reads (no PostgREST embedded filters), matching this module's house
+style; short-circuit on empty sets. **Not cached** — enrollments mutate.
+
+A term **label → term_id** mapping is already implemented as
+`routes/gradebook.py::_term_id_for_semester`; extract/reuse an equivalent so the
+`semester` query value (a term label, e.g. "Spring 2026") resolves consistently.
+
+**Endpoint changes** (all optional param; absent = all terms, unchanged behavior):
+
+- `GET /api/graph/{user_id}` (`routes/graph.py:24`, `get_user_graph`) gains
+  `semester: str | None = Query(None)`. When present: resolve `term_id`, compute
+  `allowed = user_course_ids_for_term(user_id, term_id)`, return only nodes whose
+  `course_id ∈ allowed`, filter edges to surviving node ids, and **recompute
+  `stats` over the filtered set** (mastered/learning/struggling/unexplored/total).
+- `GET /api/graph/{user_id}/recommendations` (`routes/graph.py:30`) gains the same
+  `semester` param and restricts recommendations to that term's courses.
+- Session listing and quiz-exam listing that feed the learning surfaces take the
+  same optional `semester` and filter to the term's courses. Quiz already keys on
+  `offering_id`, so this is threading the param through, not re-keying.
+
+**No-retake guard — `create_course` (`routes/graph.py:63`) / `graph_service.add_course`:**
+Before enrolling, reject if the user already has **any** offering of that abstract
+course (any term). Return a structured error (e.g. `already_existed=True` with a
+message naming the term), so the rule holds even if the UI is bypassed. Today
+`add_course` only checks the current-term offering; broaden to all terms.
+
+### 2. Frontend — "Courses & Semesters" hub (`ManageCoursesModal.tsx`)
+
+Redesign the modal into the single management + switching hub:
+
+- **Term tabs / selector** at the top listing the terms the user is enrolled in
+  (derived from `getCourses`' per-course `term` label), newest first. Selecting a
+  term sets the **active semester** (see §3).
+- **Enrolled courses grouped by semester** — replace the flat `courses.map`
+  (`ManageCoursesModal.tsx:109`) with per-term groups (term header + its courses).
+- **Add-a-course** section: mechanics unchanged (`addCourse` →
+  `resolve_offering`), plus the re-add rule (§4).
+- **"Personal learning"** row at the bottom: a **disabled** button with a
+  **"Coming soon"** caption beneath it. Non-functional placeholder.
+- **Entry point** stays the existing dashboard "Manage" button
+  (`Dashboard.tsx:435` sidebar `CoursesKey`, `Dashboard.tsx:737` legacy panel);
+  relabel it "Courses & Semesters".
+
+### 3. Active-semester context + persistence
+
+- A lightweight **`useActiveSemester` hook + context**, same shape as the existing
+  `useLayoutPref`, backed by `localStorage` (per user), **defaulting to the current
+  term**. Value is a term label (matching the `semester` query param).
+- **Tree, Learn, Study, Quiz, and the Dashboard graph** read the active semester
+  and pass it as `semester` to the scoped endpoints (§1), showing only that term's
+  courses/graph. Selecting a term in the hub updates the context; all readers
+  react.
+- Default resolution: if the persisted value is missing/not among the user's
+  enrolled terms, fall back to the current term (or the most-recent enrolled term).
+
+### 4. No-retake rule + messaging (`ManageCoursesModal.tsx`)
+
+- Enrollment dedup is already by `course_id` across all terms
+  (`enrolledIds`, `ManageCoursesModal.tsx:65`). Make it **explicit**: a course
+  taken in any semester shows a disabled **"Already taken · <term>"** in the
+  add-search results, replacing the generic "Enrolled" (`:157`). The term label
+  comes from the matching enrolled course.
+- Backend enforces the same rule defensively (§1 guard), so a bypassed UI can't
+  create a duplicate-across-terms enrollment.
+
+### 5. Testing
+
+Backend (pytest, mock Supabase/Gemini per `tests/conftest.py`):
+
+- `user_course_ids_for_term` resolves the correct course set for a term and
+  returns empty for a term the user has no enrollment in.
+- `GET /api/graph/{user}?semester=` returns only that term's nodes/edges and
+  recomputes stats; omitting `semester` is unchanged (all terms).
+- `create_course` / `add_course` rejects enrolling in a course the user already
+  has in a different term, with a clear error.
+
+Frontend:
+
+- Hub groups enrolled courses by term and lists term tabs.
+- `useActiveSemester` persists across reloads and defaults to the current term.
+- Selecting a term scopes the course list; scoped readers pass the `semester` param.
+- A prior-term course renders the disabled "Already taken · <term>" state.
+
+## Non-goals
+
+- Re-keying the graph to `offering_id` or any data migration (Path B).
+- Supporting retakes with separate graphs.
+- A separate always-visible semester switcher outside the hub.
+- Implementing "Personal learning" (placeholder only).
+- Changing Gradebook's existing `SemesterChips` (it keeps its own semester UI).

--- a/frontend/e2e/semester-scope.spec.ts
+++ b/frontend/e2e/semester-scope.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Journey — semester scoping is opt-in, All semesters is the default (#360).
+ *
+ * The e2e lane vetoed auto-resolving a default term: the rich seed spans
+ * Fall 2025 / Spring 2026 / Summer 2026, and an auto-picked term silently hid
+ * cross-term fixtures (dashboard lost MATH210; the graph shrank to one term's
+ * nodes). This journey pins the reworked contract:
+ *
+ *   1. Default (nothing stored) = ALL SEMESTERS — courses from different
+ *      terms are visible together (Spring 2026 MATH210 AND Fall 2025 BIO110).
+ *   2. Picking "Fall 2025" in the Courses & Semesters hub scopes the
+ *      dashboard: the Fall course stays, the Spring-only MATH210 disappears.
+ *   3. Picking "All semesters" clears the scope: MATH210 is back.
+ *
+ * Selectors: the `dashboard` testid surface (docs/frontend-testids.md) for the
+ * key overlay + hub trigger; the hub's semester tabs are plain text buttons
+ * selected by role/name ("Fall 2025", "All semesters" — unique in the page).
+ * Course rows are asserted by seeded DATA (db/seed_local_rich.py):
+ * rich-user-active is enrolled in MATH210 only in spring-2026 and BIO110 only
+ * in fall-2025. Every assertion is an auto-waiting expect — no timeouts.
+ */
+import { expect, test } from "./support/fixtures";
+
+test("dashboard defaults to all semesters; picking a term scopes it; All clears", async ({
+  page,
+}) => {
+  await page.goto("/dashboard");
+
+  // Expand the "My courses" key overlay (collapsed by default). The toggle
+  // only mounts once enrollments have loaded, so Playwright's auto-wait on
+  // the click doubles as the "dashboard data arrived" gate.
+  await page.getByTestId("dashboard-courses-key-toggle").click();
+
+  const courseRow = (code: string) =>
+    page.getByTestId("dashboard-course-code").filter({ hasText: code });
+
+  // 1. Default = All semesters: cross-term courses are visible TOGETHER.
+  await expect(courseRow("MATH210")).toBeVisible(); // Spring 2026 only
+  await expect(courseRow("BIO110")).toBeVisible(); // Fall 2025 only
+
+  // 2. Open the Courses & Semesters hub and pick Fall 2025.
+  await page.getByTestId("dashboard-courses-manage").click();
+  await page.getByRole("button", { name: "Fall 2025" }).click();
+  await page.getByRole("button", { name: "Close" }).click();
+
+  // Scoped: the Fall course stays, the Spring-only course is gone.
+  await expect(courseRow("BIO110")).toBeVisible();
+  await expect(courseRow("MATH210")).toHaveCount(0);
+
+  // 3. Back to All semesters — the cross-term view is restored.
+  await page.getByTestId("dashboard-courses-manage").click();
+  await page.getByRole("button", { name: "All semesters" }).click();
+  await page.getByRole("button", { name: "Close" }).click();
+
+  await expect(courseRow("MATH210")).toBeVisible();
+  await expect(courseRow("BIO110")).toBeVisible();
+});

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -88,7 +88,7 @@
   },
   "src/components/screens/Dashboard.tsx": {
     "no-restricted-syntax": {
-      "count": 22
+      "count": 21
     },
     "react/no-unescaped-entities": {
       "count": 2

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -88,7 +88,7 @@
   },
   "src/components/screens/Dashboard.tsx": {
     "no-restricted-syntax": {
-      "count": 25
+      "count": 22
     },
     "react/no-unescaped-entities": {
       "count": 2
@@ -125,6 +125,11 @@
   "src/lib/api.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 26
+    }
+  },
+  "src/lib/useActiveSemester.ts": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
     }
   },
   "src/lib/useLayoutPref.ts": {

--- a/frontend/src/components/ManageCoursesModal.test.tsx
+++ b/frontend/src/components/ManageCoursesModal.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+/**
+ * ManageCoursesModal add-flow tests (#360 review fixes):
+ *   1. `already_existed: true` responses show an informational "Already taken
+ *      in <term>" toast — NOT a false success toast (the no-retake rule fired,
+ *      nothing was created).
+ *   2. A created enrollment still gets the success toast.
+ *   3. The Add button is disabled while the add request is in flight, so a
+ *      double-click can't race two enrollments.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/api", () => ({
+  addCourse: vi.fn(),
+  deleteCourse: vi.fn(),
+  updateCourseColor: vi.fn(),
+  onboardingCoursesSearch: vi.fn(async () => ({
+    courses: [{ id: "c-bio", course_code: "BIO-101", course_name: "Biology" }],
+  })),
+}));
+
+import { ManageCoursesModal } from "./ManageCoursesModal";
+import { ToastProvider } from "./ToastProvider";
+import { addCourse } from "@/lib/api";
+
+const mockedAddCourse = vi.mocked(addCourse);
+
+function renderModal() {
+  return render(
+    <ToastProvider>
+      <ManageCoursesModal
+        open
+        userId="u1"
+        courses={[]}
+        onClose={() => {}}
+        onChanged={() => {}}
+      />
+    </ToastProvider>,
+  );
+}
+
+/** The search results load behind a 200ms debounce; wait the Add button out. */
+async function findAddButton() {
+  return await screen.findByRole(
+    "button",
+    { name: /add/i },
+    { timeout: 2000 },
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ManageCoursesModal handleAdd", () => {
+  it("shows an informational already-taken toast naming the term, not a success toast", async () => {
+    mockedAddCourse.mockResolvedValue({
+      course_id: "c-bio",
+      already_existed: true,
+      term: "Fall 2025",
+    });
+
+    renderModal();
+    fireEvent.click(await findAddButton());
+
+    await waitFor(() =>
+      expect(screen.getByText("Already taken in Fall 2025")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/^Added /)).toBeNull();
+  });
+
+  it("shows the success toast only when a row was created", async () => {
+    mockedAddCourse.mockResolvedValue({
+      course_id: "c-bio",
+      already_existed: false,
+    });
+
+    renderModal();
+    fireEvent.click(await findAddButton());
+
+    await waitFor(() => expect(screen.getByText("Added BIO-101")).toBeInTheDocument());
+    expect(screen.queryByText(/already taken/i)).toBeNull();
+  });
+
+  it("disables the Add button while the request is in flight", async () => {
+    let release: (v: { course_id: string; already_existed: boolean }) => void;
+    mockedAddCourse.mockImplementation(
+      () => new Promise((resolve) => { release = resolve; }),
+    );
+
+    renderModal();
+    const button = await findAddButton();
+    fireEvent.click(button);
+
+    await waitFor(() => expect(screen.getByText("Adding…")).toBeInTheDocument());
+    expect((screen.getByText("Adding…") as HTMLButtonElement).disabled).toBe(true);
+    // A second click while in flight must not fire another request.
+    fireEvent.click(screen.getByText("Adding…"));
+    expect(mockedAddCourse).toHaveBeenCalledTimes(1);
+
+    release!({ course_id: "c-bio", already_existed: false });
+    await waitFor(() => expect(screen.getByText("Added BIO-101")).toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/ManageCoursesModal.test.tsx
+++ b/frontend/src/components/ManageCoursesModal.test.tsx
@@ -1,17 +1,27 @@
 // @vitest-environment jsdom
 /**
- * ManageCoursesModal add-flow tests (#360 review fixes):
+ * ManageCoursesModal tests (#360 review fixes):
+ *
+ * Add flow:
  *   1. `already_existed: true` responses show an informational "Already taken
  *      in <term>" toast — NOT a false success toast (the no-retake rule fired,
  *      nothing was created).
  *   2. A created enrollment still gets the success toast.
  *   3. The Add button is disabled while the add request is in flight, so a
  *      double-click can't race two enrollments.
+ *
+ * Semester tabs (default = All semesters; scoping is opt-in):
+ *   4. The "All semesters" tab renders and is active by default (empty stored
+ *      value = unscoped).
+ *   5. Clicking a term persists it (localStorage) and activates its tab.
+ *   6. Clicking "All semesters" clears the stored value back to unscoped.
  */
 
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import type { EnrolledCourse } from "@/lib/api";
+import { ACTIVE_SEMESTER_STORAGE_KEY } from "@/lib/useActiveSemester";
 
 vi.mock("@/lib/api", () => ({
   addCourse: vi.fn(),
@@ -28,19 +38,37 @@ import { addCourse } from "@/lib/api";
 
 const mockedAddCourse = vi.mocked(addCourse);
 
-function renderModal() {
+function enrolled(code: string, term: string): EnrolledCourse {
+  return {
+    enrollment_id: `e-${code}`,
+    course_id: `c-${code}`,
+    course_code: code,
+    course_name: code,
+    school: "BU",
+    department: "CS",
+    color: null,
+    nickname: null,
+    node_count: 0,
+    enrolled_at: "2025-08-25",
+    term,
+  };
+}
+
+function renderModal(courses: EnrolledCourse[] = []) {
   return render(
     <ToastProvider>
       <ManageCoursesModal
         open
         userId="u1"
-        courses={[]}
+        courses={courses}
         onClose={() => {}}
         onChanged={() => {}}
       />
     </ToastProvider>,
   );
 }
+
+const tab = (name: string) => screen.getByRole("button", { name });
 
 /** The search results load behind a 200ms debounce; wait the Add button out. */
 async function findAddButton() {
@@ -108,5 +136,41 @@ describe("ManageCoursesModal handleAdd", () => {
 
     release!({ course_id: "c-bio", already_existed: false });
     await waitFor(() => expect(screen.getByText("Added BIO-101")).toBeInTheDocument());
+  });
+});
+
+describe("ManageCoursesModal semester tabs", () => {
+  const courses = [enrolled("CS101", "Fall 2025"), enrolled("MATH210", "Spring 2026")];
+
+  it("renders the All-semesters tab, active by default (empty stored value)", () => {
+    renderModal(courses);
+
+    expect(tab("All semesters")).toHaveAttribute("aria-pressed", "true");
+    expect(tab("Fall 2025")).toHaveAttribute("aria-pressed", "false");
+    expect(tab("Spring 2026")).toHaveAttribute("aria-pressed", "false");
+    // All semesters → no term filter: both courses listed.
+    expect(screen.getByText("Your courses")).toBeInTheDocument();
+  });
+
+  it("clicking a term persists it and activates its tab", () => {
+    renderModal(courses);
+
+    fireEvent.click(tab("Fall 2025"));
+
+    expect(window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY)).toBe("Fall 2025");
+    expect(tab("Fall 2025")).toHaveAttribute("aria-pressed", "true");
+    expect(tab("All semesters")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("clicking All semesters clears the stored value back to unscoped", () => {
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Spring 2026");
+    renderModal(courses);
+
+    expect(tab("Spring 2026")).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(tab("All semesters"));
+
+    expect(window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY)).toBe("");
+    expect(tab("All semesters")).toHaveAttribute("aria-pressed", "true");
+    expect(tab("Spring 2026")).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/frontend/src/components/ManageCoursesModal.tsx
+++ b/frontend/src/components/ManageCoursesModal.tsx
@@ -14,7 +14,7 @@ import {
   type EnrolledCourse,
   type OnboardingCourse,
 } from "@/lib/api";
-import { useActiveSemester, distinctTerms, resolveActiveSemester } from "@/lib/useActiveSemester";
+import { useActiveSemester, distinctTerms } from "@/lib/useActiveSemester";
 
 const COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 
@@ -35,7 +35,10 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
   const toast = useToast();
   const [activeSemester, setActiveSemester] = useActiveSemester();
   const terms = React.useMemo(() => distinctTerms(courses), [courses]);
-  const activeTerm = resolveActiveSemester(activeSemester, courses);
+  // Empty stored value = "All semesters" (the default): no term filter, and
+  // every surface fetches unscoped. A term only scopes once the user picks it
+  // here — the choice persists via the shared hook.
+  const activeTerm = activeSemester;
   const [query, setQuery] = React.useState("");
   const [results, setResults] = React.useState<OnboardingCourse[]>([]);
   const [loading, setLoading] = React.useState(false);
@@ -135,11 +138,26 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
             </div>
           ) : (
             <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 16 }}>
+              {/* "All semesters" is the default (empty stored value); clicking
+                  it clears the stored term so every surface goes unscoped. */}
+              <button
+                onClick={() => setActiveSemester("")}
+                className="btn btn--sm"
+                aria-pressed={activeTerm === ""}
+                style={{
+                  background: activeTerm === "" ? "var(--accent-soft)" : "var(--bg-panel)",
+                  color: activeTerm === "" ? "var(--accent)" : "var(--text-dim)",
+                  border: "1px solid var(--border)",
+                }}
+              >
+                All semesters
+              </button>
               {terms.map((t) => (
                 <button
                   key={t}
                   onClick={() => setActiveSemester(t)}
                   className="btn btn--sm"
+                  aria-pressed={t === activeTerm}
                   style={{
                     background: t === activeTerm ? "var(--accent-soft)" : "var(--bg-panel)",
                     color: t === activeTerm ? "var(--accent)" : "var(--text-dim)",

--- a/frontend/src/components/ManageCoursesModal.tsx
+++ b/frontend/src/components/ManageCoursesModal.tsx
@@ -14,7 +14,7 @@ import {
   type EnrolledCourse,
   type OnboardingCourse,
 } from "@/lib/api";
-import { groupCoursesByTerm } from "@/lib/semesters";
+import { useActiveSemester, distinctTerms, resolveActiveSemester } from "@/lib/useActiveSemester";
 
 const COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 
@@ -33,6 +33,9 @@ interface Props {
 
 export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }: Props) {
   const toast = useToast();
+  const [activeSemester, setActiveSemester] = useActiveSemester();
+  const terms = React.useMemo(() => distinctTerms(courses), [courses]);
+  const activeTerm = resolveActiveSemester(activeSemester, courses);
   const [query, setQuery] = React.useState("");
   const [results, setResults] = React.useState<OnboardingCourse[]>([]);
   const [loading, setLoading] = React.useState(false);
@@ -64,14 +67,19 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
   }, [query, open]);
 
   const enrolledIds = React.useMemo(() => new Set(courses.map(c => c.course_id)), [courses]);
-  // No /api/semesters call here — the modal only needs a stable, readable
-  // order, which the label-derived rank already gives it.
-  const termGroups = React.useMemo(() => groupCoursesByTerm(courses), [courses]);
+  const enrolledTermById = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of courses) m.set(c.course_id, c.term);
+    return m;
+  }, [courses]);
 
   const handleAdd = async (course: OnboardingCourse) => {
     try {
       const color = DEFAULT_COLORS[courses.length % DEFAULT_COLORS.length];
-      await addCourse(userId, course.id, color);
+      // Enroll into the semester tab the user is viewing so the course lands
+      // where they expect it. Empty activeTerm (no courses yet) → the backend
+      // falls back to the current term.
+      await addCourse(userId, course.id, color, undefined, activeTerm || undefined);
       toast.success(`Added ${course.course_code || course.course_name}`);
       await onChanged();
     } catch (err) {
@@ -97,7 +105,7 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "16px 20px", borderBottom: "1px solid var(--border)" }}>
           <div>
             <div className="label-micro">Manage</div>
-            <div className="h-serif" style={{ fontSize: 20 }}>My Courses</div>
+            <div className="h-serif" style={{ fontSize: 20 }}>Courses & Semesters</div>
           </div>
           <button className="btn btn--ghost btn--sm" onClick={onClose} aria-label="Close">
             <Icon name="x" size={14} />
@@ -105,26 +113,44 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
         </div>
 
         <div style={{ padding: 20, overflowY: "auto" }}>
-          <div className="label-micro" style={{ marginBottom: 8 }}>Your courses</div>
-          {courses.length === 0 && (
-            <div style={{ fontSize: 12, color: "var(--text-muted)" }}>No courses enrolled yet.</div>
+          <div className="label-micro" style={{ marginBottom: 8 }}>Semester</div>
+          {terms.length === 0 ? (
+            <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 16 }}>
+              No semesters yet — add a course below.
+            </div>
+          ) : (
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 16 }}>
+              {terms.map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setActiveSemester(t)}
+                  className="btn btn--sm"
+                  style={{
+                    background: t === activeTerm ? "var(--accent-soft)" : "var(--bg-panel)",
+                    color: t === activeTerm ? "var(--accent)" : "var(--text-dim)",
+                    border: "1px solid var(--border)",
+                  }}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
           )}
+
+          <div className="label-micro" style={{ marginBottom: 8 }}>
+            {activeTerm ? `Courses · ${activeTerm}` : "Your courses"}
+          </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 20 }}>
-            {termGroups.map(group => (
-              <React.Fragment key={group.label}>
-                {termGroups.length > 1 && (
-                  <div
-                    className="mono"
-                    style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}
-                  >
-                    {group.label}
-                  </div>
-                )}
-                {group.courses.map(c => (
-                  <EnrolledRow key={c.course_id} userId={userId} course={c} onChanged={onChanged} />
-                ))}
-              </React.Fragment>
-            ))}
+            {courses.filter((c) => !activeTerm || c.term === activeTerm).length === 0 && (
+              <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
+                No courses in this semester yet.
+              </div>
+            )}
+            {courses
+              .filter((c) => !activeTerm || c.term === activeTerm)
+              .map((c) => (
+                <EnrolledRow key={c.course_id} userId={userId} course={c} onChanged={onChanged} />
+              ))}
           </div>
 
           <div className="label-micro" style={{ marginBottom: 8 }}>Add a course</div>
@@ -169,12 +195,29 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
                       opacity: enrolled ? 0.55 : 1,
                       background: enrolled ? "var(--bg-subtle)" : undefined,
                     }}
+                    title={enrolled ? "A course can only be taken once across semesters" : undefined}
                   >
-                    {enrolled ? "Enrolled" : <><Icon name="plus" size={12} /> Add</>}
+                    {enrolled
+                      ? `Already taken${enrolledTermById.get(c.id) ? ` · ${enrolledTermById.get(c.id)}` : ""}`
+                      : <><Icon name="plus" size={12} /> Add</>}
                   </button>
                 </div>
               );
             })}
+          </div>
+
+          <div style={{ borderTop: "1px solid var(--border)", marginTop: 20, paddingTop: 16 }}>
+            <button
+              className="btn btn--sm"
+              disabled
+              aria-disabled="true"
+              style={{ opacity: 0.5, cursor: "not-allowed" }}
+            >
+              <Icon name="sparkle" size={12} /> Personal learning
+            </button>
+            <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 6 }}>
+              Coming soon
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/ManageCoursesModal.tsx
+++ b/frontend/src/components/ManageCoursesModal.tsx
@@ -73,17 +73,32 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
     return m;
   }, [courses]);
 
+  // Course id whose add request is in flight; disables the Add buttons so a
+  // double-click can't race two enrollments for the same course.
+  const [addingId, setAddingId] = React.useState<string | null>(null);
+
   const handleAdd = async (course: OnboardingCourse) => {
+    if (addingId) return;
+    setAddingId(course.id);
     try {
       const color = DEFAULT_COLORS[courses.length % DEFAULT_COLORS.length];
       // Enroll into the semester tab the user is viewing so the course lands
       // where they expect it. Empty activeTerm (no courses yet) → the backend
       // falls back to the current term.
-      await addCourse(userId, course.id, color, undefined, activeTerm || undefined);
-      toast.success(`Added ${course.course_code || course.course_name}`);
+      const res = await addCourse(userId, course.id, color, undefined, activeTerm || undefined);
+      if (res.already_existed) {
+        // The no-retake rule caught an enrollment this list didn't know about
+        // (e.g. added from another tab/device). Nothing was created, so don't
+        // claim success.
+        toast.info(res.term ? `Already taken in ${res.term}` : "Already taken");
+      } else {
+        toast.success(`Added ${course.course_code || course.course_name}`);
+      }
       await onChanged();
     } catch (err) {
       toast.error(`Failed to add course: ${String(err)}`);
+    } finally {
+      setAddingId(null);
     }
   };
 
@@ -189,7 +204,7 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
                   </div>
                   <button
                     className="btn btn--sm"
-                    disabled={enrolled}
+                    disabled={enrolled || addingId !== null}
                     onClick={() => handleAdd(c)}
                     style={{
                       opacity: enrolled ? 0.55 : 1,
@@ -199,7 +214,9 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
                   >
                     {enrolled
                       ? `Already taken${enrolledTermById.get(c.id) ? ` · ${enrolledTermById.get(c.id)}` : ""}`
-                      : <><Icon name="plus" size={12} /> Add</>}
+                      : addingId === c.id
+                        ? "Adding…"
+                        : <><Icon name="plus" size={12} /> Add</>}
                   </button>
                 </div>
               );

--- a/frontend/src/components/screens/Dashboard.test.tsx
+++ b/frontend/src/components/screens/Dashboard.test.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, waitFor, within } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, waitFor, within } from "@testing-library/react";
 import type { EnrolledCourse, Semester } from "@/lib/api";
 import { ACTIVE_SEMESTER_STORAGE_KEY } from "@/lib/useActiveSemester";
 
@@ -33,8 +33,10 @@ vi.mock("@/context/UserContext", () => ({
 }));
 
 vi.mock("@/lib/useIsMobile", () => ({ useIsMobile: () => false }));
-// "topnav" renders the legacy My Courses panel, the easiest surface to assert on.
-vi.mock("@/lib/useLayoutPref", () => ({ useLayoutPref: () => ["topnav", vi.fn()] }));
+// "topnav" renders the legacy My Courses panel, the easiest surface to assert
+// on; the CoursesKey empty-state test flips this to "sidebar".
+const layoutState = vi.hoisted(() => ({ pref: "topnav" }));
+vi.mock("@/lib/useLayoutPref", () => ({ useLayoutPref: () => [layoutState.pref, vi.fn()] }));
 
 vi.mock("../KnowledgeGraph", () => ({ KnowledgeGraph: () => null }));
 vi.mock("../ManageCoursesModal", () => ({ ManageCoursesModal: () => null }));
@@ -86,6 +88,7 @@ function course(code: string, term: string): EnrolledCourse {
 }
 
 beforeEach(() => {
+  layoutState.pref = "topnav";
   window.localStorage.clear();
   globalThis.ResizeObserver = class {
     observe() {}
@@ -127,6 +130,22 @@ describe("Dashboard course list by active semester", () => {
 
     // No current/archive split any more.
     expect(screen.queryByRole("button", { name: /archive/i })).toBeNull();
+
+    // The default is resolved and persisted BEFORE the scoped fetch, so the
+    // graph is fetched exactly once, already scoped — no unscoped first pass.
+    expect(getGraph).toHaveBeenCalledTimes(1);
+    expect(getGraph).toHaveBeenCalledWith("u1", "Spring 2026");
+  });
+
+  it("loads unscoped in a single pass when the user has no courses", async () => {
+    mockedGetCourses.mockResolvedValue({ courses: [] });
+
+    render(<Dashboard />);
+
+    await waitFor(() => expect(screen.getByText("No enrolled courses yet.")).toBeInTheDocument());
+    // No term to default to → one unscoped fetch, not a resolution pass + refetch.
+    expect(getGraph).toHaveBeenCalledTimes(1);
+    expect(getGraph).toHaveBeenCalledWith("u1", undefined);
   });
 
   it("scopes the list and the graph fetch to a semester chosen from storage", async () => {
@@ -139,6 +158,21 @@ describe("Dashboard course list by active semester", () => {
     // The graph is fetched scoped to the stored term, no unscoped first pass.
     expect(getGraph).toHaveBeenCalledWith("u1", "Fall 2025");
     expect(getGraph).not.toHaveBeenCalledWith("u1", undefined);
+  });
+
+  it("shows the courses-key empty state when the active semester has no courses", async () => {
+    // Sidebar layout renders the CoursesKey overlay instead of the legacy panel.
+    layoutState.pref = "sidebar";
+    // A stored semester none of the enrolled courses belong to → courseProgress
+    // is empty, but courses exist, so the key must render its empty state
+    // rather than disappearing entirely.
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Summer 2026");
+
+    render(<Dashboard />);
+
+    const toggle = await screen.findByTestId("dashboard-courses-key-toggle");
+    fireEvent.click(toggle);
+    expect(screen.getByText("Nothing enrolled this semester.")).toBeInTheDocument();
   });
 
   it("degrades to label-derived ranking when /api/semesters fails", async () => {

--- a/frontend/src/components/screens/Dashboard.test.tsx
+++ b/frontend/src/components/screens/Dashboard.test.tsx
@@ -1,13 +1,14 @@
 // @vitest-environment jsdom
 /**
  * Active-semester scoping of the dashboard course list (#360):
- *   1. The course list is scoped to the active semester, which defaults to the
- *      most-recent enrolled term by `sort_key` (from /api/semesters).
- *   2. A semester previously chosen (persisted in localStorage) scopes both the
- *      panel and the graph fetch to that term.
- *   3. When /api/semesters fails there is no `sort_key` to rank by, so the
- *      default degrades to the term label's derived rank (still Spring 2026),
- *      not a blank or unscoped panel.
+ *   1. DEFAULT = ALL SEMESTERS: with nothing stored, every enrolled course is
+ *      visible and the graph is fetched unscoped, exactly once — nothing
+ *      auto-resolves a default term (the e2e lane vetoed that: an auto-picked
+ *      term hid cross-term fixtures).
+ *   2. A semester previously chosen in the Courses & Semesters hub (persisted
+ *      in localStorage) scopes both the panel and the graph fetch to that term.
+ *   3. A picked term that scopes to zero courses keeps the CoursesKey mounted
+ *      so its "Nothing enrolled this semester." empty state is reachable.
  *
  * There is no separate "current vs. archive" split — the semester selector (the
  * ManageCoursesModal term tabs, stubbed here) is the single source of truth.
@@ -18,7 +19,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent, waitFor, within } from "@testing-library/react";
-import type { EnrolledCourse, Semester } from "@/lib/api";
+import type { EnrolledCourse } from "@/lib/api";
 import { ACTIVE_SEMESTER_STORAGE_KEY } from "@/lib/useActiveSemester";
 
 const push = vi.fn();
@@ -50,7 +51,6 @@ vi.mock("@/lib/api", () => ({
   getUpcomingAssignments: vi.fn(),
   getSessions: vi.fn(),
   getRecommendations: vi.fn(),
-  getSemesters: vi.fn(),
 }));
 
 import { Dashboard } from "./Dashboard";
@@ -58,18 +58,11 @@ import {
   getCourses,
   getGraph,
   getRecommendations,
-  getSemesters,
   getSessions,
   getUpcomingAssignments,
 } from "@/lib/api";
 
 const mockedGetCourses = vi.mocked(getCourses);
-const mockedGetSemesters = vi.mocked(getSemesters);
-
-const SEMESTERS: Semester[] = [
-  { id: "spring-2026", term: "Spring", year: 2026, label: "Spring 2026", start_date: "2026-01-05", end_date: "2026-05-17", sort_key: 20261 },
-  { id: "fall-2025", term: "Fall", year: 2025, label: "Fall 2025", start_date: "2025-08-25", end_date: "2026-01-04", sort_key: 20253 },
-];
 
 function course(code: string, term: string): EnrolledCourse {
   return {
@@ -102,10 +95,7 @@ beforeEach(() => {
   vi.mocked(getUpcomingAssignments).mockResolvedValue({ assignments: [] });
   vi.mocked(getSessions).mockResolvedValue({ sessions: [] });
   vi.mocked(getRecommendations).mockResolvedValue({ recommendations: [] });
-  mockedGetSemesters.mockResolvedValue({ semesters: SEMESTERS });
   mockedGetCourses.mockResolvedValue({
-    // BIO-101 is enrolled first, so enrollment order ranks it before PSY-110;
-    // by sort_key, Spring 2026 (20261) still outranks Fall 2025 (20253).
     courses: [course("BIO-101", "Spring 2026"), course("PSY-110", "Fall 2025")],
   });
 });
@@ -121,20 +111,20 @@ afterEach(() => {
 const panel = () => within(screen.getByText("My courses").closest(".card") as HTMLElement);
 
 describe("Dashboard course list by active semester", () => {
-  it("defaults to the most-recent term by sort_key and scopes the list to it", async () => {
+  it("defaults to All semesters: every course visible, one unscoped fetch", async () => {
     render(<Dashboard />);
 
-    // Spring 2026 has the higher sort_key, so it is the default active term.
+    // Nothing stored → All semesters: BOTH terms' courses render.
     await waitFor(() => expect(panel().getByText("BIO-101")).toBeInTheDocument());
-    expect(screen.queryByText("PSY-110")).toBeNull();
+    expect(panel().getByText("PSY-110")).toBeInTheDocument();
 
     // No current/archive split any more.
     expect(screen.queryByRole("button", { name: /archive/i })).toBeNull();
 
-    // The default is resolved and persisted BEFORE the scoped fetch, so the
-    // graph is fetched exactly once, already scoped — no unscoped first pass.
+    // No auto-default resolution: exactly one fetch, unscoped — never an
+    // unscoped-then-scoped double, never a silently picked term.
     expect(getGraph).toHaveBeenCalledTimes(1);
-    expect(getGraph).toHaveBeenCalledWith("u1", "Spring 2026");
+    expect(getGraph).toHaveBeenCalledWith("u1", undefined);
   });
 
   it("loads unscoped in a single pass when the user has no courses", async () => {
@@ -143,7 +133,6 @@ describe("Dashboard course list by active semester", () => {
     render(<Dashboard />);
 
     await waitFor(() => expect(screen.getByText("No enrolled courses yet.")).toBeInTheDocument());
-    // No term to default to → one unscoped fetch, not a resolution pass + refetch.
     expect(getGraph).toHaveBeenCalledTimes(1);
     expect(getGraph).toHaveBeenCalledWith("u1", undefined);
   });
@@ -173,17 +162,5 @@ describe("Dashboard course list by active semester", () => {
     const toggle = await screen.findByTestId("dashboard-courses-key-toggle");
     fireEvent.click(toggle);
     expect(screen.getByText("Nothing enrolled this semester.")).toBeInTheDocument();
-  });
-
-  it("degrades to label-derived ranking when /api/semesters fails", async () => {
-    mockedGetSemesters.mockRejectedValue(new Error("500"));
-
-    render(<Dashboard />);
-
-    // No sort_key to rank by, so the default degrades to the label's derived
-    // rank — Spring 2026 (20261) still outranks Fall 2025 (20253).
-    await waitFor(() => expect(panel().getByText("BIO-101")).toBeInTheDocument());
-    expect(screen.queryByText("PSY-110")).toBeNull();
-    expect(screen.queryByRole("button", { name: /archive/i })).toBeNull();
   });
 });

--- a/frontend/src/components/screens/Dashboard.test.tsx
+++ b/frontend/src/components/screens/Dashboard.test.tsx
@@ -1,19 +1,25 @@
 // @vitest-environment jsdom
 /**
- * Semester grouping on the dashboard course list (#140):
- *   1. Current-term courses render; earlier terms don't until Archive opens.
- *   2. An archived course routes into that semester's gradebook.
- *   3. A failed /api/semesters degrades to one flat list, never a blank panel.
+ * Active-semester scoping of the dashboard course list (#360):
+ *   1. The course list is scoped to the active semester, which defaults to the
+ *      most-recent enrolled term by `sort_key` (from /api/semesters).
+ *   2. A semester previously chosen (persisted in localStorage) scopes both the
+ *      panel and the graph fetch to that term.
+ *   3. When /api/semesters fails there is no `sort_key` to rank by, so the
+ *      default degrades to the term label's derived rank (still Spring 2026),
+ *      not a blank or unscoped panel.
  *
- * The graph, modals and skeleton are stubbed — this exercises the course-list
- * partition only.
+ * There is no separate "current vs. archive" split — the semester selector (the
+ * ManageCoursesModal term tabs, stubbed here) is the single source of truth.
+ * The graph, modals and skeleton are stubbed — this exercises the scoped
+ * course list only.
  */
 
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import type { EnrolledCourse, Semester } from "@/lib/api";
+import { ACTIVE_SEMESTER_STORAGE_KEY } from "@/lib/useActiveSemester";
 
 const push = vi.fn();
 
@@ -27,7 +33,7 @@ vi.mock("@/context/UserContext", () => ({
 }));
 
 vi.mock("@/lib/useIsMobile", () => ({ useIsMobile: () => false }));
-// "topnav" renders the legacy My Courses panel, which owns the Archive.
+// "topnav" renders the legacy My Courses panel, the easiest surface to assert on.
 vi.mock("@/lib/useLayoutPref", () => ({ useLayoutPref: () => ["topnav", vi.fn()] }));
 
 vi.mock("../KnowledgeGraph", () => ({ KnowledgeGraph: () => null }));
@@ -80,6 +86,7 @@ function course(code: string, term: string): EnrolledCourse {
 }
 
 beforeEach(() => {
+  window.localStorage.clear();
   globalThis.ResizeObserver = class {
     observe() {}
     unobserve() {}
@@ -94,6 +101,8 @@ beforeEach(() => {
   vi.mocked(getRecommendations).mockResolvedValue({ recommendations: [] });
   mockedGetSemesters.mockResolvedValue({ semesters: SEMESTERS });
   mockedGetCourses.mockResolvedValue({
+    // BIO-101 is enrolled first, so enrollment order ranks it before PSY-110;
+    // by sort_key, Spring 2026 (20261) still outranks Fall 2025 (20253).
     courses: [course("BIO-101", "Spring 2026"), course("PSY-110", "Fall 2025")],
   });
 });
@@ -108,41 +117,39 @@ afterEach(() => {
 // panel assertions have to be scoped.
 const panel = () => within(screen.getByText("My courses").closest(".card") as HTMLElement);
 
-describe("Dashboard course list by semester", () => {
-  it("shows only current-term courses until the archive is opened", async () => {
+describe("Dashboard course list by active semester", () => {
+  it("defaults to the most-recent term by sort_key and scopes the list to it", async () => {
     render(<Dashboard />);
 
+    // Spring 2026 has the higher sort_key, so it is the default active term.
     await waitFor(() => expect(panel().getByText("BIO-101")).toBeInTheDocument());
     expect(screen.queryByText("PSY-110")).toBeNull();
 
-    const archive = screen.getByRole("button", { name: /archive/i });
-    expect(archive).toHaveAttribute("aria-expanded", "false");
-
-    await userEvent.click(archive);
-
-    expect(await screen.findByText("PSY-110")).toBeInTheDocument();
-    expect(panel().getByText("Fall 2025")).toBeInTheDocument();
+    // No current/archive split any more.
+    expect(screen.queryByRole("button", { name: /archive/i })).toBeNull();
   });
 
-  it("opens that semester's gradebook when an archived course is picked", async () => {
+  it("scopes the list and the graph fetch to a semester chosen from storage", async () => {
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Fall 2025");
+
     render(<Dashboard />);
 
-    await waitFor(() => expect(panel().getByText("BIO-101")).toBeInTheDocument());
-    await userEvent.click(screen.getByRole("button", { name: /archive/i }));
-    await userEvent.click(
-      await screen.findByRole("button", { name: /PSY-110 — open the Fall 2025 gradebook/ }),
-    );
-
-    expect(push).toHaveBeenCalledWith("/gradebook?semester=Fall%202025");
+    await waitFor(() => expect(panel().getByText("PSY-110")).toBeInTheDocument());
+    expect(screen.queryByText("BIO-101")).toBeNull();
+    // The graph is fetched scoped to the stored term, no unscoped first pass.
+    expect(getGraph).toHaveBeenCalledWith("u1", "Fall 2025");
+    expect(getGraph).not.toHaveBeenCalledWith("u1", undefined);
   });
 
-  it("falls back to one flat list when /api/semesters fails", async () => {
+  it("degrades to label-derived ranking when /api/semesters fails", async () => {
     mockedGetSemesters.mockRejectedValue(new Error("500"));
 
     render(<Dashboard />);
 
+    // No sort_key to rank by, so the default degrades to the label's derived
+    // rank — Spring 2026 (20261) still outranks Fall 2025 (20253).
     await waitFor(() => expect(panel().getByText("BIO-101")).toBeInTheDocument());
-    expect(panel().getByText("PSY-110")).toBeInTheDocument();
+    expect(screen.queryByText("PSY-110")).toBeNull();
     expect(screen.queryByRole("button", { name: /archive/i })).toBeNull();
   });
 });

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -11,21 +11,19 @@ import { DashboardSkeleton } from "../Skeleton";
 import { useUser } from "@/context/UserContext";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { useLayoutPref } from "@/lib/useLayoutPref";
-import { useActiveSemester, resolveActiveSemester } from "@/lib/useActiveSemester";
+import { useActiveSemester } from "@/lib/useActiveSemester";
 import {
   getGraph,
   getCourses,
   getUpcomingAssignments,
   getSessions,
   getRecommendations,
-  getSemesters,
   type EnrolledCourse,
   type Session,
   type Assignment,
 } from "@/lib/api";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
 import { apiToGraphNode, learnHrefForNode, type GraphNode, type GraphEdge } from "@/lib/data";
-import { courseTermLabels } from "@/lib/semesters";
 import { IS_TEST_MODE, now } from "@/lib/testMode";
 
 const QUOTES = [
@@ -194,7 +192,7 @@ export function Dashboard() {
   const router = useRouter();
   const search = useSearchParams();
   const { userId, userName, userReady } = useUser();
-  const [activeSemester, setActiveSemester, semesterHydrated] = useActiveSemester();
+  const [activeSemester, , semesterHydrated] = useActiveSemester();
   const isMobile = useIsMobile();
   const [layoutPref] = useLayoutPref();
   // Top-nav layout keeps the pre-revamp 3-column dashboard with the
@@ -264,33 +262,12 @@ export function Dashboard() {
     if (!userId) return;
     setLoading(true);
     setLoadError(null);
-    // True when this pass only resolved the default semester: keep `loading`
-    // on so the effect re-run (triggered by setActiveSemester) performs the
-    // single scoped fetch without a skeleton flash in between.
-    let deferredToScopedPass = false;
     try {
-      if (!activeSemester) {
-        // First run with no stored semester: resolve + persist the default
-        // BEFORE the scoped graph/recommendations fetch, so the effect re-run
-        // does one scoped fetch instead of unscoped-then-scoped. Default is the
-        // most-recent enrolled term by `sort_key` (courseTermLabels), falling
-        // back to enrollment order.
-        const [coursesRes, semestersRes] = await Promise.all([
-          getCourses(userId),
-          // Term calendar ranks the default; if it fails we fall back to
-          // enrollment order rather than failing the load.
-          getSemesters().catch(() => ({ semesters: [] })),
-        ]);
-        const cs = coursesRes.courses || [];
-        const def = courseTermLabels(cs, semestersRes.semesters || [])[0] || resolveActiveSemester("", cs);
-        if (def) {
-          deferredToScopedPass = true;
-          setActiveSemester(def);
-          return;
-        }
-        // No enrolled terms (e.g. zero courses) → nothing to scope by; fall
-        // through and load unscoped in this same pass.
-      }
+      // Empty `activeSemester` means "All semesters" — the DEFAULT — so the
+      // fetch goes out unscoped. Scoping is opt-in: it only applies once the
+      // user picks a term in the Courses & Semesters hub (nothing auto-resolves
+      // a default term; an auto-picked term hides cross-term data — vetoed by
+      // the e2e lane, #360).
       const [graphRes, coursesRes, assignsRes, sessionsRes, recsRes] = await Promise.all([
         getGraph(userId, activeSemester || undefined),
         getCourses(userId),
@@ -326,9 +303,9 @@ export function Dashboard() {
       console.error("dashboard load failed", err);
       setLoadError(String(err));
     } finally {
-      if (!deferredToScopedPass) setLoading(false);
+      setLoading(false);
     }
-  }, [userId, activeSemester, setActiveSemester]);
+  }, [userId, activeSemester]);
 
   React.useEffect(() => {
     // Wait for the active-semester read from localStorage before the first load,
@@ -1227,7 +1204,9 @@ function CoursesKey({
               className="btn btn--ghost btn--sm"
               onClick={onManage}
               title="Courses & Semesters"
+              aria-label="Courses & Semesters"
               style={paddedIconBtn}
+              data-testid="dashboard-courses-manage"
             >
               <Icon name="cog" size={13} />
             </button>

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -11,6 +11,7 @@ import { DashboardSkeleton } from "../Skeleton";
 import { useUser } from "@/context/UserContext";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { useLayoutPref } from "@/lib/useLayoutPref";
+import { useActiveSemester, resolveActiveSemester } from "@/lib/useActiveSemester";
 import {
   getGraph,
   getCourses,
@@ -19,13 +20,12 @@ import {
   getRecommendations,
   getSemesters,
   type EnrolledCourse,
-  type Semester,
   type Session,
   type Assignment,
 } from "@/lib/api";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
 import { apiToGraphNode, learnHrefForNode, type GraphNode, type GraphEdge } from "@/lib/data";
-import { partitionCurrentAndArchive } from "@/lib/semesters";
+import { courseTermLabels } from "@/lib/semesters";
 import { IS_TEST_MODE, now } from "@/lib/testMode";
 
 const QUOTES = [
@@ -194,6 +194,7 @@ export function Dashboard() {
   const router = useRouter();
   const search = useSearchParams();
   const { userId, userName, userReady } = useUser();
+  const [activeSemester, setActiveSemester, semesterHydrated] = useActiveSemester();
   const isMobile = useIsMobile();
   const [layoutPref] = useLayoutPref();
   // Top-nav layout keeps the pre-revamp 3-column dashboard with the
@@ -208,7 +209,6 @@ export function Dashboard() {
     streak: 0, mastered: 0, total: 0, learning: 0, struggling: 0, unexplored: 0,
   });
   const [courses, setCourses] = React.useState<EnrolledCourse[]>([]);
-  const [semesters, setSemesters] = React.useState<Semester[]>([]);
   const [sessions, setSessions] = React.useState<Session[]>([]);
   const [assignments, setAssignments] = React.useState<Assignment[]>([]);
   const [recommendations, setRecommendations] = React.useState<{ concept_name: string; reason?: string }[]>([]);
@@ -217,7 +217,6 @@ export function Dashboard() {
   const [activeDays, setActiveDays] = React.useState<Set<string>>(new Set());
 
   const [coursesOpen, setCoursesOpen] = React.useState(false);
-  const [archiveOpen, setArchiveOpen] = React.useState(false);
   const [fullscreen, setFullscreen] = React.useState(false);
   const [mobileTab, setMobileTab] = React.useState<"courses" | "stats">("courses");
 
@@ -267,18 +266,24 @@ export function Dashboard() {
     setLoadError(null);
     try {
       const [graphRes, coursesRes, assignsRes, sessionsRes, recsRes, semestersRes] = await Promise.all([
-        getGraph(userId),
+        getGraph(userId, activeSemester || undefined),
         getCourses(userId),
         getUpcomingAssignments(userId),
         getSessions(userId, 10),
-        getRecommendations(userId).catch(() => ({ recommendations: [] })),
-        // Term calendar is a nicety: without it the course lists stay flat
-        // rather than the dashboard failing to load.
+        getRecommendations(userId, activeSemester || undefined).catch(() => ({ recommendations: [] })),
+        // Term calendar drives the default active-semester resolution below;
+        // if it fails we fall back to enrollment order rather than failing the load.
         getSemesters().catch(() => ({ semesters: [] })),
       ]);
       const cs = coursesRes.courses || [];
+      const sems = semestersRes.semesters || [];
       setCourses(cs);
-      setSemesters(semestersRes.semesters || []);
+      // First run with no stored semester: default to the most-recent enrolled
+      // term by `sort_key` (courseTermLabels), falling back to enrollment order.
+      if (!activeSemester) {
+        const def = courseTermLabels(cs, sems)[0] || resolveActiveSemester("", cs);
+        if (def) setActiveSemester(def);
+      }
       const gNodes: GraphNode[] = (graphRes.nodes || []).map((n: ApiNode) => apiToGraphNode(n, cs));
       setNodes(gNodes);
       setEdges((graphRes.edges || []).map(apiToGraphEdge));
@@ -307,11 +312,13 @@ export function Dashboard() {
     } finally {
       setLoading(false);
     }
-  }, [userId]);
+  }, [userId, activeSemester, setActiveSemester]);
 
   React.useEffect(() => {
-    if (userReady && userId) load();
-  }, [userReady, userId, load]);
+    // Wait for the active-semester read from localStorage before the first load,
+    // so returning users fetch scoped once instead of unscoped-then-scoped.
+    if (userReady && userId && semesterHydrated) load();
+  }, [userReady, userId, semesterHydrated, load]);
 
   useScrollLock(fullscreen);
 
@@ -335,8 +342,13 @@ export function Dashboard() {
   // return JSX), not as TopBar title/subtitle. Leaving the TopBar lean
   // makes the Dashboard feel like an arrival page, not a tool page.
 
+  const scopedCourses = React.useMemo(
+    () => (activeSemester ? courses.filter((c) => c.term === activeSemester) : courses),
+    [courses, activeSemester],
+  );
+
   const courseProgress = React.useMemo(() => {
-    return courses.map(c => {
+    return scopedCourses.map(c => {
       const courseNodes = nodes.filter(n => n.course_id === c.course_id && !n.is_subject_root);
       const mastered = courseNodes.filter(n => n.mastery_tier === "mastered").length;
       const learning = courseNodes.filter(n => n.mastery_tier === "learning").length;
@@ -353,51 +365,7 @@ export function Dashboard() {
         progress: total ? mastered / total : 0,
       };
     });
-  }, [courses, nodes]);
-
-  // Semester split (#140). Only courses that provably belong to an earlier term
-  // move behind the Archive; everything else — including undatable courses and
-  // the whole list when /api/semesters gave us nothing — stays visible.
-  const partition = React.useMemo(
-    () => partitionCurrentAndArchive(courses, semesters, today),
-    [courses, semesters, today],
-  );
-
-  const progressByCourse = React.useMemo(() => {
-    const byId = new Map<string, CourseProgressEntry>();
-    for (const entry of courseProgress) byId.set(entry.course.course_id, entry);
-    return byId;
-  }, [courseProgress]);
-
-  const currentProgress = React.useMemo(
-    () =>
-      partition.current
-        .map((c) => progressByCourse.get(c.course_id))
-        .filter((e): e is CourseProgressEntry => Boolean(e)),
-    [partition, progressByCourse],
-  );
-
-  const archivedProgress = React.useMemo(
-    () =>
-      partition.archive
-        .map((group) => ({
-          label: group.label,
-          entries: group.courses
-            .map((c) => progressByCourse.get(c.course_id))
-            .filter((e): e is CourseProgressEntry => Boolean(e)),
-        }))
-        .filter((group) => group.entries.length > 0),
-    [partition, progressByCourse],
-  );
-
-  const archivedCount = archivedProgress.reduce((n, g) => n + g.entries.length, 0);
-
-  // An archived course opens the gradebook scoped to its own term, not the
-  // current one — the whole point of surfacing it separately.
-  const openArchivedTerm = React.useCallback(
-    (label: string) => router.push(`/gradebook?semester=${encodeURIComponent(label)}`),
-    [router],
-  );
+  }, [scopedCourses, nodes]);
 
   const suggestNode = React.useMemo(() => {
     if (!suggest) return null;
@@ -449,11 +417,11 @@ export function Dashboard() {
         <div>
           <div className="label-micro">Your knowledge graph</div>
           <div className="h-serif" style={{ fontSize: 20, marginTop: 2 }}>
-            {stats.total || nodes.filter((n) => !n.is_subject_root).length} concepts across {courses.length} courses
+            {stats.total || nodes.filter((n) => !n.is_subject_root).length} concepts across {scopedCourses.length} courses
           </div>
         </div>
         <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
-          {useLegacyPanels && partition.current.slice(0, 5).map((c) => (
+          {useLegacyPanels && scopedCourses.slice(0, 5).map((c) => (
             <div key={c.course_id} style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 11, color: "var(--text-dim)" }}>
               <span style={{ width: 10, height: 10, borderRadius: "50%", background: c.color || "var(--accent)" }} />
               {c.course_code || c.course_name}
@@ -481,10 +449,8 @@ export function Dashboard() {
             full My Courses panel in the left column instead. */}
         {!useLegacyPanels && (
           <CoursesKey
-            courseProgress={currentProgress}
-            archived={archivedProgress}
+            courseProgress={courseProgress}
             onManage={() => setCoursesOpen(true)}
-            onOpenTerm={openArchivedTerm}
           />
         )}
         <div style={{ position: "absolute", left: 16, bottom: 14, display: "flex", gap: 12, fontSize: 11, color: "var(--text-muted)" }}>
@@ -787,29 +753,19 @@ export function Dashboard() {
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
           <div className="label-micro">My courses</div>
           <button className="btn btn--ghost btn--sm" onClick={() => setCoursesOpen(true)}>
-            <Icon name="cog" size={12} /> Manage
+            <Icon name="cog" size={12} /> Courses & Semesters
           </button>
         </div>
-        {courseProgress.length === 0 && (
+        {courses.length === 0 ? (
           <div style={{ fontSize: 12, color: "var(--text-muted)" }}>No enrolled courses yet.</div>
-        )}
-        {courseProgress.length > 0 && currentProgress.length === 0 && (
+        ) : courseProgress.length === 0 ? (
           <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
             Nothing enrolled this semester.
           </div>
-        )}
-        {currentProgress.map((entry) => (
+        ) : null}
+        {courseProgress.map((entry) => (
           <CourseProgressRow key={entry.course.course_id} entry={entry} />
         ))}
-        {archivedCount > 0 && (
-          <CoursesArchive
-            groups={archivedProgress}
-            count={archivedCount}
-            open={archiveOpen}
-            onToggle={() => setArchiveOpen(v => !v)}
-            onOpenTerm={openArchivedTerm}
-          />
-        )}
       </div>
 
       <div className="card" style={{ padding: "var(--pad-lg)" }}>
@@ -1100,83 +1056,12 @@ type CourseProgressEntry = {
   progress: number;
 };
 
-type ArchivedTermProgress = {
-  label: string;
-  entries: CourseProgressEntry[];
-};
-
-// Past terms, collapsed by default. Expanding lists each prior semester with
-// its courses; picking one opens that semester's gradebook.
-function CoursesArchive({
-  groups,
-  count,
-  open,
-  onToggle,
-  onOpenTerm,
-}: {
-  groups: ArchivedTermProgress[];
-  count: number;
-  open: boolean;
-  onToggle: () => void;
-  onOpenTerm: (label: string) => void;
-}) {
-  return (
-    <div style={{ borderTop: "1px solid var(--border)", marginTop: 4, paddingTop: 10 }}>
-      <button
-        type="button"
-        className="btn btn--ghost btn--sm"
-        onClick={onToggle}
-        aria-expanded={open}
-        aria-controls="dashboard-courses-archive"
-        title={open ? "Hide past semesters" : "Show past semesters"}
-        style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", justifyContent: "flex-start" }}
-      >
-        <span
-          aria-hidden
-          style={{
-            display: "inline-flex",
-            transition: "transform var(--dur-fast) var(--ease)",
-            transform: open ? "rotate(90deg)" : "none",
-          }}
-        >
-          <Icon name="chev" size={11} />
-        </span>
-        Archive
-        <span className="mono" style={{ color: "var(--text-muted)", fontSize: 11 }}>{count}</span>
-      </button>
-
-      {open && (
-        <div id="dashboard-courses-archive" style={{ marginTop: 10 }}>
-          {groups.map((group) => (
-            <div key={group.label} style={{ marginBottom: 8 }}>
-              <div className="label-micro" style={{ marginBottom: 6 }}>{group.label}</div>
-              {group.entries.map((entry) => (
-                <CourseProgressRow
-                  key={entry.course.course_id}
-                  entry={entry}
-                  onOpen={() => onOpenTerm(group.label)}
-                  ariaLabel={`${entry.course.course_code || entry.course.course_name} — open the ${group.label} gradebook`}
-                />
-              ))}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
 // One "My courses" line: colour dot, course code, mastery percentage and the
-// four-segment mastery bar. Rendered as a button when `onOpen` is supplied so
-// archived courses can route into their own semester's gradebook.
+// four-segment mastery bar.
 function CourseProgressRow({
   entry,
-  onOpen,
-  ariaLabel,
 }: {
   entry: CourseProgressEntry;
-  onOpen?: () => void;
-  ariaLabel?: string;
 }) {
   const { course, mastered, learning, struggling, unexplored, total, progress } = entry;
   const pct = Math.round(progress * 100);
@@ -1230,45 +1115,19 @@ function CourseProgressRow({
     </>
   );
 
-  if (!onOpen) return <div style={{ marginBottom: 12 }}>{body}</div>;
-
-  return (
-    <button
-      type="button"
-      onClick={onOpen}
-      aria-label={ariaLabel}
-      style={{
-        display: "block",
-        width: "100%",
-        marginBottom: 12,
-        padding: 0,
-        background: "transparent",
-        border: 0,
-        textAlign: "left",
-        color: "inherit",
-        font: "inherit",
-        cursor: "pointer",
-      }}
-    >
-      {body}
-    </button>
-  );
+  return <div style={{ marginBottom: 12 }}>{body}</div>;
 }
 
 function CoursesKey({
   courseProgress,
-  archived,
   onManage,
-  onOpenTerm,
 }: {
   courseProgress: CourseProgressEntry[];
-  archived: ArchivedTermProgress[];
   onManage: () => void;
-  onOpenTerm: (label: string) => void;
 }) {
   const [collapsed, setCollapsed] = React.useState(true);
 
-  if (courseProgress.length === 0 && archived.length === 0) return null;
+  if (courseProgress.length === 0) return null;
 
   // A thick white outline painted BEHIND the glyphs, plus a soft halo.
   // `paint-order: stroke fill` pushes the stroke under the fill so
@@ -1341,7 +1200,7 @@ function CoursesKey({
             <button
               className="btn btn--ghost btn--sm"
               onClick={onManage}
-              title="Manage courses"
+              title="Courses & Semesters"
               style={paddedIconBtn}
             >
               <Icon name="cog" size={13} />
@@ -1418,39 +1277,6 @@ function CoursesKey({
           {courseProgress.length === 0 && (
             <div style={{ fontSize: 12, color: "var(--text-dim)", ...legibleText }}>
               Nothing enrolled this semester.
-            </div>
-          )}
-
-          {archived.length > 0 && (
-            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              <div className="label-micro" style={{ fontSize: 10, ...legibleText }}>Archive</div>
-              {archived.map((group) => (
-                <button
-                  key={group.label}
-                  type="button"
-                  onClick={() => onOpenTerm(group.label)}
-                  aria-label={`Open the ${group.label} gradebook`}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    gap: 8,
-                    width: "100%",
-                    padding: 0,
-                    background: "transparent",
-                    border: 0,
-                    cursor: "pointer",
-                    fontSize: 12,
-                    color: "var(--text-dim)",
-                    ...legibleText,
-                  }}
-                >
-                  <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                    {group.label}
-                  </span>
-                  <span className="mono" style={{ fontSize: 11 }}>{group.entries.length}</span>
-                </button>
-              ))}
             </div>
           )}
         </div>

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -264,26 +264,42 @@ export function Dashboard() {
     if (!userId) return;
     setLoading(true);
     setLoadError(null);
+    // True when this pass only resolved the default semester: keep `loading`
+    // on so the effect re-run (triggered by setActiveSemester) performs the
+    // single scoped fetch without a skeleton flash in between.
+    let deferredToScopedPass = false;
     try {
-      const [graphRes, coursesRes, assignsRes, sessionsRes, recsRes, semestersRes] = await Promise.all([
+      if (!activeSemester) {
+        // First run with no stored semester: resolve + persist the default
+        // BEFORE the scoped graph/recommendations fetch, so the effect re-run
+        // does one scoped fetch instead of unscoped-then-scoped. Default is the
+        // most-recent enrolled term by `sort_key` (courseTermLabels), falling
+        // back to enrollment order.
+        const [coursesRes, semestersRes] = await Promise.all([
+          getCourses(userId),
+          // Term calendar ranks the default; if it fails we fall back to
+          // enrollment order rather than failing the load.
+          getSemesters().catch(() => ({ semesters: [] })),
+        ]);
+        const cs = coursesRes.courses || [];
+        const def = courseTermLabels(cs, semestersRes.semesters || [])[0] || resolveActiveSemester("", cs);
+        if (def) {
+          deferredToScopedPass = true;
+          setActiveSemester(def);
+          return;
+        }
+        // No enrolled terms (e.g. zero courses) → nothing to scope by; fall
+        // through and load unscoped in this same pass.
+      }
+      const [graphRes, coursesRes, assignsRes, sessionsRes, recsRes] = await Promise.all([
         getGraph(userId, activeSemester || undefined),
         getCourses(userId),
         getUpcomingAssignments(userId),
         getSessions(userId, 10),
         getRecommendations(userId, activeSemester || undefined).catch(() => ({ recommendations: [] })),
-        // Term calendar drives the default active-semester resolution below;
-        // if it fails we fall back to enrollment order rather than failing the load.
-        getSemesters().catch(() => ({ semesters: [] })),
       ]);
       const cs = coursesRes.courses || [];
-      const sems = semestersRes.semesters || [];
       setCourses(cs);
-      // First run with no stored semester: default to the most-recent enrolled
-      // term by `sort_key` (courseTermLabels), falling back to enrollment order.
-      if (!activeSemester) {
-        const def = courseTermLabels(cs, sems)[0] || resolveActiveSemester("", cs);
-        if (def) setActiveSemester(def);
-      }
       const gNodes: GraphNode[] = (graphRes.nodes || []).map((n: ApiNode) => apiToGraphNode(n, cs));
       setNodes(gNodes);
       setEdges((graphRes.edges || []).map(apiToGraphEdge));
@@ -310,7 +326,7 @@ export function Dashboard() {
       console.error("dashboard load failed", err);
       setLoadError(String(err));
     } finally {
-      setLoading(false);
+      if (!deferredToScopedPass) setLoading(false);
     }
   }, [userId, activeSemester, setActiveSemester]);
 
@@ -450,6 +466,8 @@ export function Dashboard() {
         {!useLegacyPanels && (
           <CoursesKey
             courseProgress={courseProgress}
+            hasCourses={courses.length > 0}
+            semesterActive={!!activeSemester}
             onManage={() => setCoursesOpen(true)}
           />
         )}
@@ -1120,14 +1138,22 @@ function CourseProgressRow({
 
 function CoursesKey({
   courseProgress,
+  hasCourses,
+  semesterActive,
   onManage,
 }: {
   courseProgress: CourseProgressEntry[];
+  hasCourses: boolean;
+  semesterActive: boolean;
   onManage: () => void;
 }) {
   const [collapsed, setCollapsed] = React.useState(true);
 
-  if (courseProgress.length === 0) return null;
+  // No enrolled courses at all → nothing to key, render nothing (the original
+  // null case). But when courses exist and the active semester merely has none
+  // of them, keep the panel so the "Nothing enrolled this semester." empty
+  // state below is reachable.
+  if (courseProgress.length === 0 && !(hasCourses && semesterActive)) return null;
 
   // A thick white outline painted BEHIND the glyphs, plus a soft halo.
   // `paint-order: stroke fill` pushes the stroke under the fill so

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -18,7 +18,8 @@ import { KnowledgeGraph } from "../KnowledgeGraph";
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
 import { useIsMobile } from "@/lib/useIsMobile";
-import { useActiveSemester } from "@/lib/useActiveSemester";
+import { ensureDefaultActiveSemester, useActiveSemester } from "@/lib/useActiveSemester";
+import { courseTermLabels } from "@/lib/semesters";
 import { useUser } from "@/context/UserContext";
 import {
   startSession,
@@ -448,6 +449,10 @@ function LearnInner() {
           filteredSessions.map(s => [s.id, s.topic] as const),
         );
         setCourses(cRes.courses ?? []);
+        // No stored semester yet (e.g. first visit lands here, not on the
+        // Dashboard): persist the most-recent enrolled term as the default.
+        // The change event re-runs this effect once, scoped.
+        ensureDefaultActiveSemester(courseTermLabels(cRes.courses ?? []));
         const nodes = (gRes.nodes ?? []) as Array<{ id: string; concept_name?: string; name?: string; course_id?: string | null; is_subject_root?: boolean }>;
         const courseById = new Map((cRes.courses ?? []).map(c => [c.course_id, c]));
         setConcepts(

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -18,8 +18,7 @@ import { KnowledgeGraph } from "../KnowledgeGraph";
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
 import { useIsMobile } from "@/lib/useIsMobile";
-import { ensureDefaultActiveSemester, useActiveSemester } from "@/lib/useActiveSemester";
-import { courseTermLabels } from "@/lib/semesters";
+import { useActiveSemester } from "@/lib/useActiveSemester";
 import { useUser } from "@/context/UserContext";
 import {
   startSession,
@@ -449,10 +448,6 @@ function LearnInner() {
           filteredSessions.map(s => [s.id, s.topic] as const),
         );
         setCourses(cRes.courses ?? []);
-        // No stored semester yet (e.g. first visit lands here, not on the
-        // Dashboard): persist the most-recent enrolled term as the default.
-        // The change event re-runs this effect once, scoped.
-        ensureDefaultActiveSemester(courseTermLabels(cRes.courses ?? []));
         const nodes = (gRes.nodes ?? []) as Array<{ id: string; concept_name?: string; name?: string; course_id?: string | null; is_subject_root?: boolean }>;
         const courseById = new Map((cRes.courses ?? []).map(c => [c.course_id, c]));
         setConcepts(

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -18,6 +18,7 @@ import { KnowledgeGraph } from "../KnowledgeGraph";
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
 import { useIsMobile } from "@/lib/useIsMobile";
+import { useActiveSemester } from "@/lib/useActiveSemester";
 import { useUser } from "@/context/UserContext";
 import {
   startSession,
@@ -307,6 +308,7 @@ function LearnInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { userId, userReady } = useUser();
+  const [activeSemester, , semesterHydrated] = useActiveSemester();
   const toast = useToast();
   const isMobile = useIsMobile();
 
@@ -334,7 +336,7 @@ function LearnInner() {
 
   const [recentSessions, setRecentSessions] = useState<Session[]>([]);
   const [courses, setCourses] = useState<EnrolledCourse[]>([]);
-  const [concepts, setConcepts] = useState<{ id: string; name: string; course_id: string | null; course_code: string | null }[]>([]);
+  const [concepts, setConcepts] = useState<{ id: string; name: string; course_id: string | null; course_code: string | null; term: string | null }[]>([]);
   const [graphNodes, setGraphNodes] = useState<GraphNode[]>([]);
   const [graphEdges, setGraphEdges] = useState<GraphEdge[]>([]);
 
@@ -426,16 +428,18 @@ function LearnInner() {
   const railDragRef = useRef<{ startX: number; startWidth: number; width: number; moved: boolean; pointerId: number } | null>(null);
   const [railHydrated, setRailHydrated] = useState(false);
 
-  // Initial data load
+  // Initial data load. Waits for the active-semester read from localStorage
+  // before fetching, so returning users fetch scoped once instead of
+  // unscoped-then-scoped; re-runs when the active semester changes.
   useEffect(() => {
-    if (!userReady || !userId) return;
+    if (!userReady || !userId || !semesterHydrated) return;
     let cancelled = false;
     (async () => {
       try {
         const [sRes, cRes, gRes] = await Promise.all([
           getSessions(userId, 10).catch(() => ({ sessions: [] })),
           getCourses(userId).catch(() => ({ courses: [] })),
-          getGraph(userId).catch(() => ({ nodes: [] as any[], edges: [] as any[], stats: {} })),
+          getGraph(userId, activeSemester || undefined).catch(() => ({ nodes: [] as any[], edges: [] as any[], stats: {} })),
         ]);
         if (cancelled) return;
         const filteredSessions = (sRes.sessions ?? []).filter(s => s.message_count > 0);
@@ -454,6 +458,7 @@ function LearnInner() {
               name: n.concept_name || n.name || "Concept",
               course_id: n.course_id ?? null,
               course_code: n.course_id ? (courseById.get(n.course_id)?.course_code ?? null) : null,
+              term: n.course_id ? (courseById.get(n.course_id)?.term ?? null) : null,
             })),
         );
         const apiNodes = (gRes.nodes ?? []) as ApiNode[];
@@ -465,7 +470,7 @@ function LearnInner() {
       }
     })();
     return () => { cancelled = true; };
-  }, [userReady, userId]);
+  }, [userReady, userId, semesterHydrated, activeSemester]);
 
   // Sync URL params when mode changes (preserve other params)
   useEffect(() => {
@@ -794,6 +799,14 @@ function LearnInner() {
 
   const modeOptions = useMemo(() => MODES.map(m => ({ value: m.id, label: m.name, description: m.tip })), []);
 
+  // Scope the course picker to the active semester (falls back to all
+  // courses when no semester is selected). The suggest/highlight logic that
+  // sat next to this pre-revamp now lives up top with the rail-focus state.
+  const scopedCourses = useMemo(
+    () => (activeSemester ? courses.filter(c => c.term === activeSemester) : courses),
+    [courses, activeSemester],
+  );
+
   // Jump the chat to `name`: resume an existing session on that concept if one
   // exists, otherwise start a fresh one. Both paths clear the map focus so the
   // rail follows the now-active session.
@@ -1033,7 +1046,7 @@ function LearnInner() {
               value={selectedCourseId}
               options={[
                 { value: "", label: "No course" },
-                ...courses.map(c => ({ value: c.course_id, label: `${c.course_code} — ${c.course_name}` })),
+                ...scopedCourses.map(c => ({ value: c.course_id, label: `${c.course_code} — ${c.course_name}` })),
               ]}
               onChange={setSelectedCourseId}
               style={{ width: "100%", marginBottom: 16 }}
@@ -1046,6 +1059,7 @@ function LearnInner() {
               concepts={concepts}
               courses={courses}
               selectedCourseId={selectedCourseId}
+              activeSemester={activeSemester}
             />
             <div className="label-micro" style={{ marginBottom: 8 }}>Mode</div>
             <div style={{ marginBottom: 20 }}>
@@ -1726,14 +1740,15 @@ function SessionRow({ s, onResume, onDelete, onRename }: {
 const GENERAL_TOPIC = "Course overview — pick the next concept I should learn next.";
 
 function TopicPicker({
-  value, onChange, onSubmit, concepts, courses, selectedCourseId,
+  value, onChange, onSubmit, concepts, courses, selectedCourseId, activeSemester,
 }: {
   value: string;
   onChange: (v: string) => void;
   onSubmit: () => void;
-  concepts: { id: string; name: string; course_id: string | null; course_code: string | null }[];
+  concepts: { id: string; name: string; course_id: string | null; course_code: string | null; term: string | null }[];
   courses: EnrolledCourse[];
   selectedCourseId: string;
+  activeSemester: string;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -1756,9 +1771,10 @@ function TopicPicker({
     const q = query.trim().toLowerCase();
     return concepts
       .filter(c => !selectedCourseId || c.course_id === selectedCourseId)
+      .filter(c => (activeSemester ? c.term === activeSemester : true))
       .filter(c => !q || c.name.toLowerCase().includes(q))
       .slice(0, 80);
-  }, [concepts, query, selectedCourseId]);
+  }, [concepts, query, selectedCourseId, activeSemester]);
 
   const isGeneral = value === GENERAL_TOPIC;
   const courseLabel = selectedCourse

--- a/frontend/src/components/screens/Quiz.tsx
+++ b/frontend/src/components/screens/Quiz.tsx
@@ -8,10 +8,11 @@ import { AIDisclaimerChip } from "../AIDisclaimerChip";
 import { DisclaimerModal } from "../DisclaimerModal";
 import { QuizPanel } from "../QuizPanel";
 import { useUser } from "@/context/UserContext";
+import { useActiveSemester } from "@/lib/useActiveSemester";
 import { getCourses, getGraph, type EnrolledCourse } from "@/lib/api";
 import type { GraphNode as ApiNode } from "@/lib/types";
 
-type Concept = { id: string; name: string; course_id: string | null; course_code: string | null };
+type Concept = { id: string; name: string; course_id: string | null; course_code: string | null; term: string | null };
 
 export function Quiz() {
   return (
@@ -25,19 +26,23 @@ function QuizInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { userId, userReady } = useUser();
+  const [activeSemester, , semesterHydrated] = useActiveSemester();
 
   const [concepts, setConcepts] = useState<Concept[]>([]);
   const [courses, setCourses] = useState<EnrolledCourse[]>([]);
   const [loaded, setLoaded] = useState(false);
 
+  // Waits for the active-semester read from localStorage before the first
+  // fetch, so returning users fetch scoped once instead of unscoped-then-scoped;
+  // re-runs when the active semester changes.
   useEffect(() => {
-    if (!userReady || !userId) return;
+    if (!userReady || !userId || !semesterHydrated) return;
     let cancelled = false;
     (async () => {
       try {
         const [cRes, gRes] = await Promise.all([
           getCourses(userId).catch(() => ({ courses: [] as EnrolledCourse[] })),
-          getGraph(userId).catch(() => ({ nodes: [] as ApiNode[], edges: [], stats: {} })),
+          getGraph(userId, activeSemester || undefined).catch(() => ({ nodes: [] as ApiNode[], edges: [], stats: {} })),
         ]);
         if (cancelled) return;
         setCourses(cRes.courses ?? []);
@@ -51,6 +56,7 @@ function QuizInner() {
               name: n.concept_name || "Concept",
               course_id: n.course_id ?? null,
               course_code: n.course_id ? (courseById.get(n.course_id)?.course_code ?? null) : null,
+              term: n.course_id ? (courseById.get(n.course_id)?.term ?? null) : null,
             })),
         );
       } catch (err) {
@@ -60,7 +66,21 @@ function QuizInner() {
       }
     })();
     return () => { cancelled = true; };
-  }, [userReady, userId]);
+  }, [userReady, userId, semesterHydrated, activeSemester]);
+
+  // The graph fetch above is already scoped to the active semester, so this
+  // is defensive rather than load-bearing — matches the Tree/Learn pickers.
+  const scopedConcepts = useMemo(
+    () => (activeSemester ? concepts.filter(c => c.term === activeSemester) : concepts),
+    [concepts, activeSemester],
+  );
+
+  // Scope the course picker to the active semester too, so it stays consistent
+  // with the concept list the quiz draws from.
+  const scopedCourses = useMemo(
+    () => (activeSemester ? courses.filter(c => c.term === activeSemester) : courses),
+    [courses, activeSemester],
+  );
 
   const topicParam = searchParams.get("topic");
   const conceptParam = searchParams.get("concept");
@@ -69,8 +89,8 @@ function QuizInner() {
     if (conceptParam) return conceptParam;
     if (!topicParam) return null;
     const t = topicParam.trim().toLowerCase();
-    return concepts.find(c => c.name.toLowerCase() === t)?.id ?? null;
-  }, [conceptParam, topicParam, concepts]);
+    return scopedConcepts.find(c => c.name.toLowerCase() === t)?.id ?? null;
+  }, [conceptParam, topicParam, scopedConcepts]);
 
   return (
     <FullHeightScreen>
@@ -95,8 +115,8 @@ function QuizInner() {
         ) : loaded ? (
           <QuizPanel
             userId={userId}
-            concepts={concepts}
-            courses={courses}
+            concepts={scopedConcepts}
+            courses={scopedCourses}
             initialConceptId={initialConceptId}
             onExit={() => router.push("/learn")}
           />

--- a/frontend/src/components/screens/Quiz.tsx
+++ b/frontend/src/components/screens/Quiz.tsx
@@ -8,8 +8,7 @@ import { AIDisclaimerChip } from "../AIDisclaimerChip";
 import { DisclaimerModal } from "../DisclaimerModal";
 import { QuizPanel } from "../QuizPanel";
 import { useUser } from "@/context/UserContext";
-import { ensureDefaultActiveSemester, useActiveSemester } from "@/lib/useActiveSemester";
-import { courseTermLabels } from "@/lib/semesters";
+import { useActiveSemester } from "@/lib/useActiveSemester";
 import { getCourses, getGraph, type EnrolledCourse } from "@/lib/api";
 import type { GraphNode as ApiNode } from "@/lib/types";
 
@@ -47,10 +46,6 @@ function QuizInner() {
         ]);
         if (cancelled) return;
         setCourses(cRes.courses ?? []);
-        // No stored semester yet (e.g. first visit lands here, not on the
-        // Dashboard): persist the most-recent enrolled term as the default.
-        // The change event re-runs this effect once, scoped.
-        ensureDefaultActiveSemester(courseTermLabels(cRes.courses ?? []));
         const courseById = new Map((cRes.courses ?? []).map(c => [c.course_id, c]));
         const nodes = (gRes.nodes ?? []) as ApiNode[];
         setConcepts(

--- a/frontend/src/components/screens/Quiz.tsx
+++ b/frontend/src/components/screens/Quiz.tsx
@@ -8,7 +8,8 @@ import { AIDisclaimerChip } from "../AIDisclaimerChip";
 import { DisclaimerModal } from "../DisclaimerModal";
 import { QuizPanel } from "../QuizPanel";
 import { useUser } from "@/context/UserContext";
-import { useActiveSemester } from "@/lib/useActiveSemester";
+import { ensureDefaultActiveSemester, useActiveSemester } from "@/lib/useActiveSemester";
+import { courseTermLabels } from "@/lib/semesters";
 import { getCourses, getGraph, type EnrolledCourse } from "@/lib/api";
 import type { GraphNode as ApiNode } from "@/lib/types";
 
@@ -46,6 +47,10 @@ function QuizInner() {
         ]);
         if (cancelled) return;
         setCourses(cRes.courses ?? []);
+        // No stored semester yet (e.g. first visit lands here, not on the
+        // Dashboard): persist the most-recent enrolled term as the default.
+        // The change event re-runs this effect once, scoped.
+        ensureDefaultActiveSemester(courseTermLabels(cRes.courses ?? []));
         const courseById = new Map((cRes.courses ?? []).map(c => [c.course_id, c]));
         const nodes = (gRes.nodes ?? []) as ApiNode[];
         setConcepts(

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -26,8 +26,7 @@ import { useToast } from "../ToastProvider";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { humanizeError, isNotFound } from "@/lib/errorMessage";
 import { useUser } from "@/context/UserContext";
-import { ensureDefaultActiveSemester, useActiveSemester } from "@/lib/useActiveSemester";
-import { courseTermLabels } from "@/lib/semesters";
+import { useActiveSemester } from "@/lib/useActiveSemester";
 import {
   getCourses,
   getStudyGuideExams,
@@ -83,14 +82,7 @@ export function Study() {
   React.useEffect(() => {
     if (!userReady || !userId) return;
     getCourses(userId)
-      .then(r => {
-        const cs = r.courses || [];
-        setCourses(cs);
-        // No stored semester yet (e.g. first visit lands here, not on the
-        // Dashboard): persist the most-recent enrolled term as the default so
-        // the client-side semester filter below scopes like every other screen.
-        ensureDefaultActiveSemester(courseTermLabels(cs));
-      })
+      .then(r => setCourses(r.courses || []))
       .catch(err => console.error("study courses load failed", err));
   }, [userReady, userId]);
 

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -26,7 +26,8 @@ import { useToast } from "../ToastProvider";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { humanizeError, isNotFound } from "@/lib/errorMessage";
 import { useUser } from "@/context/UserContext";
-import { useActiveSemester } from "@/lib/useActiveSemester";
+import { ensureDefaultActiveSemester, useActiveSemester } from "@/lib/useActiveSemester";
+import { courseTermLabels } from "@/lib/semesters";
 import {
   getCourses,
   getStudyGuideExams,
@@ -82,7 +83,14 @@ export function Study() {
   React.useEffect(() => {
     if (!userReady || !userId) return;
     getCourses(userId)
-      .then(r => setCourses(r.courses || []))
+      .then(r => {
+        const cs = r.courses || [];
+        setCourses(cs);
+        // No stored semester yet (e.g. first visit lands here, not on the
+        // Dashboard): persist the most-recent enrolled term as the default so
+        // the client-side semester filter below scopes like every other screen.
+        ensureDefaultActiveSemester(courseTermLabels(cs));
+      })
       .catch(err => console.error("study courses load failed", err));
   }, [userReady, userId]);
 

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -26,6 +26,7 @@ import { useToast } from "../ToastProvider";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { humanizeError, isNotFound } from "@/lib/errorMessage";
 import { useUser } from "@/context/UserContext";
+import { useActiveSemester } from "@/lib/useActiveSemester";
 import {
   getCourses,
   getStudyGuideExams,
@@ -76,6 +77,7 @@ export function Study() {
     searchParams.get("mode") === "cards" ? "cards" : "guide",
   );
   const [courses, setCourses] = React.useState<EnrolledCourse[]>([]);
+  const [activeSemester] = useActiveSemester();
 
   React.useEffect(() => {
     if (!userReady || !userId) return;
@@ -83,6 +85,14 @@ export function Study() {
       .then(r => setCourses(r.courses || []))
       .catch(err => console.error("study courses load failed", err));
   }, [userReady, userId]);
+
+  // Scope the study surfaces to the active semester's courses (course pickers,
+  // guide/flashcard generation). Study has no graph fetch of its own, so this
+  // client-side filter is all the scoping it needs.
+  const scopedCourses = React.useMemo(
+    () => (activeSemester ? courses.filter(c => c.term === activeSemester) : courses),
+    [courses, activeSemester],
+  );
 
   const actions = (
     <>
@@ -148,9 +158,9 @@ export function Study() {
           style={{ display: "flex", flex: 1, minHeight: 0 }}
         >
           {mode === "guide" ? (
-            <GuideMode courses={courses} isMobile={isMobile} />
+            <GuideMode courses={scopedCourses} isMobile={isMobile} />
           ) : (
-            <FlashcardsMode courses={courses} isMobile={isMobile} />
+            <FlashcardsMode courses={scopedCourses} isMobile={isMobile} />
           )}
         </motion.div>
       </AnimatePresence>

--- a/frontend/src/components/screens/Tree.tsx
+++ b/frontend/src/components/screens/Tree.tsx
@@ -10,8 +10,7 @@ import { KnowledgeGraph } from "../KnowledgeGraph";
 import { GraphPanelSkeleton } from "../Skeleton";
 import { useUser } from "@/context/UserContext";
 import { useIsMobile } from "@/lib/useIsMobile";
-import { ensureDefaultActiveSemester, useActiveSemester } from "@/lib/useActiveSemester";
-import { courseTermLabels } from "@/lib/semesters";
+import { useActiveSemester } from "@/lib/useActiveSemester";
 import { getGraph, getCourses, getSessions, deleteGraphNode, type EnrolledCourse, type Session } from "@/lib/api";
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
@@ -68,10 +67,6 @@ export function Tree() {
       ]);
       const cs = coursesRes.courses || [];
       setCourses(cs);
-      // No stored semester yet (e.g. first visit lands here, not on the
-      // Dashboard): persist the most-recent enrolled term as the default.
-      // The change event re-runs the load once, scoped.
-      ensureDefaultActiveSemester(courseTermLabels(cs));
       setNodes((graphRes.nodes || []).map((n: ApiNode) => apiToGraphNode(n, cs)));
       setEdges(
         (graphRes.edges || []).map((e: ApiEdge) => ({

--- a/frontend/src/components/screens/Tree.tsx
+++ b/frontend/src/components/screens/Tree.tsx
@@ -10,6 +10,7 @@ import { KnowledgeGraph } from "../KnowledgeGraph";
 import { GraphPanelSkeleton } from "../Skeleton";
 import { useUser } from "@/context/UserContext";
 import { useIsMobile } from "@/lib/useIsMobile";
+import { useActiveSemester } from "@/lib/useActiveSemester";
 import { getGraph, getCourses, getSessions, deleteGraphNode, type EnrolledCourse, type Session } from "@/lib/api";
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
@@ -29,6 +30,7 @@ export function Tree() {
   const router = useRouter();
   const search = useSearchParams();
   const { userId, userReady } = useUser();
+  const [activeSemester, , semesterHydrated] = useActiveSemester();
   const isMobile = useIsMobile();
   const suggest = search.get("suggest");
 
@@ -59,7 +61,7 @@ export function Tree() {
     if (!userId) return;
     try {
       const [graphRes, coursesRes, sessionsRes] = await Promise.all([
-        getGraph(userId),
+        getGraph(userId, activeSemester || undefined),
         getCourses(userId),
         getSessions(userId, 50).catch(() => ({ sessions: [] })),
       ]);
@@ -79,11 +81,13 @@ export function Tree() {
     } finally {
       setLoading(false);
     }
-  }, [userId]);
+  }, [userId, activeSemester]);
 
   React.useEffect(() => {
-    if (userReady && userId) load();
-  }, [userReady, userId, load]);
+    // Wait for the active-semester read from localStorage before the first load,
+    // so returning users fetch scoped once instead of unscoped-then-scoped.
+    if (userReady && userId && semesterHydrated) load();
+  }, [userReady, userId, semesterHydrated, load]);
 
   // Auto-select node matching ?suggest= once data loads.
   React.useEffect(() => {
@@ -102,6 +106,11 @@ export function Tree() {
       document.removeEventListener("keydown", h);
     };
   }, [fullscreen]);
+
+  const scopedCourses = React.useMemo(
+    () => (activeSemester ? courses.filter((c) => c.term === activeSemester) : courses),
+    [courses, activeSemester],
+  );
 
   const filteredNodes = React.useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -299,7 +308,7 @@ export function Tree() {
         }}
       >
         <Pill active={courseFilter === "all"} onClick={() => setCourseFilter("all")}>All courses</Pill>
-        {courses.map((c) => (
+        {scopedCourses.map((c) => (
           <Pill
             key={c.course_id}
             active={courseFilter === c.course_id}

--- a/frontend/src/components/screens/Tree.tsx
+++ b/frontend/src/components/screens/Tree.tsx
@@ -10,7 +10,8 @@ import { KnowledgeGraph } from "../KnowledgeGraph";
 import { GraphPanelSkeleton } from "../Skeleton";
 import { useUser } from "@/context/UserContext";
 import { useIsMobile } from "@/lib/useIsMobile";
-import { useActiveSemester } from "@/lib/useActiveSemester";
+import { ensureDefaultActiveSemester, useActiveSemester } from "@/lib/useActiveSemester";
+import { courseTermLabels } from "@/lib/semesters";
 import { getGraph, getCourses, getSessions, deleteGraphNode, type EnrolledCourse, type Session } from "@/lib/api";
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
@@ -67,6 +68,10 @@ export function Tree() {
       ]);
       const cs = coursesRes.courses || [];
       setCourses(cs);
+      // No stored semester yet (e.g. first visit lands here, not on the
+      // Dashboard): persist the most-recent enrolled term as the default.
+      // The change event re-runs the load once, scoped.
+      ensureDefaultActiveSemester(courseTermLabels(cs));
       setNodes((graphRes.nodes || []).map((n: ApiNode) => apiToGraphNode(n, cs)));
       setEdges(
         (graphRes.edges || []).map((e: ApiEdge) => ({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -70,11 +70,15 @@ export interface MeResponse {
 export const getMe = () => fetchJSON<MeResponse>('/api/auth/me');
 
 // Graph
-export const getGraph = (userId: string) =>
-  fetchJSON<{ nodes: any[]; edges: any[]; stats: any }>(`/api/graph/${userId}`);
+export const getGraph = (userId: string, semester?: string) =>
+  fetchJSON<{ nodes: any[]; edges: any[]; stats: any }>(
+    `/api/graph/${userId}${semester ? `?semester=${encodeURIComponent(semester)}` : ""}`,
+  );
 
-export const getRecommendations = (userId: string) =>
-  fetchJSON<{ recommendations: any[] }>(`/api/graph/${userId}/recommendations`);
+export const getRecommendations = (userId: string, semester?: string) =>
+  fetchJSON<{ recommendations: any[] }>(
+    `/api/graph/${userId}/recommendations${semester ? `?semester=${encodeURIComponent(semester)}` : ""}`,
+  );
 
 export interface EnrolledCourse {
   enrollment_id: string;
@@ -96,10 +100,10 @@ export interface EnrolledCourse {
 export const getCourses = (userId: string) =>
   fetchJSON<{ courses: EnrolledCourse[] }>(`/api/graph/${userId}/courses`);
 
-export const addCourse = (userId: string, courseId: string, color?: string, nickname?: string) =>
-  fetchJSON<{ course_id: string; already_existed: boolean; error?: string }>(`/api/graph/${userId}/courses`, {
+export const addCourse = (userId: string, courseId: string, color?: string, nickname?: string, term?: string) =>
+  fetchJSON<{ course_id: string; already_existed: boolean; term?: string; error?: string }>(`/api/graph/${userId}/courses`, {
     method: 'POST',
-    body: JSON.stringify({ course_id: courseId, ...(color ? { color } : {}), ...(nickname ? { nickname } : {}) }),
+    body: JSON.stringify({ course_id: courseId, ...(color ? { color } : {}), ...(nickname ? { nickname } : {}), ...(term ? { term } : {}) }),
   });
 
 export const deleteCourse = (userId: string, courseId: string) =>

--- a/frontend/src/lib/semesters.test.ts
+++ b/frontend/src/lib/semesters.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
-  UNKNOWN_TERM_LABEL,
   courseTermLabels,
   currentTerm,
-  groupCoursesByTerm,
-  partitionCurrentAndArchive,
   termRankFromLabel,
 } from "./semesters";
 import type { EnrolledCourse, Semester } from "./api";
@@ -36,8 +33,6 @@ function course(course_id: string, term: string): EnrolledCourse {
     term,
   };
 }
-
-const ids = (courses: EnrolledCourse[]) => courses.map((c) => c.course_id);
 
 describe("termRankFromLabel", () => {
   it("mirrors the sort_key formula (year * 10 + term ordinal)", () => {
@@ -110,151 +105,6 @@ describe("currentTerm", () => {
       { id: "x", term: "Fall", year: 2025, label: "Fall 2025", start_date: "", end_date: "", sort_key: 20253 },
     ] as Semester[];
     expect(currentTerm(partial, "2025-09-10")?.label).toBe("Fall 2025");
-  });
-});
-
-describe("groupCoursesByTerm", () => {
-  it("groups by term label, most recent term first", () => {
-    const groups = groupCoursesByTerm(
-      [course("a", "Fall 2025"), course("b", "Spring 2026"), course("c", "Fall 2025")],
-      SEMESTERS,
-    );
-    expect(groups.map((g) => g.label)).toEqual(["Spring 2026", "Fall 2025"]);
-    expect(ids(groups[1].courses)).toEqual(["a", "c"]);
-  });
-
-  it("preserves input order inside a group", () => {
-    const groups = groupCoursesByTerm(
-      [course("z", "Fall 2025"), course("a", "Fall 2025"), course("m", "Fall 2025")],
-      SEMESTERS,
-    );
-    expect(ids(groups[0].courses)).toEqual(["z", "a", "m"]);
-  });
-
-  it("buckets courses with an empty or whitespace term instead of dropping them", () => {
-    const groups = groupCoursesByTerm(
-      [course("a", "Spring 2026"), course("b", ""), course("c", "   ")],
-      SEMESTERS,
-    );
-    const other = groups.find((g) => g.label === UNKNOWN_TERM_LABEL);
-    expect(ids(other!.courses)).toEqual(["b", "c"]);
-    // Unrankable bucket sorts last.
-    expect(groups[groups.length - 1].label).toBe(UNKNOWN_TERM_LABEL);
-  });
-
-  it("keeps a course whose term field is missing entirely", () => {
-    const missing = { ...course("a", "") } as Partial<EnrolledCourse>;
-    delete missing.term;
-    const groups = groupCoursesByTerm([missing as EnrolledCourse], SEMESTERS);
-    expect(groups).toHaveLength(1);
-    expect(groups[0].label).toBe(UNKNOWN_TERM_LABEL);
-  });
-
-  it("orders by label rank when no semesters are supplied", () => {
-    const groups = groupCoursesByTerm([
-      course("a", "Fall 2025"),
-      course("b", "Fall 2026"),
-      course("c", "Spring 2026"),
-    ]);
-    expect(groups.map((g) => g.label)).toEqual(["Fall 2026", "Spring 2026", "Fall 2025"]);
-  });
-
-  it("prefers the server sort_key over the label rank when they disagree", () => {
-    // A school whose 'Winter 2026' term genuinely precedes Spring 2026.
-    // Label parsing alone would rank Winter after Spring.
-    const custom: Semester[] = [
-      { id: "w", term: "Winter", year: 2026, label: "Winter 2026", start_date: "2026-01-02", end_date: "2026-01-20", sort_key: 20260 },
-      { id: "s", term: "Spring", year: 2026, label: "Spring 2026", start_date: "2026-01-21", end_date: "2026-05-17", sort_key: 20261 },
-    ];
-    const groups = groupCoursesByTerm(
-      [course("a", "Winter 2026"), course("b", "Spring 2026")],
-      custom,
-    );
-    expect(groups.map((g) => g.label)).toEqual(["Spring 2026", "Winter 2026"]);
-  });
-
-  it("returns an empty list for no courses", () => {
-    expect(groupCoursesByTerm([], SEMESTERS)).toEqual([]);
-    expect(groupCoursesByTerm(null, SEMESTERS)).toEqual([]);
-  });
-});
-
-describe("partitionCurrentAndArchive", () => {
-  const enrolled = [
-    course("bio", "Spring 2026"),
-    course("psy", "Fall 2025"),
-    course("mat", "Spring 2026"),
-    course("cs", "Fall 2026"),
-  ];
-
-  it("keeps the current term up front and archives only earlier terms", () => {
-    const { current, archive } = partitionCurrentAndArchive(enrolled, SEMESTERS, "2026-03-01");
-    expect(ids(current)).toEqual(["bio", "mat", "cs"]);
-    expect(archive.map((g) => g.label)).toEqual(["Fall 2025"]);
-    expect(ids(archive[0].courses)).toEqual(["psy"]);
-  });
-
-  it("does not archive a future term", () => {
-    const { current } = partitionCurrentAndArchive(enrolled, SEMESTERS, "2026-03-01");
-    expect(ids(current)).toContain("cs");
-  });
-
-  it("orders archive groups most recent first", () => {
-    const older = [
-      course("a", "Fall 2025"),
-      course("b", "Spring 2026"),
-      course("c", "Summer 2026"),
-    ];
-    const { archive } = partitionCurrentAndArchive(older, SEMESTERS, "2026-10-01");
-    expect(archive.map((g) => g.label)).toEqual(["Summer 2026", "Spring 2026", "Fall 2025"]);
-  });
-
-  it("moves with the calendar — the same data partitions differently later", () => {
-    const spring = partitionCurrentAndArchive(enrolled, SEMESTERS, "2026-03-01");
-    const fall = partitionCurrentAndArchive(enrolled, SEMESTERS, "2026-09-15");
-    expect(ids(spring.current)).toEqual(["bio", "mat", "cs"]);
-    expect(ids(fall.current)).toEqual(["cs"]);
-    expect(fall.archive.map((g) => g.label)).toEqual(["Spring 2026", "Fall 2025"]);
-  });
-
-  it("keeps undatable courses in the current list rather than hiding them", () => {
-    const mixed = [course("bio", "Spring 2026"), course("solo", ""), course("odd", "Interterm")];
-    const { current, archive } = partitionCurrentAndArchive(mixed, SEMESTERS, "2026-03-01");
-    expect(ids(current)).toEqual(["bio", "solo", "odd"]);
-    expect(archive).toEqual([]);
-  });
-
-  it("archives a past term the semesters payload never mentioned", () => {
-    const { current, archive } = partitionCurrentAndArchive(
-      [course("bio", "Spring 2026"), course("old", "Fall 2019")],
-      SEMESTERS,
-      "2026-03-01",
-    );
-    expect(ids(current)).toEqual(["bio"]);
-    expect(archive.map((g) => g.label)).toEqual(["Fall 2019"]);
-  });
-
-  it("shows everything ungrouped when the semesters fetch yields nothing", () => {
-    for (const empty of [[], null, undefined]) {
-      const { current, archive } = partitionCurrentAndArchive(enrolled, empty, "2026-03-01");
-      expect(ids(current)).toEqual(["bio", "psy", "mat", "cs"]);
-      expect(archive).toEqual([]);
-    }
-  });
-
-  it("handles no courses at all", () => {
-    expect(partitionCurrentAndArchive([], SEMESTERS, "2026-03-01")).toEqual({
-      current: [],
-      archive: [],
-    });
-    expect(partitionCurrentAndArchive(null, SEMESTERS, "2026-03-01").current).toEqual([]);
-  });
-
-  it("defaults today to now when it is not injected", () => {
-    const result = partitionCurrentAndArchive(enrolled, SEMESTERS);
-    expect(result.current.length + result.archive.reduce((n, g) => n + g.courses.length, 0)).toBe(
-      enrolled.length,
-    );
   });
 });
 

--- a/frontend/src/lib/semesters.ts
+++ b/frontend/src/lib/semesters.ts
@@ -1,15 +1,5 @@
 import type { EnrolledCourse, Semester } from "@/lib/api";
 
-// Bucket for enrollments whose offering has no term joined (the backend
-// sends `term: ""`). These are never archived — an undatable course is
-// shown with the current term rather than hidden behind the archive.
-export const UNKNOWN_TERM_LABEL = "Other";
-
-export type TermGroup = {
-  label: string;
-  courses: EnrolledCourse[];
-};
-
 // Mirrors the `sort_key` formula in migration 0019: year * 10 + term ordinal.
 const TERM_ORDINALS: Record<string, number> = {
   spring: 1,
@@ -91,31 +81,6 @@ function compareLabels(a: string, b: string, index: Map<string, number>): number
 }
 
 /**
- * Group courses by their term label, most recent term first.
- *
- * Ordering keys on each semester's `sort_key` when `semesters` is supplied and
- * degrades to a label-derived rank otherwise. Courses with no term land in the
- * `UNKNOWN_TERM_LABEL` bucket — never dropped. Order within a group is the
- * caller's input order.
- */
-export function groupCoursesByTerm(
-  courses: EnrolledCourse[] | null | undefined,
-  semesters?: Semester[] | null,
-): TermGroup[] {
-  const index = rankIndex(semesters);
-  const buckets = new Map<string, EnrolledCourse[]>();
-  for (const course of courses ?? []) {
-    const label = (course.term || "").trim() || UNKNOWN_TERM_LABEL;
-    const bucket = buckets.get(label);
-    if (bucket) bucket.push(course);
-    else buckets.set(label, [course]);
-  }
-  return Array.from(buckets, ([label, grouped]) => ({ label, courses: grouped })).sort(
-    (a, b) => compareLabels(a.label, b.label, index),
-  );
-}
-
-/**
  * Distinct term labels off a course list, most recent first — the semester
  * chips on the gradebook landing. Courses with no term contribute nothing;
  * a chip for them would filter to an empty gradebook.
@@ -131,43 +96,4 @@ export function courseTermLabels(
     if (label) labels.add(label);
   }
   return Array.from(labels).sort((a, b) => compareLabels(a, b, index));
-}
-
-export type CoursePartition = {
-  current: EnrolledCourse[];
-  archive: TermGroup[];
-};
-
-/**
- * Split enrolled courses into what to show by default and what to hide behind
- * the archive: only a course that ranks strictly below the current term is
- * archived, grouped by term, most recent first.
- *
- * Anything we can't date — no term, an unparseable label, or no semesters at
- * all because `/api/semesters` failed — stays in `current`. Hiding a course is
- * worse than showing it in the wrong bucket, so degradation is always toward
- * the flat, ungrouped list.
- */
-export function partitionCurrentAndArchive(
-  courses: EnrolledCourse[] | null | undefined,
-  semesters: Semester[] | null | undefined,
-  today: Date | string = new Date(),
-): CoursePartition {
-  const all = courses ?? [];
-  const term = currentTerm(semesters, today);
-  if (!term) return { current: all, archive: [] };
-
-  const index = rankIndex(semesters);
-  const currentRank = term.sort_key ?? termRankFromLabel(term.label);
-  if (currentRank === null) return { current: all, archive: [] };
-
-  const current: EnrolledCourse[] = [];
-  const archived: EnrolledCourse[] = [];
-  for (const course of all) {
-    const label = (course.term || "").trim();
-    const rank = label ? labelRank(label, index) : null;
-    if (rank !== null && rank < currentRank) archived.push(course);
-    else current.push(course);
-  }
-  return { current, archive: groupCoursesByTerm(archived, semesters) };
 }

--- a/frontend/src/lib/useActiveSemester.test.ts
+++ b/frontend/src/lib/useActiveSemester.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { distinctTerms, resolveActiveSemester } from "./useActiveSemester";
+
+const c = (term: string) => ({ term });
+
+describe("distinctTerms", () => {
+  it("dedups preserving first-seen order and drops blanks", () => {
+    expect(distinctTerms([c("Fall 2025"), c("Spring 2026"), c("Fall 2025"), c("")]))
+      .toEqual(["Fall 2025", "Spring 2026"]);
+  });
+});
+
+describe("resolveActiveSemester", () => {
+  it("keeps the active value when it is among the enrolled terms", () => {
+    expect(resolveActiveSemester("Fall 2025", [c("Fall 2025"), c("Spring 2026")]))
+      .toBe("Fall 2025");
+  });
+
+  it("defaults to the most-recently-enrolled term when active is unset/stale", () => {
+    // courses arrive enrolled_at ascending → last is most recent.
+    expect(resolveActiveSemester("", [c("Fall 2025"), c("Spring 2026")]))
+      .toBe("Spring 2026");
+    expect(resolveActiveSemester("Winter 1999", [c("Fall 2025"), c("Spring 2026")]))
+      .toBe("Spring 2026");
+  });
+
+  it("returns empty string when there are no terms", () => {
+    expect(resolveActiveSemester("", [])).toBe("");
+  });
+});

--- a/frontend/src/lib/useActiveSemester.test.ts
+++ b/frontend/src/lib/useActiveSemester.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { distinctTerms, resolveActiveSemester } from "./useActiveSemester";
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ACTIVE_SEMESTER_STORAGE_KEY,
+  distinctTerms,
+  ensureDefaultActiveSemester,
+  resolveActiveSemester,
+} from "./useActiveSemester";
 
 const c = (term: string) => ({ term });
 
@@ -26,5 +32,32 @@ describe("resolveActiveSemester", () => {
 
   it("returns empty string when there are no terms", () => {
     expect(resolveActiveSemester("", [])).toBe("");
+  });
+});
+
+describe("ensureDefaultActiveSemester", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("persists the first label and notifies mounted hooks when nothing is stored", () => {
+    const listener = vi.fn();
+    window.addEventListener("sapling-active-semester-change", listener);
+    ensureDefaultActiveSemester(["Spring 2026", "Fall 2025"]);
+    expect(window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY)).toBe("Spring 2026");
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener("sapling-active-semester-change", listener);
+  });
+
+  it("never overwrites an already-stored semester", () => {
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Fall 2025");
+    ensureDefaultActiveSemester(["Spring 2026"]);
+    expect(window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY)).toBe("Fall 2025");
+  });
+
+  it("no-ops when there is no usable label (screen stays unscoped)", () => {
+    ensureDefaultActiveSemester([]);
+    ensureDefaultActiveSemester([""]);
+    expect(window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY)).toBeNull();
   });
 });

--- a/frontend/src/lib/useActiveSemester.test.ts
+++ b/frontend/src/lib/useActiveSemester.test.ts
@@ -1,63 +1,16 @@
-// @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  ACTIVE_SEMESTER_STORAGE_KEY,
-  distinctTerms,
-  ensureDefaultActiveSemester,
-  resolveActiveSemester,
-} from "./useActiveSemester";
+import { describe, expect, it } from "vitest";
+import { distinctTerms } from "./useActiveSemester";
 
 const c = (term: string) => ({ term });
+
+// Note: there is deliberately no default-resolution helper here. The empty
+// stored value IS the default and means "All semesters" (unscoped) — scoping
+// only starts when the user picks a term in the Courses & Semesters hub
+// (see ManageCoursesModal.test.tsx for that behavior).
 
 describe("distinctTerms", () => {
   it("dedups preserving first-seen order and drops blanks", () => {
     expect(distinctTerms([c("Fall 2025"), c("Spring 2026"), c("Fall 2025"), c("")]))
       .toEqual(["Fall 2025", "Spring 2026"]);
-  });
-});
-
-describe("resolveActiveSemester", () => {
-  it("keeps the active value when it is among the enrolled terms", () => {
-    expect(resolveActiveSemester("Fall 2025", [c("Fall 2025"), c("Spring 2026")]))
-      .toBe("Fall 2025");
-  });
-
-  it("defaults to the most-recently-enrolled term when active is unset/stale", () => {
-    // courses arrive enrolled_at ascending → last is most recent.
-    expect(resolveActiveSemester("", [c("Fall 2025"), c("Spring 2026")]))
-      .toBe("Spring 2026");
-    expect(resolveActiveSemester("Winter 1999", [c("Fall 2025"), c("Spring 2026")]))
-      .toBe("Spring 2026");
-  });
-
-  it("returns empty string when there are no terms", () => {
-    expect(resolveActiveSemester("", [])).toBe("");
-  });
-});
-
-describe("ensureDefaultActiveSemester", () => {
-  beforeEach(() => {
-    window.localStorage.clear();
-  });
-
-  it("persists the first label and notifies mounted hooks when nothing is stored", () => {
-    const listener = vi.fn();
-    window.addEventListener("sapling-active-semester-change", listener);
-    ensureDefaultActiveSemester(["Spring 2026", "Fall 2025"]);
-    expect(window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY)).toBe("Spring 2026");
-    expect(listener).toHaveBeenCalledTimes(1);
-    window.removeEventListener("sapling-active-semester-change", listener);
-  });
-
-  it("never overwrites an already-stored semester", () => {
-    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Fall 2025");
-    ensureDefaultActiveSemester(["Spring 2026"]);
-    expect(window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY)).toBe("Fall 2025");
-  });
-
-  it("no-ops when there is no usable label (screen stays unscoped)", () => {
-    ensureDefaultActiveSemester([]);
-    ensureDefaultActiveSemester([""]);
-    expect(window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY)).toBeNull();
   });
 });

--- a/frontend/src/lib/useActiveSemester.ts
+++ b/frontend/src/lib/useActiveSemester.ts
@@ -18,43 +18,20 @@ export function distinctTerms(courses: { term: string }[]): string[] {
   return out;
 }
 
-/**
- * The semester to actually scope by: the stored `active` value when it is one
- * of the user's enrolled terms, else the most-recently-enrolled term. Courses
- * arrive `enrolled_at` ascending, so the last distinct term is the most recent.
- * (Heuristic default; can be upgraded to term `sort_key` ordering later.)
- */
-export function resolveActiveSemester(active: string, courses: { term: string }[]): string {
-  const terms = distinctTerms(courses);
-  if (active && terms.includes(active)) return active;
-  return terms.length ? terms[terms.length - 1] : "";
-}
-
 function read(): string {
   if (typeof window === "undefined") return "";
   return window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY) ?? "";
 }
 
-/**
- * Persist a default active semester when none is stored yet. Screens that read
- * `useActiveSemester` but don't run the Dashboard's default resolution call
- * this at the point where they already have the user's term labels (most
- * recent first, e.g. `courseTermLabels(courses)`). No-op when a value is
- * already stored or no label is available. Writes through the same
- * change-event path as the hook's setter, so every mounted `useActiveSemester`
- * updates and scoped fetches re-run scoped.
- */
-export function ensureDefaultActiveSemester(termLabels: string[]): void {
-  if (typeof window === "undefined") return;
-  if (read()) return;
-  const def = termLabels.find((t) => !!t);
-  if (!def) return;
-  window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, def);
-  window.dispatchEvent(new Event(CHANGE_EVENT));
-}
-
 /** [activeSemester, setActiveSemester, hydrated] — persisted to localStorage, cross-tab + same-tab
- *  reactive. `hydrated` is false until the localStorage read completes after mount. */
+ *  reactive. `hydrated` is false until the localStorage read completes after mount.
+ *
+ *  Semantics: the EMPTY string is the default and means "All semesters" —
+ *  every surface fetches/filters unscoped. Scoping is strictly opt-in: it
+ *  applies only once the user picks a term in the Courses & Semesters hub
+ *  (which stores the term label here); the hub's "All semesters" tab clears it
+ *  back to "". Nothing auto-resolves a default term — an auto-picked term
+ *  silently hides cross-term data (vetoed by the e2e lane, see #360). */
 export function useActiveSemester(): [string, (v: string) => void, boolean] {
   const [sem, setSem] = useState<string>("");
   // `hydrated` flips true once we've read localStorage after mount. We start at

--- a/frontend/src/lib/useActiveSemester.ts
+++ b/frontend/src/lib/useActiveSemester.ts
@@ -35,6 +35,24 @@ function read(): string {
   return window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY) ?? "";
 }
 
+/**
+ * Persist a default active semester when none is stored yet. Screens that read
+ * `useActiveSemester` but don't run the Dashboard's default resolution call
+ * this at the point where they already have the user's term labels (most
+ * recent first, e.g. `courseTermLabels(courses)`). No-op when a value is
+ * already stored or no label is available. Writes through the same
+ * change-event path as the hook's setter, so every mounted `useActiveSemester`
+ * updates and scoped fetches re-run scoped.
+ */
+export function ensureDefaultActiveSemester(termLabels: string[]): void {
+  if (typeof window === "undefined") return;
+  if (read()) return;
+  const def = termLabels.find((t) => !!t);
+  if (!def) return;
+  window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, def);
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
 /** [activeSemester, setActiveSemester, hydrated] — persisted to localStorage, cross-tab + same-tab
  *  reactive. `hydrated` is false until the localStorage read completes after mount. */
 export function useActiveSemester(): [string, (v: string) => void, boolean] {

--- a/frontend/src/lib/useActiveSemester.ts
+++ b/frontend/src/lib/useActiveSemester.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export const ACTIVE_SEMESTER_STORAGE_KEY = "sapling_active_semester";
+const CHANGE_EVENT = "sapling-active-semester-change";
+
+/** Distinct term labels in first-seen order, dropping blanks. */
+export function distinctTerms(courses: { term: string }[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const c of courses) {
+    if (c.term && !seen.has(c.term)) {
+      seen.add(c.term);
+      out.push(c.term);
+    }
+  }
+  return out;
+}
+
+/**
+ * The semester to actually scope by: the stored `active` value when it is one
+ * of the user's enrolled terms, else the most-recently-enrolled term. Courses
+ * arrive `enrolled_at` ascending, so the last distinct term is the most recent.
+ * (Heuristic default; can be upgraded to term `sort_key` ordering later.)
+ */
+export function resolveActiveSemester(active: string, courses: { term: string }[]): string {
+  const terms = distinctTerms(courses);
+  if (active && terms.includes(active)) return active;
+  return terms.length ? terms[terms.length - 1] : "";
+}
+
+function read(): string {
+  if (typeof window === "undefined") return "";
+  return window.localStorage.getItem(ACTIVE_SEMESTER_STORAGE_KEY) ?? "";
+}
+
+/** [activeSemester, setActiveSemester, hydrated] — persisted to localStorage, cross-tab + same-tab
+ *  reactive. `hydrated` is false until the localStorage read completes after mount. */
+export function useActiveSemester(): [string, (v: string) => void, boolean] {
+  const [sem, setSem] = useState<string>("");
+  // `hydrated` flips true once we've read localStorage after mount. We start at
+  // "" (not the stored value) to avoid an SSR/CSR hydration mismatch, so callers
+  // that fetch based on the active semester should wait for `hydrated` to avoid
+  // an initial unscoped fetch followed by a scoped refetch.
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setSem(read());
+    setHydrated(true);
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === ACTIVE_SEMESTER_STORAGE_KEY) setSem(read());
+    };
+    const onCustom = () => setSem(read());
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(CHANGE_EVENT, onCustom);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(CHANGE_EVENT, onCustom);
+    };
+  }, []);
+
+  // Stable identity so consumers can safely list it in effect/callback deps.
+  const update = useCallback((v: string) => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, v);
+    setSem(v);
+    window.dispatchEvent(new Event(CHANGE_EVENT));
+  }, []);
+
+  return [sem, update, hydrated];
+}

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -3,3 +3,26 @@
 // Loaded only for tests that opt into a DOM via // @vitest-environment jsdom;
 // the matchers themselves are no-ops when there's no document.
 import "@testing-library/jest-dom/vitest";
+
+// jsdom 29 under Vitest exposes no `window.localStorage` (it is simply
+// undefined, even at a non-opaque origin), so components that persist prefs
+// there — useLayoutPref, useActiveSemester — explode in DOM tests. Install a
+// plain in-memory Storage per test file when the environment has a window but
+// no localStorage. Real browsers are unaffected; node-env tests skip this.
+if (typeof window !== "undefined" && !window.localStorage) {
+  const store = new Map<string, string>();
+  const localStorageShim: Storage = {
+    get length() {
+      return store.size;
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(String(k), String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  };
+  Object.defineProperty(window, "localStorage", {
+    value: localStorageShim,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## Summary

Adds a semester switcher (a redesigned **Courses & Semesters** hub) that scopes the learning surfaces to a chosen term, and enforces a no-retake rule. Implements the approved design/plan under `docs/superpowers/`.

**Approach: Path A — read-time filtering, no schema change / no migration.** The knowledge graph stays keyed on the abstract `course_id`; a term filter is applied at the read boundary. Retakes are disallowed, so each course lives in exactly one semester.

### Backend
- `services/academics.py`: `term_id_for_label` (label → term id, mirrors gradebook) + `user_course_ids_for_term` (the courses a user is enrolled in for a term).
- `services/graph_service.py`: `get_graph(semester=)` and `get_recommendations(semester=)` filter nodes/edges/stats (and DB-side `course_id in (...)` for recs) to the term's courses; `add_course` now rejects re-adding a course enrolled in **any** term (no-retake), surfacing the existing term.
- `routes/graph.py`: optional `?semester=<term label>` on `GET /api/graph/{user}` and `/recommendations`. Absent ⇒ all terms (unchanged).

### Frontend
- `lib/api.ts`: `EnrolledCourse.term`; optional `semester` on `getGraph`/`getRecommendations`.
- `lib/useActiveSemester.ts`: persisted active-semester hook (`[value, setter, hydrated]`) + `distinctTerms`/`resolveActiveSemester` helpers.
- Dashboard / Tree / Learn / Quiz / Study scope to the active semester; graph fetches are gated on hydration to avoid an unscoped→scoped double-fetch.
- `ManageCoursesModal` → **Courses & Semesters** hub: term tabs (set the active semester), courses grouped by term, "Already taken · <term>" disabled state, disabled "Personal learning — Coming soon" placeholder.

## Test Plan
- [x] Backend: `python -m pytest tests/ -q` → 981 passed, 1 skipped (1 pre-existing unrelated OCR event-loop error).
- [x] Frontend: `npm run typecheck` clean, `npm run lint` 0 errors, `npm run test` 92 passed.
- [ ] Manual: open **Courses & Semesters**, switch term tabs, confirm Tree/Learn/Study/Quiz + dashboard graph scope to that term.
- [ ] Manual: search a course taken in a previous term in "Add a course" → shows "Already taken · <term>", disabled.

## Known non-blocking follow-ups
- Recent-**session lists** (Dashboard/Tree) are not yet term-filtered (spec §1; needs a `sessions` backend change).
- Stale local course selection can persist if the semester is switched mid-screen (cosmetic; shared across Learn/Tree/Quiz/Study).
- `resolveActiveSemester` defaults to the most-recently-*enrolled* term (documented heuristic, not term `sort_key`).
- `term_id_for_label` duplicates gradebook's private `_term_id_for_semester` — a later cleanup could consolidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Semester-scoped learning: graph loading and recommendations (and the related learning screens) now optionally filter by a selected semester.
  * Added a persisted “active semester” selector with automatic fallback to the most recent enrolled term.
  * Updated course management to “Courses & Semesters,” including term-aware enrollment and no-retake enforcement across all terms.
  * Improved tutor retrieval with category-aware document chunking, plus stronger academic integrity guidance.

* **Bug Fixes**
  * Ensured semester-filtered graph, stats, and recommendation results stay consistent.

* **Tests**
  * Expanded coverage for semester filtering/resolution, term enrollment behavior, API passthrough, and category chunking/indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->