### PR TITLE
fix(backend): keyless rag_service import + hermetic LLM egress guard (#378, #379)

### DIFF
--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -17,8 +17,13 @@ from db.connection import rpc, table
 # grounding indefinitely — retrieve_chunks() runs inline on the request path.
 _HTTP_TIMEOUT_MS = 60_000
 
+# `genai.Client(api_key="")` raises ValueError at construction, so a missing
+# GEMINI_API_KEY would break `import main` (routes/quiz.py and routes/learn.py
+# both pull this module in). Fall back to a dummy key the same way
+# services/gemini_service.py and agents/_providers.py do: imports stay clean and
+# the failure surfaces at call time, where it's actionable.
 _client = genai.Client(
-    api_key=os.getenv("GEMINI_API_KEY", ""),
+    api_key=os.getenv("GEMINI_API_KEY", "") or "dummy-key-for-import",
     http_options=genai_types.HttpOptions(timeout=_HTTP_TIMEOUT_MS),
 )
 _EMBED_MODEL = "gemini-embedding-001"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,6 +8,11 @@ Also installs an autouse fixture that bypasses session auth for tests so
 they can exercise route logic without minting real HMAC tokens. The bypass
 is test-only and lives entirely inside conftest.py — production code is
 unaffected.
+
+Two autouse hermetic guards keep the default lane offline: no test may reach
+real Supabase (`_hermetic_supabase_client`, #210) or a real model
+(`_hermetic_llm_transport`, #379). The `e2e_staging`, `integration` and
+`live_llm` markers are the documented opt-outs.
 """
 import sys
 import os
@@ -34,6 +39,11 @@ def pytest_configure(config):
         "markers",
         "integration: opt-in tests against the REAL local Supabase stack (needs the "
         "stack up + RUN_INTEGRATION=1). Bypasses the hermetic DB + auth fixtures.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "live_llm: this test deliberately calls a REAL model (billable). Bypasses the "
+        "hermetic LLM fixture; pair it with a skipif so it only runs when a key is set.",
     )
 
 
@@ -80,6 +90,86 @@ def _hermetic_supabase_client(request, monkeypatch):
     for verb in ("get", "post", "patch", "delete"):
         getattr(fake_client, verb).side_effect = _empty_response
     monkeypatch.setattr(dbconn, "_client", fake_client)
+
+
+class UnstubbedLLMEgress(RuntimeError):
+    """Raised by `_hermetic_llm_transport` when a test reaches the LLM network."""
+
+
+# Every google-genai call — unary, streaming, sync, async, plus the File API's
+# upload/download side channels — bottoms out in one of these BaseApiClient
+# methods. We patch the CLASS, not an instance: several modules build a
+# module-level `genai.Client` at import time (services/rag_service.py,
+# services/gemini_service.py, and pydantic-ai's GoogleProvider in
+# agents/_providers.py), so instance-level patching would miss whichever client
+# was already constructed. Names are probed with hasattr so a google-genai bump
+# that drops a private helper degrades gracefully instead of erroring.
+_GENAI_EGRESS_METHODS = (
+    # Public transport entry points (stable across google-genai majors).
+    "request", "request_streamed", "async_request", "async_request_streamed",
+    # Lower-level chokepoints, in case a public wrapper is ever bypassed.
+    "_request", "_request_once", "_async_request", "_async_request_once",
+    # File API paths that skip the request pipeline and drive httpx directly.
+    "upload_file", "async_upload_file", "download_file", "async_download_file",
+    "_upload_fd", "_async_upload_fd",
+)
+# If these ever stop existing the guard has silently become a no-op, which is
+# worse than no guard at all — fail loudly instead.
+_GENAI_REQUIRED_METHODS = ("request", "async_request")
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_llm_transport(request, monkeypatch):
+    """Hermetic safety net (#379): no test may make a real LLM call.
+
+    The sibling `_hermetic_supabase_client` guarantees the default lane never
+    touches Supabase; this is the same guarantee for Gemini. Without it, a
+    forgotten `patch(...)` plus a `GEMINI_API_KEY` in the environment (CI sets a
+    dummy one, dev machines have a real one) turns a unit test into a real,
+    billable network call — silently, since a passing test looks identical
+    either way. Rather than stub agent logic, we cut the wire underneath it:
+    the google-genai transport class raises instead of dialling out, so an
+    unstubbed call path fails with a pointed error naming the escape hatch.
+
+    The opt-in lanes are the exceptions: `e2e_staging` and `integration` talk to
+    real infrastructure, and `live_llm` marks the handful of tests (see
+    test_ocr_pipeline.py) that deliberately exercise a live model.
+    """
+    if (
+        request.node.get_closest_marker("e2e_staging")
+        or request.node.get_closest_marker("integration")
+        or request.node.get_closest_marker("live_llm")
+    ):
+        return
+    from google.genai import _api_client as genai_api_client
+
+    def _blocked(*_args, **_kwargs):
+        raise UnstubbedLLMEgress(
+            "unstubbed LLM egress: this test reached the google-genai transport "
+            "(google.genai._api_client.BaseApiClient) and would have made a real, "
+            "billable model call. Patch the service/agent seam the code path uses "
+            "(e.g. services.gemini_service.call_gemini, <agent>.run, "
+            "services.rag_service._client), or mark the test @pytest.mark.live_llm "
+            "if the live call is intentional."
+        )
+
+    # Lets tests assert the guard is installed without invoking it.
+    _blocked._sapling_llm_guard = True
+
+    patched = []
+    for name in _GENAI_EGRESS_METHODS:
+        if hasattr(genai_api_client.BaseApiClient, name):
+            monkeypatch.setattr(genai_api_client.BaseApiClient, name, _blocked)
+            patched.append(name)
+
+    missing = [n for n in _GENAI_REQUIRED_METHODS if n not in patched]
+    if missing:  # pragma: no cover - only trips on a google-genai API change
+        raise RuntimeError(
+            f"hermetic LLM guard could not patch {missing} on "
+            "google.genai._api_client.BaseApiClient — the installed google-genai "
+            "moved its transport seam. Update _GENAI_EGRESS_METHODS in "
+            "tests/conftest.py; do not leave the suite unguarded."
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_hermetic_llm_guard.py
+++ b/backend/tests/test_hermetic_llm_guard.py
@@ -1,0 +1,144 @@
+"""#379: the autouse hermetic LLM guard must make the default lane provably offline.
+
+`conftest._hermetic_llm_transport` patches the google-genai transport class so a
+forgotten stub can never turn into a real, billable Gemini call. These tests pin
+that contract from both directions: unmarked tests are blocked, and the opt-in
+live lanes (`live_llm` / `e2e_staging` / `integration`) are left alone.
+"""
+import asyncio
+
+import pytest
+from google import genai
+
+# A syntactically valid but non-functional key: `genai.Client` validates that a
+# key is present at construction, so we can't pass "".
+_DUMMY_KEY = "dummy-key-for-import"
+
+
+def _client() -> genai.Client:
+    return genai.Client(api_key=_DUMMY_KEY)
+
+
+class TestDefaultLaneIsOffline:
+    def test_sync_generate_content_raises_unstubbed_llm_egress(self):
+        """A forgotten patch must fail loudly, not hit the network."""
+        with pytest.raises(RuntimeError, match="unstubbed LLM egress"):
+            _client().models.generate_content(
+                model="gemini-2.5-flash-lite", contents="hello",
+            )
+
+    def test_sync_embed_content_raises_unstubbed_llm_egress(self):
+        """The RAG embedding path (services/rag_service) is covered too."""
+        with pytest.raises(RuntimeError, match="unstubbed LLM egress"):
+            _client().models.embed_content(
+                model="gemini-embedding-001", contents=["hello"],
+            )
+
+    def test_streaming_generate_content_raises_unstubbed_llm_egress(self):
+        """The SSE tutor path streams, which uses a different transport method
+        than the unary one — both must be blocked."""
+        with pytest.raises(RuntimeError, match="unstubbed LLM egress"):
+            list(_client().models.generate_content_stream(
+                model="gemini-2.5-flash-lite", contents="hello",
+            ))
+
+    def test_async_generate_content_raises_unstubbed_llm_egress(self):
+        """Agents run through the async client; that seam must be blocked too."""
+        async def _go():
+            await _client().aio.models.generate_content(
+                model="gemini-2.5-flash-lite", contents="hello",
+            )
+
+        with pytest.raises(RuntimeError, match="unstubbed LLM egress"):
+            asyncio.run(_go())
+
+    def test_error_message_names_the_escape_hatch(self):
+        """The failure has to tell whoever hits it what to do next."""
+        with pytest.raises(RuntimeError) as exc:
+            _client().models.generate_content(
+                model="gemini-2.5-flash-lite", contents="hello",
+            )
+        msg = str(exc.value)
+        assert "unstubbed LLM egress" in msg
+        assert "live_llm" in msg
+
+
+class TestRealSaplingCallPathsAreBlocked:
+    """The synthetic-client tests above prove the seam; these prove it on the
+    real, module-level clients Sapling actually builds at import time — the
+    exact objects a forgotten `patch(...)` would leave live."""
+
+    def test_gemini_service_call_gemini_is_blocked(self):
+        """services/gemini_service.py holds a module-level genai.Client."""
+        from services.gemini_service import call_gemini
+
+        with pytest.raises(RuntimeError, match="unstubbed LLM egress"):
+            call_gemini("summarize this", retries=0)
+
+    def test_rag_service_embedding_is_blocked(self):
+        """services/rag_service.py holds its own module-level genai.Client
+        (the one #378 fixed the keyless construction of)."""
+        from services.rag_service import _embed_query
+
+        with pytest.raises(RuntimeError, match="unstubbed LLM egress"):
+            _embed_query("dynamic programming")
+
+
+class TestPydanticAISharesTheSameSeam:
+    """The agents run on pydantic-ai's GoogleModel, which wraps a
+    `google.genai.Client` of its own. Patching the transport CLASS (rather than
+    a client instance) is what makes that already-constructed, module-level
+    provider client blocked as well."""
+
+    def test_agent_provider_client_transport_is_guarded(self):
+        from google.genai._api_client import BaseApiClient
+
+        from agents._providers import _provider
+
+        api_client = _provider.client._api_client
+        assert isinstance(api_client, BaseApiClient)
+        assert getattr(type(api_client).request, "_sapling_llm_guard", False), (
+            "pydantic-ai's provider client is not covered by the LLM guard"
+        )
+
+
+class TestGuardIsInstalledOnUnmarkedTests:
+    def test_transport_methods_are_patched(self):
+        from google.genai._api_client import BaseApiClient
+
+        for name in ("request", "async_request", "request_streamed",
+                     "async_request_streamed"):
+            assert getattr(getattr(BaseApiClient, name), "_sapling_llm_guard", False), (
+                f"BaseApiClient.{name} escaped the hermetic LLM guard"
+            )
+
+
+class TestOptInLanesAreExempt:
+    """The live lanes deliberately talk to a real model; the guard must step
+    aside for them exactly the way the Supabase/auth guards already do."""
+
+    @pytest.mark.live_llm
+    def test_live_llm_marker_leaves_the_transport_alone(self):
+        from google.genai._api_client import BaseApiClient
+
+        assert not getattr(BaseApiClient.request, "_sapling_llm_guard", False)
+
+    @pytest.mark.e2e_staging
+    def test_e2e_staging_marker_leaves_the_transport_alone(self):
+        from google.genai._api_client import BaseApiClient
+
+        assert not getattr(BaseApiClient.request, "_sapling_llm_guard", False)
+
+    @pytest.mark.integration
+    def test_integration_marker_leaves_the_transport_alone(self):
+        from google.genai._api_client import BaseApiClient
+
+        assert not getattr(BaseApiClient.request, "_sapling_llm_guard", False)
+
+
+def test_guard_is_restored_after_an_exempt_test():
+    """monkeypatch teardown must put the real transport back, so an exempt test
+    can't leave the next test unguarded (or vice versa)."""
+    from google.genai._api_client import BaseApiClient
+
+    assert getattr(BaseApiClient.request, "_sapling_llm_guard", False)

--- a/backend/tests/test_ocr_pipeline.py
+++ b/backend/tests/test_ocr_pipeline.py
@@ -17,10 +17,16 @@ import pytest
 # The integration tests below hit live Gemini + Supabase. The agent-path
 # unit tests in TestExtractAssignmentsViaAgent are fully mocked, so they
 # run without GEMINI_API_KEY — gate per-test rather than at the module.
+#
+# `live_llm` (#379) is what exempts them from the autouse hermetic LLM guard in
+# conftest.py; the skipif alone is not enough, because a *skipif* is invisible
+# to `request.node.get_closest_marker`. Both are needed: the marker lets the
+# real call through, the skipif keeps it from being attempted without a key.
 _requires_gemini = pytest.mark.skipif(
     not os.getenv("GEMINI_API_KEY"),
     reason="OCR/Gemini integration tests require GEMINI_API_KEY",
 )
+_live_llm = pytest.mark.live_llm
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -44,6 +50,7 @@ Quiz 4: OOP Basics                  Due: March 28, 2026
 TEST_USER = "user_andres"
 
 
+@_live_llm
 @_requires_gemini
 def test_agent_parse():
     print("\n[1] Testing agent parsing from raw text...")
@@ -63,6 +70,7 @@ def parsed_assignments():
     return result.get("assignments", [])
 
 
+@_live_llm
 @_requires_gemini
 def test_save_to_db(parsed_assignments):
     print("\n[2] Testing save_assignments_to_db()...")
@@ -89,6 +97,7 @@ def test_save_to_db(parsed_assignments):
         print(f"      • {r['title']} | {r['due_date']} | {r['assignment_type']}")
 
 
+@_live_llm
 @_requires_gemini
 def test_full_pipeline():
     print("\n[3] Testing process_and_save_syllabus() full pipeline with a text/plain file...")

--- a/backend/tests/test_rag_service.py
+++ b/backend/tests/test_rag_service.py
@@ -1,4 +1,46 @@
+import os
+import subprocess
+import sys
 from unittest.mock import MagicMock, patch
+
+
+def test_import_succeeds_without_gemini_api_key():
+    """#378: rag_service builds a module-level `genai.Client` at import time and
+    `genai.Client(api_key="")` raises ValueError, so a missing GEMINI_API_KEY
+    broke `import main` (via routes/quiz.py -> services/rag_service.py) outright.
+
+    Its siblings already fall back to a dummy key — services/gemini_service.py
+    and agents/_providers.py — so imports stay clean and the failure surfaces at
+    call time instead. This pins that behaviour for the whole import graph.
+
+    Run in a subprocess: the modules are already imported in-process, so this is
+    the only way to observe import-time behaviour. `load_dotenv` is stubbed out
+    first so a developer's backend/.env can't silently re-supply the key and
+    make the assertion vacuous.
+    """
+    backend_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env = {k: v for k, v in os.environ.items() if k != "GEMINI_API_KEY"}
+    env.update({
+        "ENCRYPTION_KEY": "0" * 64,
+        "APP_ENV": "test",
+        "SUPABASE_URL": "https://dummy.supabase.co",
+        "SUPABASE_SERVICE_KEY": "dummy-service-key",
+        "SESSION_SECRET": "dummy-session-secret",
+    })
+    program = (
+        "import dotenv; dotenv.load_dotenv = lambda *a, **k: False\n"
+        "import os; os.environ.pop('GEMINI_API_KEY', None)\n"
+        "import main\n"
+        "import services.rag_service as rag\n"
+        "assert rag._client is not None\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", program],
+        cwd=backend_root, env=env, capture_output=True, text=True, timeout=180,
+    )
+    assert proc.returncode == 0, (
+        "importing main without GEMINI_API_KEY failed:\n" + proc.stderr
+    )
 
 
 def _make_embedding_response(vecs: list[list[float]]):


### PR DESCRIPTION
Two linked pieces of test/import plumbing. Closes #378 and Closes #379.

## #378 — keyless `import main`

`services/rag_service.py` built its module-level client with
`api_key=os.getenv("GEMINI_API_KEY", "")`, and `genai.Client(api_key="")` raises
`ValueError` **at construction**. Since `routes/quiz.py` and `routes/learn.py`
both import the module, `import main` failed outright without a key:

```
File "backend/routes/quiz.py", line 25, in <module>
    from services.rag_service import retrieve_chunks, format_rag_context
File "backend/services/rag_service.py", line 20, in <module>
ValueError: No API key was provided. ...
```

Fixed by matching the pattern its two siblings already use —
`services/gemini_service.py:18` and `agents/_providers.py:86` both fall back to
`"dummy-key-for-import"`. Imports stay clean; the failure moves to call time
where it is actionable. **No behaviour change when a real key is present.**

Supporting evidence that the bug was real: `.github/workflows/ci.yml` injects
`GEMINI_API_KEY: dummy-not-used-in-tests` precisely so import-time client
construction succeeds. That line is deliberately left alone here — it is
harmless, and touching CI would widen this PR's blast radius.

Pinned by a new subprocess test, `test_rag_service.py::test_import_succeeds_without_gemini_api_key`.
It stubs `dotenv.load_dotenv` in the child before importing, so a developer's
`backend/.env` cannot silently re-supply the key and make the assertion vacuous.

## #379 — hermetic LLM egress guard

`tests/conftest.py` had `_hermetic_supabase_client` guaranteeing no test reaches
real Supabase, but nothing equivalent for the model. A forgotten `patch(...)`
plus a `GEMINI_API_KEY` in the environment produced a real, billable Gemini call
— silently, because a passing test looks identical either way.

New autouse `_hermetic_llm_transport` fixture, written to mirror
`_hermetic_supabase_client`'s structure and docstring style.

**Seam chosen: `google.genai._api_client.BaseApiClient`, patched at the CLASS
level.** Verified against the installed google-genai (1.74.0) rather than
assumed. Rationale:

- Several modules build a module-level `genai.Client` at **import** time
  (`services/rag_service.py`, `services/gemini_service.py`, and pydantic-ai's
  `GoogleProvider` in `agents/_providers.py`). Patching instances would miss
  whichever client was already constructed; patching the class reaches all of
  them, including ones constructed later.
- pydantic-ai's `GoogleModel` wraps a `google.genai.Client` of its own, so the
  agents lane rides the same seam — no separate transport path needed. There is
  a test asserting exactly that (`TestPydanticAISharesTheSameSeam`).
- The guard covers `request` / `request_streamed` / `async_request` /
  `async_request_streamed`, the lower-level `_request*` chokepoints, and the
  File API `upload_file` / `download_file` paths that drive httpx directly and
  would otherwise bypass the request pipeline. Note the streaming methods
  matter: the SSE tutor path does not go through the unary `request`.
- `aiohttp` is not installed, so the httpx path underneath is the only transport
  in play.
- The fixture raises if `request` / `async_request` ever stop existing on
  `BaseApiClient`. A guard that silently degrades to a no-op after a dependency
  bump is worse than no guard, so a moved seam fails loudly instead.

Unstubbed calls now raise
`UnstubbedLLMEgress("unstubbed LLM egress: ...")`, naming the seams to patch and
the `live_llm` escape hatch. Only the network boundary is blocked — no agent
logic is stubbed.

### Exemptions

`e2e_staging` and `integration` as specified, plus a **new `live_llm` marker**.
`tests/test_ocr_pipeline.py` has three genuinely live tests (`test_agent_parse`,
`test_save_to_db`, `test_full_pipeline`) gated by a module-local
`_requires_gemini = pytest.mark.skipif(...)`. A *skipif is not a marker*, so
`request.node.get_closest_marker` cannot see it — without `live_llm` those three
would flip from live-passing to "unstubbed LLM egress" failures on any machine
with a real key. They now carry both: the marker lets the real call through, the
skipif keeps it from being attempted without a key. This is local-only (CI
already runs with `--ignore=tests/test_ocr_pipeline.py`), but it makes the local
full-suite run honest.

The CI comment at that step claims "The gated tests mock their own
Supabase/Gemini calls." This guard is what makes the Gemini half of that claim
enforced rather than aspirational.

### New tests — `tests/test_hermetic_llm_guard.py` (13)

Blocked: sync unary, embeddings, streaming, async. Blocked through the *real*
Sapling call paths (`gemini_service.call_gemini`, `rag_service._embed_query`) on
their actual import-time clients, not just a synthetic one. Error message names
the escape hatch. pydantic-ai's provider client is covered. All three exemption
markers verified, plus a test that monkeypatch teardown restores the transport
so an exempt test cannot leave the next one unguarded.

## Verification

Full suite, from `backend/`:

```
$ .../venv/bin/pytest tests/ -q
987 passed, 5 skipped, 70 warnings, 1 error in 23.69s
ERROR tests/test_ocr_pipeline.py::test_save_to_db - RuntimeError: Event loop ...
```

Baseline on the same commit before these changes was `973 passed, 5 skipped, 1
error` — the delta is exactly the 14 new tests, and **that one error is
pre-existing on `main` and unchanged** (it is the live `test_save_to_db`, which
this PR leaves live via `live_llm`).

CI-equivalent lane (the actual gate, with CI's `--ignore` set and dummy env):

```
929 passed, 5 skipped, 66 warnings in 5.52s
```

Keyless import (`GEMINI_API_KEY` unset in the process environment; the print
runs *after* `import main`, proving `load_dotenv` did not re-supply it):

```
$ ... env -u GEMINI_API_KEY .../venv/bin/python import_check.py
import main OK; GEMINI_API_KEY set: False
```

Lint:

```
$ .../venv/bin/python -m ruff check .
All checks passed!
```

## Findings worth flagging

**`env -u GEMINI_API_KEY pytest tests/ -q` is *not* a viable clean invocation**,
even after #378 — and it cannot be. `config.py::validate_config()` deliberately
fail-closes on a missing `GEMINI_API_KEY` (#174), and one test enters the FastAPI
lifespan, so it fails with:

```
RuntimeError: Missing required configuration: GEMINI_API_KEY. (APP_ENV='test'; ...)
```

That is a product invariant, not a bug, and weakening it is out of scope here.
The better outcome is what this PR actually delivers: with the guard in place you
no longer *need* to unset the key. CI's existing dummy-key invocation is now
provably offline, and so is a local run with a **real** key in the environment.
That is a stronger guarantee than unsetting ever gave.

**Second instance of the #378 bug class, left unfixed by scope.**
`routes/documents.py:1091` does `_genai.Client(api_key=os.getenv("GEMINI_API_KEY", ""))`
lazily inside `_index_document_chunks`. Keyless, it raises `ValueError`, gets
swallowed by the surrounding `except Exception`, and silently skips indexing —
which is why `test_document_indexing.py::test_happy_path_indexes_chunks_when_no_catalog_embedding`
fails in a keyless run today. It is unreachable in production (`validate_config`
fail-closes at startup first) and pre-existing, so it is left for a follow-up
rather than widened into this PR. `scripts/ingest_catalog.py:41` has the same
shape but is a standalone script, not on the `import main` graph.

**Dependency drift, unrelated but noted:** `backend/requirements.txt` pins
`google-genai==2.9.0`; the local venv has `1.74.0`. The seam was verified against
what is installed, and the fixture's fail-loud check is what protects the guard
if 2.9.0 moved it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
