### PR TITLE
fix(tree): don't seed course name as quiz topic on course-node click (#319)

### DIFF
--- a/frontend/src/components/screens/Tree.tsx
+++ b/frontend/src/components/screens/Tree.tsx
@@ -144,8 +144,12 @@ export function Tree() {
   const onLearn = (n: GraphNode) => router.push(
     `/learn?topic=${encodeURIComponent(n.name)}&mode=socratic${n.course_id ? `&course_id=${encodeURIComponent(n.course_id)}` : ""}`,
   );
+  // Subject-root (course) nodes have no single quiz topic — open the picker
+  // rather than seeding the course name (mirrors the tutor fix, #319). The
+  // Quiz screen only reads `topic`/`concept`, so the old `course_id` param was
+  // dead and is dropped.
   const onQuiz = (n: GraphNode) => router.push(
-    `/quiz?topic=${encodeURIComponent(n.name)}${n.course_id ? `&course_id=${encodeURIComponent(n.course_id)}` : ""}`,
+    n.is_subject_root ? "/quiz" : `/quiz?topic=${encodeURIComponent(n.name)}`,
   );
 
   const del = useConfirm(async () => {


### PR DESCRIPTION
Follow-up to #369 (the AI-Tutor fix for #319), on a separate branch.

## Context
The Tree detail panel's **"Quick quiz"** button ran `onQuiz` for any node, including subject-root (course) nodes, passing `topic=<course name>`.

Unlike the tutor, the Quiz screen resolves `topic` against the concept list **with subject-roots excluded** (`Quiz.tsx`), and `QuizPanel` only ever uses the resolved `initialConceptId` — it never reads the raw topic string. So the course name never actually became the quiz topic. This is **hygiene, not a user-facing leak**: the param was dead and misleading.

## Change (`Tree.tsx` only)
- Guard `onQuiz` so a course node opens the quiz picker with no seeded topic (mirrors the tutor behavior); concept nodes keep `topic=name`.
- Drop the `course_id` query param — the Quiz screen only reads `topic`/`concept`, so it was dead.

## Verification
- `tsc --noEmit` and `eslint src/components/screens/Tree.tsx`: clean.
- (vitest 4 can't start on the local Node v20.12.1 — pre-existing rolldown `styleText` incompatibility, unrelated.)

## Base
Stacked on `feat/semester-scoped-learning` (PR #360), same base as #369, since the `onQuiz` handler only exists on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)