### PR TITLE
feat(dashboard): group courses by semester with an Archive for past terms (#140)

### DIFF
--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -91,11 +91,6 @@
       "count": 2
     }
   },
-  "src/components/screens/Gradebook/Landing.tsx": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
   "src/components/screens/Learn.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2

--- a/frontend/src/components/DocumentUploadModal.test.tsx
+++ b/frontend/src/components/DocumentUploadModal.test.tsx
@@ -48,6 +48,7 @@ const COURSE: EnrolledCourse = {
   nickname: null,
   node_count: 0,
   enrolled_at: "2026-01-01",
+  term: "Spring 2026",
 };
 
 function renderModal() {

--- a/frontend/src/components/ManageCoursesModal.tsx
+++ b/frontend/src/components/ManageCoursesModal.tsx
@@ -14,6 +14,7 @@ import {
   type EnrolledCourse,
   type OnboardingCourse,
 } from "@/lib/api";
+import { groupCoursesByTerm } from "@/lib/semesters";
 
 const COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 
@@ -63,6 +64,9 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
   }, [query, open]);
 
   const enrolledIds = React.useMemo(() => new Set(courses.map(c => c.course_id)), [courses]);
+  // No /api/semesters call here — the modal only needs a stable, readable
+  // order, which the label-derived rank already gives it.
+  const termGroups = React.useMemo(() => groupCoursesByTerm(courses), [courses]);
 
   const handleAdd = async (course: OnboardingCourse) => {
     try {
@@ -106,8 +110,20 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
             <div style={{ fontSize: 12, color: "var(--text-muted)" }}>No courses enrolled yet.</div>
           )}
           <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 20 }}>
-            {courses.map(c => (
-              <EnrolledRow key={c.course_id} userId={userId} course={c} onChanged={onChanged} />
+            {termGroups.map(group => (
+              <React.Fragment key={group.label}>
+                {termGroups.length > 1 && (
+                  <div
+                    className="mono"
+                    style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}
+                  >
+                    {group.label}
+                  </div>
+                )}
+                {group.courses.map(c => (
+                  <EnrolledRow key={c.course_id} userId={userId} course={c} onChanged={onChanged} />
+                ))}
+              </React.Fragment>
             ))}
           </div>
 

--- a/frontend/src/components/screens/Dashboard.test.tsx
+++ b/frontend/src/components/screens/Dashboard.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+/**
+ * Semester grouping on the dashboard course list (#140):
+ *   1. Current-term courses render; earlier terms don't until Archive opens.
+ *   2. An archived course routes into that semester's gradebook.
+ *   3. A failed /api/semesters degrades to one flat list, never a blank panel.
+ *
+ * The graph, modals and skeleton are stubbed — this exercises the course-list
+ * partition only.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { EnrolledCourse, Semester } from "@/lib/api";
+
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => ({ userId: "u1", userReady: true, userName: "Ada" }),
+}));
+
+vi.mock("@/lib/useIsMobile", () => ({ useIsMobile: () => false }));
+// "topnav" renders the legacy My Courses panel, which owns the Archive.
+vi.mock("@/lib/useLayoutPref", () => ({ useLayoutPref: () => ["topnav", vi.fn()] }));
+
+vi.mock("../KnowledgeGraph", () => ({ KnowledgeGraph: () => null }));
+vi.mock("../ManageCoursesModal", () => ({ ManageCoursesModal: () => null }));
+vi.mock("../Skeleton", () => ({ DashboardSkeleton: () => null }));
+vi.mock("../MiniStat", () => ({ MiniStat: () => null }));
+vi.mock("../Icon", () => ({ Icon: () => null }));
+
+vi.mock("@/lib/api", () => ({
+  getGraph: vi.fn(),
+  getCourses: vi.fn(),
+  getUpcomingAssignments: vi.fn(),
+  getSessions: vi.fn(),
+  getRecommendations: vi.fn(),
+  getSemesters: vi.fn(),
+}));
+
+import { Dashboard } from "./Dashboard";
+import {
+  getCourses,
+  getGraph,
+  getRecommendations,
+  getSemesters,
+  getSessions,
+  getUpcomingAssignments,
+} from "@/lib/api";
+
+const mockedGetCourses = vi.mocked(getCourses);
+const mockedGetSemesters = vi.mocked(getSemesters);
+
+const SEMESTERS: Semester[] = [
+  { id: "spring-2026", term: "Spring", year: 2026, label: "Spring 2026", start_date: "2026-01-05", end_date: "2026-05-17", sort_key: 20261 },
+  { id: "fall-2025", term: "Fall", year: 2025, label: "Fall 2025", start_date: "2025-08-25", end_date: "2026-01-04", sort_key: 20253 },
+];
+
+function course(code: string, term: string): EnrolledCourse {
+  return {
+    enrollment_id: `e-${code}`,
+    course_id: `c-${code}`,
+    course_code: code,
+    course_name: code,
+    school: "BU",
+    department: "CS",
+    color: null,
+    nickname: null,
+    node_count: 0,
+    enrolled_at: "2025-08-25",
+    term,
+  };
+}
+
+beforeEach(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(new Date(2026, 2, 1));
+
+  vi.mocked(getGraph).mockResolvedValue({ nodes: [], edges: [], stats: {} });
+  vi.mocked(getUpcomingAssignments).mockResolvedValue({ assignments: [] });
+  vi.mocked(getSessions).mockResolvedValue({ sessions: [] });
+  vi.mocked(getRecommendations).mockResolvedValue({ recommendations: [] });
+  mockedGetSemesters.mockResolvedValue({ semesters: SEMESTERS });
+  mockedGetCourses.mockResolvedValue({
+    courses: [course("BIO-101", "Spring 2026"), course("PSY-110", "Fall 2025")],
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+// The "My courses" card. Course codes also appear in the graph legend, so
+// panel assertions have to be scoped.
+const panel = () => within(screen.getByText("My courses").closest(".card") as HTMLElement);
+
+describe("Dashboard course list by semester", () => {
+  it("shows only current-term courses until the archive is opened", async () => {
+    render(<Dashboard />);
+
+    await waitFor(() => expect(panel().getByText("BIO-101")).toBeInTheDocument());
+    expect(screen.queryByText("PSY-110")).toBeNull();
+
+    const archive = screen.getByRole("button", { name: /archive/i });
+    expect(archive).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(archive);
+
+    expect(await screen.findByText("PSY-110")).toBeInTheDocument();
+    expect(panel().getByText("Fall 2025")).toBeInTheDocument();
+  });
+
+  it("opens that semester's gradebook when an archived course is picked", async () => {
+    render(<Dashboard />);
+
+    await waitFor(() => expect(panel().getByText("BIO-101")).toBeInTheDocument());
+    await userEvent.click(screen.getByRole("button", { name: /archive/i }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /PSY-110 — open the Fall 2025 gradebook/ }),
+    );
+
+    expect(push).toHaveBeenCalledWith("/gradebook?semester=Fall%202025");
+  });
+
+  it("falls back to one flat list when /api/semesters fails", async () => {
+    mockedGetSemesters.mockRejectedValue(new Error("500"));
+
+    render(<Dashboard />);
+
+    await waitFor(() => expect(panel().getByText("BIO-101")).toBeInTheDocument());
+    expect(panel().getByText("PSY-110")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /archive/i })).toBeNull();
+  });
+});

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -216,6 +216,7 @@ export function Dashboard() {
   const [activeDays, setActiveDays] = React.useState<Set<string>>(new Set());
 
   const [coursesOpen, setCoursesOpen] = React.useState(false);
+  const [archiveOpen, setArchiveOpen] = React.useState(false);
   const [fullscreen, setFullscreen] = React.useState(false);
   const [mobileTab, setMobileTab] = React.useState<"courses" | "stats">("courses");
 
@@ -387,6 +388,13 @@ export function Dashboard() {
   );
 
   const archivedCount = archivedProgress.reduce((n, g) => n + g.entries.length, 0);
+
+  // An archived course opens the gradebook scoped to its own term, not the
+  // current one — the whole point of surfacing it separately.
+  const openArchivedTerm = React.useCallback(
+    (label: string) => router.push(`/gradebook?semester=${encodeURIComponent(label)}`),
+    [router],
+  );
 
   const suggestNode = React.useMemo(() => {
     if (!suggest) return null;
@@ -786,9 +794,23 @@ export function Dashboard() {
         {courseProgress.length === 0 && (
           <div style={{ fontSize: 12, color: "var(--text-muted)" }}>No enrolled courses yet.</div>
         )}
-        {courseProgress.map((entry) => (
+        {courseProgress.length > 0 && currentProgress.length === 0 && (
+          <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
+            Nothing enrolled this semester.
+          </div>
+        )}
+        {currentProgress.map((entry) => (
           <CourseProgressRow key={entry.course.course_id} entry={entry} />
         ))}
+        {archivedCount > 0 && (
+          <CoursesArchive
+            groups={archivedProgress}
+            count={archivedCount}
+            open={archiveOpen}
+            onToggle={() => setArchiveOpen(v => !v)}
+            onOpenTerm={openArchivedTerm}
+          />
+        )}
       </div>
 
       <div className="card" style={{ padding: "var(--pad-lg)" }}>
@@ -1083,6 +1105,65 @@ type ArchivedTermProgress = {
   label: string;
   entries: CourseProgressEntry[];
 };
+
+// Past terms, collapsed by default. Expanding lists each prior semester with
+// its courses; picking one opens that semester's gradebook.
+function CoursesArchive({
+  groups,
+  count,
+  open,
+  onToggle,
+  onOpenTerm,
+}: {
+  groups: ArchivedTermProgress[];
+  count: number;
+  open: boolean;
+  onToggle: () => void;
+  onOpenTerm: (label: string) => void;
+}) {
+  return (
+    <div style={{ borderTop: "1px solid var(--border)", marginTop: 4, paddingTop: 10 }}>
+      <button
+        type="button"
+        className="btn btn--ghost btn--sm"
+        onClick={onToggle}
+        aria-expanded={open}
+        style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", justifyContent: "flex-start" }}
+      >
+        <span
+          aria-hidden
+          style={{
+            display: "inline-flex",
+            transition: "transform var(--dur-fast) var(--ease)",
+            transform: open ? "rotate(90deg)" : "none",
+          }}
+        >
+          <Icon name="chev" size={11} />
+        </span>
+        Archive
+        <span className="mono" style={{ color: "var(--text-muted)", fontSize: 11 }}>{count}</span>
+      </button>
+
+      {open && (
+        <div style={{ marginTop: 10 }}>
+          {groups.map((group) => (
+            <div key={group.label} style={{ marginBottom: 8 }}>
+              <div className="label-micro" style={{ marginBottom: 6 }}>{group.label}</div>
+              {group.entries.map((entry) => (
+                <CourseProgressRow
+                  key={entry.course.course_id}
+                  entry={entry}
+                  onOpen={() => onOpenTerm(group.label)}
+                  ariaLabel={`${entry.course.course_code || entry.course.course_name} — open the ${group.label} gradebook`}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 // One "My courses" line: colour dot, course code, mastery percentage and the
 // four-segment mastery bar. Rendered as a button when `onOpen` is supplied so

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -1130,6 +1130,8 @@ function CoursesArchive({
         className="btn btn--ghost btn--sm"
         onClick={onToggle}
         aria-expanded={open}
+        aria-controls="dashboard-courses-archive"
+        title={open ? "Hide past semesters" : "Show past semesters"}
         style={{ display: "flex", alignItems: "center", gap: 6, width: "100%", justifyContent: "flex-start" }}
       >
         <span
@@ -1147,7 +1149,7 @@ function CoursesArchive({
       </button>
 
       {open && (
-        <div style={{ marginTop: 10 }}>
+        <div id="dashboard-courses-archive" style={{ marginTop: 10 }}>
           {groups.map((group) => (
             <div key={group.label} style={{ marginBottom: 8 }}>
               <div className="label-micro" style={{ marginBottom: 6 }}>{group.label}</div>

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/api";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
 import { apiToGraphNode, type GraphNode, type GraphEdge } from "@/lib/data";
+import { partitionCurrentAndArchive } from "@/lib/semesters";
 
 const QUOTES = [
   "Learning is the only thing the mind never exhausts, never fears, and never regrets. — da Vinci",
@@ -349,6 +350,43 @@ export function Dashboard() {
       };
     });
   }, [courses, nodes]);
+
+  // Semester split (#140). Only courses that provably belong to an earlier term
+  // move behind the Archive; everything else — including undatable courses and
+  // the whole list when /api/semesters gave us nothing — stays visible.
+  const partition = React.useMemo(
+    () => partitionCurrentAndArchive(courses, semesters, today),
+    [courses, semesters, today],
+  );
+
+  const progressByCourse = React.useMemo(() => {
+    const byId = new Map<string, CourseProgressEntry>();
+    for (const entry of courseProgress) byId.set(entry.course.course_id, entry);
+    return byId;
+  }, [courseProgress]);
+
+  const currentProgress = React.useMemo(
+    () =>
+      partition.current
+        .map((c) => progressByCourse.get(c.course_id))
+        .filter((e): e is CourseProgressEntry => Boolean(e)),
+    [partition, progressByCourse],
+  );
+
+  const archivedProgress = React.useMemo(
+    () =>
+      partition.archive
+        .map((group) => ({
+          label: group.label,
+          entries: group.courses
+            .map((c) => progressByCourse.get(c.course_id))
+            .filter((e): e is CourseProgressEntry => Boolean(e)),
+        }))
+        .filter((group) => group.entries.length > 0),
+    [partition, progressByCourse],
+  );
+
+  const archivedCount = archivedProgress.reduce((n, g) => n + g.entries.length, 0);
 
   const suggestNode = React.useMemo(() => {
     if (!suggest) return null;

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -786,57 +786,9 @@ export function Dashboard() {
         {courseProgress.length === 0 && (
           <div style={{ fontSize: 12, color: "var(--text-muted)" }}>No enrolled courses yet.</div>
         )}
-        {courseProgress.map(({ course, mastered, learning, struggling, unexplored, total, progress }) => {
-          const pct = Math.round(progress * 100);
-          const baseColor = course.color || "var(--accent)";
-          const segments = [
-            { key: "mastered",   count: mastered,   color: baseColor, opacity: 1,    label: "Mastered" },
-            { key: "learning",   count: learning,   color: baseColor, opacity: 0.78, label: "Learning" },
-            { key: "struggling", count: struggling, color: baseColor, opacity: 0.55, label: "Struggling" },
-            { key: "unexplored", count: unexplored, color: "var(--bg-soft)", opacity: 1, label: "Unexplored" },
-          ];
-          return (
-            <div key={course.course_id} style={{ marginBottom: 12 }}>
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: 12, marginBottom: 4 }}>
-                <span style={{ display: "inline-flex", alignItems: "center", gap: 8, minWidth: 0 }}>
-                  <span style={{ width: 10, height: 10, borderRadius: "50%", background: baseColor, flexShrink: 0 }} />
-                  <strong style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                    {course.course_code || course.course_name}
-                  </strong>
-                </span>
-                <span className="mono" style={{ color: "var(--text-dim)", fontSize: 11, flexShrink: 0, marginLeft: 8 }}>
-                  {pct}%
-                </span>
-              </div>
-              {total > 0 ? (
-                <div
-                  style={{
-                    display: "flex",
-                    height: 8,
-                    background: "var(--bg-soft)",
-                    borderRadius: "var(--r-full)",
-                    overflow: "hidden",
-                  }}
-                  title={segments.filter(s => s.count > 0).map(s => `${s.label}: ${s.count}`).join(" · ")}
-                >
-                  {segments.map((s) => s.count > 0 && (
-                    <div
-                      key={s.key}
-                      style={{
-                        width: `${(s.count / total) * 100}%`,
-                        background: s.color,
-                        opacity: s.opacity,
-                        transition: "width var(--dur) var(--ease)",
-                      }}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <div style={{ height: 8, background: "var(--bg-soft)", borderRadius: "var(--r-full)" }} />
-              )}
-            </div>
-          );
-        })}
+        {courseProgress.map((entry) => (
+          <CourseProgressRow key={entry.course.course_id} entry={entry} />
+        ))}
       </div>
 
       <div className="card" style={{ padding: "var(--pad-lg)" }}>
@@ -1126,6 +1078,100 @@ type CourseProgressEntry = {
   total: number;
   progress: number;
 };
+
+type ArchivedTermProgress = {
+  label: string;
+  entries: CourseProgressEntry[];
+};
+
+// One "My courses" line: colour dot, course code, mastery percentage and the
+// four-segment mastery bar. Rendered as a button when `onOpen` is supplied so
+// archived courses can route into their own semester's gradebook.
+function CourseProgressRow({
+  entry,
+  onOpen,
+  ariaLabel,
+}: {
+  entry: CourseProgressEntry;
+  onOpen?: () => void;
+  ariaLabel?: string;
+}) {
+  const { course, mastered, learning, struggling, unexplored, total, progress } = entry;
+  const pct = Math.round(progress * 100);
+  const baseColor = course.color || "var(--accent)";
+  const segments = [
+    { key: "mastered",   count: mastered,   color: baseColor, opacity: 1,    label: "Mastered" },
+    { key: "learning",   count: learning,   color: baseColor, opacity: 0.78, label: "Learning" },
+    { key: "struggling", count: struggling, color: baseColor, opacity: 0.55, label: "Struggling" },
+    { key: "unexplored", count: unexplored, color: "var(--bg-soft)", opacity: 1, label: "Unexplored" },
+  ];
+
+  const body = (
+    <>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: 12, marginBottom: 4 }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+          <span style={{ width: 10, height: 10, borderRadius: "50%", background: baseColor, flexShrink: 0 }} />
+          <strong style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {course.course_code || course.course_name}
+          </strong>
+        </span>
+        <span className="mono" style={{ color: "var(--text-dim)", fontSize: 11, flexShrink: 0, marginLeft: 8 }}>
+          {pct}%
+        </span>
+      </div>
+      {total > 0 ? (
+        <div
+          style={{
+            display: "flex",
+            height: 8,
+            background: "var(--bg-soft)",
+            borderRadius: "var(--r-full)",
+            overflow: "hidden",
+          }}
+          title={segments.filter(s => s.count > 0).map(s => `${s.label}: ${s.count}`).join(" · ")}
+        >
+          {segments.map((s) => s.count > 0 && (
+            <div
+              key={s.key}
+              style={{
+                width: `${(s.count / total) * 100}%`,
+                background: s.color,
+                opacity: s.opacity,
+                transition: "width var(--dur) var(--ease)",
+              }}
+            />
+          ))}
+        </div>
+      ) : (
+        <div style={{ height: 8, background: "var(--bg-soft)", borderRadius: "var(--r-full)" }} />
+      )}
+    </>
+  );
+
+  if (!onOpen) return <div style={{ marginBottom: 12 }}>{body}</div>;
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      aria-label={ariaLabel}
+      style={{
+        display: "block",
+        width: "100%",
+        marginBottom: 12,
+        padding: 0,
+        background: "transparent",
+        border: 0,
+        textAlign: "left",
+        color: "inherit",
+        font: "inherit",
+        cursor: "pointer",
+      }}
+    >
+      {body}
+    </button>
+  );
+}
 
 function CoursesKey({
   courseProgress,

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -484,8 +484,10 @@ export function Dashboard() {
             full My Courses panel in the left column instead. */}
         {!useLegacyPanels && (
           <CoursesKey
-            courseProgress={courseProgress}
+            courseProgress={currentProgress}
+            archived={archivedProgress}
             onManage={() => setCoursesOpen(true)}
+            onOpenTerm={openArchivedTerm}
           />
         )}
         <div style={{ position: "absolute", left: 16, bottom: 14, display: "flex", gap: 12, fontSize: 11, color: "var(--text-muted)" }}>
@@ -1256,14 +1258,18 @@ function CourseProgressRow({
 
 function CoursesKey({
   courseProgress,
+  archived,
   onManage,
+  onOpenTerm,
 }: {
   courseProgress: CourseProgressEntry[];
+  archived: ArchivedTermProgress[];
   onManage: () => void;
+  onOpenTerm: (label: string) => void;
 }) {
   const [collapsed, setCollapsed] = React.useState(true);
 
-  if (courseProgress.length === 0) return null;
+  if (courseProgress.length === 0 && archived.length === 0) return null;
 
   // A thick white outline painted BEHIND the glyphs, plus a soft halo.
   // `paint-order: stroke fill` pushes the stroke under the fill so
@@ -1405,6 +1411,45 @@ function CoursesKey({
               </div>
             );
           })}
+
+          {courseProgress.length === 0 && (
+            <div style={{ fontSize: 12, color: "var(--text-dim)", ...legibleText }}>
+              Nothing enrolled this semester.
+            </div>
+          )}
+
+          {archived.length > 0 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              <div className="label-micro" style={{ fontSize: 10, ...legibleText }}>Archive</div>
+              {archived.map((group) => (
+                <button
+                  key={group.label}
+                  type="button"
+                  onClick={() => onOpenTerm(group.label)}
+                  aria-label={`Open the ${group.label} gradebook`}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 8,
+                    width: "100%",
+                    padding: 0,
+                    background: "transparent",
+                    border: 0,
+                    cursor: "pointer",
+                    fontSize: 12,
+                    color: "var(--text-dim)",
+                    ...legibleText,
+                  }}
+                >
+                  <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {group.label}
+                  </span>
+                  <span className="mono" style={{ fontSize: 11 }}>{group.entries.length}</span>
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -17,7 +17,9 @@ import {
   getUpcomingAssignments,
   getSessions,
   getRecommendations,
+  getSemesters,
   type EnrolledCourse,
+  type Semester,
   type Session,
   type Assignment,
 } from "@/lib/api";
@@ -204,6 +206,7 @@ export function Dashboard() {
     streak: 0, mastered: 0, total: 0, learning: 0, struggling: 0, unexplored: 0,
   });
   const [courses, setCourses] = React.useState<EnrolledCourse[]>([]);
+  const [semesters, setSemesters] = React.useState<Semester[]>([]);
   const [sessions, setSessions] = React.useState<Session[]>([]);
   const [assignments, setAssignments] = React.useState<Assignment[]>([]);
   const [recommendations, setRecommendations] = React.useState<{ concept_name: string; reason?: string }[]>([]);
@@ -258,15 +261,19 @@ export function Dashboard() {
     setLoading(true);
     setLoadError(null);
     try {
-      const [graphRes, coursesRes, assignsRes, sessionsRes, recsRes] = await Promise.all([
+      const [graphRes, coursesRes, assignsRes, sessionsRes, recsRes, semestersRes] = await Promise.all([
         getGraph(userId),
         getCourses(userId),
         getUpcomingAssignments(userId),
         getSessions(userId, 10),
         getRecommendations(userId).catch(() => ({ recommendations: [] })),
+        // Term calendar is a nicety: without it the course lists stay flat
+        // rather than the dashboard failing to load.
+        getSemesters().catch(() => ({ semesters: [] })),
       ]);
       const cs = coursesRes.courses || [];
       setCourses(cs);
+      setSemesters(semestersRes.semesters || []);
       const gNodes: GraphNode[] = (graphRes.nodes || []).map((n: ApiNode) => apiToGraphNode(n, cs));
       setNodes(gNodes);
       setEdges((graphRes.edges || []).map(apiToGraphEdge));

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -450,7 +450,7 @@ export function Dashboard() {
           </div>
         </div>
         <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
-          {useLegacyPanels && courses.slice(0, 5).map((c) => (
+          {useLegacyPanels && partition.current.slice(0, 5).map((c) => (
             <div key={c.course_id} style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 11, color: "var(--text-dim)" }}>
               <span style={{ width: 10, height: 10, borderRadius: "50%", background: c.color || "var(--accent)" }} />
               {c.course_code || c.course_name}

--- a/frontend/src/components/screens/Gradebook/Landing.test.tsx
+++ b/frontend/src/components/screens/Gradebook/Landing.test.tsx
@@ -87,6 +87,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  window.history.replaceState({}, "", "/gradebook");
 });
 
 describe("GradebookLanding semester chips", () => {
@@ -118,6 +119,29 @@ describe("GradebookLanding semester chips", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("opens the term named by ?semester= so archived courses deep-link", async () => {
+    window.history.replaceState({}, "", "/gradebook?semester=Fall+2024");
+    mockedGetCourses.mockResolvedValue({
+      courses: [course("bio", "Fall 2024"), course("psy", "Spring 2025")],
+    });
+
+    render(<GradebookLanding />);
+
+    const chip = await screen.findByRole("button", { name: "Fall 2024" });
+    expect(chip.getAttribute("aria-pressed")).toBe("true");
+    await waitFor(() => expect(mockedGetSummary).toHaveBeenCalledWith("u1", "Fall 2024"));
+  });
+
+  it("ignores a ?semester= the user is not enrolled in", async () => {
+    window.history.replaceState({}, "", "/gradebook?semester=Fall+1999");
+    mockedGetCourses.mockResolvedValue({ courses: [course("psy", "Spring 2025")] });
+
+    render(<GradebookLanding />);
+
+    const chip = await screen.findByRole("button", { name: "Spring 2025" });
+    expect(chip.getAttribute("aria-pressed")).toBe("true");
   });
 
   it("still orders the chips when /api/semesters fails", async () => {

--- a/frontend/src/components/screens/Gradebook/Landing.test.tsx
+++ b/frontend/src/components/screens/Gradebook/Landing.test.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import type { EnrolledCourse } from "@/lib/api";
+import type { GradebookCourseSummary } from "@/lib/types";
 
 const mockUser = { userId: "u1" as string | null, userReady: true };
 
@@ -32,7 +33,9 @@ vi.mock("@/components/Gradebook/SyllabusUploadFlow", () => ({
   SyllabusUploadFlow: () => null,
 }));
 vi.mock("@/components/Gradebook/CourseCard", () => ({
-  CourseCard: ({ course }: any) => <a href="#">{course.course_name}</a>,
+  CourseCard: ({ course }: { course: GradebookCourseSummary }) => (
+    <a href="#">{course.course_name}</a>
+  ),
   COURSE_CARD_GRID_GAP: 24,
   COURSE_CARD_HEIGHT: 244,
 }));

--- a/frontend/src/components/screens/Gradebook/Landing.test.tsx
+++ b/frontend/src/components/screens/Gradebook/Landing.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+/**
+ * Regression tests for the gradebook landing's semester chips (#140).
+ *
+ * The landing used to read `(c as any).semester` off the /courses payload,
+ * which has always been `term`. `distinct` was therefore always empty and
+ * every signed-in user fell through to the SAMPLE_SEMESTERS demo chips.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import type { EnrolledCourse } from "@/lib/api";
+
+const mockUser = { userId: "u1" as string | null, userReady: true };
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => mockUser,
+}));
+
+vi.mock("@/lib/api", () => ({
+  getCourses: vi.fn(),
+  getGradebookSummary: vi.fn(),
+}));
+
+// Presentational children — stubbed so the test only exercises the landing's
+// own term resolution.
+vi.mock("@/components/Gradebook/AmbientOrbs", () => ({
+  AmbientOrbs: () => null,
+}));
+vi.mock("@/components/Gradebook/SyllabusUploadFlow", () => ({
+  SyllabusUploadFlow: () => null,
+}));
+vi.mock("@/components/Gradebook/CourseCard", () => ({
+  CourseCard: ({ course }: any) => <a href="#">{course.course_name}</a>,
+  COURSE_CARD_GRID_GAP: 24,
+  COURSE_CARD_HEIGHT: 244,
+}));
+
+import { GradebookLanding } from "./Landing";
+import { getCourses, getGradebookSummary } from "@/lib/api";
+
+const mockedGetCourses = vi.mocked(getCourses);
+const mockedGetSummary = vi.mocked(getGradebookSummary);
+
+function course(course_id: string, term: string): EnrolledCourse {
+  return {
+    enrollment_id: `e-${course_id}`,
+    course_id,
+    course_code: course_id.toUpperCase(),
+    course_name: course_id,
+    school: "BU",
+    department: "CS",
+    color: null,
+    nickname: null,
+    node_count: 0,
+    enrolled_at: "2026-01-01",
+    term,
+  };
+}
+
+beforeEach(() => {
+  mockUser.userId = "u1";
+  mockedGetSummary.mockResolvedValue({ courses: [] });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("GradebookLanding semester chips", () => {
+  it("builds the chips from each course's term", async () => {
+    mockedGetCourses.mockResolvedValue({
+      courses: [course("bio", "Fall 2024"), course("psy", "Spring 2025"), course("mat", "Fall 2024")],
+    });
+
+    render(<GradebookLanding />);
+
+    expect(await screen.findByText("Fall 2024")).toBeInTheDocument();
+    expect(screen.getByText("Spring 2025")).toBeInTheDocument();
+  });
+
+  it("never falls back to the demo chips for a signed-in user", async () => {
+    mockedGetCourses.mockResolvedValue({ courses: [course("bio", "Fall 2024")] });
+
+    render(<GradebookLanding />);
+
+    await screen.findByText("Fall 2024");
+    // SAMPLE_SEMESTERS — the logged-out preview. Leaking these into a real
+    // account is the bug this file exists for.
+    expect(screen.queryByText("Spring 2026")).toBeNull();
+    expect(screen.queryByText("Fall 2025")).toBeNull();
+  });
+
+  it("fetches the gradebook summary for the resolved term", async () => {
+    mockedGetCourses.mockResolvedValue({ courses: [course("bio", "Fall 2024")] });
+
+    render(<GradebookLanding />);
+
+    await waitFor(() => expect(mockedGetSummary).toHaveBeenCalledWith("u1", "Fall 2024"));
+  });
+
+  it("shows the empty state, not demo chips, when the user has no terms", async () => {
+    mockedGetCourses.mockResolvedValue({ courses: [] });
+
+    render(<GradebookLanding />);
+
+    expect(await screen.findByText(/A blank semester, ready to plant\./)).toBeInTheDocument();
+    expect(screen.queryByText("Spring 2026")).toBeNull();
+    expect(mockedGetSummary).not.toHaveBeenCalled();
+  });
+
+  it("shows the empty state when the courses request fails", async () => {
+    mockedGetCourses.mockRejectedValue(new Error("500"));
+
+    render(<GradebookLanding />);
+
+    expect(await screen.findByText(/A blank semester, ready to plant\./)).toBeInTheDocument();
+    expect(screen.queryByText("Spring 2026")).toBeNull();
+  });
+
+  it("still previews the sample semesters when logged out", async () => {
+    mockUser.userId = null;
+
+    render(<GradebookLanding />);
+
+    expect(await screen.findByText("Spring 2026")).toBeInTheDocument();
+    expect(screen.getByText("Fall 2025")).toBeInTheDocument();
+    expect(mockedGetCourses).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/screens/Gradebook/Landing.test.tsx
+++ b/frontend/src/components/screens/Gradebook/Landing.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/context/UserContext", () => ({
 vi.mock("@/lib/api", () => ({
   getCourses: vi.fn(),
   getGradebookSummary: vi.fn(),
+  getSemesters: vi.fn(),
 }));
 
 // Presentational children — stubbed so the test only exercises the landing's
@@ -41,10 +42,17 @@ vi.mock("@/components/Gradebook/CourseCard", () => ({
 }));
 
 import { GradebookLanding } from "./Landing";
-import { getCourses, getGradebookSummary } from "@/lib/api";
+import { getCourses, getGradebookSummary, getSemesters } from "@/lib/api";
+import type { Semester } from "@/lib/api";
 
 const mockedGetCourses = vi.mocked(getCourses);
 const mockedGetSummary = vi.mocked(getGradebookSummary);
+const mockedGetSemesters = vi.mocked(getSemesters);
+
+const SEMESTERS: Semester[] = [
+  { id: "spring-2025", term: "Spring", year: 2025, label: "Spring 2025", start_date: "2025-01-05", end_date: "2025-05-17", sort_key: 20251 },
+  { id: "fall-2024", term: "Fall", year: 2024, label: "Fall 2024", start_date: "2024-08-25", end_date: "2025-01-04", sort_key: 20243 },
+];
 
 function course(course_id: string, term: string): EnrolledCourse {
   return {
@@ -62,9 +70,18 @@ function course(course_id: string, term: string): EnrolledCourse {
   };
 }
 
+// The chips are the only aria-pressed controls on the page, so this reads
+// the rendered semester list — and its order — without depending on styling.
+const chipLabels = () =>
+  screen
+    .getAllByRole("button")
+    .filter((b) => b.getAttribute("aria-pressed") !== null)
+    .map((b) => b.textContent);
+
 beforeEach(() => {
   mockUser.userId = "u1";
   mockedGetSummary.mockResolvedValue({ courses: [] });
+  mockedGetSemesters.mockResolvedValue({ semesters: SEMESTERS });
 });
 
 afterEach(() => {
@@ -80,8 +97,39 @@ describe("GradebookLanding semester chips", () => {
 
     render(<GradebookLanding />);
 
-    expect(await screen.findByText("Fall 2024")).toBeInTheDocument();
-    expect(screen.getByText("Spring 2025")).toBeInTheDocument();
+    await screen.findByRole("button", { name: "Fall 2024" });
+    expect(chipLabels()).toEqual(["Spring 2025", "Fall 2024"]);
+  });
+
+  it("preselects the term today falls in, not just the newest one", async () => {
+    // Inside Fall 2024's range, which is NOT the highest sort_key.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2024, 9, 1));
+    try {
+      mockedGetCourses.mockResolvedValue({
+        courses: [course("bio", "Fall 2024"), course("psy", "Spring 2025")],
+      });
+
+      render(<GradebookLanding />);
+
+      const chip = await screen.findByRole("button", { name: "Fall 2024" });
+      expect(chipLabels()).toEqual(["Spring 2025", "Fall 2024"]);
+      expect(chip.getAttribute("aria-pressed")).toBe("true");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still orders the chips when /api/semesters fails", async () => {
+    mockedGetSemesters.mockRejectedValue(new Error("500"));
+    mockedGetCourses.mockResolvedValue({
+      courses: [course("bio", "Fall 2024"), course("psy", "Spring 2025")],
+    });
+
+    render(<GradebookLanding />);
+
+    await screen.findByRole("button", { name: "Fall 2024" });
+    expect(chipLabels()).toEqual(["Spring 2025", "Fall 2024"]);
   });
 
   it("never falls back to the demo chips for a signed-in user", async () => {
@@ -89,11 +137,10 @@ describe("GradebookLanding semester chips", () => {
 
     render(<GradebookLanding />);
 
-    await screen.findByText("Fall 2024");
+    await screen.findByRole("button", { name: "Fall 2024" });
     // SAMPLE_SEMESTERS — the logged-out preview. Leaking these into a real
     // account is the bug this file exists for.
-    expect(screen.queryByText("Spring 2026")).toBeNull();
-    expect(screen.queryByText("Fall 2025")).toBeNull();
+    expect(chipLabels()).toEqual(["Fall 2024"]);
   });
 
   it("fetches the gradebook summary for the resolved term", async () => {
@@ -128,8 +175,8 @@ describe("GradebookLanding semester chips", () => {
 
     render(<GradebookLanding />);
 
-    expect(await screen.findByText("Spring 2026")).toBeInTheDocument();
-    expect(screen.getByText("Fall 2025")).toBeInTheDocument();
+    await screen.findByRole("button", { name: "Spring 2026" });
+    expect(chipLabels()).toEqual(["Spring 2026", "Fall 2025"]);
     expect(mockedGetCourses).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/screens/Gradebook/Landing.tsx
+++ b/frontend/src/components/screens/Gradebook/Landing.tsx
@@ -9,7 +9,8 @@ import {
 } from "@/components/Gradebook/CourseCard";
 import { AmbientOrbs } from "@/components/Gradebook/AmbientOrbs";
 import { useUser } from "@/context/UserContext";
-import { getGradebookSummary, getCourses } from "@/lib/api";
+import { getGradebookSummary, getCourses, getSemesters } from "@/lib/api";
+import { courseTermLabels, currentTerm } from "@/lib/semesters";
 import type { GradebookCourseSummary } from "@/lib/types";
 import { SyllabusUploadFlow } from "@/components/Gradebook/SyllabusUploadFlow";
 import { Button } from "@/components/ui";
@@ -112,12 +113,19 @@ export function GradebookLanding() {
       setTermsReady(true);
       return;
     }
-    getCourses(userId)
-      .then((res) => {
-        const all = res.courses ?? [];
-        const distinct = Array.from(new Set(all.map((c) => c.term).filter(Boolean)));
-        setSemesters(distinct);
-        setSelected(distinct[0] ?? "");
+    Promise.all([
+      getCourses(userId),
+      // The chips still work off the course terms alone if this 404s or the
+      // project has no terms seeded — sort_key just stops informing the order.
+      getSemesters().catch(() => ({ semesters: [] })),
+    ])
+      .then(([coursesRes, semestersRes]) => {
+        const all = coursesRes.courses ?? [];
+        const terms = semestersRes.semesters ?? [];
+        const labels = courseTermLabels(all, terms);
+        setSemesters(labels);
+        const preferred = currentTerm(terms)?.label;
+        setSelected(preferred && labels.includes(preferred) ? preferred : labels[0] ?? "");
         const colors: Record<string, string> = {};
         for (const c of all) {
           if (c.color) colors[c.course_id] = c.color;

--- a/frontend/src/components/screens/Gradebook/Landing.tsx
+++ b/frontend/src/components/screens/Gradebook/Landing.tsx
@@ -10,7 +10,6 @@ import {
 import { AmbientOrbs } from "@/components/Gradebook/AmbientOrbs";
 import { useUser } from "@/context/UserContext";
 import { getGradebookSummary, getCourses } from "@/lib/api";
-import type { EnrolledCourse } from "@/lib/api";
 import type { GradebookCourseSummary } from "@/lib/types";
 import { SyllabusUploadFlow } from "@/components/Gradebook/SyllabusUploadFlow";
 import { Button } from "@/components/ui";
@@ -101,23 +100,24 @@ export function GradebookLanding() {
   const [courses, setCourses] = React.useState<GradebookCourseSummary[]>([]);
   const [colorMap, setColorMap] = React.useState<Record<string, string>>({});
   const [loading, setLoading] = React.useState(true);
+  const [termsReady, setTermsReady] = React.useState(false);
   const [uploadOpen, setUploadOpen] = React.useState(false);
 
   React.useEffect(() => {
+    // SAMPLE_SEMESTERS is the logged-out marketing preview only. A signed-in
+    // user with no terms must see their own empty state, never demo chips.
     if (!userId) {
       setSemesters(SAMPLE_SEMESTERS);
       setSelected(SAMPLE_SEMESTERS[0]);
+      setTermsReady(true);
       return;
     }
     getCourses(userId)
       .then((res) => {
-        const all = res.courses as (EnrolledCourse & { semester?: string })[];
-        const distinct = Array.from(
-          new Set(all.map((c) => (c as any).semester).filter(Boolean)),
-        ) as string[];
-        const list = distinct.length ? distinct : SAMPLE_SEMESTERS;
-        setSemesters(list);
-        setSelected(list[0]);
+        const all = res.courses ?? [];
+        const distinct = Array.from(new Set(all.map((c) => c.term).filter(Boolean)));
+        setSemesters(distinct);
+        setSelected(distinct[0] ?? "");
         const colors: Record<string, string> = {};
         for (const c of all) {
           if (c.color) colors[c.course_id] = c.color;
@@ -125,13 +125,19 @@ export function GradebookLanding() {
         setColorMap(colors);
       })
       .catch(() => {
-        setSemesters(SAMPLE_SEMESTERS);
-        setSelected(SAMPLE_SEMESTERS[0]);
-      });
+        setSemesters([]);
+        setSelected("");
+      })
+      .finally(() => setTermsReady(true));
   }, [userId]);
 
   React.useEffect(() => {
-    if (!selected) return;
+    if (!termsReady) return;
+    if (!selected) {
+      setCourses([]);
+      setLoading(false);
+      return;
+    }
     if (!userId) {
       setCourses(SAMPLE_COURSES[selected] ?? []);
       setLoading(false);
@@ -146,7 +152,7 @@ export function GradebookLanding() {
         setCourses([]);
       })
       .finally(() => setLoading(false));
-  }, [userId, selected]);
+  }, [userId, selected, termsReady]);
 
   const gridRef = React.useRef<HTMLDivElement>(null);
 

--- a/frontend/src/components/screens/Gradebook/Landing.tsx
+++ b/frontend/src/components/screens/Gradebook/Landing.tsx
@@ -104,6 +104,15 @@ export function GradebookLanding() {
   const [termsReady, setTermsReady] = React.useState(false);
   const [uploadOpen, setUploadOpen] = React.useState(false);
 
+  // /gradebook?semester=<label> is how the dashboard archive deep-links into a
+  // past term. Read straight off location because useSearchParams() would need
+  // a Suspense boundary in the route shell, which this component doesn't own.
+  const [requestedTerm] = React.useState(() =>
+    typeof window === "undefined"
+      ? ""
+      : new URLSearchParams(window.location.search).get("semester") ?? "",
+  );
+
   React.useEffect(() => {
     // SAMPLE_SEMESTERS is the logged-out marketing preview only. A signed-in
     // user with no terms must see their own empty state, never demo chips.
@@ -124,7 +133,9 @@ export function GradebookLanding() {
         const terms = semestersRes.semesters ?? [];
         const labels = courseTermLabels(all, terms);
         setSemesters(labels);
-        const preferred = currentTerm(terms)?.label;
+        const preferred = labels.includes(requestedTerm)
+          ? requestedTerm
+          : currentTerm(terms)?.label;
         setSelected(preferred && labels.includes(preferred) ? preferred : labels[0] ?? "");
         const colors: Record<string, string> = {};
         for (const c of all) {
@@ -137,7 +148,7 @@ export function GradebookLanding() {
         setSelected("");
       })
       .finally(() => setTermsReady(true));
-  }, [userId]);
+  }, [userId, requestedTerm]);
 
   React.useEffect(() => {
     if (!termsReady) return;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -993,6 +993,23 @@ export const uploadAvatar = async (userId: string, file: File): Promise<{ avatar
   });
 };
 
+// ── Semesters ────────────────────────────────────────────────────────────────
+
+export interface Semester {
+  id: string;
+  term: string;
+  year: number;
+  label: string;
+  start_date: string;
+  end_date: string;
+  // year * 10 + term ordinal (Spring=1, Summer=2, Fall=3, Winter=4) — the
+  // canonical ordering key; the backend serves terms sort_key-descending.
+  sort_key: number;
+}
+
+export const getSemesters = () =>
+  fetchJSON<{ semesters: Semester[] }>('/api/semesters');
+
 // ── Gradebook ────────────────────────────────────────────────────────────────
 
 export const getGradebookSummary = (userId: string, semester: string) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -51,6 +51,10 @@ export interface EnrolledCourse {
   nickname: string | null;
   node_count: number;
   enrolled_at: string;
+  // Human term label of the offering the enrollment hangs off, e.g. "Fall 2025".
+  // The backend emits "" when the offering has no term joined — treat it as unknown,
+  // never as a past term.
+  term: string;
 }
 
 export const getCourses = (userId: string) =>

--- a/frontend/src/lib/data.test.ts
+++ b/frontend/src/lib/data.test.ts
@@ -32,6 +32,7 @@ function makeCourse(over: Partial<EnrolledCourse> = {}): EnrolledCourse {
     nickname: null,
     node_count: 8,
     enrolled_at: "2026-01-01",
+    term: "Spring 2026",
     ...over,
   };
 }

--- a/frontend/src/lib/semesters.test.ts
+++ b/frontend/src/lib/semesters.test.ts
@@ -3,6 +3,7 @@ import {
   UNKNOWN_TERM_LABEL,
   currentTerm,
   groupCoursesByTerm,
+  partitionCurrentAndArchive,
   termRankFromLabel,
 } from "./semesters";
 import type { EnrolledCourse, Semester } from "./api";
@@ -174,5 +175,84 @@ describe("groupCoursesByTerm", () => {
   it("returns an empty list for no courses", () => {
     expect(groupCoursesByTerm([], SEMESTERS)).toEqual([]);
     expect(groupCoursesByTerm(null, SEMESTERS)).toEqual([]);
+  });
+});
+
+describe("partitionCurrentAndArchive", () => {
+  const enrolled = [
+    course("bio", "Spring 2026"),
+    course("psy", "Fall 2025"),
+    course("mat", "Spring 2026"),
+    course("cs", "Fall 2026"),
+  ];
+
+  it("keeps the current term up front and archives only earlier terms", () => {
+    const { current, archive } = partitionCurrentAndArchive(enrolled, SEMESTERS, "2026-03-01");
+    expect(ids(current)).toEqual(["bio", "mat", "cs"]);
+    expect(archive.map((g) => g.label)).toEqual(["Fall 2025"]);
+    expect(ids(archive[0].courses)).toEqual(["psy"]);
+  });
+
+  it("does not archive a future term", () => {
+    const { current } = partitionCurrentAndArchive(enrolled, SEMESTERS, "2026-03-01");
+    expect(ids(current)).toContain("cs");
+  });
+
+  it("orders archive groups most recent first", () => {
+    const older = [
+      course("a", "Fall 2025"),
+      course("b", "Spring 2026"),
+      course("c", "Summer 2026"),
+    ];
+    const { archive } = partitionCurrentAndArchive(older, SEMESTERS, "2026-10-01");
+    expect(archive.map((g) => g.label)).toEqual(["Summer 2026", "Spring 2026", "Fall 2025"]);
+  });
+
+  it("moves with the calendar — the same data partitions differently later", () => {
+    const spring = partitionCurrentAndArchive(enrolled, SEMESTERS, "2026-03-01");
+    const fall = partitionCurrentAndArchive(enrolled, SEMESTERS, "2026-09-15");
+    expect(ids(spring.current)).toEqual(["bio", "mat", "cs"]);
+    expect(ids(fall.current)).toEqual(["cs"]);
+    expect(fall.archive.map((g) => g.label)).toEqual(["Spring 2026", "Fall 2025"]);
+  });
+
+  it("keeps undatable courses in the current list rather than hiding them", () => {
+    const mixed = [course("bio", "Spring 2026"), course("solo", ""), course("odd", "Interterm")];
+    const { current, archive } = partitionCurrentAndArchive(mixed, SEMESTERS, "2026-03-01");
+    expect(ids(current)).toEqual(["bio", "solo", "odd"]);
+    expect(archive).toEqual([]);
+  });
+
+  it("archives a past term the semesters payload never mentioned", () => {
+    const { current, archive } = partitionCurrentAndArchive(
+      [course("bio", "Spring 2026"), course("old", "Fall 2019")],
+      SEMESTERS,
+      "2026-03-01",
+    );
+    expect(ids(current)).toEqual(["bio"]);
+    expect(archive.map((g) => g.label)).toEqual(["Fall 2019"]);
+  });
+
+  it("shows everything ungrouped when the semesters fetch yields nothing", () => {
+    for (const empty of [[], null, undefined]) {
+      const { current, archive } = partitionCurrentAndArchive(enrolled, empty, "2026-03-01");
+      expect(ids(current)).toEqual(["bio", "psy", "mat", "cs"]);
+      expect(archive).toEqual([]);
+    }
+  });
+
+  it("handles no courses at all", () => {
+    expect(partitionCurrentAndArchive([], SEMESTERS, "2026-03-01")).toEqual({
+      current: [],
+      archive: [],
+    });
+    expect(partitionCurrentAndArchive(null, SEMESTERS, "2026-03-01").current).toEqual([]);
+  });
+
+  it("defaults today to now when it is not injected", () => {
+    const result = partitionCurrentAndArchive(enrolled, SEMESTERS);
+    expect(result.current.length + result.archive.reduce((n, g) => n + g.courses.length, 0)).toBe(
+      enrolled.length,
+    );
   });
 });

--- a/frontend/src/lib/semesters.test.ts
+++ b/frontend/src/lib/semesters.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { currentTerm, termRankFromLabel } from "./semesters";
-import type { Semester } from "./api";
+import {
+  UNKNOWN_TERM_LABEL,
+  currentTerm,
+  groupCoursesByTerm,
+  termRankFromLabel,
+} from "./semesters";
+import type { EnrolledCourse, Semester } from "./api";
 
 /**
  * The four terms seeded by migration 0019, verbatim. Keeping the real rows
@@ -13,6 +18,24 @@ const SEMESTERS: Semester[] = [
   { id: "spring-2026", term: "Spring", year: 2026, label: "Spring 2026", start_date: "2026-01-05", end_date: "2026-05-17", sort_key: 20261 },
   { id: "fall-2025", term: "Fall", year: 2025, label: "Fall 2025", start_date: "2025-08-25", end_date: "2026-01-04", sort_key: 20253 },
 ];
+
+function course(course_id: string, term: string): EnrolledCourse {
+  return {
+    enrollment_id: `e-${course_id}`,
+    course_id,
+    course_code: course_id.toUpperCase(),
+    course_name: course_id,
+    school: "BU",
+    department: "CS",
+    color: null,
+    nickname: null,
+    node_count: 0,
+    enrolled_at: "2026-01-01",
+    term,
+  };
+}
+
+const ids = (courses: EnrolledCourse[]) => courses.map((c) => c.course_id);
 
 describe("termRankFromLabel", () => {
   it("mirrors the sort_key formula (year * 10 + term ordinal)", () => {
@@ -85,5 +108,71 @@ describe("currentTerm", () => {
       { id: "x", term: "Fall", year: 2025, label: "Fall 2025", start_date: "", end_date: "", sort_key: 20253 },
     ] as Semester[];
     expect(currentTerm(partial, "2025-09-10")?.label).toBe("Fall 2025");
+  });
+});
+
+describe("groupCoursesByTerm", () => {
+  it("groups by term label, most recent term first", () => {
+    const groups = groupCoursesByTerm(
+      [course("a", "Fall 2025"), course("b", "Spring 2026"), course("c", "Fall 2025")],
+      SEMESTERS,
+    );
+    expect(groups.map((g) => g.label)).toEqual(["Spring 2026", "Fall 2025"]);
+    expect(ids(groups[1].courses)).toEqual(["a", "c"]);
+  });
+
+  it("preserves input order inside a group", () => {
+    const groups = groupCoursesByTerm(
+      [course("z", "Fall 2025"), course("a", "Fall 2025"), course("m", "Fall 2025")],
+      SEMESTERS,
+    );
+    expect(ids(groups[0].courses)).toEqual(["z", "a", "m"]);
+  });
+
+  it("buckets courses with an empty or whitespace term instead of dropping them", () => {
+    const groups = groupCoursesByTerm(
+      [course("a", "Spring 2026"), course("b", ""), course("c", "   ")],
+      SEMESTERS,
+    );
+    const other = groups.find((g) => g.label === UNKNOWN_TERM_LABEL);
+    expect(ids(other!.courses)).toEqual(["b", "c"]);
+    // Unrankable bucket sorts last.
+    expect(groups[groups.length - 1].label).toBe(UNKNOWN_TERM_LABEL);
+  });
+
+  it("keeps a course whose term field is missing entirely", () => {
+    const missing = { ...course("a", "") } as Partial<EnrolledCourse>;
+    delete missing.term;
+    const groups = groupCoursesByTerm([missing as EnrolledCourse], SEMESTERS);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe(UNKNOWN_TERM_LABEL);
+  });
+
+  it("orders by label rank when no semesters are supplied", () => {
+    const groups = groupCoursesByTerm([
+      course("a", "Fall 2025"),
+      course("b", "Fall 2026"),
+      course("c", "Spring 2026"),
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(["Fall 2026", "Spring 2026", "Fall 2025"]);
+  });
+
+  it("prefers the server sort_key over the label rank when they disagree", () => {
+    // A school whose 'Winter 2026' term genuinely precedes Spring 2026.
+    // Label parsing alone would rank Winter after Spring.
+    const custom: Semester[] = [
+      { id: "w", term: "Winter", year: 2026, label: "Winter 2026", start_date: "2026-01-02", end_date: "2026-01-20", sort_key: 20260 },
+      { id: "s", term: "Spring", year: 2026, label: "Spring 2026", start_date: "2026-01-21", end_date: "2026-05-17", sort_key: 20261 },
+    ];
+    const groups = groupCoursesByTerm(
+      [course("a", "Winter 2026"), course("b", "Spring 2026")],
+      custom,
+    );
+    expect(groups.map((g) => g.label)).toEqual(["Spring 2026", "Winter 2026"]);
+  });
+
+  it("returns an empty list for no courses", () => {
+    expect(groupCoursesByTerm([], SEMESTERS)).toEqual([]);
+    expect(groupCoursesByTerm(null, SEMESTERS)).toEqual([]);
   });
 });

--- a/frontend/src/lib/semesters.test.ts
+++ b/frontend/src/lib/semesters.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   UNKNOWN_TERM_LABEL,
+  courseTermLabels,
   currentTerm,
   groupCoursesByTerm,
   partitionCurrentAndArchive,
@@ -254,5 +255,29 @@ describe("partitionCurrentAndArchive", () => {
     expect(result.current.length + result.archive.reduce((n, g) => n + g.courses.length, 0)).toBe(
       enrolled.length,
     );
+  });
+});
+
+describe("courseTermLabels", () => {
+  it("dedupes and orders most recent first", () => {
+    const labels = courseTermLabels(
+      [
+        course("a", "Fall 2025"),
+        course("b", "Spring 2026"),
+        course("c", "Fall 2025"),
+        course("d", "Fall 2026"),
+      ],
+      SEMESTERS,
+    );
+    expect(labels).toEqual(["Fall 2026", "Spring 2026", "Fall 2025"]);
+  });
+
+  it("skips courses with no term — a chip for them would filter to nothing", () => {
+    expect(courseTermLabels([course("a", ""), course("b", "  ")], SEMESTERS)).toEqual([]);
+  });
+
+  it("still orders sensibly with no semesters payload", () => {
+    const labels = courseTermLabels([course("a", "Fall 2025"), course("b", "Spring 2026")]);
+    expect(labels).toEqual(["Spring 2026", "Fall 2025"]);
   });
 });

--- a/frontend/src/lib/semesters.test.ts
+++ b/frontend/src/lib/semesters.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { currentTerm, termRankFromLabel } from "./semesters";
+import type { Semester } from "./api";
+
+/**
+ * The four terms seeded by migration 0019, verbatim. Keeping the real rows
+ * here means these tests would catch a drift between the client's
+ * current-term rule and `services/academics.py::current_term`.
+ */
+const SEMESTERS: Semester[] = [
+  { id: "fall-2026", term: "Fall", year: 2026, label: "Fall 2026", start_date: "2026-08-24", end_date: "2027-01-03", sort_key: 20263 },
+  { id: "summer-2026", term: "Summer", year: 2026, label: "Summer 2026", start_date: "2026-05-18", end_date: "2026-08-23", sort_key: 20262 },
+  { id: "spring-2026", term: "Spring", year: 2026, label: "Spring 2026", start_date: "2026-01-05", end_date: "2026-05-17", sort_key: 20261 },
+  { id: "fall-2025", term: "Fall", year: 2025, label: "Fall 2025", start_date: "2025-08-25", end_date: "2026-01-04", sort_key: 20253 },
+];
+
+describe("termRankFromLabel", () => {
+  it("mirrors the sort_key formula (year * 10 + term ordinal)", () => {
+    expect(termRankFromLabel("Fall 2025")).toBe(20253);
+    expect(termRankFromLabel("Spring 2026")).toBe(20261);
+    expect(termRankFromLabel("Summer 2026")).toBe(20262);
+    expect(termRankFromLabel("Winter 2026")).toBe(20264);
+  });
+
+  it("is case- and order-insensitive", () => {
+    expect(termRankFromLabel("fall 2025")).toBe(20253);
+    expect(termRankFromLabel("2025 FALL")).toBe(20253);
+  });
+
+  it("ranks a bare year below every named term in it", () => {
+    expect(termRankFromLabel("2025")).toBe(20250);
+    expect(termRankFromLabel("2025")! < termRankFromLabel("Spring 2025")!).toBe(true);
+  });
+
+  it("returns null for a label with no year", () => {
+    expect(termRankFromLabel("Fall")).toBeNull();
+    expect(termRankFromLabel("")).toBeNull();
+  });
+});
+
+describe("currentTerm", () => {
+  it("picks the term whose date range contains today", () => {
+    expect(currentTerm(SEMESTERS, "2026-03-01")?.label).toBe("Spring 2026");
+    expect(currentTerm(SEMESTERS, "2025-09-10")?.label).toBe("Fall 2025");
+    expect(currentTerm(SEMESTERS, "2026-07-01")?.label).toBe("Summer 2026");
+  });
+
+  it("includes both range endpoints", () => {
+    expect(currentTerm(SEMESTERS, "2026-01-05")?.label).toBe("Spring 2026");
+    expect(currentTerm(SEMESTERS, "2026-05-17")?.label).toBe("Spring 2026");
+    // One day earlier is still the term that straddles the new year.
+    expect(currentTerm(SEMESTERS, "2026-01-04")?.label).toBe("Fall 2025");
+  });
+
+  it("falls back to the highest sort_key when today sits in a gap", () => {
+    // Well past the last seeded term.
+    expect(currentTerm(SEMESTERS, "2030-04-01")?.label).toBe("Fall 2026");
+    // Before the first seeded term — same rule, same answer.
+    expect(currentTerm(SEMESTERS, "2001-04-01")?.label).toBe("Fall 2026");
+  });
+
+  it("breaks a range overlap on the higher sort_key, like the backend's order+limit", () => {
+    const overlapping: Semester[] = [
+      { id: "a", term: "Spring", year: 2026, label: "Spring 2026", start_date: "2026-01-01", end_date: "2026-12-31", sort_key: 20261 },
+      { id: "b", term: "Fall", year: 2026, label: "Fall 2026", start_date: "2026-01-01", end_date: "2026-12-31", sort_key: 20263 },
+    ];
+    expect(currentTerm(overlapping, "2026-06-01")?.label).toBe("Fall 2026");
+  });
+
+  it("accepts a Date and reads it in local time", () => {
+    // 23:30 local on the last day of Spring 2026. Converting via toISOString()
+    // would roll this into the next day in any timezone east of UTC.
+    const d = new Date(2026, 4, 17, 23, 30, 0);
+    expect(currentTerm(SEMESTERS, d)?.label).toBe("Spring 2026");
+  });
+
+  it("returns null when there are no semesters", () => {
+    expect(currentTerm([], "2026-03-01")).toBeNull();
+    expect(currentTerm(null, "2026-03-01")).toBeNull();
+    expect(currentTerm(undefined, "2026-03-01")).toBeNull();
+  });
+
+  it("ignores rows with missing date bounds instead of throwing", () => {
+    const partial = [
+      { id: "x", term: "Fall", year: 2025, label: "Fall 2025", start_date: "", end_date: "", sort_key: 20253 },
+    ] as Semester[];
+    expect(currentTerm(partial, "2025-09-10")?.label).toBe("Fall 2025");
+  });
+});

--- a/frontend/src/lib/semesters.ts
+++ b/frontend/src/lib/semesters.ts
@@ -66,3 +66,51 @@ export function currentTerm(
   );
   return containing ?? byRank[0];
 }
+
+function rankIndex(semesters: Semester[] | null | undefined): Map<string, number> {
+  const index = new Map<string, number>();
+  for (const s of semesters ?? []) {
+    if (s.label) index.set(s.label, s.sort_key ?? 0);
+  }
+  return index;
+}
+
+function labelRank(label: string, index: Map<string, number>): number | null {
+  const known = index.get(label);
+  return known !== undefined ? known : termRankFromLabel(label);
+}
+
+// Most recent first; labels we can't rank at all sort to the end.
+function compareLabels(a: string, b: string, index: Map<string, number>): number {
+  const ra = labelRank(a, index);
+  const rb = labelRank(b, index);
+  if (ra !== null && rb !== null) return rb - ra || a.localeCompare(b);
+  if (ra !== null) return -1;
+  if (rb !== null) return 1;
+  return a.localeCompare(b);
+}
+
+/**
+ * Group courses by their term label, most recent term first.
+ *
+ * Ordering keys on each semester's `sort_key` when `semesters` is supplied and
+ * degrades to a label-derived rank otherwise. Courses with no term land in the
+ * `UNKNOWN_TERM_LABEL` bucket — never dropped. Order within a group is the
+ * caller's input order.
+ */
+export function groupCoursesByTerm(
+  courses: EnrolledCourse[] | null | undefined,
+  semesters?: Semester[] | null,
+): TermGroup[] {
+  const index = rankIndex(semesters);
+  const buckets = new Map<string, EnrolledCourse[]>();
+  for (const course of courses ?? []) {
+    const label = (course.term || "").trim() || UNKNOWN_TERM_LABEL;
+    const bucket = buckets.get(label);
+    if (bucket) bucket.push(course);
+    else buckets.set(label, [course]);
+  }
+  return Array.from(buckets, ([label, grouped]) => ({ label, courses: grouped })).sort(
+    (a, b) => compareLabels(a.label, b.label, index),
+  );
+}

--- a/frontend/src/lib/semesters.ts
+++ b/frontend/src/lib/semesters.ts
@@ -1,0 +1,33 @@
+import type { EnrolledCourse, Semester } from "@/lib/api";
+
+// Bucket for enrollments whose offering has no term joined (the backend
+// sends `term: ""`). These are never archived — an undatable course is
+// shown with the current term rather than hidden behind the archive.
+export const UNKNOWN_TERM_LABEL = "Other";
+
+export type TermGroup = {
+  label: string;
+  courses: EnrolledCourse[];
+};
+
+// Mirrors the `sort_key` formula in migration 0019: year * 10 + term ordinal.
+const TERM_ORDINALS: Record<string, number> = {
+  spring: 1,
+  summer: 2,
+  fall: 3,
+  winter: 4,
+};
+
+/**
+ * Derive a `sort_key`-equivalent rank from a term label ("Fall 2025" -> 20253).
+ *
+ * Only used when `/api/semesters` gave us nothing to key on; when a real
+ * semester row exists its `sort_key` always wins. Returns null when the label
+ * carries no year, since there is then no defensible ordering for it.
+ */
+export function termRankFromLabel(label: string): number | null {
+  const year = label.match(/\b(\d{4})\b/);
+  if (!year) return null;
+  const term = label.toLowerCase().match(/\b(spring|summer|fall|winter)\b/);
+  return Number(year[1]) * 10 + (term ? TERM_ORDINALS[term[1]] : 0);
+}

--- a/frontend/src/lib/semesters.ts
+++ b/frontend/src/lib/semesters.ts
@@ -31,3 +31,38 @@ export function termRankFromLabel(label: string): number | null {
   const term = label.toLowerCase().match(/\b(spring|summer|fall|winter)\b/);
   return Number(year[1]) * 10 + (term ? TERM_ORDINALS[term[1]] : 0);
 }
+
+// Local calendar date as YYYY-MM-DD. Not toISOString(), which converts to UTC
+// and lands on the wrong day either side of midnight.
+function toISODate(today: Date | string): string {
+  if (typeof today === "string") return today.slice(0, 10);
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const day = String(today.getDate()).padStart(2, "0");
+  return `${today.getFullYear()}-${month}-${day}`;
+}
+
+/**
+ * The term `today` falls in, mirroring `services/academics.py::current_term`:
+ * the highest-`sort_key` term whose [start_date, end_date] contains today,
+ * falling back to the highest `sort_key` overall when today sits in a gap.
+ *
+ * Both rules must stay identical to the backend's or the two disagree about
+ * which semester is "current". Date bounds are compared as YYYY-MM-DD strings,
+ * where lexicographic order is chronological order.
+ */
+export function currentTerm(
+  semesters: Semester[] | null | undefined,
+  today: Date | string = new Date(),
+): Semester | null {
+  if (!semesters || semesters.length === 0) return null;
+  const d = toISODate(today);
+  const byRank = [...semesters].sort((a, b) => (b.sort_key ?? 0) - (a.sort_key ?? 0));
+  const containing = byRank.find(
+    (s) =>
+      s.start_date &&
+      s.end_date &&
+      s.start_date.slice(0, 10) <= d &&
+      s.end_date.slice(0, 10) >= d,
+  );
+  return containing ?? byRank[0];
+}

--- a/frontend/src/lib/semesters.ts
+++ b/frontend/src/lib/semesters.ts
@@ -115,6 +115,24 @@ export function groupCoursesByTerm(
   );
 }
 
+/**
+ * Distinct term labels off a course list, most recent first — the semester
+ * chips on the gradebook landing. Courses with no term contribute nothing;
+ * a chip for them would filter to an empty gradebook.
+ */
+export function courseTermLabels(
+  courses: EnrolledCourse[] | null | undefined,
+  semesters?: Semester[] | null,
+): string[] {
+  const index = rankIndex(semesters);
+  const labels = new Set<string>();
+  for (const course of courses ?? []) {
+    const label = (course.term || "").trim();
+    if (label) labels.add(label);
+  }
+  return Array.from(labels).sort((a, b) => compareLabels(a, b, index));
+}
+
 export type CoursePartition = {
   current: EnrolledCourse[];
   archive: TermGroup[];

--- a/frontend/src/lib/semesters.ts
+++ b/frontend/src/lib/semesters.ts
@@ -114,3 +114,42 @@ export function groupCoursesByTerm(
     (a, b) => compareLabels(a.label, b.label, index),
   );
 }
+
+export type CoursePartition = {
+  current: EnrolledCourse[];
+  archive: TermGroup[];
+};
+
+/**
+ * Split enrolled courses into what to show by default and what to hide behind
+ * the archive: only a course that ranks strictly below the current term is
+ * archived, grouped by term, most recent first.
+ *
+ * Anything we can't date — no term, an unparseable label, or no semesters at
+ * all because `/api/semesters` failed — stays in `current`. Hiding a course is
+ * worse than showing it in the wrong bucket, so degradation is always toward
+ * the flat, ungrouped list.
+ */
+export function partitionCurrentAndArchive(
+  courses: EnrolledCourse[] | null | undefined,
+  semesters: Semester[] | null | undefined,
+  today: Date | string = new Date(),
+): CoursePartition {
+  const all = courses ?? [];
+  const term = currentTerm(semesters, today);
+  if (!term) return { current: all, archive: [] };
+
+  const index = rankIndex(semesters);
+  const currentRank = term.sort_key ?? termRankFromLabel(term.label);
+  if (currentRank === null) return { current: all, archive: [] };
+
+  const current: EnrolledCourse[] = [];
+  const archived: EnrolledCourse[] = [];
+  for (const course of all) {
+    const label = (course.term || "").trim();
+    const rank = label ? labelRank(label, index) : null;
+    if (rank !== null && rank < currentRank) archived.push(course);
+    else current.push(course);
+  }
+  return { current, archive: groupCoursesByTerm(archived, semesters) };
+}


### PR DESCRIPTION
Closes #140.

Groups enrolled classes by semester, defaults to the current term, and puts past terms behind an Archive.

## The dependency was already satisfied

#140 is filed as "depends on the backend API issue", but that's stale — nothing was blocking:

- `GET /api/semesters` already exists and serves `{id, term, year, label, start_date, end_date, sort_key}`.
- `GET /api/graph/{user_id}/courses` already returns a **`term`** label per course; only the frontend `EnrolledCourse` interface hadn't declared it.

So this is frontend-only.

## It also fixes a live bug

`screens/Gradebook/Landing.tsx` read `(c as any).semester` off the courses payload — but the API sends **`term`**. The lookup therefore always came back empty and fell through to the hardcoded demo constant:

```ts
const SAMPLE_SEMESTERS = ["Spring 2026", "Fall 2025"];
```

**Every signed-in user was being shown those two fake semester chips instead of their own.** The `as any` is exactly what let the field-name mismatch through the type checker. `SAMPLE_SEMESTERS` is now strictly the logged-out preview; a signed-in user with no terms gets their own empty state (a `termsReady` gate keeps that from hanging on the skeleton). Covered by tests.

## New `src/lib/semesters.ts` — one tested source of truth

- `currentTerm(semesters, today)` mirrors `services/academics.py::current_term` **exactly**: the highest-`sort_key` term whose `[start_date, end_date]` contains today, falling back to the highest `sort_key` overall when today lands in a gap between terms. `today` is injectable. Dates compare as `YYYY-MM-DD` strings (lexicographic == chronological), and a `Date` is read in **local** time — `toISOString()` would shift the day either side of midnight.
- `termRankFromLabel("Fall 2025") -> 20253`, mirroring migration 0019's `year * 10 + ordinal`. Only consulted when no real `sort_key` is available; `sort_key` always wins.
- `groupCoursesByTerm`, `courseTermLabels`, `partitionCurrentAndArchive`.

## Degradation — the rule is "never hide a course"

If `/api/semesters` fails or returns nothing, everything collapses to one flat ungrouped list with no Archive control and nothing hidden. Courses with an empty or unparseable `term` are never dropped and never archived. Future-term courses are never archived. Only a course ranking *strictly below* the current term is archived — showing a course in the wrong bucket is recoverable, hiding it isn't.

## UI

The partition is applied to the "My courses" panel (which is also the mobile `courses` tab), the graph legend chips, the `CoursesKey` overlay, and `ManageCoursesModal`'s list. `CourseProgressRow` was extracted rather than copying that markup a third time. Archived rows route to `/gradebook?semester=<label>`, which the gradebook landing reads and preselects — so selecting an archived class lands in that semester's gradebook, per the acceptance criteria.

**The Calendar is untouched**, per the explicit product decision in the issue.

## Verification

| Gate | Result |
|---|---|
| `npm test` | **131 passing** (baseline 88) — 15 files, +43 tests |
| `npx tsc --noEmit` | 0 errors |
| `npx eslint . --max-warnings=-1` | exit 0, 36 warnings (baseline) |
| `npm run build` | exit 0, compiled successfully |

One thing worth flagging because it nearly shipped broken: fixing the `as any` removed the only `no-explicit-any` in `Landing.tsx`, which left a **stale entry in `eslint-suppressions.json`**. ESLint exits **2** on a stale suppression even with zero errors — `main` exits 0, this branch did not — so the lint gate would have failed CI. Pruned in its own commit.

## For the reviewer

1. Two files outside the intended scope got a one-line fixture addition each (`src/lib/data.test.ts`, `src/components/DocumentUploadModal.test.tsx`), forced by making `term` required on `EnrolledCourse`.
2. `Landing` reads `?semester=` from `window.location.search` in a `useState` initializer rather than `useSearchParams()`, which would require a `Suspense` boundary in the route shell this component doesn't own. It never reaches the rendered tree, so there's no hydration mismatch — but adding the boundary instead is a reasonable alternative.
3. The client's current-term rule is a hand-mirror of the Python one. Test fixtures are migration 0019's four terms verbatim so drift surfaces, but there is no automated cross-language check.
4. The knowledge graph still renders nodes from *all* terms — only the course lists and legends are term-scoped. Filtering graph data by term is a separate product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
