### PR TITLE
fix(calendar): animate view switch instead of snapping (#295)

### DIFF
--- a/frontend/src/components/screens/Calendar.test.tsx
+++ b/frontend/src/components/screens/Calendar.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+/**
+ * Component tests for the Calendar view switch (#295).
+ *
+ * The fix wraps the calendar body in `AnimatePresence` + a keyed
+ * `motion.div` so switching Month/Week/Day/Table crossfades instead of
+ * snapping. Animation itself isn't asserted here — framer-motion is
+ * stubbed to a passthrough so assertions don't race the real 220ms
+ * transition. What these tests guard is the behavior the wrapper must
+ * preserve: the correct view renders for each toggle state, the loading
+ * skeleton still shows first, and nothing leaks between views.
+ *
+ * Unique per-view markers used below (with zero assignments):
+ *   - Month  : weekday header row ("Mon".."Sun"), and NO em-dash filler.
+ *   - Week   : an em-dash (U+2014) filler in each empty day cell.
+ *   - Day    : "Nothing scheduled." empty state.
+ *   - Table  : a real <table> + "No assignments yet." empty row.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+const EM_DASH = "—"; // WeekView's empty-day filler
+
+// Passthrough framer-motion so the keyed body renders synchronously.
+type Kids = { children?: React.ReactNode };
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: Kids) => <>{children}</>,
+  motion: new Proxy(
+    {},
+    { get: () => ({ children }: Kids) => <div>{children}</div> },
+  ),
+  useReducedMotion: () => false,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => ({ userId: "u1", userReady: true }),
+}));
+
+vi.mock("../ToastProvider", () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock("@/lib/useConfirm", () => ({
+  useConfirm: () => ({ armed: false, trigger: vi.fn(), reset: vi.fn() }),
+}));
+
+vi.mock("@/lib/useScrollLock", () => ({ useScrollLock: () => {} }));
+
+vi.mock("../Icon", () => ({
+  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+}));
+
+vi.mock("../CustomSelect", () => ({
+  CustomSelect: ({ value }: { value?: string }) => (
+    <div data-testid="custom-select">{value}</div>
+  ),
+}));
+
+vi.mock("../DocumentUploadModal", () => ({ DocumentUploadModal: () => null }));
+
+vi.mock("../Skeleton", () => ({
+  CalendarMonthSkeleton: () => <div data-testid="calendar-skeleton" />,
+}));
+
+// TopBar just needs to surface `actions` (which hold the view Toggle) and
+// the subtitle so the test can drive and inspect the switch.
+vi.mock("../TopBar", () => ({
+  TopBar: ({ subtitle, actions }: { subtitle?: React.ReactNode; actions?: React.ReactNode }) => (
+    <div>
+      <div data-testid="subtitle">{subtitle}</div>
+      <div data-testid="actions">{actions}</div>
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getAllAssignments: vi.fn(() => Promise.resolve({ assignments: [] })),
+  getCourses: vi.fn(() => Promise.resolve({ courses: [] })),
+  getCalendarStatus: vi.fn(() => Promise.resolve({ connected: false })),
+  disconnectCalendar: vi.fn(),
+  syncCalendar: vi.fn(),
+  calendarAuthUrl: vi.fn(() => "#"),
+  updateAssignment: vi.fn(),
+  deleteAssignment: vi.fn(),
+  importGoogleEvents: vi.fn(),
+  exportToGoogleCalendar: vi.fn(),
+}));
+
+import { Calendar } from "./Calendar";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const clickView = (label: string) =>
+  fireEvent.click(screen.getByRole("button", { name: label }));
+
+describe("Calendar — loading", () => {
+  it("shows the skeleton before data loads, then the month grid", async () => {
+    render(<Calendar />);
+    // Before the load promise resolves, the skeleton is the keyed body.
+    expect(screen.getByTestId("calendar-skeleton")).toBeInTheDocument();
+    // Once loaded it crossfades to the default Month view.
+    await waitFor(() => expect(screen.getByText("Mon")).toBeInTheDocument());
+    expect(screen.queryByTestId("calendar-skeleton")).toBeNull();
+  });
+});
+
+describe("Calendar — view switch (#295)", () => {
+  const loaded = async () => {
+    render(<Calendar />);
+    await waitFor(() => expect(screen.getByText("Mon")).toBeInTheDocument());
+  };
+
+  it("defaults to the Month view", async () => {
+    await loaded();
+    // Month header is present; the week/day/table markers are not.
+    expect(screen.getByText("Sun")).toBeInTheDocument();
+    expect(screen.queryByText(EM_DASH)).toBeNull();
+    expect(screen.queryByText("Nothing scheduled.")).toBeNull();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("switches to the Week view", async () => {
+    await loaded();
+    clickView("Week");
+    // Empty week renders an em-dash filler in each of the 7 day cells.
+    const fillers = await screen.findAllByText(EM_DASH);
+    expect(fillers.length).toBe(7);
+    expect(screen.queryByRole("table")).toBeNull();
+    expect(screen.queryByText("Nothing scheduled.")).toBeNull();
+  });
+
+  it("switches to the Day view", async () => {
+    await loaded();
+    clickView("Day");
+    expect(await screen.findByText("Nothing scheduled.")).toBeInTheDocument();
+    expect(screen.queryByText(EM_DASH)).toBeNull();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("switches to the Table view", async () => {
+    await loaded();
+    clickView("Table");
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+    expect(screen.getByText("No assignments yet.")).toBeInTheDocument();
+    expect(screen.getByTestId("subtitle")).toHaveTextContent("All assignments");
+  });
+
+  it("does not leak the previous view's body when switching (no double-render)", async () => {
+    await loaded();
+    clickView("Day");
+    expect(await screen.findByText("Nothing scheduled.")).toBeInTheDocument();
+    // Switching away must remove the Day body entirely.
+    clickView("Month");
+    await waitFor(() => expect(screen.queryByText("Nothing scheduled.")).toBeNull());
+    expect(screen.getByText("Mon")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/screens/Calendar.tsx
+++ b/frontend/src/components/screens/Calendar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { TopBar } from "../TopBar";
 import { Icon } from "../Icon";
 import { useScrollLock } from "@/lib/useScrollLock";
@@ -69,6 +70,10 @@ export function Calendar() {
   const search = useSearchParams();
   const toast = useToast();
   const { userId, userReady } = useUser();
+  // Disable the view-swap fade/slide for users who ask for reduced motion.
+  // The global CSS reduced-motion rule only neutralises CSS transitions;
+  // framer's JS-driven animations need this explicit opt-out.
+  const prefersReduced = useReducedMotion();
 
   const [assignments, setAssignments] = React.useState<Assignment[]>([]);
   const [courses, setCourses] = React.useState<EnrolledCourse[]>([]);
@@ -250,21 +255,38 @@ export function Calendar() {
         actions={topActions}
       />
 
-      {loading && <CalendarMonthSkeleton />}
-      {!loading && view === "month" && <MonthView cursor={cursor} byDate={byDate} today={today} courses={courses} />}
-      {!loading && view === "week" && <WeekView cursor={cursor} byDate={byDate} today={today} courses={courses} />}
-      {!loading && view === "day" && <DayView cursor={cursor} byDate={byDate} courses={courses} />}
-      {!loading && view === "table" && (
-        <AssignmentTable
-          assignments={assignments}
-          courses={courses}
-          selected={selected}
-          onSelectedChange={setSelected}
-          onExport={exportCsv}
-          onReload={load}
-          googleConnected={googleConnected}
-        />
-      )}
+      {/* Crossfade/slide the calendar body when the view (or load state)
+          changes, keyed on that state. Mirrors Study.tsx's mode="wait"
+          pattern so the swap settles instead of snapping (#295). */}
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          key={loading ? "loading" : view}
+          initial={prefersReduced ? false : { opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={prefersReduced ? { opacity: 1 } : { opacity: 0, y: -8 }}
+          transition={{ duration: prefersReduced ? 0 : 0.22, ease: [0.2, 0.85, 0.35, 1] }}
+        >
+          {loading ? (
+            <CalendarMonthSkeleton />
+          ) : view === "month" ? (
+            <MonthView cursor={cursor} byDate={byDate} today={today} courses={courses} />
+          ) : view === "week" ? (
+            <WeekView cursor={cursor} byDate={byDate} today={today} courses={courses} />
+          ) : view === "day" ? (
+            <DayView cursor={cursor} byDate={byDate} courses={courses} />
+          ) : (
+            <AssignmentTable
+              assignments={assignments}
+              courses={courses}
+              selected={selected}
+              onSelectedChange={setSelected}
+              onExport={exportCsv}
+              onReload={load}
+              googleConnected={googleConnected}
+            />
+          )}
+        </motion.div>
+      </AnimatePresence>
 
       <DocumentUploadModal
         open={uploadOpen}

--- a/frontend/src/components/screens/Calendar.tsx
+++ b/frontend/src/components/screens/Calendar.tsx
@@ -1,7 +1,15 @@
 "use client";
 import React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { AnimatePresence, motion, MotionGlobalConfig, useReducedMotion } from "framer-motion";
+import { IS_TEST_MODE } from "@/lib/testMode";
+
+// Deterministic DOM for browser tests (#383): framer-motion's own test
+// seam jumps every animation straight to its final keyframe. No-op in
+// production builds (flag inlined to false at build time). Same gate as
+// Study.tsx / HowItWorks.tsx — the flag is module-side-effect scoped, so
+// every framer-motion consumer must set it for direct-navigation runs.
+if (IS_TEST_MODE) MotionGlobalConfig.skipAnimations = true;
 import { TopBar } from "../TopBar";
 import { Icon } from "../Icon";
 import { useScrollLock } from "@/lib/useScrollLock";


### PR DESCRIPTION
Closes #295.

## Problem
Switching between the Calendar views (**Month / Week / Day / Table**) was a jarring, instant hard swap. The body rendered each view as a plain conditional with no transition wrapper (`Calendar.tsx`), and because the four layouts have very different heights, content and page height snapped between states.

## Fix
Wrap the calendar body in `AnimatePresence mode="wait"` + a keyed `motion.div`, mirroring the in-repo precedent already used by `Study.tsx` (fade + small slide, `opacity`/`y`). The body is keyed on the current state (`loading ? "loading" : view`), so:

- switching views crossfades instead of snapping, and the height change now happens during the low-opacity window rather than under fully-opaque content;
- the initial skeleton → month load also crossfades in.

`prefers-reduced-motion` is honored via framer's `useReducedMotion` — the fade/slide collapses to an instant swap. This is needed because the global CSS reduced-motion rule (`globals.css`) only neutralizes CSS transitions, not framer's JS-driven animations.

No behavioral change to any view's contents — only the swap is wrapped.

## Tests
Adds `Calendar.test.tsx` (vitest + jsdom, framer stubbed to a passthrough so assertions don't race the 220ms animation):

- shows the loading skeleton first, then crossfades to the default Month view;
- each of Month/Week/Day/Table renders its own body on toggle;
- no previous-view content leaks after a switch (guards the `mode="wait"` single-child invariant).

### Verification
- `vitest run` — **94 passed** (13 files), including the 6 new cases
- `tsc --noEmit` — clean
- `eslint .` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar view transitions now provide smoother visual feedback when switching between Month, Week, Day, and Table views.
  * Animations automatically reduce or disable motion according to the device’s accessibility preferences.

* **Tests**
  * Added coverage for calendar loading, view switching, empty states, and prevention of stale content appearing between views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->