### PR TITLE
fix(study): friendly guidance instead of raw error toasts (#361)

### DIFF
--- a/backend/routes/study_guide.py
+++ b/backend/routes/study_guide.py
@@ -36,7 +36,12 @@ def _generate_and_insert(user_id: str, offering_id: str, exam_id: str) -> dict:
         limit=1,
     )
     if not exams:
-        raise HTTPException(status_code=404, detail="Exam not found.")
+        # The frontend renders this detail verbatim, so it has to read like
+        # guidance rather than a status line.
+        raise HTTPException(
+            status_code=404,
+            detail="Exam not found. It may have been deleted — pick another exam.",
+        )
     exam = exams[0]
     exam_title = exam.get("title", "")
     due_date = exam.get("due_date", "")

--- a/backend/tests/test_study_guide_routes.py
+++ b/backend/tests/test_study_guide_routes.py
@@ -163,6 +163,13 @@ class TestGetGuide:
         with patch("routes.study_guide.table", side_effect=table_side_effect):
             r = client.get(f"/api/study-guide/{USER_ID}/guide?course_id={COURSE_ID}&exam_id=nope")
         assert r.status_code == 404
+        # The frontend surfaces this detail verbatim (#361), so it must stay a
+        # plain, actionable sentence — no payload, markup or identifiers.
+        detail = r.json()["detail"]
+        assert detail.startswith("Exam not found.")
+        assert "pick another exam" in detail.lower()
+        assert len(detail) <= 160
+        assert not any(ch in detail for ch in "{}[]<>\n")
 
 
 # ── POST /api/study-guide/regenerate ─────────────────────────────────────────

--- a/frontend/src/components/screens/Study.test.tsx
+++ b/frontend/src/components/screens/Study.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+/**
+ * Component tests for the Study screen's study-guide failure UX (#361):
+ *   1. A guide whose exam is gone lands on inline guidance, with NO toast
+ *   2. A genuine generation failure toasts a sentence (never the raw body)
+ *      and leaves a working retry on screen
+ *
+ * The recent-guides rail is the entry point under test because it's the real
+ * path to a stale exam id, and it needs no dropdown interaction to reach.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => ({ userId: "u1", userReady: true }),
+}));
+
+vi.mock("@/lib/useIsMobile", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("@/lib/api", () => ({
+  getCourses: vi.fn(async () => ({ courses: [] })),
+  getStudyGuideExams: vi.fn(async () => ({ exams: [] })),
+  getStudyGuide: vi.fn(),
+  regenerateStudyGuide: vi.fn(),
+  getCachedStudyGuides: vi.fn(async () => ({ guides: [] })),
+  getFlashcards: vi.fn(async () => ({ flashcards: [] })),
+  generateFlashcards: vi.fn(),
+  rateFlashcard: vi.fn(),
+  deleteFlashcard: vi.fn(),
+  getDocuments: vi.fn(async () => ({ documents: [] })),
+}));
+
+import { Study } from "./Study";
+import { ToastProvider } from "../ToastProvider";
+import { getCachedStudyGuides, getStudyGuide } from "@/lib/api";
+
+const mockedCached = vi.mocked(getCachedStudyGuides);
+const mockedGuide = vi.mocked(getStudyGuide);
+
+const RECENT = {
+  id: "g1",
+  course_id: "c1",
+  exam_id: "exam-deleted",
+  course_name: "Intro to CS",
+  exam_title: "Midterm 1",
+  overview: "",
+  generated_at: "2026-04-01T00:00:00Z",
+};
+
+/** Clicks the recent-guides entry, which sets the course + exam and kicks
+ *  off the guide load the tests are about. */
+async function openRecentGuide() {
+  render(
+    <ToastProvider>
+      <Study />
+    </ToastProvider>,
+  );
+  await userEvent.click(await screen.findByText("Midterm 1"));
+}
+
+beforeEach(() => {
+  mockedCached.mockResolvedValue({ guides: [RECENT] });
+  // The screen logs the real error for debuggability; keep it out of the
+  // test output.
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("Study — study guide for an exam that no longer exists", () => {
+  beforeEach(() => {
+    mockedGuide.mockRejectedValue(
+      new Error('{"detail":"Exam not found. It may have been deleted — pick another exam."}'),
+    );
+  });
+
+  it("shows inline guidance instead of an error toast", async () => {
+    await openRecentGuide();
+
+    expect(await screen.findByText(/isn't around anymore/i)).toBeTruthy();
+    expect(screen.getByText(/Calendar page/i)).toBeTruthy();
+    // Toasts render with role="status"; a missing exam must produce none.
+    expect(screen.queryAllByRole("status")).toHaveLength(0);
+  });
+
+  it("does not stack the generic no-exams hint on top of the guidance", async () => {
+    await openRecentGuide();
+
+    await screen.findByText(/isn't around anymore/i);
+    expect(screen.queryByText(/No exams for this course yet/i)).toBeNull();
+  });
+
+  it("offers no retry — retrying a deleted exam can't succeed", async () => {
+    await openRecentGuide();
+
+    await screen.findByText(/isn't around anymore/i);
+    expect(screen.queryByRole("button", { name: /try again/i })).toBeNull();
+  });
+});
+
+describe("Study — study guide that genuinely fails to build", () => {
+  beforeEach(() => {
+    mockedGuide.mockRejectedValue(
+      new Error('{"detail":"Study guide generation failed."}'),
+    );
+  });
+
+  it("toasts the server sentence, not the raw response body", async () => {
+    await openRecentGuide();
+
+    const toasts = await screen.findAllByRole("status");
+    const text = toasts.map(t => t.textContent).join(" ");
+    expect(text).toContain("Study guide generation failed.");
+    expect(text).not.toContain("{");
+    expect(text).not.toContain("detail");
+    expect(text).not.toContain("[object Object]");
+  });
+
+  it("keeps a working retry on screen", async () => {
+    await openRecentGuide();
+
+    const retry = await screen.findByRole("button", { name: /try again/i });
+    expect(mockedGuide).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(retry);
+
+    expect(mockedGuide).toHaveBeenCalledTimes(2);
+    // Retries the exam that failed, not whatever the selects currently hold.
+    expect(mockedGuide).toHaveBeenLastCalledWith("u1", "c1", "exam-deleted");
+  });
+});

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -343,6 +343,21 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
             body="It was probably deleted. Pick another exam above, or add one on the Calendar page to build a guide for it."
           />
         )}
+        {!loadingGuide && !regenerating && guideProblem?.kind === "failed" && (
+          <EmptyHint
+            title="Couldn't build that study guide"
+            body={guideProblem.message}
+            action={
+              <button
+                className="btn btn--sm btn--primary"
+                onClick={() => loadGuide(courseId, examId)}
+                disabled={!courseId || !examId}
+              >
+                Try again
+              </button>
+            }
+          />
+        )}
 
         {(loadingGuide || regenerating) && <StudyGuideSkeleton />}
 
@@ -771,11 +786,14 @@ function CourseFilterRow({
   );
 }
 
-function EmptyHint({ title, body }: { title: string; body: string }) {
+function EmptyHint({ title, body, action }: { title: string; body: string; action?: React.ReactNode }) {
   return (
     <div className="card" style={{ padding: "32px 28px", textAlign: "center", color: "var(--text-muted)" }}>
       <div className="h-serif" style={{ fontSize: 18, color: "var(--text)", marginBottom: 6 }}>{title}</div>
       <div style={{ fontSize: 13 }}>{body}</div>
+      {action && (
+        <div style={{ marginTop: 16, display: "flex", justifyContent: "center" }}>{action}</div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -43,9 +43,12 @@ type Mode = "guide" | "cards";
 // A guide load can fail two ways that deserve different UI: the exam is gone
 // (normal — a deleted assignment, or a stale "recent guides" entry), or the
 // generation itself broke. Only the second one is worth a red toast.
+// The failed variant carries the ids it was built from: opening a recent guide
+// clears the exam selection, so the current selects are not a reliable retry
+// target.
 type GuideProblem =
   | { kind: "missing" }
-  | { kind: "failed"; message: string };
+  | { kind: "failed"; message: string; courseId: string; examId: string };
 
 type RawCard = {
   id: string;
@@ -212,7 +215,7 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
         setGuideProblem({ kind: "missing" });
       } else {
         const message = humanizeError(err, "Couldn't build that study guide.");
-        setGuideProblem({ kind: "failed", message });
+        setGuideProblem({ kind: "failed", message, courseId: cid, examId: eid });
         toast.error(message);
       }
     } finally {
@@ -354,8 +357,8 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
             action={
               <button
                 className="btn btn--sm btn--primary"
-                onClick={() => loadGuide(courseId, examId)}
-                disabled={!courseId || !examId}
+                onClick={() => loadGuide(guideProblem.courseId, guideProblem.examId)}
+                disabled={loadingGuide}
               >
                 Try again
               </button>

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -334,8 +334,8 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
         )}
         {courseId && !examId && !loadingExams && exams.length === 0 && (
           <EmptyHint
-            title="No exams found for this course"
-            body="Import a syllabus on the Calendar page, or add an assignment with type = Exam."
+            title="No exams for this course yet"
+            body="Study guides are built one exam at a time. Import a syllabus on the Calendar page, or add an assignment with type = Exam, and it'll show up here."
           />
         )}
         {courseId && !examId && exams.length > 0 && (

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -243,7 +243,8 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
       await loadRecent();
       toast.success("Study guide regenerated.");
     } catch (err) {
-      toast.error(`Regenerate failed: ${String(err)}`);
+      console.error("study guide regenerate failed", err);
+      toast.error(humanizeError(err, "Couldn't regenerate that study guide."));
     } finally {
       setRegenerating(false);
     }

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -525,7 +525,8 @@ function FlashcardsMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMo
       toast.success("Card deleted");
       await load();
     } catch (err) {
-      toast.error(`Delete failed: ${String(err)}`);
+      console.error("flashcard delete failed", err);
+      toast.error(humanizeError(err, "Couldn't delete that card."));
     }
   }, [card, userId, toast, load]);
 
@@ -560,7 +561,8 @@ function FlashcardsMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMo
       await load();
       toast.success(`Added ${r.flashcards.length} new card${r.flashcards.length === 1 ? "" : "s"}.`);
     } catch (err) {
-      toast.error(`Generate failed: ${String(err)}`);
+      console.error("flashcard generate failed", err);
+      toast.error(humanizeError(err, "Couldn't generate cards right now."));
     } finally {
       setGenerating(false);
     }

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -196,7 +196,9 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
       setCached(r.cached);
       if (!r.cached) loadRecent();
     } catch (err) {
-      toast.error(`Couldn't load guide: ${String(err)}`);
+      console.error("study guide load failed", err);
+      setGuide(null);
+      toast.error(humanizeError(err, "Couldn't build that study guide."));
     } finally {
       setLoadingGuide(false);
     }

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -18,6 +18,7 @@ const MarkdownChat = dynamic(
 import { StudyGuideSkeleton, FlashcardsSkeleton } from "../Skeleton";
 import { useToast } from "../ToastProvider";
 import { useIsMobile } from "@/lib/useIsMobile";
+import { humanizeError } from "@/lib/errorMessage";
 import { useUser } from "@/context/UserContext";
 import {
   getCourses,
@@ -178,7 +179,10 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
     setLoadingExams(true);
     getStudyGuideExams(userId, courseId)
       .then(r => setExams(r.exams || []))
-      .catch(err => toast.error(`Couldn't load exams: ${String(err)}`))
+      .catch(err => {
+        console.error("study exams load failed", err);
+        toast.error(humanizeError(err, "Couldn't load the exams for this course."));
+      })
       .finally(() => setLoadingExams(false));
   }, [courseId, userId, toast]);
 

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -230,8 +230,11 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
   };
 
   const regenerate = async () => {
+    // Regeneration is meaningless without a target exam, and the endpoint
+    // 400s on a blank one — bail before the request.
     if (!userId || !courseId || !examId) return;
     setRegenerating(true);
+    setGuideProblem(null);
     try {
       const r = await regenerateStudyGuide(userId, courseId, examId);
       setGuide(r.guide);
@@ -315,7 +318,7 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
             <button
               className="btn btn--sm"
               onClick={regenerate}
-              disabled={regenerating || loadingGuide}
+              disabled={regenerating || loadingGuide || !examId}
             >
               <Icon name="sparkle" size={12} /> {regenerating ? "Regenerating…" : "Regenerate"}
             </button>

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -332,13 +332,13 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
             body="Your generated study guides live here — grouped by exam and built from the documents in your library."
           />
         )}
-        {courseId && !examId && !loadingExams && exams.length === 0 && (
+        {courseId && !examId && !guideProblem && !loadingExams && exams.length === 0 && (
           <EmptyHint
             title="No exams for this course yet"
             body="Study guides are built one exam at a time. Import a syllabus on the Calendar page, or add an assignment with type = Exam, and it'll show up here."
           />
         )}
-        {courseId && !examId && exams.length > 0 && (
+        {courseId && !examId && !guideProblem && exams.length > 0 && (
           <EmptyHint title="Choose an exam" body="The guide will be generated from your course material the first time." />
         )}
         {!loadingGuide && !regenerating && guideProblem?.kind === "missing" && (

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -40,12 +40,11 @@ import { FlashcardImportModal } from "../flashcards/FlashcardImportModal";
 
 type Mode = "guide" | "cards";
 
-// A guide load can fail two ways that deserve different UI: the exam is gone
+// A guide load fails two ways that deserve different UI: the exam is gone
 // (normal — a deleted assignment, or a stale "recent guides" entry), or the
-// generation itself broke. Only the second one is worth a red toast.
-// The failed variant carries the ids it was built from: opening a recent guide
-// clears the exam selection, so the current selects are not a reliable retry
-// target.
+// generation itself broke. Only the second is worth a red toast, and it carries
+// the ids it was built from because opening a recent guide clears the exam
+// selection — the selects are not a reliable retry target.
 type GuideProblem =
   | { kind: "missing" }
   | { kind: "failed"; message: string; courseId: string; examId: string };
@@ -352,7 +351,7 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
         )}
         {!loadingGuide && !regenerating && guideProblem?.kind === "failed" && (
           <EmptyHint
-            title="Couldn't build that study guide"
+            title="That guide didn't come through"
             body={guideProblem.message}
             action={
               <button

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -18,7 +18,7 @@ const MarkdownChat = dynamic(
 import { StudyGuideSkeleton, FlashcardsSkeleton } from "../Skeleton";
 import { useToast } from "../ToastProvider";
 import { useIsMobile } from "@/lib/useIsMobile";
-import { humanizeError } from "@/lib/errorMessage";
+import { humanizeError, isNotFound } from "@/lib/errorMessage";
 import { useUser } from "@/context/UserContext";
 import {
   getCourses,
@@ -39,6 +39,13 @@ import {
 import { FlashcardImportModal } from "../flashcards/FlashcardImportModal";
 
 type Mode = "guide" | "cards";
+
+// A guide load can fail two ways that deserve different UI: the exam is gone
+// (normal — a deleted assignment, or a stale "recent guides" entry), or the
+// generation itself broke. Only the second one is worth a red toast.
+type GuideProblem =
+  | { kind: "missing" }
+  | { kind: "failed"; message: string };
 
 type RawCard = {
   id: string;
@@ -158,6 +165,7 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
   const [loadingGuide, setLoadingGuide] = React.useState(false);
   const [regenerating, setRegenerating] = React.useState(false);
   const [recent, setRecent] = React.useState<StudyGuideCacheEntry[]>([]);
+  const [guideProblem, setGuideProblem] = React.useState<GuideProblem | null>(null);
 
   const loadRecent = React.useCallback(async () => {
     if (!userId) return;
@@ -175,6 +183,7 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
     setExamId("");
     setExams([]);
     setGuide(null);
+    setGuideProblem(null);
     if (!courseId || !userId) return;
     setLoadingExams(true);
     getStudyGuideExams(userId, courseId)
@@ -189,6 +198,7 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
   const loadGuide = React.useCallback(async (cid: string, eid: string) => {
     if (!userId) return;
     setLoadingGuide(true);
+    setGuideProblem(null);
     try {
       const r = await getStudyGuide(userId, cid, eid);
       setGuide(r.guide);
@@ -198,7 +208,13 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
     } catch (err) {
       console.error("study guide load failed", err);
       setGuide(null);
-      toast.error(humanizeError(err, "Couldn't build that study guide."));
+      if (isNotFound(err)) {
+        setGuideProblem({ kind: "missing" });
+      } else {
+        const message = humanizeError(err, "Couldn't build that study guide.");
+        setGuideProblem({ kind: "failed", message });
+        toast.error(message);
+      }
     } finally {
       setLoadingGuide(false);
     }
@@ -320,6 +336,12 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
         )}
         {courseId && !examId && exams.length > 0 && (
           <EmptyHint title="Choose an exam" body="The guide will be generated from your course material the first time." />
+        )}
+        {!loadingGuide && !regenerating && guideProblem?.kind === "missing" && (
+          <EmptyHint
+            title="That exam isn't around anymore"
+            body="It was probably deleted. Pick another exam above, or add one on the Calendar page to build a guide for it."
+          />
         )}
 
         {(loadingGuide || regenerating) && <StudyGuideSkeleton />}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  ApiError,
   extractSyllabus,
+  getCourses,
   uploadAvatar,
   uploadDocument,
   uploadDocumentStream,
@@ -179,5 +181,30 @@ describe('credentials: include on auth-protected multipart uploads', () => {
     } finally {
       (globalThis as any).FileReader = originalFR;
     }
+  });
+});
+
+describe('fetchJSON error shape', () => {
+  it('throws an ApiError carrying the HTTP status, body text preserved', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      new Response('{"detail":"Exam not found."}', { status: 404 }),
+    );
+
+    // The status is what lets lib/errorMessage branch without pattern-matching
+    // the copy; the message stays the raw body so existing callers are unaffected.
+    const err = await getCourses('u1').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(404);
+    expect((err as ApiError).message).toBe('{"detail":"Exam not found."}');
+  });
+
+  it('still reports a status when the body is empty', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(new Response('', { status: 502 }));
+
+    const err = await getCourses('u1').catch((e: unknown) => e);
+    expect((err as ApiError).status).toBe(502);
+    expect((err as ApiError).message).toBe('HTTP 502');
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,6 +13,24 @@ import { handleLocalRequest } from '@/lib/localData';
 export const API_URL = '';
 export const IS_LOCAL_MODE = process.env.NEXT_PUBLIC_LOCAL_MODE === 'true';
 
+/**
+ * A failed API response. Carries the HTTP status alongside the body text so
+ * callers can branch on the status instead of pattern-matching the message —
+ * `lib/errorMessage.ts` reads `status` off the thrown value.
+ *
+ * `message` stays the raw body for backward compatibility: callers that
+ * stringify the error, or read `.message`, behave exactly as they did before.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
 async function fetchJSON<T>(path: string, options?: RequestInit): Promise<T> {
   if (IS_LOCAL_MODE) {
     return handleLocalRequest(path, options) as T;
@@ -24,7 +42,7 @@ async function fetchJSON<T>(path: string, options?: RequestInit): Promise<T> {
   });
   if (!res.ok) {
     const err = await res.text();
-    throw new Error(err || `HTTP ${res.status}`);
+    throw new ApiError(err || `HTTP ${res.status}`, res.status);
   }
   return res.json();
 }

--- a/frontend/src/lib/errorMessage.test.ts
+++ b/frontend/src/lib/errorMessage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { extractErrorDetail, humanizeError, isNotFound, statusOf } from './errorMessage';
+import { ApiError } from './api';
 
 const FALLBACK = "Couldn't load that.";
 
@@ -191,5 +192,28 @@ describe('isNotFound', () => {
     expect(isNotFound(null)).toBe(false);
     expect(isNotFound(undefined)).toBe(false);
     expect(isNotFound({})).toBe(false);
+  });
+});
+
+describe('ApiError integration', () => {
+  it('branches on the status even when the wording gives nothing away', () => {
+    // The whole point of ApiError carrying `status`: a 404 whose copy never
+    // says "not found" must still route to guidance rather than a red toast.
+    const err = new ApiError('{"detail":"That exam is no longer available."}', 404);
+    expect(isNotFound(err)).toBe(true);
+    expect(statusOf(err)).toBe(404);
+  });
+
+  it('does not treat a non-404 as missing just because it says not found', () => {
+    const err = new ApiError('{"detail":"Course material not found for this exam."}', 502);
+    expect(isNotFound(err)).toBe(false);
+    expect(humanizeError(err, FALLBACK)).toBe('Course material not found for this exam.');
+  });
+
+  it('falls back to status copy when the body carries no readable detail', () => {
+    expect(humanizeError(new ApiError('', 503), FALLBACK))
+      .toBe("That's temporarily unavailable. Try again in a moment.");
+    expect(humanizeError(new ApiError('<html>502 Bad Gateway</html>', 502), FALLBACK))
+      .toBe("That's temporarily unavailable. Try again in a moment.");
   });
 });

--- a/frontend/src/lib/errorMessage.test.ts
+++ b/frontend/src/lib/errorMessage.test.ts
@@ -116,3 +116,50 @@ describe('humanizeError — status mapping', () => {
     expect(humanizeError('HTTP 302', FALLBACK)).toBe(FALLBACK);
   });
 });
+
+describe('humanizeError — server detail', () => {
+  it('surfaces a sentence-like FastAPI detail verbatim', () => {
+    expect(humanizeError(new Error('{"detail":"Exam not found."}'), FALLBACK))
+      .toBe('Exam not found.');
+  });
+
+  it('prefers the detail over the status copy', () => {
+    const err = Object.assign(new Error('{"detail":"Exam not found."}'), { status: 404 });
+    expect(humanizeError(err, FALLBACK)).toBe('Exam not found.');
+  });
+
+  it('falls back to status copy when the detail is not presentable', () => {
+    expect(humanizeError({ detail: '[object Object]', status: 502 }, FALLBACK))
+      .toMatch(/temporarily unavailable/i);
+    expect(humanizeError({ detail: 'x'.repeat(400), status: 500 }, FALLBACK))
+      .toMatch(/our end/i);
+  });
+
+  it('never leaks a raw body, markup, a stack or [object Object]', () => {
+    const cases: unknown[] = [
+      new Error('{"error":{"code":"boom"}}'),
+      { detail: '{"nested":"payload"}' },
+      { detail: '<html><body>502 Bad Gateway</body></html>' },
+      { detail: 'Traceback (most recent call last)' },
+      { detail: 'Error: boom\n    at loadGuide (Study.tsx:190:7)' },
+      { detail: '[object Object]' },
+      { detail: '   ' },
+      { detail: '!!!' },
+    ];
+    for (const err of cases) {
+      const out = humanizeError(err, FALLBACK);
+      expect(out).toBe(FALLBACK);
+    }
+  });
+
+  it('returns the fallback for anything unrecognizable', () => {
+    expect(humanizeError(new Error('kaboom'), FALLBACK)).toBe(FALLBACK);
+    expect(humanizeError('kaboom', FALLBACK)).toBe(FALLBACK);
+    expect(humanizeError(null, FALLBACK)).toBe(FALLBACK);
+    expect(humanizeError(undefined, FALLBACK)).toBe(FALLBACK);
+    expect(humanizeError(0, FALLBACK)).toBe(FALLBACK);
+    expect(humanizeError(Symbol('nope'), FALLBACK)).toBe(FALLBACK);
+    expect(humanizeError({}, FALLBACK)).toBe(FALLBACK);
+    expect(humanizeError([1, 2, 3], FALLBACK)).toBe(FALLBACK);
+  });
+});

--- a/frontend/src/lib/errorMessage.test.ts
+++ b/frontend/src/lib/errorMessage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractErrorDetail, humanizeError, statusOf } from './errorMessage';
+import { extractErrorDetail, humanizeError, isNotFound, statusOf } from './errorMessage';
 
 const FALLBACK = "Couldn't load that.";
 
@@ -161,5 +161,35 @@ describe('humanizeError — server detail', () => {
     expect(humanizeError(Symbol('nope'), FALLBACK)).toBe(FALLBACK);
     expect(humanizeError({}, FALLBACK)).toBe(FALLBACK);
     expect(humanizeError([1, 2, 3], FALLBACK)).toBe(FALLBACK);
+  });
+});
+
+describe('isNotFound', () => {
+  it('recognizes the study-guide 404, whose status fetchJSON discards', () => {
+    expect(isNotFound(new Error('{"detail":"Exam not found."}'))).toBe(true);
+    expect(isNotFound(new Error('{"detail":"Exam not found. It may have been deleted."}'))).toBe(true);
+  });
+
+  it('recognizes a bare HTTP 404', () => {
+    expect(isNotFound(new Error('HTTP 404'))).toBe(true);
+    expect(isNotFound({ status: 404 })).toBe(true);
+  });
+
+  it('recognizes not-found wording on a plain error', () => {
+    expect(isNotFound(new Error('Exam not found'))).toBe(true);
+    expect(isNotFound('Course Not Found')).toBe(true);
+  });
+
+  it('lets an explicit status override the wording', () => {
+    expect(isNotFound({ detail: 'Exam not found.', status: 500 })).toBe(false);
+  });
+
+  it('is false for every other failure', () => {
+    expect(isNotFound(new Error('{"detail":"Study guide generation failed."}'))).toBe(false);
+    expect(isNotFound(new Error('HTTP 502'))).toBe(false);
+    expect(isNotFound('Failed to fetch')).toBe(false);
+    expect(isNotFound(null)).toBe(false);
+    expect(isNotFound(undefined)).toBe(false);
+    expect(isNotFound({})).toBe(false);
   });
 });

--- a/frontend/src/lib/errorMessage.test.ts
+++ b/frontend/src/lib/errorMessage.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { extractErrorDetail } from './errorMessage';
+
+describe('extractErrorDetail', () => {
+  it('reads the detail out of a FastAPI error body', () => {
+    expect(extractErrorDetail(new Error('{"detail":"Exam not found."}')))
+      .toEqual({ detail: 'Exam not found.' });
+  });
+
+  it('reads the detail off a bare JSON string', () => {
+    expect(extractErrorDetail('{"detail":"Study guide generation failed."}'))
+      .toEqual({ detail: 'Study guide generation failed.' });
+  });
+
+  it('tolerates whitespace around the body', () => {
+    expect(extractErrorDetail('  \n{"detail":"Exam not found."}\n '))
+      .toEqual({ detail: 'Exam not found.' });
+  });
+
+  it('reads the first msg out of a FastAPI validation detail array', () => {
+    const body = JSON.stringify({
+      detail: [{ loc: ['query', 'exam_id'], msg: 'field required', type: 'value_error' }],
+    });
+    expect(extractErrorDetail(new Error(body))).toEqual({ detail: 'field required' });
+  });
+
+  it('accepts an already-parsed body object', () => {
+    expect(extractErrorDetail({ detail: 'Exam not found.' }))
+      .toEqual({ detail: 'Exam not found.' });
+  });
+
+  it('ignores a blank or non-string detail', () => {
+    expect(extractErrorDetail('{"detail":"   "}')).toEqual({});
+    expect(extractErrorDetail('{"detail":42}')).toEqual({});
+    expect(extractErrorDetail('{"detail":null}')).toEqual({});
+    expect(extractErrorDetail('{"detail":[]}')).toEqual({});
+  });
+
+  it('returns nothing for non-JSON, malformed, or empty input', () => {
+    expect(extractErrorDetail(new Error('boom'))).toEqual({});
+    expect(extractErrorDetail('{not json')).toEqual({});
+    expect(extractErrorDetail('')).toEqual({});
+    expect(extractErrorDetail(null)).toEqual({});
+    expect(extractErrorDetail(undefined)).toEqual({});
+    expect(extractErrorDetail(0)).toEqual({});
+    expect(extractErrorDetail(['a', 'b'])).toEqual({});
+  });
+});

--- a/frontend/src/lib/errorMessage.test.ts
+++ b/frontend/src/lib/errorMessage.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { extractErrorDetail, statusOf } from './errorMessage';
+import { extractErrorDetail, humanizeError, statusOf } from './errorMessage';
+
+const FALLBACK = "Couldn't load that.";
 
 describe('extractErrorDetail', () => {
   it('reads the detail out of a FastAPI error body', () => {
@@ -79,5 +81,38 @@ describe('statusOf', () => {
     expect(statusOf(new Error('{"detail":"Exam not found."}'))).toBeUndefined();
     expect(statusOf(null)).toBeUndefined();
     expect(statusOf(undefined)).toBeUndefined();
+  });
+});
+
+describe('humanizeError — status mapping', () => {
+  it('maps auth failures to sign-in / permission copy', () => {
+    expect(humanizeError('HTTP 401', FALLBACK)).toMatch(/sign in again/i);
+    expect(humanizeError('HTTP 403', FALLBACK)).toMatch(/access/i);
+  });
+
+  it('maps 404 to not-found copy', () => {
+    expect(humanizeError('HTTP 404', FALLBACK)).toMatch(/couldn't find/i);
+  });
+
+  it('maps 429 to rate-limit copy', () => {
+    expect(humanizeError('HTTP 429', FALLBACK)).toMatch(/too many requests/i);
+  });
+
+  it('maps 5xx to try-again-later copy', () => {
+    expect(humanizeError('HTTP 500', FALLBACK)).toMatch(/our end/i);
+    expect(humanizeError('HTTP 502', FALLBACK)).toMatch(/temporarily unavailable/i);
+    expect(humanizeError('HTTP 503', FALLBACK)).toMatch(/temporarily unavailable/i);
+    expect(humanizeError('HTTP 504', FALLBACK)).toMatch(/temporarily unavailable/i);
+  });
+
+  it('maps the remaining actionable 4xx codes', () => {
+    expect(humanizeError('HTTP 400', FALLBACK)).toMatch(/wasn't valid/i);
+    expect(humanizeError('HTTP 408', FALLBACK)).toMatch(/too long/i);
+    expect(humanizeError('HTTP 409', FALLBACK)).toMatch(/reload/i);
+  });
+
+  it('falls back for statuses with no dedicated copy', () => {
+    expect(humanizeError('HTTP 418', FALLBACK)).toBe(FALLBACK);
+    expect(humanizeError('HTTP 302', FALLBACK)).toBe(FALLBACK);
   });
 });

--- a/frontend/src/lib/errorMessage.test.ts
+++ b/frontend/src/lib/errorMessage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractErrorDetail } from './errorMessage';
+import { extractErrorDetail, statusOf } from './errorMessage';
 
 describe('extractErrorDetail', () => {
   it('reads the detail out of a FastAPI error body', () => {
@@ -44,5 +44,40 @@ describe('extractErrorDetail', () => {
     expect(extractErrorDetail(undefined)).toEqual({});
     expect(extractErrorDetail(0)).toEqual({});
     expect(extractErrorDetail(['a', 'b'])).toEqual({});
+  });
+});
+
+describe('statusOf', () => {
+  it('reads the bare "HTTP <code>" fetchJSON throws for an empty body', () => {
+    expect(statusOf(new Error('HTTP 404'))).toBe(404);
+    expect(statusOf('HTTP 502')).toBe(502);
+  });
+
+  it('reads a status attached to the thrown value', () => {
+    expect(statusOf({ status: 403 })).toBe(403);
+    expect(statusOf({ statusCode: 429 })).toBe(429);
+  });
+
+  it('reads a status carried inside the JSON body', () => {
+    expect(statusOf('{"detail":"Nope.","status":401}')).toBe(401);
+    expect(statusOf('{"detail":"Nope.","status_code":409}')).toBe(409);
+  });
+
+  it('prefers an attached status over one parsed from the message', () => {
+    const err = Object.assign(new Error('HTTP 500'), { status: 404 });
+    expect(statusOf(err)).toBe(404);
+  });
+
+  it('ignores values that are not plausible HTTP statuses', () => {
+    expect(statusOf({ status: 42 })).toBeUndefined();
+    expect(statusOf({ status: '404' })).toBeUndefined();
+    expect(statusOf('HTTP 4040')).toBeUndefined();
+    expect(statusOf('there are 404 items')).toBeUndefined();
+  });
+
+  it('returns undefined when no status is recoverable', () => {
+    expect(statusOf(new Error('{"detail":"Exam not found."}'))).toBeUndefined();
+    expect(statusOf(null)).toBeUndefined();
+    expect(statusOf(undefined)).toBeUndefined();
   });
 });

--- a/frontend/src/lib/errorMessage.ts
+++ b/frontend/src/lib/errorMessage.ts
@@ -1,19 +1,24 @@
 /**
  * Turns a thrown API error into copy a person can read.
  *
- * `lib/api.ts` rejects with `new Error(await res.text())`, so a FastAPI failure
- * arrives as an Error whose message is the raw response body — literally
- * `{"detail":"Exam not found."}`. Rendering that with `String(err)` dumps JSON
- * into the UI, which is what these helpers exist to prevent.
+ * `lib/api.ts` rejects with an `ApiError` whose message is the raw response
+ * body — literally `{"detail":"Exam not found."}`. Rendering that with
+ * `String(err)` dumps JSON into the UI, which is what these helpers exist to
+ * prevent.
+ *
+ * Everything here accepts `unknown` and degrades rather than throwing: not
+ * every rejection in this app is an `ApiError` (a few call sites still throw a
+ * bare `Error`, and network failures throw `TypeError`), so nothing may assume
+ * a shape.
  */
 
 export interface ErrorDetail {
   /** A server-supplied `detail` string, when the body carried one. */
   detail?: string;
   /**
-   * The HTTP status, when it survived the trip. `fetchJSON` only spells the
-   * status out (`HTTP 404`) for an empty response body, so a FastAPI failure —
-   * which always carries a JSON body — usually arrives without one.
+   * The HTTP status, when it survived the trip — off an `ApiError.status`, a
+   * body field, or an `HTTP 404` message. Absent for the call sites that still
+   * throw a bare `Error`, and for transport failures that never got a response.
    */
   status?: number;
 }
@@ -99,9 +104,10 @@ const NOT_FOUND_TEXT = /\bnot found\b/i;
  * Whether an error means "that thing doesn't exist" rather than "something
  * broke" — the difference between friendly guidance and a red toast.
  *
- * Detection is looser than display on purpose: `fetchJSON` keeps the status
- * only for an empty body, so a FastAPI 404 is recognizable by its wording
- * alone. An explicit status always wins over the wording.
+ * An explicit status decides it. The wording fallback only covers the call
+ * sites that still throw a bare `Error` without one; it is a safety net, not
+ * the primary path, so rewording a server message can't silently turn
+ * guidance back into an error toast.
  */
 export function isNotFound(err: unknown): boolean {
   const { detail, status } = extractErrorDetail(err);

--- a/frontend/src/lib/errorMessage.ts
+++ b/frontend/src/lib/errorMessage.ts
@@ -1,0 +1,61 @@
+/**
+ * Turns a thrown API error into copy a person can read.
+ *
+ * `lib/api.ts` rejects with `new Error(await res.text())`, so a FastAPI failure
+ * arrives as an Error whose message is the raw response body — literally
+ * `{"detail":"Exam not found."}`. Rendering that with `String(err)` dumps JSON
+ * into the UI, which is what these helpers exist to prevent.
+ */
+
+export interface ErrorDetail {
+  /** A server-supplied `detail` string, when the body carried one. */
+  detail?: string;
+}
+
+type Body = Record<string, unknown>;
+
+function asRecord(value: unknown): Body | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Body)
+    : null;
+}
+
+function rawMessage(err: unknown): string {
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  const record = asRecord(err);
+  const message = record?.message;
+  return typeof message === "string" ? message : "";
+}
+
+function parseJson(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function detailOf(body: Body): string | undefined {
+  const detail = body.detail;
+  if (typeof detail === "string") return detail.trim() || undefined;
+  // FastAPI request-validation failures nest the message under detail[].msg.
+  if (Array.isArray(detail)) {
+    for (const entry of detail) {
+      const msg = asRecord(entry)?.msg;
+      if (typeof msg === "string" && msg.trim()) return msg.trim();
+    }
+  }
+  return undefined;
+}
+
+/** Pulls what the server actually told us out of a thrown error. */
+export function extractErrorDetail(err: unknown): ErrorDetail {
+  const body = (err instanceof Error ? null : asRecord(err))
+    ?? asRecord(parseJson(rawMessage(err)));
+  if (!body) return {};
+  const detail = detailOf(body);
+  return detail ? { detail } : {};
+}

--- a/frontend/src/lib/errorMessage.ts
+++ b/frontend/src/lib/errorMessage.ts
@@ -93,6 +93,22 @@ export function statusOf(err: unknown): number | undefined {
   return extractErrorDetail(err).status;
 }
 
+const NOT_FOUND_TEXT = /\bnot found\b/i;
+
+/**
+ * Whether an error means "that thing doesn't exist" rather than "something
+ * broke" — the difference between friendly guidance and a red toast.
+ *
+ * Detection is looser than display on purpose: `fetchJSON` keeps the status
+ * only for an empty body, so a FastAPI 404 is recognizable by its wording
+ * alone. An explicit status always wins over the wording.
+ */
+export function isNotFound(err: unknown): boolean {
+  const { detail, status } = extractErrorDetail(err);
+  if (status !== undefined) return status === 404;
+  return NOT_FOUND_TEXT.test(detail ?? rawMessage(err));
+}
+
 const STATUS_COPY: Record<number, string> = {
   400: "That request wasn't valid. Check your selection and try again.",
   401: "Your session expired — sign in again.",

--- a/frontend/src/lib/errorMessage.ts
+++ b/frontend/src/lib/errorMessage.ts
@@ -92,3 +92,29 @@ export function extractErrorDetail(err: unknown): ErrorDetail {
 export function statusOf(err: unknown): number | undefined {
   return extractErrorDetail(err).status;
 }
+
+const STATUS_COPY: Record<number, string> = {
+  400: "That request wasn't valid. Check your selection and try again.",
+  401: "Your session expired — sign in again.",
+  403: "You don't have access to that.",
+  404: "We couldn't find that — it may have been deleted.",
+  408: "That took too long. Try again.",
+  409: "That changed somewhere else. Reload and try again.",
+  429: "Too many requests right now. Wait a moment and try again.",
+  500: "Something went wrong on our end. Try again in a moment.",
+};
+
+function statusCopy(status: number | undefined): string | undefined {
+  if (status === undefined) return undefined;
+  if (status in STATUS_COPY) return STATUS_COPY[status];
+  if (status >= 500) return "That's temporarily unavailable. Try again in a moment.";
+  return undefined;
+}
+
+/**
+ * A short sentence safe to put in a toast. Never returns `[object Object]`,
+ * a raw JSON body, or a stack trace — worst case it returns `fallback`.
+ */
+export function humanizeError(err: unknown, fallback: string): string {
+  return statusCopy(statusOf(err)) ?? fallback;
+}

--- a/frontend/src/lib/errorMessage.ts
+++ b/frontend/src/lib/errorMessage.ts
@@ -111,10 +111,28 @@ function statusCopy(status: number | undefined): string | undefined {
   return undefined;
 }
 
+const MAX_DETAIL_LENGTH = 160;
+
+// Brackets, angle brackets and line breaks are the tells of a serialized
+// payload, markup, a stack trace or "[object Object]" — none of which belong
+// in front of a user.
+const UNFRIENDLY = /[{}[\]<>\n\r]|\bTraceback\b/;
+
+function looksHuman(text: string): boolean {
+  return (
+    text.length > 0
+    && text.length <= MAX_DETAIL_LENGTH
+    && /[a-z]/i.test(text)
+    && !UNFRIENDLY.test(text)
+  );
+}
+
 /**
  * A short sentence safe to put in a toast. Never returns `[object Object]`,
  * a raw JSON body, or a stack trace — worst case it returns `fallback`.
  */
 export function humanizeError(err: unknown, fallback: string): string {
-  return statusCopy(statusOf(err)) ?? fallback;
+  const { detail, status } = extractErrorDetail(err);
+  if (detail && looksHuman(detail)) return detail;
+  return statusCopy(status) ?? fallback;
 }

--- a/frontend/src/lib/errorMessage.ts
+++ b/frontend/src/lib/errorMessage.ts
@@ -10,6 +10,12 @@
 export interface ErrorDetail {
   /** A server-supplied `detail` string, when the body carried one. */
   detail?: string;
+  /**
+   * The HTTP status, when it survived the trip. `fetchJSON` only spells the
+   * status out (`HTTP 404`) for an empty response body, so a FastAPI failure —
+   * which always carries a JSON body — usually arrives without one.
+   */
+  status?: number;
 }
 
 type Body = Record<string, unknown>;
@@ -51,11 +57,38 @@ function detailOf(body: Body): string | undefined {
   return undefined;
 }
 
+const HTTP_STATUS_RE = /\bHTTP\s+(\d{3})\b/;
+
+function isStatus(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 100 && value <= 599;
+}
+
+function statusFrom(err: unknown, body: Body | null): number | undefined {
+  const attached = asRecord(err);
+  for (const candidate of [attached?.status, attached?.statusCode, body?.status, body?.status_code]) {
+    if (isStatus(candidate)) return candidate;
+  }
+  const matched = HTTP_STATUS_RE.exec(rawMessage(err));
+  if (matched) {
+    const parsed = Number(matched[1]);
+    if (isStatus(parsed)) return parsed;
+  }
+  return undefined;
+}
+
 /** Pulls what the server actually told us out of a thrown error. */
 export function extractErrorDetail(err: unknown): ErrorDetail {
   const body = (err instanceof Error ? null : asRecord(err))
     ?? asRecord(parseJson(rawMessage(err)));
-  if (!body) return {};
-  const detail = detailOf(body);
-  return detail ? { detail } : {};
+  const out: ErrorDetail = {};
+  const detail = body ? detailOf(body) : undefined;
+  if (detail) out.detail = detail;
+  const status = statusFrom(err, body);
+  if (status !== undefined) out.status = status;
+  return out;
+}
+
+/** The HTTP status behind an error, when one can be recovered. */
+export function statusOf(err: unknown): number | undefined {
+  return extractErrorDetail(err).status;
 }


### PR DESCRIPTION
Closes #361.

Creating a study guide for a class with no exam dumped a raw stringified error into a toast. This replaces that with friendly guidance, and humanizes the rest of the Study screen's error copy.

## The actual cause

`lib/api.ts::fetchJSON` rejects with the raw response body, so a FastAPI failure arrives as an error whose message is literally `{"detail":"Exam not found."}`. Five call sites in `Study.tsx` then rendered it with `String(err)` — that JSON blob (or `[object Object]`) *is* the ugly toast.

## What changed

**New `frontend/src/lib/errorMessage.ts`** — a small, dependency-free helper that turns a thrown API error into copy a person can read:

- `extractErrorDetail(err)` → `{detail?, status?}`, handling `Error` / string / plain object / FastAPI validation arrays (`detail[].msg`).
- `statusOf(err)` / `isNotFound(err)` — so callers branch on a status rather than pattern-matching prose.
- `humanizeError(err, fallback)` — prefers a server `detail` that actually reads like a sentence, else status-mapped copy (400/401/403/404/408/409/429/500 + a 5xx family line), else the caller's fallback. It can never return `[object Object]`, a raw JSON body, markup, or a stack — that's asserted in tests.

**`fetchJSON` now throws an `ApiError` carrying `status`.** This was the root cause of a weakness worth calling out: because the status was previously discarded, "is this a 404?" had to be inferred from the words *"not found"* — which would have silently regressed into a red toast the first time someone reworded a server message. `ApiError.message` is still the raw body, so every existing caller that stringifies the error or reads `.message` behaves exactly as before.

**`Study.tsx`:**
- All five `String(err)` toasts replaced with `humanizeError`, each now `console.error`-ing the real error so debuggability is unchanged.
- A `GuideProblem` discriminated union drives the UI. A **404 fires no toast at all** and lands on inline guidance ("That exam isn't around anymore"). A genuine failure toasts the human message *and* leaves an inline card with a working **Try again** — which retries the ids that actually failed, not whatever the selects currently hold (they diverge when you open a recent guide).
- Regenerate is now `disabled` without a selected exam, on top of its existing early-return.
- The no-exam empty state is sharper and actionable, and now outranks the generic hints instead of stacking on top of them.

**Backend** — the 404 detail is now `"Exam not found. It may have been deleted — pick another exam."`, with a test pinning it as *user-facing copy* (≤160 chars, no braces/brackets/angles/newlines) so it stays safe to render verbatim.

## Verification

| Gate | Result |
|---|---|
| `npm test` | **127 passing** (baseline 88) — 14 files |
| `npx tsc --noEmit` | 0 errors |
| `npx eslint . --max-warnings=-1` | 0 errors, 36 warnings (**exactly** baseline) |
| backend `pytest` | 908 passed, 1 skipped |
| backend `ruff check .` | clean |

`tests/test_migrate.py` doesn't collect locally (this machine's `python3` lacks `psycopg`) — reproduced identically on `main`, so it's a local env gap, not this branch. CI installs it from `requirements.lock`.

## Note for the reviewer

One **pre-existing** quirk surfaced but was deliberately left alone: `openRecent` sets `courseId`, whose effect resets `examId` to `""` — so opening a recent guide renders the guide but leaves the exam dropdown blank. Regenerate was already a silent no-op in that state (the `!examId` early-return predates this PR); it's now visibly `disabled` instead. No functional regression, but fixing `openRecent` properly is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Study Guide and Flashcards error messages with clearer, human-readable guidance.
  * Missing exams now explain that they may have been deleted and suggest choosing another exam.
  * Added targeted retry actions for genuine Study Guide generation failures.
  * Prevented raw server errors, JSON, and technical details from appearing in user-facing messages.
  * Improved handling of API status codes, including not-found, authorization, rate-limit, and server errors.
* **Tests**
  * Added coverage for missing exams, retry behavior, error formatting, and API error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->