### PR TITLE
feat(observability): admin analytics + cost API /api/admin/analytics (#120)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ logging.basicConfig(
 from routes import graph, learn, quiz, calendar, social, extract, auth, documents, flashcards, study_guide, feedback, careers, onboarding, gradebook, gradescope, notes, academics
 from routes.profile import router as profile_router
 from routes.admin import router as admin_router
+from routes.admin_analytics import router as admin_analytics_router
 from routes.newsletter import router as newsletter_router
 from services.logfire_scrubber import EXTRA_PATTERNS, scrub_value
 from services.request_context import RequestIDMiddleware, current_request_id
@@ -168,6 +169,7 @@ app.include_router(careers.router,     prefix="/api/careers")
 app.include_router(onboarding.router,  prefix="/api/onboarding")
 app.include_router(profile_router,     prefix="/api/profile")
 app.include_router(admin_router,       prefix="/api/admin")
+app.include_router(admin_analytics_router, prefix="/api/admin/analytics")
 app.include_router(newsletter_router,  prefix="/api/newsletter")
 app.include_router(gradebook.router,   prefix="/api/gradebook")
 app.include_router(gradescope.router,  prefix="/api/gradescope")

--- a/backend/routes/admin_analytics.py
+++ b/backend/routes/admin_analytics.py
@@ -1,0 +1,349 @@
+"""Admin-only, read-only analytics + cost-rollup API (issue #120).
+
+Turns the `events` and `llm_usage` tables (written by services/events_service.py,
+#116/#118) into usage summaries, per-user rollups, LLM cost breakdowns, and an
+error feed. Mounted at `/api/admin/analytics`; every endpoint is gated by
+`require_admin`. Read-only — no mutation endpoints.
+
+Aggregation strategy: PostgREST (via `db/connection.py::table()`) has no
+GROUP BY, so the grouped endpoints scan the (date-bounded) rows and aggregate
+in Python. Scans page through `select_with_count` and use its exact count both
+to know when to stop and to detect the rare truncation case (logged, never
+silent). The `/errors` feed needs no aggregation, so it paginates server-side.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+from fastapi import APIRouter, Query, Request
+from pydantic import BaseModel
+
+from db.connection import table
+from services.auth_guard import require_admin
+
+logger = logging.getLogger("sapling.admin_analytics")
+
+router = APIRouter()
+
+# Page size for range scans, and a hard ceiling so a pathological range can't
+# pull unbounded rows into memory. Hitting the cap is logged, never silent.
+_PAGE = 1000
+_SCAN_CAP = 100_000
+
+GroupBy = Literal["user", "feature", "model"]
+_GROUP_COLUMN = {"user": "user_id", "feature": "feature", "model": "model"}
+
+
+# ── Response models ──────────────────────────────────────────────────────────
+
+
+class Range(BaseModel):
+    from_: str
+    to: str
+
+
+class EventTypeCount(BaseModel):
+    event_type: str
+    count: int
+
+
+class UsageSummary(BaseModel):
+    range: Range
+    total_events: int
+    distinct_active_users: int
+    by_event_type: list[EventTypeCount]
+
+
+class UserUsage(BaseModel):
+    user_id: str
+    event_count: int
+    by_category: dict[str, int]
+    llm_cost_usd: float
+    total_tokens: int
+
+
+class UsageByUser(BaseModel):
+    range: Range
+    total_users: int
+    limit: int
+    offset: int
+    users: list[UserUsage]
+
+
+class CostRow(BaseModel):
+    key: str
+    calls: int
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    cost_usd: float
+
+
+class CostTotals(BaseModel):
+    calls: int
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    cost_usd: float
+
+
+class LLMCost(BaseModel):
+    range: Range
+    group_by: GroupBy
+    rows: list[CostRow]
+    totals: CostTotals
+
+
+class ErrorEvent(BaseModel):
+    created_at: str | None
+    event_type: str
+    request_id: str | None
+    user_id: str | None
+    path: str | None
+    method: str | None
+    status_code: int | None
+    duration_ms: float | None
+
+
+class ErrorsPage(BaseModel):
+    range: Range
+    total: int
+    limit: int
+    offset: int
+    errors: list[ErrorEvent]
+
+
+# ── Date range helpers ───────────────────────────────────────────────────────
+
+
+def _resolve_range(from_: str | None, to: str | None) -> tuple[str, str]:
+    """Default to the last 30 days; echo caller-supplied ISO bounds otherwise."""
+    now = datetime.now(timezone.utc)
+    to_iso = to or now.isoformat()
+    from_iso = from_ or (now - timedelta(days=30)).isoformat()
+    return from_iso, to_iso
+
+
+def _scan_range(
+    table_name: str, columns: str, from_iso: str, to_iso: str,
+    extra_filters: dict | None = None,
+) -> list[dict]:
+    """Fetch every row in [from, to] for a table, paging via select_with_count.
+
+    Aggregation endpoints need the full (date-bounded) set — PostgREST won't
+    GROUP BY for us — so we page to completion rather than relying on the
+    server's default row cap. A range large enough to hit _SCAN_CAP is logged.
+    """
+    out: list[dict] = []
+    offset = 0
+    while True:
+        filters: dict = {"created_at": [f"gte.{from_iso}", f"lte.{to_iso}"]}
+        if extra_filters:
+            filters.update(extra_filters)
+        rows, total = table(table_name).select_with_count(
+            columns, filters=filters, order="created_at.asc", limit=_PAGE, offset=offset,
+        )
+        out.extend(rows)
+        if len(out) >= total or not rows:
+            break
+        if len(out) >= _SCAN_CAP:
+            logger.warning(
+                "admin_analytics scan hit cap %d on %r (total=%d); results truncated",
+                _SCAN_CAP, table_name, total,
+            )
+            break
+        offset += _PAGE
+    return out
+
+
+def _as_float(value) -> float:
+    try:
+        return float(value) if value is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _as_int(value) -> int:
+    try:
+        return int(value) if value is not None else 0
+    except (TypeError, ValueError):
+        return 0
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+
+@router.get("/usage/summary", response_model=UsageSummary)
+def usage_summary(
+    request: Request,
+    from_: str | None = Query(None, alias="from"),
+    to: str | None = Query(None),
+) -> UsageSummary:
+    require_admin(request)
+    from_iso, to_iso = _resolve_range(from_, to)
+    rows = _scan_range("events", "event_type,user_id,created_at", from_iso, to_iso)
+
+    by_type: dict[str, int] = defaultdict(int)
+    users: set[str] = set()
+    for r in rows:
+        by_type[r.get("event_type") or ""] += 1
+        if r.get("user_id"):
+            users.add(r["user_id"])
+
+    return UsageSummary(
+        range=Range(from_=from_iso, to=to_iso),
+        total_events=len(rows),
+        distinct_active_users=len(users),
+        by_event_type=sorted(
+            (EventTypeCount(event_type=k, count=v) for k, v in by_type.items()),
+            key=lambda e: e.count, reverse=True,
+        ),
+    )
+
+
+@router.get("/usage/by-user", response_model=UsageByUser)
+def usage_by_user(
+    request: Request,
+    from_: str | None = Query(None, alias="from"),
+    to: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> UsageByUser:
+    require_admin(request)
+    from_iso, to_iso = _resolve_range(from_, to)
+
+    event_rows = _scan_range("events", "user_id,category,created_at", from_iso, to_iso)
+    usage_rows = _scan_range(
+        "llm_usage", "user_id,cost_usd,total_tokens,created_at", from_iso, to_iso,
+    )
+
+    agg: dict[str, dict] = defaultdict(
+        lambda: {"event_count": 0, "by_category": defaultdict(int), "llm_cost_usd": 0.0, "total_tokens": 0},
+    )
+    for r in event_rows:
+        uid = r.get("user_id")
+        if not uid:
+            continue
+        a = agg[uid]
+        a["event_count"] += 1
+        a["by_category"][r.get("category") or ""] += 1
+    for r in usage_rows:
+        uid = r.get("user_id")
+        if not uid:
+            continue
+        a = agg[uid]
+        a["llm_cost_usd"] += _as_float(r.get("cost_usd"))
+        a["total_tokens"] += _as_int(r.get("total_tokens"))
+
+    # Sort by spend then activity so the most expensive users surface first.
+    ordered = sorted(
+        agg.items(),
+        key=lambda kv: (kv[1]["llm_cost_usd"], kv[1]["event_count"]),
+        reverse=True,
+    )
+    page = ordered[offset:offset + limit]
+    users = [
+        UserUsage(
+            user_id=uid,
+            event_count=a["event_count"],
+            by_category=dict(a["by_category"]),
+            llm_cost_usd=round(a["llm_cost_usd"], 6),
+            total_tokens=a["total_tokens"],
+        )
+        for uid, a in page
+    ]
+    return UsageByUser(
+        range=Range(from_=from_iso, to=to_iso),
+        total_users=len(ordered), limit=limit, offset=offset, users=users,
+    )
+
+
+@router.get("/llm/cost", response_model=LLMCost)
+def llm_cost(
+    request: Request,
+    from_: str | None = Query(None, alias="from"),
+    to: str | None = Query(None),
+    group_by: GroupBy = Query("feature"),
+) -> LLMCost:
+    require_admin(request)
+    from_iso, to_iso = _resolve_range(from_, to)
+    column = _GROUP_COLUMN[group_by]
+    rows = _scan_range(
+        "llm_usage",
+        f"{column},prompt_tokens,completion_tokens,total_tokens,cost_usd,created_at",
+        from_iso, to_iso,
+    )
+
+    buckets: dict[str, dict] = defaultdict(
+        lambda: {"calls": 0, "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost_usd": 0.0},
+    )
+    for r in rows:
+        key = r.get(column)
+        b = buckets["" if key is None else str(key)]
+        b["calls"] += 1
+        b["prompt_tokens"] += _as_int(r.get("prompt_tokens"))
+        b["completion_tokens"] += _as_int(r.get("completion_tokens"))
+        b["total_tokens"] += _as_int(r.get("total_tokens"))
+        b["cost_usd"] += _as_float(r.get("cost_usd"))
+
+    cost_rows = sorted(
+        (
+            CostRow(
+                key=k, calls=b["calls"],
+                prompt_tokens=b["prompt_tokens"], completion_tokens=b["completion_tokens"],
+                total_tokens=b["total_tokens"], cost_usd=round(b["cost_usd"], 6),
+            )
+            for k, b in buckets.items()
+        ),
+        key=lambda c: c.cost_usd, reverse=True,
+    )
+    totals = CostTotals(
+        calls=sum(c.calls for c in cost_rows),
+        prompt_tokens=sum(c.prompt_tokens for c in cost_rows),
+        completion_tokens=sum(c.completion_tokens for c in cost_rows),
+        total_tokens=sum(c.total_tokens for c in cost_rows),
+        cost_usd=round(sum(c.cost_usd for c in cost_rows), 6),
+    )
+    return LLMCost(
+        range=Range(from_=from_iso, to=to_iso), group_by=group_by,
+        rows=cost_rows, totals=totals,
+    )
+
+
+@router.get("/errors", response_model=ErrorsPage)
+def errors(
+    request: Request,
+    from_: str | None = Query(None, alias="from"),
+    to: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> ErrorsPage:
+    require_admin(request)
+    from_iso, to_iso = _resolve_range(from_, to)
+    # error.* events, newest first — paginated server-side (no aggregation).
+    rows, total = table("events").select_with_count(
+        "created_at,event_type,request_id,user_id,payload",
+        filters={"created_at": [f"gte.{from_iso}", f"lte.{to_iso}"], "event_type": "like.error.*"},
+        order="created_at.desc", limit=limit, offset=offset,
+    )
+    items = []
+    for r in rows:
+        payload = r.get("payload") or {}
+        items.append(ErrorEvent(
+            created_at=r.get("created_at"),
+            event_type=r.get("event_type") or "",
+            request_id=r.get("request_id"),
+            user_id=r.get("user_id"),
+            path=payload.get("path"),
+            method=payload.get("method"),
+            status_code=payload.get("status_code"),
+            duration_ms=payload.get("duration_ms"),
+        ))
+    return ErrorsPage(
+        range=Range(from_=from_iso, to=to_iso),
+        total=total, limit=limit, offset=offset, errors=items,
+    )

--- a/backend/tests/test_admin_analytics_routes.py
+++ b/backend/tests/test_admin_analytics_routes.py
@@ -1,0 +1,233 @@
+"""Tests for routes/admin_analytics.py — the admin cost-rollup / analytics API
+(issue #120).
+
+A small but faithful fake of the PostgREST `table()` seam interprets the
+`eq.`/`gte.`/`lte.`/`like.` filters, ordering, and limit/offset that the route
+builds, so date-range filtering, aggregation, and pagination are exercised for
+real (not mocked away).
+"""
+from __future__ import annotations
+
+import fnmatch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+import routes.admin_analytics as analytics
+
+client = TestClient(app)
+
+BASE = "/api/admin/analytics"
+
+# In-range = July 2026; OUT = 2020. Default range is last 30 days from today
+# (2026-07-21 per the test clock), so the July rows are in the default window.
+IN1 = "2026-07-10T09:00:00+00:00"
+IN2 = "2026-07-12T09:00:00+00:00"
+IN3 = "2026-07-15T09:00:00+00:00"
+OUT = "2020-01-01T00:00:00+00:00"
+
+
+def _seed():
+    events = [
+        {"event_type": "document.upload", "category": "usage", "user_id": "u1", "request_id": "r1", "payload": {}, "created_at": IN1},
+        {"event_type": "quiz.completed", "category": "usage", "user_id": "u1", "request_id": "r2", "payload": {}, "created_at": IN2},
+        {"event_type": "quiz.completed", "category": "usage", "user_id": "u2", "request_id": "r3", "payload": {}, "created_at": IN3},
+        {"event_type": "error.5xx", "category": "error", "user_id": "u2", "request_id": "r4",
+         "payload": {"path": "/api/quiz", "method": "POST", "status_code": 500, "duration_ms": 12.3}, "created_at": IN3},
+        {"event_type": "auth.login", "category": "audit", "user_id": "u1", "request_id": "r0", "payload": {}, "created_at": OUT},
+    ]
+    llm = [
+        {"user_id": "u1", "feature": "quiz", "task": "quiz", "model": "gemini-2.5-flash", "provider": "gemini",
+         "prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150, "cost_usd": 0.01, "created_at": IN1},
+        {"user_id": "u1", "feature": "chat_tutor", "task": "chat_tutor", "model": "gemini-2.5-pro", "provider": "gemini",
+         "prompt_tokens": 200, "completion_tokens": 100, "total_tokens": 300, "cost_usd": 0.05, "created_at": IN2},
+        {"user_id": "u2", "feature": "quiz", "task": "quiz", "model": "gemini-2.5-flash", "provider": "gemini",
+         "prompt_tokens": 80, "completion_tokens": 40, "total_tokens": 120, "cost_usd": 0.02, "created_at": IN3},
+        {"user_id": "u1", "feature": "quiz", "task": "quiz", "model": "gemini-2.5-flash", "provider": "gemini",
+         "prompt_tokens": 999, "completion_tokens": 999, "total_tokens": 1998, "cost_usd": 9.99, "created_at": OUT},
+    ]
+    return {"events": events, "llm_usage": llm}
+
+
+class _FakeTable:
+    def __init__(self, rows):
+        self.rows = rows
+
+    @staticmethod
+    def _match(value, cond: str) -> bool:
+        op, _, target = cond.partition(".")
+        sval = "" if value is None else str(value)
+        if op == "eq":
+            return sval == target
+        if op == "gte":
+            return sval >= target
+        if op == "lte":
+            return sval <= target
+        if op == "like":
+            return fnmatch.fnmatch(sval, target)
+        raise AssertionError(f"unsupported op in test fake: {op}")
+
+    def _filtered(self, filters):
+        rows = list(self.rows)
+        for col, cond in (filters or {}).items():
+            conds = cond if isinstance(cond, list) else [cond]
+            for c in conds:
+                rows = [r for r in rows if self._match(r.get(col), c)]
+        return rows
+
+    @staticmethod
+    def _ordered(rows, order):
+        if not order:
+            return rows
+        col, _, direction = order.partition(".")
+        return sorted(rows, key=lambda r: (r.get(col) is None, r.get(col)), reverse=direction == "desc")
+
+    def select_with_count(self, columns="*", filters=None, order=None, limit=None, offset=None):
+        rows = self._ordered(self._filtered(filters), order)
+        total = len(rows)
+        if offset:
+            rows = rows[offset:]
+        if limit is not None:
+            rows = rows[:limit]
+        return rows, total
+
+    def select(self, columns="*", filters=None, order=None, limit=None):
+        rows, _ = self.select_with_count(columns, filters, order, limit, None)
+        return rows
+
+
+@pytest.fixture
+def seeded(monkeypatch):
+    store = _seed()
+    monkeypatch.setattr(analytics, "table", lambda name: _FakeTable(store.get(name, [])))
+    return store
+
+
+# Explicit window covering the July rows (and excluding the 2020 rows).
+RANGE = {"from": "2026-07-01T00:00:00+00:00", "to": "2026-08-01T00:00:00+00:00"}
+
+
+# ── /usage/summary ───────────────────────────────────────────────────────────
+
+
+def test_usage_summary_counts(seeded):
+    r = client.get(f"{BASE}/usage/summary", params=RANGE)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total_events"] == 4  # the 2020 auth.login is excluded
+    assert body["distinct_active_users"] == 2
+    by_type = {row["event_type"]: row["count"] for row in body["by_event_type"]}
+    assert by_type["quiz.completed"] == 2
+    assert by_type["document.upload"] == 1
+    assert "auth.login" not in by_type
+
+
+# ── /usage/by-user ───────────────────────────────────────────────────────────
+
+
+def test_usage_by_user_totals(seeded):
+    r = client.get(f"{BASE}/usage/by-user", params=RANGE)
+    assert r.status_code == 200
+    body = r.json()
+    users = {u["user_id"]: u for u in body["users"]}
+    assert body["total_users"] == 2
+    assert users["u1"]["event_count"] == 2
+    assert users["u1"]["llm_cost_usd"] == pytest.approx(0.06)
+    assert users["u1"]["total_tokens"] == 450
+    assert users["u2"]["llm_cost_usd"] == pytest.approx(0.02)
+
+
+def test_usage_by_user_pagination(seeded):
+    r = client.get(f"{BASE}/usage/by-user", params={**RANGE, "limit": 1, "offset": 0})
+    body = r.json()
+    assert body["total_users"] == 2
+    assert len(body["users"]) == 1
+
+
+# ── /llm/cost ────────────────────────────────────────────────────────────────
+
+
+def test_llm_cost_group_by_feature(seeded):
+    r = client.get(f"{BASE}/llm/cost", params={**RANGE, "group_by": "feature"})
+    assert r.status_code == 200
+    body = r.json()
+    rows = {row["key"]: row for row in body["rows"]}
+    assert rows["quiz"]["cost_usd"] == pytest.approx(0.03)
+    assert rows["quiz"]["calls"] == 2
+    assert rows["chat_tutor"]["cost_usd"] == pytest.approx(0.05)
+    assert body["totals"]["cost_usd"] == pytest.approx(0.08)
+
+
+def test_llm_cost_group_by_model(seeded):
+    r = client.get(f"{BASE}/llm/cost", params={**RANGE, "group_by": "model"})
+    rows = {row["key"]: row for row in r.json()["rows"]}
+    assert rows["gemini-2.5-flash"]["cost_usd"] == pytest.approx(0.03)
+    assert rows["gemini-2.5-pro"]["cost_usd"] == pytest.approx(0.05)
+
+
+def test_llm_cost_group_by_user(seeded):
+    r = client.get(f"{BASE}/llm/cost", params={**RANGE, "group_by": "user"})
+    rows = {row["key"]: row for row in r.json()["rows"]}
+    assert rows["u1"]["cost_usd"] == pytest.approx(0.06)
+    assert rows["u2"]["total_tokens"] == 120
+
+
+def test_llm_cost_rejects_bad_group_by(seeded):
+    r = client.get(f"{BASE}/llm/cost", params={**RANGE, "group_by": "banana"})
+    assert r.status_code == 422
+
+
+# ── /errors ──────────────────────────────────────────────────────────────────
+
+
+def test_errors_returns_error_events_with_payload_fields(seeded):
+    r = client.get(f"{BASE}/errors", params=RANGE)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    err = body["errors"][0]
+    assert err["event_type"] == "error.5xx"
+    assert err["path"] == "/api/quiz"
+    assert err["method"] == "POST"
+    assert err["status_code"] == 500
+    assert err["duration_ms"] == pytest.approx(12.3)
+
+
+# ── date filtering + defaults ────────────────────────────────────────────────
+
+
+def test_narrow_range_excludes_rows(seeded):
+    # A window that only covers IN1 (2026-07-10).
+    r = client.get(f"{BASE}/usage/summary", params={
+        "from": "2026-07-09T00:00:00+00:00", "to": "2026-07-11T00:00:00+00:00",
+    })
+    assert r.json()["total_events"] == 1
+
+
+def test_default_range_is_last_30_days(seeded):
+    # No from/to: default window (last 30 days from 2026-07-21) covers the July
+    # rows but not the 2020 ones.
+    r = client.get(f"{BASE}/usage/summary")
+    assert r.status_code == 200
+    assert r.json()["total_events"] == 4
+
+
+# ── admin gating ─────────────────────────────────────────────────────────────
+
+
+def test_endpoints_reject_non_admin(seeded, monkeypatch):
+    from fastapi import HTTPException
+
+    def _deny(request):
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    monkeypatch.setattr(analytics, "require_admin", _deny)
+    for path, params in [
+        ("/usage/summary", RANGE),
+        ("/usage/by-user", RANGE),
+        ("/llm/cost", {**RANGE, "group_by": "feature"}),
+        ("/errors", RANGE),
+    ]:
+        resp = client.get(f"{BASE}{path}", params=params)
+        assert resp.status_code == 403, f"{path} should be admin-only"


### PR DESCRIPTION
## What & why

Closes #120 — the admin-only, read-only analytics + cost-rollup API over the `events` / `llm_usage` tables. This is the backend the future admin dashboard (#121/#122) consumes.

New `routes/admin_analytics.py`, mounted at `/api/admin/analytics`, every endpoint gated by `require_admin`.

## Endpoints

| Method | Path | Returns |
|---|---|---|
| GET | `/usage/summary` | per-`event_type` counts, total events, distinct active users |
| GET | `/usage/by-user` | per-user event counts (by category) + LLM `cost_usd` + `total_tokens`, paginated |
| GET | `/llm/cost?group_by=user\|feature\|model` | token + cost rollups by dimension, with `totals` |
| GET | `/errors` | `error.*` events with path/method/status/duration from payload, paginated |

All accept `from`/`to` ISO bounds (**default: last 30 days**) and return typed Pydantic models. No raw content — fingerprints only.

## Notes

- PostgREST has no `GROUP BY`, so the grouped endpoints scan the **date-bounded** rows and aggregate in Python (as the issue sanctions). Scans page via `select_with_count` and use its **exact count** both to stop and to detect the `_SCAN_CAP` truncation ceiling — logged, never a silent row-cap loss. `/errors` needs no aggregation, so it paginates server-side.
- Date-range filtering uses a list-valued `created_at` param (`gte.…` + `lte.…`), which PostgREST ANDs.

## Success criteria (#120)

- [x] All four endpoints return correct aggregates against seeded rows (tested).
- [x] Every endpoint rejected for non-admins / allowed for admins (`require_admin`, tested).
- [x] `group_by` switches user/feature/model correctly.
- [x] Date-range filtering + pagination work; default range last 30 days.
- [x] Router mounted in `main.py` under `/api/admin/analytics`.
- [x] Tests in `backend/tests/`, pass with a faithful mocked `table()`.

## Testing

11 cases over a fake `table()` that honors `eq/gte/lte/like` filters, ordering, and limit/offset — so aggregation, `group_by` switching, date filtering, default range, pagination, and admin gating are all genuinely exercised.

## Stacking

Stacked on **#375 (#118)** — needs the `0032` `events`/`llm_usage` tables. Base branch is `feat/118-llm-usage-observability`; retarget to `main` once #375 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
