### PR TITLE
fix(topnav): close open dropdown instantly when another tab is hovered (#320)

### DIFF
--- a/frontend/src/components/TopNav.test.tsx
+++ b/frontend/src/components/TopNav.test.tsx
@@ -166,6 +166,27 @@ describe("TopNav — dropdown behavior", () => {
     expect(screen.queryByText("Tutor")).toBeNull();
   });
 
+  it("closes the previously-open group when another opens (#320)", async () => {
+    // Regression for #320: only one group panel may be open at a time.
+    // Previously each trigger owned its own open-state, so opening a
+    // second group left the first one's panel lingering (two panels at
+    // once). Opening Community must immediately close Learn.
+    render(<TopNav />);
+    const learn = screen.getByRole("button", { name: /^Learn/ });
+    const community = screen.getByRole("button", { name: /^Community/ });
+
+    fireEvent.click(learn);
+    expect(screen.getByText("Tutor")).toBeTruthy();
+
+    fireEvent.click(community);
+    // Learn's panel is gone (no lingering second panel)...
+    expect(screen.queryByText("Tutor")).toBeNull();
+    expect(learn.getAttribute("aria-expanded")).toBe("false");
+    // ...and Community's panel is the only one showing.
+    expect(screen.getByText("Social")).toBeTruthy();
+    expect(community.getAttribute("aria-expanded")).toBe("true");
+  });
+
   it("renders the right items inside each group", async () => {
     const user = userEvent.setup();
     render(<TopNav />);

--- a/frontend/src/components/TopNav.test.tsx
+++ b/frontend/src/components/TopNav.test.tsx
@@ -187,6 +187,53 @@ describe("TopNav — dropdown behavior", () => {
     expect(community.getAttribute("aria-expanded")).toBe("true");
   });
 
+  it("dismisses an open panel on a click in the row's dead space", () => {
+    // The DesktopGroups row is flex:1, stretching across the header's blank
+    // strip. "Outside" must mean outside every trigger wrapper, not outside
+    // the row — a keyboard-opened panel (no hover timer armed) followed by a
+    // click in that strip used to stay stuck open.
+    render(<TopNav />);
+    const learn = screen.getByRole("button", { name: /^Learn/ });
+    fireEvent.focus(learn); // keyboard-style open: no close timer armed
+    expect(screen.getByText("Tutor")).toBeTruthy();
+
+    fireEvent.mouseDown(document.body); // dead space / anywhere off-wrapper
+    expect(screen.queryByText("Tutor")).toBeNull();
+    expect(learn.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("cancels a pending hover close-timer when another group opens (#320)", () => {
+    // The actual #320 mechanism: leaving Learn arms a 140ms close-timer;
+    // entering Community must (a) close Learn instantly and (b) cancel the
+    // stale timer so it cannot fire later against the shared openIndex and
+    // close Community.
+    vi.useFakeTimers();
+    try {
+      render(<TopNav />);
+      const learn = screen.getByRole("button", { name: /^Learn/ });
+      const community = screen.getByRole("button", { name: /^Community/ });
+      const learnWrapper = learn.closest("[data-nav-group]")!;
+      const communityWrapper = community.closest("[data-nav-group]")!;
+
+      fireEvent.mouseEnter(learnWrapper);
+      expect(screen.getByText("Tutor")).toBeTruthy();
+
+      fireEvent.mouseLeave(learnWrapper); // arms the 140ms close-timer
+      fireEvent.mouseEnter(communityWrapper); // pre-empts synchronously
+
+      // Learn closed instantly, Community open.
+      expect(screen.queryByText("Tutor")).toBeNull();
+      expect(screen.getByText("Social")).toBeTruthy();
+
+      // The stale timer must NOT fire and close Community.
+      vi.advanceTimersByTime(300);
+      expect(screen.getByText("Social")).toBeTruthy();
+      expect(community.getAttribute("aria-expanded")).toBe("true");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("renders the right items inside each group", async () => {
     const user = userEvent.setup();
     render(<TopNav />);

--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -198,13 +198,7 @@ export function TopNav() {
       </Link>
 
       {/* Desktop group row — hover/focus reveals each group's items */}
-      {!isMobile && (
-        <div style={{ display: "flex", alignItems: "center", gap: 4, flex: 1, minWidth: 0 }}>
-          {GROUPS.map((g) => (
-            <NavGroupTrigger key={g.label} group={g} pathname={pathname} />
-          ))}
-        </div>
-      )}
+      {!isMobile && <DesktopGroups pathname={pathname} />}
 
       <div style={{ marginLeft: isMobile ? "auto" : 0, display: "flex", alignItems: "center", gap: 8 }}>
         {isAuthenticated && (
@@ -259,19 +253,27 @@ export function TopNav() {
 }
 
 /**
- * NavGroupTrigger — one of the four top-level group buttons.
+ * DesktopGroups — the horizontal row of group triggers.
  *
- * Hover (or focus) opens a panel anchored to the trigger; mouse-leave
- * with a short delay closes it. The delay (140ms) is deliberate: the
- * trigger and panel touch but a bare 0px gap can still flicker on
- * sub-pixel cursor moves, so we let the close animation tolerate
- * cursor jitter while the user travels from label to item.
+ * Owns a SINGLE `openIndex` for the whole row so that at most one group
+ * panel is ever open. This is the fix for #320: previously each trigger
+ * kept its own open-state and its own close-timer, so moving the cursor
+ * from tab A to tab B cancelled only B's timer — A's 140ms timer kept
+ * A's panel open, briefly showing two panels at once and leaving the
+ * old one lingering. With a shared owner, entering any tab immediately
+ * preempts whichever tab was open (openIndex is replaced synchronously),
+ * so switching tabs closes the old panel with no delay.
+ *
+ * The 140ms close-delay is retained but now only applies when the cursor
+ * leaves the row entirely (to empty space) — its original purpose: the
+ * trigger and panel touch, but a bare 0px gap can still flicker on
+ * sub-pixel cursor moves, so the delay tolerates jitter as the cursor
+ * travels from label to item.
  */
-function NavGroupTrigger({ group, pathname }: { group: NavGroup; pathname: string }) {
-  const active = isActiveGroup(pathname, group);
-  const [open, setOpen] = React.useState(false);
+function DesktopGroups({ pathname }: { pathname: string }) {
+  const [openIndex, setOpenIndex] = React.useState<number | null>(null);
   const closeTimer = React.useRef<number | null>(null);
-  const wrapperRef = React.useRef<HTMLDivElement | null>(null);
+  const rowRef = React.useRef<HTMLDivElement | null>(null);
 
   const cancelClose = () => {
     if (closeTimer.current !== null) {
@@ -279,33 +281,41 @@ function NavGroupTrigger({ group, pathname }: { group: NavGroup; pathname: strin
       closeTimer.current = null;
     }
   };
+  // Open a specific group, pre-empting any other open group and any
+  // pending close. Because this replaces openIndex synchronously, the
+  // previously-open panel closes the instant the cursor reaches a new
+  // tab — no two panels can coexist.
+  const openGroup = (i: number) => {
+    cancelClose();
+    setOpenIndex(i);
+  };
+  const closeNow = () => {
+    cancelClose();
+    setOpenIndex(null);
+  };
   const scheduleClose = () => {
     cancelClose();
-    closeTimer.current = window.setTimeout(() => setOpen(false), 140);
+    closeTimer.current = window.setTimeout(() => setOpenIndex(null), 140);
   };
 
-  // Cancel any pending close-timer if this component unmounts mid-flight
-  // (e.g. route change while the dropdown is closing). Avoids a stray
-  // setState on an unmounted component.
-  React.useEffect(() => {
-    return () => cancelClose();
-  }, []);
+  // Cancel any pending close-timer on unmount (e.g. route change while
+  // the dropdown is closing). Avoids a stray setState after unmount.
+  React.useEffect(() => cancelClose, []);
 
   // Close when route changes (navigation triggered).
   React.useEffect(() => {
-    setOpen(false);
+    closeNow();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
 
-  // Click outside / Escape closes.
+  // Click outside the row / Escape closes the open panel.
   React.useEffect(() => {
-    if (!open) return;
+    if (openIndex === null) return;
     const onClick = (e: MouseEvent) => {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      if (rowRef.current && !rowRef.current.contains(e.target as Node)) closeNow();
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") closeNow();
     };
     document.addEventListener("mousedown", onClick);
     document.addEventListener("keydown", onKey);
@@ -313,13 +323,57 @@ function NavGroupTrigger({ group, pathname }: { group: NavGroup; pathname: strin
       document.removeEventListener("mousedown", onClick);
       document.removeEventListener("keydown", onKey);
     };
-  }, [open]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openIndex]);
+
+  return (
+    <div ref={rowRef} style={{ display: "flex", alignItems: "center", gap: 4, flex: 1, minWidth: 0 }}>
+      {GROUPS.map((g, i) => (
+        <NavGroupTrigger
+          key={g.label}
+          group={g}
+          pathname={pathname}
+          open={openIndex === i}
+          onOpen={() => openGroup(i)}
+          onScheduleClose={scheduleClose}
+          onClose={closeNow}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * NavGroupTrigger — one of the four top-level group buttons.
+ *
+ * Presentational + interaction only; the open-state lives in the parent
+ * DesktopGroups so the row can enforce "at most one panel open" (#320).
+ * Hover/focus asks the parent to open this group; mouse-leave asks it to
+ * schedule a close; focus leaving the wrapper closes immediately.
+ */
+function NavGroupTrigger({
+  group,
+  pathname,
+  open,
+  onOpen,
+  onScheduleClose,
+  onClose,
+}: {
+  group: NavGroup;
+  pathname: string;
+  open: boolean;
+  onOpen: () => void;
+  onScheduleClose: () => void;
+  onClose: () => void;
+}) {
+  const active = isActiveGroup(pathname, group);
+  const wrapperRef = React.useRef<HTMLDivElement | null>(null);
 
   return (
     <div
       ref={wrapperRef}
-      onMouseEnter={() => { cancelClose(); setOpen(true); }}
-      onMouseLeave={scheduleClose}
+      onMouseEnter={onOpen}
+      onMouseLeave={onScheduleClose}
       // Symmetric counterpart to onFocus opening the panel: when focus
       // leaves the wrapper entirely (Tab past the last item), close.
       // relatedTarget can be null when focus jumps to a non-focusable
@@ -327,7 +381,7 @@ function NavGroupTrigger({ group, pathname }: { group: NavGroup; pathname: strin
       onBlur={(e) => {
         const next = e.relatedTarget as Node | null;
         if (!wrapperRef.current || !next || !wrapperRef.current.contains(next)) {
-          setOpen(false);
+          onClose();
         }
       }}
       style={{ position: "relative" }}
@@ -336,8 +390,8 @@ function NavGroupTrigger({ group, pathname }: { group: NavGroup; pathname: strin
         type="button"
         aria-haspopup="true"
         aria-expanded={open}
-        onClick={() => setOpen((o) => !o)}
-        onFocus={() => { cancelClose(); setOpen(true); }}
+        onClick={() => (open ? onClose() : onOpen())}
+        onFocus={onOpen}
         style={{
           display: "inline-flex",
           alignItems: "center",

--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -273,7 +273,6 @@ export function TopNav() {
 function DesktopGroups({ pathname }: { pathname: string }) {
   const [openIndex, setOpenIndex] = React.useState<number | null>(null);
   const closeTimer = React.useRef<number | null>(null);
-  const rowRef = React.useRef<HTMLDivElement | null>(null);
 
   const cancelClose = () => {
     if (closeTimer.current !== null) {
@@ -312,7 +311,12 @@ function DesktopGroups({ pathname }: { pathname: string }) {
   React.useEffect(() => {
     if (openIndex === null) return;
     const onClick = (e: MouseEvent) => {
-      if (rowRef.current && !rowRef.current.contains(e.target as Node)) closeNow();
+      // "Outside" means outside every trigger wrapper (+ its panel), NOT
+      // outside rowRef: the row is flex:1 and stretches across the header's
+      // blank strip, so a row-bounds check would swallow clicks in that dead
+      // space and leave a keyboard-opened panel (no hover timer armed) stuck.
+      const target = e.target as Element | null;
+      if (!target?.closest?.("[data-nav-group]")) closeNow();
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") closeNow();
@@ -327,7 +331,7 @@ function DesktopGroups({ pathname }: { pathname: string }) {
   }, [openIndex]);
 
   return (
-    <div ref={rowRef} style={{ display: "flex", alignItems: "center", gap: 4, flex: 1, minWidth: 0 }}>
+    <div style={{ display: "flex", alignItems: "center", gap: 4, flex: 1, minWidth: 0 }}>
       {GROUPS.map((g, i) => (
         <NavGroupTrigger
           key={g.label}
@@ -372,6 +376,7 @@ function NavGroupTrigger({
   return (
     <div
       ref={wrapperRef}
+      data-nav-group
       onMouseEnter={onOpen}
       onMouseLeave={onScheduleClose}
       // Symmetric counterpart to onFocus opening the panel: when focus


### PR DESCRIPTION
Closes #320.

## Problem
Hovering slightly outside a top-nav tab (or moving from one tab to another) left the tab's subcategory panel open instead of closing, and could briefly show **two panels at once**.

## Root cause
Each `NavGroupTrigger` owned its own `open` state **and** its own 140ms close-timer. Moving the cursor from tab A to tab B fired B's `onMouseEnter`, which cancelled only *B's* timer — A's 140ms timer kept A's panel open, so both were visible during the overlap and the old one lingered.

## Fix
Lift the open-state into a single `DesktopGroups` owner tracking one `openIndex` for the whole row. Entering any tab replaces `openIndex` synchronously, so the previously-open panel closes the instant the cursor reaches a new tab — at most one panel is ever open. Click-outside / Escape / route-change closing move up to the same owner. The 140ms grace delay is kept but now only applies when the cursor leaves the row entirely (its original anti-flicker purpose for the trigger↔panel handoff).

## Testing
- Added a regression test asserting opening a second group closes the first (`no lingering second panel`).
- `tsc --noEmit`: clean. `eslint`: 0 errors.
- Note: the local `vitest run` could not execute in this environment — vitest 4 + rolldown require Node 22 (per `.nvmrc`) and this machine has Node 20.12; CI runs on Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop navigation dropdown behavior so only one group panel remains open at a time.
  * Opening a different group now immediately closes the previously open panel.
  * Clicking outside a navigation group, pressing Escape, or changing pages closes open panels.
  * Fixed delayed hover behavior that could incorrectly close a newly opened panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->