### PR TITLE
feat(frontend): data-testid convention on six core E2E surfaces (#382)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@
   Always include a "What I'd try next" section.
 - `architecture.md` — Short, current overview of the system. Updated when
   it gets wrong, not on a schedule.
+- `frontend-testids.md` — `data-testid` naming convention for the surfaces
+  the browser suite drives, plus the ESLint rule that enforces it.
 - `security/` — Security hardening and remediation plans (RLS lockdown,
   storage hardening, realtime JWT bridge).
 - `staging/` — Staging environment setup notes.

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -1,0 +1,203 @@
+# Frontend `data-testid` convention
+
+Browser tests (Playwright, #385) must anchor on `data-testid`. They must **not**
+anchor on CSS classes or copy: the app is mid-redesign, classes are utility-ish
+(`btn btn--primary btn--sm`) and non-unique, and every copy tweak would break a
+selector. `data-testid` is the one attribute that exists purely as a test
+contract and can be kept stable across visual churn.
+
+Introduced by #382. Scope today is the six surfaces the Chapter-1 regression
+suite drives; this is deliberately **not** a whole-app sweep.
+
+## Naming
+
+Kebab-case, `<surface>-<element>`:
+
+```
+signin-google-button
+pending-gate
+upload-modal-dropzone
+tutor-input
+tutor-send
+quiz-answer-option-A
+graph-container
+```
+
+Rules:
+
+1. **Surface prefix first.** One prefix per surface (`signin`, `pending`,
+   `upload-modal`, `tutor`, `quiz`, `graph`). The prefix names the user-facing
+   surface, not the React component — `tutor-input` lives in `ChatPanel.tsx`
+   because that is where the tutor composer renders.
+2. **Element name describes the role, not the markup or the copy.**
+   `quiz-submit-answer`, not `quiz-primary-btn` and not `quiz-submit-answer-button`
+   for a `<button>`. Suffix with `-button` / `-input` only when it disambiguates
+   (`signin-google-button` vs. the `signin-trigger` on the landing nav).
+3. **Container roots get a bare noun**: `signin-modal`, `upload-modal`,
+   `quiz-panel`, `graph-container`, `pending-gate`.
+4. **Lowercase and hyphens only**, except for a stable id suffix (below).
+5. **Stable across redesigns.** A testid is API. Renaming one is a breaking
+   change to the browser suite — do it in the same PR as the test update.
+
+## Repeated / list items
+
+A repeated element gets the base name plus a suffix. Pick, in order of
+preference:
+
+1. **A stable domain id** the test can predict or read from the payload.
+   Quiz answers use the option's own label (`A`/`B`/`C`/`D`), so:
+   `quiz-answer-option-${o.label}` → `quiz-answer-option-A`. Catalog courses use
+   the catalog id: `upload-modal-course-result-${c.id}`.
+2. **A render index** when there is no stable id worth exposing. Upload rows key
+   on the queue position: `upload-modal-file-row-${idx}`,
+   `upload-modal-file-remove-${idx}`.
+
+Never suffix with a user-visible string (file name, course title, question
+text) — that is copy-anchoring by another route.
+
+When a list needs a "the whole list" handle, add a plural container testid next
+to the items: `quiz-answer-options` wraps `quiz-answer-option-*`.
+
+## Where the testids live
+
+The surface prefix is a UX concept; the attribute goes on the file that actually
+renders the element.
+
+| Surface | Prefix | Owning file(s) |
+| --- | --- | --- |
+| Sign-in | `signin` | `frontend/src/components/SignInModal.tsx` (+ the trigger in `src/app/(public)/page.tsx`) |
+| Approval gate | `pending` | `frontend/src/app/pending/page.tsx` |
+| Upload modal | `upload-modal` | `frontend/src/components/DocumentUploadModal.tsx` |
+| Tutor | `tutor` | `frontend/src/components/ChatPanel.tsx` (rendered by `screens/Learn.tsx`) |
+| Quiz | `quiz` | `frontend/src/components/QuizPanel.tsx` (rendered by `screens/Quiz.tsx`) |
+| Knowledge graph | `graph` | `frontend/src/components/KnowledgeGraph.tsx` (wrapper only — not the 2D/3D internals) |
+
+Two surfaces do **not** carry their testids in the screen file named by the
+route:
+
+- **Tutor.** `screens/Learn.tsx` passes `onSend` to `ChatPanel`; the `<textarea>`
+  and the send `<button>` render in `ChatPanel.tsx`. `ChatPanel` has exactly one
+  consumer (Learn), so tagging it there is unambiguous. The notetaker's chat is
+  a separate `AIChatPanel` and is out of scope.
+- **Quiz.** `screens/Quiz.tsx` only fetches concepts and mounts `QuizPanel`;
+  every answer/submit control renders in `QuizPanel.tsx`.
+
+## Current inventory
+
+### `signin`
+
+| testid | element |
+| --- | --- |
+| `signin-trigger` | landing-nav "Sign In" button that opens the modal |
+| `signin-modal` | modal panel root (`role="dialog"`) |
+| `signin-close` | × close button |
+| `signin-google-button` | "Continue with Google" |
+| `signin-cancel` | "Cancel" (only while waiting on the popup) |
+| `signin-error` | error banner |
+
+### `pending`
+
+| testid | element |
+| --- | --- |
+| `pending-gate` | approval-gate page root |
+| `pending-signout` | "Sign out" |
+
+### `upload-modal`
+
+| testid | element |
+| --- | --- |
+| `upload-modal` | modal card root |
+| `upload-modal-close` | header × |
+| `upload-modal-dropzone` | drag & drop target |
+| `upload-modal-browse` | "Browse" label wrapping the file input |
+| `upload-modal-file-input` | the hidden `<input type="file">` (use `setInputFiles`) |
+| `upload-modal-course-search` | "+ Add a course" search input |
+| `upload-modal-course-result-{courseId}` | a course search result |
+| `upload-modal-file-row-{idx}` | a queued file row |
+| `upload-modal-file-remove-{idx}` | remove that row |
+| `upload-modal-file-reanalyze-{idx}` | "Re-analyze" (processed rows) |
+| `upload-modal-file-retry-{idx}` | "Retry" (error/aborted rows) |
+| `upload-modal-file-copy-request-id-{idx}` | "copy" the support reference |
+| `upload-modal-cancel` | footer "Cancel" |
+| `upload-modal-submit` | footer "Start upload" |
+| `upload-modal-done` | footer "Done" (replaces submit once every row finished) |
+
+### `tutor`
+
+| testid | element |
+| --- | --- |
+| `tutor-messages` | conversation log (`role="log"`) |
+| `tutor-input` | message `<textarea>` |
+| `tutor-send` | send button |
+| `tutor-action-hint` | "Hint" |
+| `tutor-action-confused` | "I'm confused" |
+| `tutor-action-skip` | "Skip" |
+
+### `quiz`
+
+| testid | element |
+| --- | --- |
+| `quiz-panel` | panel root (all phases) |
+| `quiz-cancel` | "Cancel" (select phase) |
+| `quiz-start` | "Start quiz" |
+| `quiz-answer-options` | answer radiogroup |
+| `quiz-answer-option-{label}` | one answer choice, suffixed with its label (`A`…) |
+| `quiz-submit-answer` | "Submit answer" |
+| `quiz-exit` | "Exit" (active phase) |
+| `quiz-review-verdict` | "Correct." / "Not quite." banner |
+| `quiz-explain-concept` | "Explain this" |
+| `quiz-next` | "Next question" / "See results" |
+| `quiz-results-score` | the score percentage |
+| `quiz-retake` | "Retake" |
+| `quiz-done` | "Done" |
+
+### `graph`
+
+| testid | element |
+| --- | --- |
+| `graph-container` | graph wrapper root (sized box holding 2D or 3D) |
+| `graph-mode-toggle` | 2D ⇄ 3D toggle |
+
+## Enforcement
+
+`frontend/eslint.config.mjs` has a per-file `no-restricted-syntax` block scoped
+to the six owning files. It errors on any `<button>`, `<input>` or `<textarea>`
+in those files that has no `data-testid` attribute:
+
+```js
+{
+  files: [ /* the six surface files */ ],
+  rules: {
+    "no-restricted-syntax": ["error", {
+      selector:
+        'JSXOpeningElement[name.name=/^(button|input|textarea)$/]' +
+        ':not(:has(JSXAttribute[name.name="data-testid"]))',
+      message: "E2E surface (#382): …",
+    }],
+  },
+}
+```
+
+It is intentionally narrow:
+
+- **Only those six files.** A repo-wide version would be pure noise; the rest of
+  the app has no browser coverage to protect.
+- **Only intrinsic interactive elements.** Custom components (`<CustomSelect>`,
+  `<Button>`) are not matched — a testid on a component is a prop the component
+  has to forward, which is a code change, not an attribute. Tag the element
+  inside the component instead.
+- **Container roots are not enforced**, only added by convention. A selector for
+  "the root `<div>` of this component" is not expressible without false
+  positives.
+
+There is no lint coverage on `signin-trigger` in `src/app/(public)/page.tsx` —
+the landing page has dozens of buttons that are not part of any browser test, so
+that file stays out of the `files` list. The trigger is documented here instead.
+
+### Adding a surface
+
+1. Pick a prefix, add the row to the table above and the testids to the
+   inventory.
+2. Add the owning file to the `files` array in the lint block.
+3. Run `npm run lint` from `frontend/` — it will list every interactive element
+   in the new file that still needs a testid.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,6 +23,12 @@ npm run lint        # eslint
 npm run typecheck   # tsc --noEmit
 ```
 
+Browser-test hooks: the six surfaces the Playwright suite drives (sign-in, the
+approval gate, the upload modal, the tutor composer, the quiz answer flow, the
+graph container) carry `data-testid` attributes. Naming rules, the current
+inventory, and the ESLint rule that keeps new controls from drifting are in
+`docs/frontend-testids.md`.
+
 Deployed to Cloudflare Workers via OpenNext:
 
 ```bash

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -36,6 +36,41 @@ const eslintConfig = [
       "react-hooks/exhaustive-deps": "error",
     },
   },
+  // ── data-testid convention on the core E2E surfaces (#382) ───────────────
+  //
+  // The browser suite (#385) drives six surfaces: sign-in, the approval gate,
+  // the upload modal, the tutor composer, the quiz answer flow, and the graph
+  // container. Those tests must anchor on `data-testid`, never on CSS classes
+  // or copy — both churn on every design pass.
+  //
+  // This block enforces the convention where it matters: any NEW `<button>`,
+  // `<input>` or `<textarea>` added to one of the files that owns those
+  // surfaces must carry a `data-testid`. It is deliberately NOT global — the
+  // rest of the app is out of scope, and a repo-wide version would be noise.
+  //
+  // Naming rules live in `docs/frontend-testids.md`. When a new surface joins
+  // the browser suite, add its owning file to `files` below.
+  {
+    files: [
+      "src/components/SignInModal.tsx",
+      "src/app/pending/page.tsx",
+      "src/components/DocumentUploadModal.tsx",
+      "src/components/ChatPanel.tsx",
+      "src/components/QuizPanel.tsx",
+      "src/components/KnowledgeGraph.tsx",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            'JSXOpeningElement[name.name=/^(button|input|textarea)$/]:not(:has(JSXAttribute[name.name="data-testid"]))',
+          message:
+            "E2E surface (#382): every <button>/<input>/<textarea> in this file needs a data-testid. See docs/frontend-testids.md for the naming convention.",
+        },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -413,7 +413,7 @@ export default function LandingPage() {
             <span style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: '20px', color: 'var(--brand-forest)', letterSpacing: '-0.02em', lineHeight: 1.1 }}>Sapling</span>
           </button>
           <div className="flex items-center">
-            <button onClick={() => { setSignInError(null); setSignInOpen(true); }} className="text-[var(--text-dim)] hover:text-[var(--text)] font-medium text-sm tracking-wide transition-all duration-300 mr-6 hidden sm:block">Sign In</button>
+            <button data-testid="signin-trigger" onClick={() => { setSignInError(null); setSignInOpen(true); }} className="text-[var(--text-dim)] hover:text-[var(--text)] font-medium text-sm tracking-wide transition-all duration-300 mr-6 hidden sm:block">Sign In</button>
             <Button variant="primary" size="lg" style={{ padding: '6px 14px' }} onClick={startOnboarding}>
               Get Started
             </Button>

--- a/frontend/src/app/pending/page.tsx
+++ b/frontend/src/app/pending/page.tsx
@@ -14,6 +14,7 @@ export default function PendingPage() {
 
   return (
     <div
+      data-testid="pending-gate"
       style={{
         minHeight: '100vh',
         display: 'flex',
@@ -35,7 +36,7 @@ export default function PendingPage() {
       <p style={{ fontSize: 15, color: 'var(--text-dim)', textAlign: 'center', maxWidth: 420, lineHeight: 1.6, marginBottom: 32 }}>
         We&apos;ll reach out when your access is approved.
       </p>
-      <button className="btn" onClick={handleSignOut}>Sign out</button>
+      <button data-testid="pending-signout" className="btn" onClick={handleSignOut}>Sign out</button>
     </div>
   );
 }

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -62,6 +62,7 @@ export function ChatPanel({
         aria-relevant="additions"
         aria-atomic="false"
         aria-label="Conversation"
+        data-testid="tutor-messages"
         style={{
           flex: 1,
           overflowY: "auto",
@@ -132,13 +133,13 @@ const ChatInputBar = React.memo(function ChatInputBar({
     >
       {onAction && (
         <div style={{ display: "flex", gap: 6 }}>
-          <button className="btn btn--sm" onClick={() => onAction("hint")} disabled={disabled} title="Ask for a small nudge">
+          <button data-testid="tutor-action-hint" className="btn btn--sm" onClick={() => onAction("hint")} disabled={disabled} title="Ask for a small nudge">
             <Icon name="sparkle" size={12} /> Hint
           </button>
-          <button className="btn btn--sm" onClick={() => onAction("confused")} disabled={disabled} title="Say you're stuck">
+          <button data-testid="tutor-action-confused" className="btn btn--sm" onClick={() => onAction("confused")} disabled={disabled} title="Say you're stuck">
             <Icon name="bolt" size={12} /> I&apos;m confused
           </button>
-          <button className="btn btn--sm" onClick={() => onAction("skip")} disabled={disabled} title="Skip this concept">
+          <button data-testid="tutor-action-skip" className="btn btn--sm" onClick={() => onAction("skip")} disabled={disabled} title="Skip this concept">
             <Icon name="chev" size={12} /> Skip
           </button>
         </div>
@@ -155,6 +156,7 @@ const ChatInputBar = React.memo(function ChatInputBar({
         }}
       >
         <textarea
+          data-testid="tutor-input"
           aria-label="Message"
           value={text}
           onChange={e => setText(e.target.value)}
@@ -181,6 +183,7 @@ const ChatInputBar = React.memo(function ChatInputBar({
           rows={1}
         />
         <button
+          data-testid="tutor-send"
           className="btn btn--primary btn--sm"
           onClick={submit}
           disabled={disabled || !text.trim()}

--- a/frontend/src/components/DocumentUploadModal.tsx
+++ b/frontend/src/components/DocumentUploadModal.tsx
@@ -286,6 +286,7 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
       }}
     >
       <div
+        data-testid="upload-modal"
         onClick={e => e.stopPropagation()}
         className="card slide-up"
         style={{ width: "min(720px, 100%)", maxHeight: "88vh", overflow: "hidden", padding: 0, display: "flex", flexDirection: "column" }}
@@ -295,13 +296,14 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
             <div className="label-micro">Upload</div>
             <div className="h-serif" style={{ fontSize: 20 }}>Add course materials</div>
           </div>
-          <button className="btn btn--ghost btn--sm" onClick={handleClose} aria-label="Close">
+          <button data-testid="upload-modal-close" className="btn btn--ghost btn--sm" onClick={handleClose} aria-label="Close">
             <Icon name="x" size={14} />
           </button>
         </div>
 
         <div style={{ padding: 20, overflowY: "auto" }}>
           <div
+            data-testid="upload-modal-dropzone"
             onDragOver={e => { e.preventDefault(); setDragging(true); }}
             onDragLeave={() => setDragging(false)}
             onDrop={e => {
@@ -322,9 +324,10 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
             <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 12 }}>
               PDF, DOCX, PPTX · max 100 MB each
             </div>
-            <label className="btn btn--primary btn--sm">
+            <label data-testid="upload-modal-browse" className="btn btn--primary btn--sm">
               <Icon name="up" size={12} /> Browse
               <input
+                data-testid="upload-modal-file-input"
                 type="file"
                 multiple
                 accept=".pdf,.docx,.pptx"
@@ -341,6 +344,7 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
             <div style={{ marginTop: 16 }}>
               <div className="label-micro" style={{ marginBottom: 6 }}>+ Add a course</div>
               <input
+                data-testid="upload-modal-course-search"
                 value={courseQuery}
                 onChange={e => setCourseQuery(e.target.value)}
                 placeholder="Search a course to add"
@@ -355,6 +359,7 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
                   {courseResults.map(c => (
                     <button
                       key={c.id}
+                      data-testid={`upload-modal-course-result-${c.id}`}
                       disabled={addingCourse}
                       onClick={() => addCourseInline(c)}
                       style={{
@@ -376,9 +381,10 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
             {items.length === 0 && (
               <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Files you add will appear here.</div>
             )}
-            {items.map(item => (
+            {items.map((item, idx) => (
               <div
                 key={item.id}
+                data-testid={`upload-modal-file-row-${idx}`}
                 className="card"
                 style={{ padding: 14, marginBottom: 10, display: "flex", flexDirection: "column", gap: 10 }}
               >
@@ -400,6 +406,7 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
                   </div>
                   <StatusBadge status={item.status} />
                   <button
+                    data-testid={`upload-modal-file-remove-${idx}`}
                     className="btn btn--ghost btn--sm"
                     disabled={item.status === "uploading"}
                     onClick={() => {
@@ -430,13 +437,13 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
                         options={CATEGORY_OPTIONS}
                         ariaLabel="Category"
                       />
-                      <button className="btn btn--ghost btn--sm" onClick={() => reanalyze(item)}>
+                      <button data-testid={`upload-modal-file-reanalyze-${idx}`} className="btn btn--ghost btn--sm" onClick={() => reanalyze(item)}>
                         <Icon name="sparkle" size={12} /> Re-analyze
                       </button>
                     </>
                   )}
                   {(item.status === "error" || item.status === "aborted") && (
-                    <button className="btn btn--ghost btn--sm" onClick={() => retry(item)}>
+                    <button data-testid={`upload-modal-file-retry-${idx}`} className="btn btn--ghost btn--sm" onClick={() => retry(item)}>
                       <Icon name="sparkle" size={12} /> Retry
                     </button>
                   )}
@@ -472,6 +479,7 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
                     <span>Reference: {item.requestId.slice(0, 8)}…</span>
                     <button
                       type="button"
+                      data-testid={`upload-modal-file-copy-request-id-${idx}`}
                       onClick={() => {
                         const rid = item.requestId || "";
                         if (navigator.clipboard) {
@@ -499,11 +507,12 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
             {activeUploads > 0 && ` · ${activeUploads} uploading`}
           </div>
           <div style={{ display: "flex", gap: 8 }}>
-            <button className="btn btn--ghost btn--sm" onClick={handleClose}>Cancel</button>
+            <button data-testid="upload-modal-cancel" className="btn btn--ghost btn--sm" onClick={handleClose}>Cancel</button>
             {allFinished ? (
-              <button className="btn btn--sm btn--primary" onClick={done}>Done</button>
+              <button data-testid="upload-modal-done" className="btn btn--sm btn--primary" onClick={done}>Done</button>
             ) : (
               <button
+                data-testid="upload-modal-submit"
                 className="btn btn--sm btn--primary"
                 disabled={items.length === 0 || items.every(i => i.status !== "pending")}
                 onClick={startAll}

--- a/frontend/src/components/KnowledgeGraph.tsx
+++ b/frontend/src/components/KnowledgeGraph.tsx
@@ -90,7 +90,7 @@ export function KnowledgeGraph(props: Props) {
   const { width = 800, height = 480 } = props;
 
   return (
-    <div style={{ position: "relative", width, height }}>
+    <div data-testid="graph-container" style={{ position: "relative", width, height }}>
       {mode === "2d" ? (
         <KnowledgeGraph2D {...props} />
       ) : (
@@ -98,6 +98,7 @@ export function KnowledgeGraph(props: Props) {
       )}
       <button
         type="button"
+        data-testid="graph-mode-toggle"
         className="btn btn--ghost btn--sm"
         onClick={() => setMode(next)}
         title={`Switch to ${next.toUpperCase()} graph`}

--- a/frontend/src/components/QuizPanel.tsx
+++ b/frontend/src/components/QuizPanel.tsx
@@ -189,6 +189,7 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
 
   return (
     <div
+      data-testid="quiz-panel"
       style={{
         display: "flex",
         flexDirection: "column",
@@ -246,8 +247,8 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
             </div>
           </div>
           <div style={{ display: "flex", justifyContent: "space-between" }}>
-            <button className="btn" onClick={onExit}>Cancel</button>
-            <button className="btn btn--primary" onClick={start} disabled={loading || !conceptId}>
+            <button data-testid="quiz-cancel" className="btn" onClick={onExit}>Cancel</button>
+            <button data-testid="quiz-start" className="btn btn--primary" onClick={start} disabled={loading || !conceptId}>
               {loading ? "Generating…" : "Start quiz"}
             </button>
           </div>
@@ -261,12 +262,13 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
             <div className="chip" style={{ textTransform: "uppercase" }}>{currentQuestion.difficulty}</div>
           </div>
           <div style={{ fontSize: 16, lineHeight: 1.55 }}>{currentQuestion.question}</div>
-          <div role="radiogroup" aria-label="Answer choices" style={{ display: "grid", gap: 8 }}>
+          <div data-testid="quiz-answer-options" role="radiogroup" aria-label="Answer choices" style={{ display: "grid", gap: 8 }}>
             {currentQuestion.options.map(o => {
               const selected = currentSelection === o.label;
               return (
                 <button
                   key={o.label}
+                  data-testid={`quiz-answer-option-${o.label}`}
                   role="radio"
                   aria-checked={selected}
                   onClick={() => setCurrentSelection(o.label)}
@@ -287,8 +289,8 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
             })}
           </div>
           <div style={{ display: "flex", justifyContent: "space-between" }}>
-            <button className="btn" onClick={onExit}>Exit</button>
-            <button className="btn btn--primary" onClick={submitCurrent} disabled={!currentSelection}>
+            <button data-testid="quiz-exit" className="btn" onClick={onExit}>Exit</button>
+            <button data-testid="quiz-submit-answer" className="btn btn--primary" onClick={submitCurrent} disabled={!currentSelection}>
               Submit answer
             </button>
           </div>
@@ -299,6 +301,7 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
         <>
           <div className="label-micro">Review</div>
           <div
+            data-testid="quiz-review-verdict"
             style={{
               padding: "10px 14px",
               borderRadius: "var(--r-md)",
@@ -352,10 +355,10 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
             {currentQuestion.explanation}
           </div>
           <div style={{ display: "flex", justifyContent: "space-between" }}>
-            <button className="btn" onClick={() => explainConcept(currentQuestion.concept_tested)}>
+            <button data-testid="quiz-explain-concept" className="btn" onClick={() => explainConcept(currentQuestion.concept_tested)}>
               Explain this
             </button>
-            <button className="btn btn--primary" onClick={next}>
+            <button data-testid="quiz-next" className="btn btn--primary" onClick={next}>
               {qIndex + 1 >= questions.length ? "See results" : "Next question"}
             </button>
           </div>
@@ -365,7 +368,7 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
       {phase === "results" && results && (
         <>
           <div className="label-micro">Results</div>
-          <div className="h-serif" style={{ fontSize: 32 }}>
+          <div data-testid="quiz-results-score" className="h-serif" style={{ fontSize: 32 }}>
             {Math.round((results.score / Math.max(1, results.total)) * 100)}%
           </div>
           <div style={{ fontSize: 13, color: "var(--text-dim)" }}>
@@ -375,8 +378,8 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
             </span>
           </div>
           <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-            <button className="btn" onClick={retake}>Retake</button>
-            <button className="btn btn--primary" onClick={onExit}>Done</button>
+            <button data-testid="quiz-retake" className="btn" onClick={retake}>Retake</button>
+            <button data-testid="quiz-done" className="btn btn--primary" onClick={onExit}>Done</button>
           </div>
         </>
       )}

--- a/frontend/src/components/SignInModal.tsx
+++ b/frontend/src/components/SignInModal.tsx
@@ -228,8 +228,10 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
         role="dialog"
         aria-modal="true"
         aria-label="Sign in to Sapling"
+        data-testid="signin-modal"
       >
         <button
+          data-testid="signin-close"
           onClick={close}
           aria-label="Close dialog"
           style={{
@@ -262,7 +264,7 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
         </p>
 
         {errorMessage && (
-          <div style={{
+          <div data-testid="signin-error" style={{
             marginTop: 20,
             background: "rgba(220,38,38,0.08)",
             color: "#b91c1c",
@@ -277,6 +279,7 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
 
         <button
           type="button"
+          data-testid="signin-google-button"
           onClick={signInWithGoogle}
           disabled={waiting}
           style={{
@@ -314,6 +317,7 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
         {waiting && (
           <button
             type="button"
+            data-testid="signin-cancel"
             onClick={cancelSignIn}
             style={{
               marginTop: 10,


### PR DESCRIPTION
Shipped code had **zero** `data-testid` attributes (the only two in the repo live inside a `vi.mock` block in `TopNav.test.tsx`). The browser suite coming in #385 would otherwise have to anchor on CSS classes — utility-ish and non-unique (`btn btn--primary btn--sm`) — or on copy. Both churn on every design pass.

This PR adds the convention, applies it to the six surfaces Chapter-1 drives, and gates drift with a scoped ESLint rule. **Attributes and lint config only** — no behavior, styling, or logic changes.

## Convention

`docs/frontend-testids.md` (new). Kebab-case `<surface>-<element>`; container roots get a bare noun (`quiz-panel`, `graph-container`); the element name describes the role, never the markup or the copy.

Repeated/list items get a suffix, preferring a **stable domain id** over a **render index**:

- `quiz-answer-option-${o.label}` → `quiz-answer-option-A` (the option's own label is the stable id)
- `upload-modal-course-result-${c.id}` (catalog id)
- `upload-modal-file-row-${idx}` (queue position — no stable id worth exposing)

Never suffix with a user-visible string (file name, question text) — that is copy-anchoring by another route. Lists that need a "whole list" handle get a plural container next to the items (`quiz-answer-options`).

## Testids added

**`signin`** — `src/components/SignInModal.tsx` (+ trigger in `src/app/(public)/page.tsx`)

| testid | element |
| --- | --- |
| `signin-trigger` | landing-nav "Sign In" button that opens the modal |
| `signin-modal` | modal panel root (`role="dialog"`) |
| `signin-close` | × close button |
| `signin-google-button` | "Continue with Google" |
| `signin-cancel` | "Cancel" (only while waiting on the popup) |
| `signin-error` | error banner |

**`pending`** — `src/app/pending/page.tsx`

| testid | element |
| --- | --- |
| `pending-gate` | approval-gate page root |
| `pending-signout` | "Sign out" |

**`upload-modal`** — `src/components/DocumentUploadModal.tsx`

| testid | element |
| --- | --- |
| `upload-modal` | modal card root |
| `upload-modal-close` | header × |
| `upload-modal-dropzone` | drag & drop target |
| `upload-modal-browse` | "Browse" label wrapping the file input |
| `upload-modal-file-input` | hidden `<input type="file">` (use `setInputFiles`) |
| `upload-modal-course-search` | "+ Add a course" search input |
| `upload-modal-course-result-{courseId}` | a course search result |
| `upload-modal-file-row-{idx}` | a queued file row |
| `upload-modal-file-remove-{idx}` | remove that row |
| `upload-modal-file-reanalyze-{idx}` | "Re-analyze" (processed rows) |
| `upload-modal-file-retry-{idx}` | "Retry" (error/aborted rows) |
| `upload-modal-file-copy-request-id-{idx}` | "copy" the support reference |
| `upload-modal-cancel` | footer "Cancel" |
| `upload-modal-submit` | footer "Start upload" |
| `upload-modal-done` | footer "Done" |

**`tutor`** — `src/components/ChatPanel.tsx`

| testid | element |
| --- | --- |
| `tutor-messages` | conversation log (`role="log"`) |
| `tutor-input` | message `<textarea>` |
| `tutor-send` | send button |
| `tutor-action-hint` / `tutor-action-confused` / `tutor-action-skip` | the three tutor action chips |

**`quiz`** — `src/components/QuizPanel.tsx`

| testid | element |
| --- | --- |
| `quiz-panel` | panel root (all phases) |
| `quiz-cancel` / `quiz-start` | select phase |
| `quiz-answer-options` | answer radiogroup |
| `quiz-answer-option-{label}` | one answer choice, suffixed with its label (`A`…) |
| `quiz-submit-answer` / `quiz-exit` | active phase |
| `quiz-review-verdict` | "Correct." / "Not quite." banner |
| `quiz-explain-concept` / `quiz-next` | review phase |
| `quiz-results-score` / `quiz-retake` / `quiz-done` | results phase |

**`graph`** — `src/components/KnowledgeGraph.tsx`

| testid | element |
| --- | --- |
| `graph-container` | wrapper root (sized box holding 2D or 3D) |
| `graph-mode-toggle` | 2D ⇄ 3D toggle |

### Where the attributes actually live

Two surfaces do not carry their testids in the screen file named by the route, because the elements do not render there:

- **Tutor** — `screens/Learn.tsx` passes `onSend` to `ChatPanel`; the `<textarea>` and send `<button>` render in `ChatPanel.tsx`. `ChatPanel` has exactly one consumer (Learn), so tagging it there is unambiguous. The notetaker's chat is a separate `AIChatPanel` and stays out of scope.
- **Quiz** — `screens/Quiz.tsx` only fetches concepts and mounts `QuizPanel`; every answer/submit control renders in `QuizPanel.tsx`.

## Lint rule

A per-file `no-restricted-syntax` block in `frontend/eslint.config.mjs`, scoped to the six owning files. Any `<button>`, `<input>` or `<textarea>` in them without a `data-testid` is an **error**:

```js
selector:
  'JSXOpeningElement[name.name=/^(button|input|textarea)$/]' +
  ':not(:has(JSXAttribute[name.name="data-testid"]))'
```

Intentionally narrow: only those six files (a repo-wide version would be noise — the rest of the app has no browser coverage to protect), and only intrinsic elements (a testid on a custom component is a prop it must forward, i.e. a code change; tag the element inside the component instead). No custom ESLint plugin, no new dependency, no rule downgrades, no additions to `eslint-suppressions.json`.

### Proof it fires

Clean tree, six scoped files → 0 errors:

```
$ npx eslint --quiet src/components/SignInModal.tsx src/app/pending/page.tsx \
    src/components/DocumentUploadModal.tsx src/components/ChatPanel.tsx \
    src/components/QuizPanel.tsx src/components/KnowledgeGraph.tsx
(no output = 0 errors)
```

Then temporarily added three untagged controls to `QuizPanel.tsx` **and** one untagged `<button>` to the out-of-scope `screens/Learn.tsx`:

```
$ npm run lint
frontend/src/components/QuizPanel.tsx
  381:13  error  E2E surface (#382): every <button>/<input>/<textarea> in this file needs a data-testid. See docs/frontend-testids.md for the naming convention  no-restricted-syntax
  382:13  error  E2E surface (#382): every <button>/<input>/<textarea> in this file needs a data-testid. See docs/frontend-testids.md for the naming convention  no-restricted-syntax
  383:13  error  E2E surface (#382): every <button>/<input>/<textarea> in this file needs a data-testid. See docs/frontend-testids.md for the naming convention  no-restricted-syntax

✖ 39 problems (3 errors, 36 warnings)

$ npm run lint 2>&1 | grep -c "screens/Learn.tsx.*no-restricted-syntax"
0          # out-of-scope file correctly NOT flagged
```

Reverted, back to green:

```
$ git checkout -- frontend/src/components/QuizPanel.tsx frontend/src/components/screens/Learn.tsx
$ npm run lint
✖ 36 problems (0 errors, 36 warnings)
```

Those 36 warnings are the pre-existing `no-img-element` / `no-unused-vars` baseline on `main` — unchanged by this PR.

## Verification

```
$ npm run lint
✖ 36 problems (0 errors, 36 warnings)        # 0 errors

$ npm run typecheck                          # tsc --noEmit
(clean, exit 0)

$ npm test                                   # vitest run
 Test Files  13 passed (13)
      Tests  97 passed (97)
```

## Notes for reviewers

- **`SignInModal.tsx` is strictly additive.** Open PRs #409 and #359 touch that file, so the change is 5 added attribute lines and nothing else — no restructuring, no renames, no env/config handling touched.
- **`src/app/(public)/page.tsx` gets exactly one attribute** (`signin-trigger`). Without it a browser test has no way to open the sign-in modal. That file is deliberately *not* in the lint `files` list — it has dozens of buttons with no browser coverage — so the trigger is documented in `docs/frontend-testids.md` instead.
- Container roots are convention-only, not lint-enforced: "the root `<div>` of this component" is not expressible as a selector without false positives.

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines and an inventory for stable frontend test selectors.
  * Updated frontend documentation with browser-test surface information.

* **Tests**
  * Added consistent `data-testid` attributes across sign-in, pending, upload, tutor, quiz, and graph interfaces.
  * Added lint enforcement requiring test selectors on key interactive elements in covered surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->