### PR TITLE
fix(dashboard): don't seed course name as tutor topic on node click (#319)

### DIFF
--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -24,7 +24,7 @@ import {
   type Assignment,
 } from "@/lib/api";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
-import { apiToGraphNode, type GraphNode, type GraphEdge } from "@/lib/data";
+import { apiToGraphNode, learnHrefForNode, type GraphNode, type GraphEdge } from "@/lib/data";
 import { partitionCurrentAndArchive } from "@/lib/semesters";
 import { IS_TEST_MODE, now } from "@/lib/testMode";
 
@@ -475,13 +475,7 @@ export function Dashboard() {
           width={size.w}
           height={size.h}
           highlightId={suggestNode?.id}
-          onNodeClick={(n) => {
-            const p = new URLSearchParams();
-            p.set("topic", n.name);
-            p.set("mode", "socratic");
-            if (n.course_id) p.set("course_id", n.course_id);
-            router.push(`/learn?${p.toString()}`);
-          }}
+          onNodeClick={(n) => router.push(learnHrefForNode(n))}
         />
         {/* Courses key — sidebar layout only. Top-nav layout uses the
             full My Courses panel in the left column instead. */}
@@ -1051,7 +1045,7 @@ export function Dashboard() {
             highlightId={suggestNode?.id}
             onNodeClick={(n) => {
               setFullscreen(false);
-              router.push(`/learn?topic=${encodeURIComponent(n.name)}&mode=socratic${n.course_id ? `&course_id=${encodeURIComponent(n.course_id)}` : ""}`);
+              router.push(learnHrefForNode(n));
             }}
           />
         </div>

--- a/frontend/src/components/screens/Tree.tsx
+++ b/frontend/src/components/screens/Tree.tsx
@@ -14,7 +14,7 @@ import { getGraph, getCourses, getSessions, deleteGraphNode, type EnrolledCourse
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
-import { apiToGraphNode, type GraphNode, type GraphEdge } from "@/lib/data";
+import { apiToGraphNode, learnHrefForNode, type GraphNode, type GraphEdge } from "@/lib/data";
 
 type Tier = "all" | "mastered" | "learning" | "struggling" | "unexplored";
 
@@ -132,9 +132,7 @@ export function Tree() {
     return n?.id;
   }, [suggest, nodes]);
 
-  const onLearn = (n: GraphNode) => router.push(
-    `/learn?topic=${encodeURIComponent(n.name)}&mode=socratic${n.course_id ? `&course_id=${encodeURIComponent(n.course_id)}` : ""}`,
-  );
+  const onLearn = (n: GraphNode) => router.push(learnHrefForNode(n));
   const onQuiz = (n: GraphNode) => router.push(
     `/quiz?topic=${encodeURIComponent(n.name)}${n.course_id ? `&course_id=${encodeURIComponent(n.course_id)}` : ""}`,
   );

--- a/frontend/src/components/screens/Tree.tsx
+++ b/frontend/src/components/screens/Tree.tsx
@@ -133,8 +133,12 @@ export function Tree() {
   }, [suggest, nodes]);
 
   const onLearn = (n: GraphNode) => router.push(learnHrefForNode(n));
+  // Subject-root (course) nodes have no single quiz topic — open the picker
+  // rather than seeding the course name (mirrors the tutor fix, #319). The
+  // Quiz screen only reads `topic`/`concept`, so the old `course_id` param was
+  // dead and is dropped.
   const onQuiz = (n: GraphNode) => router.push(
-    `/quiz?topic=${encodeURIComponent(n.name)}${n.course_id ? `&course_id=${encodeURIComponent(n.course_id)}` : ""}`,
+    n.is_subject_root ? "/quiz" : `/quiz?topic=${encodeURIComponent(n.name)}`,
   );
 
   const del = useConfirm(async () => {

--- a/frontend/src/lib/data.test.ts
+++ b/frontend/src/lib/data.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { apiToGraphNode, hashSeed, paletteFor } from "./data";
+import { apiToGraphNode, hashSeed, learnHrefForNode, paletteFor } from "./data";
 import type { GraphNode as ApiNode } from "./types";
 import type { EnrolledCourse } from "./api";
+import type { GraphNode } from "./data";
 
 function makeApiNode(over: Partial<ApiNode> = {}): ApiNode {
   return {
@@ -104,6 +105,61 @@ describe("apiToGraphNode color resolution", () => {
   it("remaps subject_root tier to mastered", () => {
     const n = makeApiNode({ mastery_tier: "subject_root", is_subject_root: true });
     expect(apiToGraphNode(n, []).mastery_tier).toBe("mastered");
+  });
+});
+
+function makeGraphNode(over: Partial<GraphNode> = {}): GraphNode {
+  return {
+    id: "n1",
+    name: "Eigenvalues",
+    subject: "Linear Algebra",
+    color: "#7a874f",
+    is_subject_root: false,
+    mastery_tier: "learning",
+    mastery_score: 0.5,
+    course_id: "c1",
+    ...over,
+  };
+}
+
+describe("learnHrefForNode", () => {
+  it("seeds the topic from a concept node's name", () => {
+    const href = learnHrefForNode(makeGraphNode({ name: "Eigenvalues" }));
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(params.get("topic")).toBe("Eigenvalues");
+    expect(params.get("mode")).toBe("socratic");
+    expect(params.get("course")).toBe("c1");
+  });
+
+  it("never sends a subject-root (course) node's name as the topic (#319)", () => {
+    const href = learnHrefForNode(
+      makeGraphNode({ name: "Linear Algebra", is_subject_root: true }),
+    );
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(params.has("topic")).toBe(false);
+    // Still scoped to the course so the tutor opens filtered to it.
+    expect(params.get("course")).toBe("c1");
+    expect(params.get("mode")).toBe("socratic");
+  });
+
+  it("scopes the course via the `course` param the Learn screen reads", () => {
+    // Regression guard: the old handlers passed `course_id`, which Learn
+    // (searchParams.get("course")) silently ignored, dropping course scope.
+    const href = learnHrefForNode(makeGraphNode({ course_id: "c42" }));
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(params.get("course")).toBe("c42");
+    expect(params.has("course_id")).toBe(false);
+  });
+
+  it("omits the course param when the node has no course_id", () => {
+    const href = learnHrefForNode(makeGraphNode({ course_id: "" }));
+    const params = new URLSearchParams(href.split("?")[1]);
+    expect(params.has("course")).toBe(false);
+  });
+
+  it("honors a non-default mode", () => {
+    const href = learnHrefForNode(makeGraphNode(), "flashcards");
+    expect(new URLSearchParams(href.split("?")[1]).get("mode")).toBe("flashcards");
   });
 });
 

--- a/frontend/src/lib/data.ts
+++ b/frontend/src/lib/data.ts
@@ -66,6 +66,26 @@ export type GraphEdge = {
   strength: number;
 };
 
+// Deep-link from a knowledge-graph node into the AI Tutor (`/learn`).
+//
+// Subject-root (course) nodes carry the *course* name, which must never be
+// sent as the session topic: doing so pre-selected the course name as a topic
+// on redirect (#319). For a course node we scope the tutor to the course and
+// leave the topic empty so the learner picks a concept; concept nodes seed
+// their own name as the topic. The course is passed as `course` — the param
+// the Learn screen reads (`searchParams.get("course")`); the earlier handlers
+// passed `course_id`, which Learn silently ignored, dropping course scope.
+export function learnHrefForNode(
+  n: Pick<GraphNode, "name" | "course_id" | "is_subject_root">,
+  mode = "socratic",
+): string {
+  const p = new URLSearchParams();
+  if (!n.is_subject_root) p.set("topic", n.name);
+  p.set("mode", mode);
+  if (n.course_id) p.set("course", n.course_id);
+  return `/learn?${p.toString()}`;
+}
+
 // Adapter from the backend `ApiNode` shape to the frontend `GraphNode`
 // shape consumed by `KnowledgeGraph`. Hoisted here from Tree/Learn/
 // Dashboard so the three screens share a single source of truth.


### PR DESCRIPTION
Closes #319.

## Problem
Clicking a **course node** on the homepage knowledge graph redirected to the AI Tutor with the **course name pre-filled as the session topic**. The node-click handlers unconditionally set `topic=n.name`; for a subject-root (course) node that name *is* the course.

## Fix
- New shared helper `learnHrefForNode(node)` in `frontend/src/lib/data.ts`:
  - **omits `topic`** for subject-root nodes → tutor opens scoped to the course with an empty topic picker so the learner chooses a concept;
  - seeds `topic=name` only for concept nodes.
- Wired into both `Dashboard.tsx` graph handlers (compact + fullscreen) and `Tree.tsx`'s "Learn this", replacing duplicated inline URL building.
- **Latent bug also fixed:** the handlers passed the course as `course_id`, but the Learn screen reads `searchParams.get("course")` — so course scope was silently dropped on every node click. The helper now passes `course`.

## Tests
- Added unit tests in `data.test.ts` (concept seeds topic; course node never does — #319 guard; scoping via `course` not `course_id`; param omitted with no course; custom mode).
- `tsc --noEmit` and `eslint` on changed files: clean.
- The vitest 4 suite can't start on the local Node v20.12.1 (pre-existing rolldown `styleText` incompatibility, unrelated), so the real compiled helper was verified end-to-end via `tsx` — all checks pass.

## Base
Stacked on `feat/semester-scoped-learning` (PR #360): the homepage-graph handlers this touches only exist in this form on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved navigation from knowledge graph concepts to the appropriate Learn experience.
  * Added support for preserving course context and selecting learning modes, including flashcards.
  * Updated quiz navigation so subject-level entries open the quiz directly, while specific concepts retain their topic.

* **Bug Fixes**
  * Standardized Learn links across dashboard and tree views for more reliable routing.

* **Tests**
  * Added coverage for topic, course, and learning-mode URL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->