### PR TITLE
test(backend): cookie-minting test-auth endpoint for local/test envs (#381)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ A FastAPI + Supabase backend that ingests student documents, calls Gemini to cla
 - backend/routes/quiz.py:1 — quiz session create/answer/score endpoints.
 - backend/routes/notes.py:32 — `/api/notes` notetaker CRUD, concept link/unlink, and agent actions (`summarize`/`extract-concepts`/`chat`/`send-to-tutor`/`generate-quiz`).
 - backend/routes/academics.py — `/api` terms/offerings/enrollments endpoints over the redesigned schema.
-- backend/routes/auth.py:1 — Google OAuth + HMAC session token issuance.
+- backend/routes/auth.py:1 — Google OAuth + HMAC session token issuance; also `POST /api/auth/test-login`, the local/test-only session minter for pytest + Playwright (404s unless `APP_ENV in {local, test}`).
+- backend/services/session_tokens.py — canonical `mint_session` / `SESSION_COOKIE_NAME`; the only place the `sapling_session` wire format is built.
 - backend/services/academics.py — term/offering/enrollment resolver (`current_term`/`list_terms`/`resolve_offering`/`offering_course_id`/`user_offering_ids_for_course`/`term_for_offering`); the API boundary keeps the abstract `course_id`.
 - backend/services/profiles.py — `get_display_name`/`get_display_names`, decrypting the name off `user_profiles`.
 - backend/services/gemini_service.py:64 — `call_gemini` plain-text call (LLM seam being deprecated).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,7 +40,7 @@ base64url(payload).base64url(signature)
 
 **Files:** `frontend/src/app/api/auth/session/route.ts`, `frontend/wrangler.toml`
 
-The session cookie is set exclusively by the Next.js route handler — never by the backend — using these flags:
+The session cookie is set exclusively by the Next.js route handler — never by the backend in any deployed environment — using these flags:
 
 | Flag        | Value                | Purpose                                             |
 |-------------|----------------------|-----------------------------------------------------|
@@ -52,6 +52,8 @@ The session cookie is set exclusively by the Next.js route handler — never by 
 | `maxAge`    | 30 days              | Set to `0` on sign-out for immediate deletion       |
 
 `COOKIE_DOMAIN=.saplinglearn.com` is shipped via `wrangler.toml [vars]` (commit `b1377ec`); the leading dot is what permits `api.saplinglearn.com` and the app origin to share the same session.
+
+**One test-only exception (#381).** `POST /api/auth/test-login` (`backend/routes/auth.py`) sets `sapling_session` directly, with the same flags, so the pytest integration suite and Playwright's global setup can obtain a session without driving real Google OAuth (which is not headless-automatable). It is hard-gated on `APP_ENV in {"local", "test"}` — evaluated per request, not captured at import — and returns a stock `404 {"detail": "Not Found"}` in every other environment, so it does not advertise its existence; it is also `include_in_schema=False`, so it never appears in `/openapi.json`. The allowlist is deliberately narrower than `config.IS_LOCAL` (`{local, development, dev, test}`). See `backend/tests/test_auth_test_login.py`.
 
 ### 1.4 Sign-out
 

--- a/backend/.env.local.example
+++ b/backend/.env.local.example
@@ -24,6 +24,8 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # as placeholders and the stack still starts, but clicking "sign in with Google"
 # fails silently. Fill both in (staging's creds work), and add
 # http://localhost:5000/api/auth/google/callback to the OAuth client's redirect URIs first.
+# (Automated tests don't need these: they mint a session via the local/test-only
+# POST /api/auth/test-login — see docs/local-supabase.md.)
 GOOGLE_CLIENT_ID=your_google_client_id_here
 GOOGLE_CLIENT_SECRET=your_google_client_secret_here
 GOOGLE_AUTH_REDIRECT_URI=http://localhost:5000/api/auth/google/callback

--- a/backend/db/e2e_staging_http.py
+++ b/backend/db/e2e_staging_http.py
@@ -11,22 +11,17 @@ Run (from backend/, staging env):
 """
 from __future__ import annotations
 
-import base64
-import hashlib
-import hmac
 import importlib
-import json
 import os
 import sys
-import time
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from fastapi.testclient import TestClient
 
-from config import SESSION_SECRET
 from db.connection import table
 from services.encryption import encrypt_if_present
+from services.session_tokens import SESSION_COOKIE_NAME, mint_session
 from main import app
 
 # Deterministic default keeps the run idempotent + self-healing (a re-run reclaims a
@@ -51,16 +46,6 @@ def check(name: str, ok: bool, detail: str = "") -> None:
     """Record + print a PASS/FAIL line. Journeys call this for every assertion."""
     _results.append((name, bool(ok)))
     print(f"  {'PASS' if ok else 'FAIL'}  {name}" + (f"  -> {detail}" if detail else ""))
-
-
-def mint_session(user_id: str, ttl: int = 3600) -> str:
-    """Mint a session token exactly as services/auth_guard._decode_session verifies:
-    `<payload_b64>.<sig_b64>`, payload {user_id, exp}, HMAC-SHA256 over payload_b64."""
-    payload = {"user_id": user_id, "exp": int(time.time()) + ttl}
-    pb = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
-    sig = hmac.new(SESSION_SECRET.encode(), pb.encode(), hashlib.sha256).digest()
-    sb = base64.urlsafe_b64encode(sig).decode().rstrip("=")
-    return f"{pb}.{sb}"
 
 
 def current_term_id() -> str | None:
@@ -91,7 +76,7 @@ def setup_fixture() -> None:
         {"user_id": USER_ID, "name": encrypt_if_present("E2E User"),
          "first_name": encrypt_if_present("E2E"), "last_name": encrypt_if_present("User")},
         on_conflict="user_id")
-    client.cookies.set("sapling_session", mint_session(USER_ID))
+    client.cookies.set(SESSION_COOKIE_NAME, mint_session(USER_ID))
 
 
 def teardown_fixture() -> None:

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -17,8 +17,13 @@ import time as _time
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, HTTPException, Query, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
+from pydantic import BaseModel, Field, ValidationError
 
+# The module (not just its constants) so request-time gates can read the LIVE
+# value of APP_ENV / SECURE_COOKIES / SESSION_SECRET instead of an import-time
+# snapshot. See _test_auth_enabled below.
+import config
 from config import (
     GOOGLE_CLIENT_ID,
     GOOGLE_CLIENT_SECRET,
@@ -34,6 +39,7 @@ from config import (
 from db.connection import table
 from services.encryption import encrypt, encrypt_if_present, decrypt_if_present
 from services.auth_guard import get_session_user_id
+from services.session_tokens import SESSION_COOKIE_NAME, mint_session
 
 try:
     from google_auth_oauthlib.flow import Flow
@@ -50,6 +56,33 @@ router = APIRouter()
 # Local-dev auto-approve fires ONLY for real local dev, NOT APP_ENV=test (which must
 # keep the #285 approval gate). So gate on APP_ENV=="local", not the broader IS_LOCAL.
 _LOCAL_AUTO_APPROVE = APP_ENV == "local"
+
+# ── Test-only session minting (#381) ──────────────────────────────────────────
+# The APP_ENVs in which POST /api/auth/test-login exists at all.
+#
+# DELIBERATELY NARROWER than config.IS_LOCAL ({local, development, dev, test}).
+# This endpoint mints a valid session for an ARBITRARY user id with no credential
+# whatsoever, so its blast radius is "full account takeover of every account" if
+# it is ever reachable. `development`/`dev` are plausible values for a real
+# shared deploy's APP_ENV, and IS_LOCAL is used for unrelated, far less dangerous
+# relaxations (unsigned OAuth-state fallback, SESSION_SECRET strength check), so
+# widening later by reusing IS_LOCAL would silently arm this too. `local` is the
+# developer's own machine and `test` is the pytest/CI harness; nothing else.
+TEST_AUTH_ENVS = frozenset({"local", "test"})
+
+TEST_LOGIN_DEFAULT_TTL_SECONDS = 3600
+TEST_LOGIN_MAX_TTL_SECONDS = 86400
+
+
+def _test_auth_enabled() -> bool:
+    """Whether POST /api/auth/test-login is available in this environment.
+
+    Evaluated per REQUEST off the live `config` module attribute — never captured
+    at import time. That makes the gate monkeypatchable (so the 404-under-
+    production behaviour is actually testable) and means no import-ordering
+    accident can freeze it in the open position.
+    """
+    return (getattr(config, "APP_ENV", "") or "").strip().lower() in TEST_AUTH_ENVS
 
 
 def _email_domain_allowed(email: str) -> bool:
@@ -525,15 +558,18 @@ def google_callback(request: Request, code: str = Query(...), state: str = Query
     # second round-trip. The frontend exchanges it for the real, long-lived
     # `sapling_session` cookie (see _REDIRECT_TOKEN_TTL_SECONDS above) — it is
     # NOT the session itself, so it expires quickly.
+    #
+    # Uses the shared minter (#381). Byte-for-byte identical to the inline code
+    # it replaces — same payload key order, same json.dumps separators, same
+    # HMAC — so no behaviour changes here; only the TTL differs from a session,
+    # and that is passed explicitly. The `if SESSION_SECRET` guard is kept (and
+    # the secret passed explicitly) so this path still degrades to "no
+    # auth_token in the redirect" rather than raising, exactly as before.
     auth_token = ""
     if SESSION_SECRET:
-        payload = json.dumps(
-            {"user_id": user_id, "exp": int(_time.time()) + _REDIRECT_TOKEN_TTL_SECONDS}
-        ).encode()
-        payload_b64 = base64.urlsafe_b64encode(payload).decode().rstrip("=")
-        sig_bytes = _hmac.new(SESSION_SECRET.encode(), payload_b64.encode(), hashlib.sha256).digest()
-        sig_b64 = base64.urlsafe_b64encode(sig_bytes).decode().rstrip("=")
-        auth_token = f"{payload_b64}.{sig_b64}"
+        auth_token = mint_session(
+            user_id, ttl=_REDIRECT_TOKEN_TTL_SECONDS, secret=SESSION_SECRET
+        )
 
     params = urlencode({
         "user_id": user_id,
@@ -553,3 +589,111 @@ def google_callback(request: Request, code: str = Query(...), state: str = Query
         path="/",
     )
     return resp
+
+
+# ── POST /api/auth/test-login ─────────────────────────────────────────────────
+
+
+class MintTestSessionBody(BaseModel):
+    """Body of POST /api/auth/test-login."""
+
+    user_id: str = Field(min_length=1, max_length=255)
+    ttl: int | None = Field(
+        default=None,
+        description="Session lifetime in seconds; clamped to [30, 86400].",
+    )
+
+
+@router.post("/test-login", include_in_schema=False)
+async def mint_test_session(request: Request):
+    """Mint a `sapling_session` cookie for a seeded user. LOCAL/TEST ONLY (#381).
+
+    `GET /api/auth/dev-login` was removed and real Google OAuth cannot be driven
+    headlessly, so the pytest integration suite and Playwright's global setup need
+    a sanctioned way to obtain a session. This is that seam — and nothing more:
+    it is NOT a sign-in flow, it is not browser-facing, and it must never be
+    linked from the frontend.
+
+    SECURITY
+    - Hard-gated on `APP_ENV in {"local", "test"}` (see TEST_AUTH_ENVS), read at
+      request time. Anywhere else this returns a plain 404 with the stock
+      "Not Found" body — deliberately not 403, so the endpoint does not even
+      advertise that it exists. `include_in_schema=False` keeps it out of
+      /openapi.json in every environment for the same reason.
+    - It performs NO credential check by design; the environment gate is the only
+      thing standing between a caller and an arbitrary account. That is why the
+      allowlist is two exact strings rather than the broader `config.IS_LOCAL`.
+    - It does not touch the database: it neither creates users nor grants
+      approval/roles, so a token minted for a non-seeded id authenticates as an
+      account that does not exist and gets nowhere.
+
+    Returns the token in the JSON body as well as in the cookie, so a Playwright
+    global-setup step can inject it with `context.addCookies()` instead of
+    replaying the response.
+    """
+    # The gate runs FIRST, before the body is even looked at. The body is parsed
+    # and validated by hand rather than declared as a `MintTestSessionBody`
+    # parameter precisely for this: FastAPI validates declared body params
+    # *before* entering the handler, so in production a malformed body would have
+    # answered 422 — and a 422 from a path that "does not exist" is exactly the
+    # disclosure the 404 is there to prevent. Now every request shape gets the
+    # same stock 404 outside local/test.
+    if not _test_auth_enabled():
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    try:
+        raw = await request.json()
+    except Exception:
+        raw = None
+    if not isinstance(raw, dict):
+        raise HTTPException(status_code=422, detail="Body must be a JSON object.")
+    try:
+        body = MintTestSessionBody.model_validate(raw)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=[
+                {"loc": list(e["loc"]), "msg": e["msg"], "type": e["type"]}
+                for e in exc.errors()
+            ],
+        )
+
+    user_id = body.user_id.strip()
+    if not user_id:
+        raise HTTPException(status_code=422, detail="user_id must not be blank")
+
+    secret = (getattr(config, "SESSION_SECRET", "") or "").strip()
+    if not secret:
+        # config.validate_config() relaxes the SESSION_SECRET requirement for
+        # IS_LOCAL, so local dev can legitimately have none. Fail loudly instead
+        # of handing back a token _decode_session would reject anyway.
+        raise HTTPException(
+            status_code=500,
+            detail="SESSION_SECRET is not configured; cannot mint a test session.",
+        )
+
+    requested = TEST_LOGIN_DEFAULT_TTL_SECONDS if body.ttl is None else body.ttl
+    ttl = max(30, min(int(requested), TEST_LOGIN_MAX_TTL_SECONDS))
+    token = mint_session(user_id, ttl=ttl, secret=secret)
+
+    logger.warning("test-login: minted a session for %r (APP_ENV=%s)", user_id, config.APP_ENV)
+
+    response = JSONResponse({
+        "ok": True,
+        "user_id": user_id,
+        "cookie_name": SESSION_COOKIE_NAME,
+        "token": token,
+        "expires_in": ttl,
+    })
+    # Same attributes the real session cookie carries (frontend BFF
+    # /api/auth/session and the OAuth-state cookie above).
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=token,
+        max_age=ttl,
+        httponly=True,
+        secure=bool(getattr(config, "SECURE_COOKIES", False)),
+        samesite="lax",
+        path="/",
+    )
+    return response

--- a/backend/services/auth_guard.py
+++ b/backend/services/auth_guard.py
@@ -12,11 +12,12 @@ import time as _time
 from fastapi import HTTPException, Request
 from config import SESSION_SECRET
 from db.connection import table
+from services.session_tokens import SESSION_COOKIE_NAME
 
 
 def _decode_session(request: Request) -> dict:
     """Extract and verify the session token from query params or cookies."""
-    token = request.query_params.get("auth_token") or request.cookies.get("sapling_session")
+    token = request.query_params.get("auth_token") or request.cookies.get(SESSION_COOKIE_NAME)
     if not token or not SESSION_SECRET:
         raise HTTPException(status_code=401, detail="Not authenticated")
 

--- a/backend/services/session_tokens.py
+++ b/backend/services/session_tokens.py
@@ -1,0 +1,69 @@
+"""
+Canonical `sapling_session` token minting (#381).
+
+Wire format — this is exactly what `services/auth_guard._decode_session` verifies
+and what the frontend session BFF (`frontend/src/lib/sessionToken.ts`) issues to
+the browser:
+
+    payload     = {"user_id": <str>, "exp": <unix seconds>}
+    payload_b64 = base64url(json.dumps(payload)).rstrip("=")
+    sig_b64     = base64url(HMAC_SHA256(SESSION_SECRET, payload_b64)).rstrip("=")
+    token       = f"{payload_b64}.{sig_b64}"
+
+Before #381 those five lines were re-implemented in three separate places
+(`routes/auth.py`'s OAuth redirect handoff, `db/e2e_staging_http.py`, and
+`tests/integration/conftest.py`). Every copy is a chance for the minted format to
+drift away from the verifier, so everything that mints a token now calls
+`mint_session` here.
+
+(`tests/test_auth_session_contract.py::_mint` deliberately stays an independent
+re-implementation — its entire job is to pin the cross-service contract from the
+outside, which it could not do by calling the code under test.)
+
+SECURITY — this module only *formats and signs*. It performs no authentication
+and no authorization: reaching it means the caller has already decided the
+subject is entitled to a session. No request-path code may call it without such
+a check. The single test-only HTTP surface that exposes it,
+`routes/auth.py::mint_test_session`, is hard-gated on `APP_ENV in {local, test}`
+and 404s everywhere else.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+import config
+
+# The cookie `auth_guard._decode_session` reads and the frontend BFF sets.
+SESSION_COOKIE_NAME = "sapling_session"
+
+DEFAULT_TTL_SECONDS = 3600
+
+
+def _now() -> int:
+    """Current unix time. Seam so tests can freeze the clock and compare tokens
+    byte-for-byte against a reference implementation."""
+    return int(time.time())
+
+
+def mint_session(user_id: str, ttl: int = DEFAULT_TTL_SECONDS, *, secret: str | None = None) -> str:
+    """Mint a signed session token for `user_id`, valid for `ttl` seconds.
+
+    `secret` defaults to the live `config.SESSION_SECRET` (read at call time, not
+    captured at import, so tests and env overrides take effect). An empty secret
+    raises instead of silently signing with a zero-length key: `_decode_session`
+    rejects every token when `SESSION_SECRET` is falsy, so such a token could
+    never authenticate and the failure would surface far from its cause.
+    """
+    key = secret if secret is not None else (config.SESSION_SECRET or "")
+    if not key:
+        raise RuntimeError(
+            "SESSION_SECRET is not configured; refusing to mint an unsigned session token."
+        )
+    payload = json.dumps({"user_id": user_id, "exp": _now() + int(ttl)}).encode()
+    payload_b64 = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    sig = hmac.new(key.encode(), payload_b64.encode(), hashlib.sha256).digest()
+    sig_b64 = base64.urlsafe_b64encode(sig).decode().rstrip("=")
+    return f"{payload_b64}.{sig_b64}"

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -4,12 +4,7 @@ Runs ONLY when RUN_INTEGRATION=1 and SUPABASE_URL is local. Loads backend/.env
 with override so the seed's ENCRYPTION_KEY / SESSION_SECRET / SUPABASE_* win over
 the root conftest's hermetic test defaults (else decryption silently mismatches).
 """
-import base64
-import hashlib
-import hmac
-import json
 import os
-import time
 from pathlib import Path
 
 import pytest
@@ -28,13 +23,14 @@ def _is_local() -> bool:
 
 
 def mint_session(user_id: str, ttl: int = 3600) -> str:
-    """Mint a sapling_session token exactly as auth_guard._decode_session verifies."""
-    from config import SESSION_SECRET
-    payload = {"user_id": user_id, "exp": int(time.time()) + ttl}
-    pb = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
-    sig = hmac.new(SESSION_SECRET.encode(), pb.encode(), hashlib.sha256).digest()
-    sb = base64.urlsafe_b64encode(sig).decode().rstrip("=")
-    return f"{pb}.{sb}"
+    """Mint a sapling_session token via the canonical minter (#381).
+
+    Thin wrapper, not a re-implementation: the import stays function-local so
+    `config` is not imported at module scope, which would freeze SESSION_SECRET /
+    ENCRYPTION_KEY before the `load_dotenv(override=True)` above has run.
+    """
+    from services.session_tokens import mint_session as _mint_session
+    return _mint_session(user_id, ttl)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/backend/tests/test_auth_session_contract.py
+++ b/backend/tests/test_auth_session_contract.py
@@ -1,9 +1,11 @@
 """
 Cross-service session-token contract (#168).
 
-The backend never sets the `sapling_session` cookie itself — the frontend
-session BFF mints it (30-day `SESSION_MAX_AGE`) in a format that must stay
-compatible with what `auth_guard._decode_session` verifies. These tests assert
+In every deployed environment the backend never sets the `sapling_session`
+cookie itself — the frontend session BFF mints it (30-day `SESSION_MAX_AGE`) in
+a format that must stay compatible with what `auth_guard._decode_session`
+verifies. (The one exception is `POST /api/auth/test-login`, gated to
+`APP_ENV in {local, test}`; see test_auth_test_login.py.) These tests assert
 the backend accepts a long-lived token in that format (so sessions do NOT die at
 5 minutes) and rejects expired/tampered ones.
 
@@ -36,15 +38,21 @@ def _mint(user_id: str, ttl_seconds: int, secret: str) -> str:
     """Mint a token in the shape both services use:
     base64url(no pad) JSON {"user_id","exp"} . base64url(HMAC-SHA256(payload_b64)).
 
-    This mirrors the *backend* mint (routes/auth.py) byte-for-byte. It is close
-    to, but not byte-identical with, the frontend's signSession: Python's
-    json.dumps emits `{"user_id": "x", "exp": 1}` (with spaces) where JS
-    JSON.stringify emits `{"user_id":"x","exp":1}` (without). That difference is
-    immaterial to the contract under test — the verifier HMACs the received
-    `payload_b64` opaquely and never re-serializes the payload — but it does mean
-    this helper is a third Python re-implementation of the format, so these tests
-    prove a *Python-minted* token is accepted, not a real frontend-minted one.
-    See the ADR follow-ups for the shared-fixture idea that would close that gap.
+    This mirrors the *backend* mint (services/session_tokens.mint_session)
+    byte-for-byte. It is close to, but not byte-identical with, the frontend's
+    signSession: Python's json.dumps emits `{"user_id": "x", "exp": 1}` (with
+    spaces) where JS JSON.stringify emits `{"user_id":"x","exp":1}` (without).
+    That difference is immaterial to the contract under test — the verifier HMACs
+    the received `payload_b64` opaquely and never re-serializes the payload — but
+    it does mean this helper is a Python re-implementation of the format, so
+    these tests prove a *Python-minted* token is accepted, not a real
+    frontend-minted one. See the ADR follow-ups for the shared-fixture idea that
+    would close that gap.
+
+    Kept deliberately independent of session_tokens.mint_session even after #381
+    unified the production copies: its whole job is to pin the wire format from
+    the outside, which it could not do by calling the code under test.
+    (test_auth_test_login.py asserts the two agree byte-for-byte.)
     """
     payload = json.dumps({"user_id": user_id, "exp": int(time.time()) + ttl_seconds}).encode()
     payload_b64 = base64.urlsafe_b64encode(payload).decode().rstrip("=")

--- a/backend/tests/test_auth_test_login.py
+++ b/backend/tests/test_auth_test_login.py
@@ -145,9 +145,16 @@ class TestProductionGate:
 
     def test_route_exists_but_is_gated(self, client, monkeypatch):
         """404 must come from the gate, not from an unmounted route — otherwise
-        this test would pass trivially even if the endpoint were deleted."""
-        paths = {getattr(r, "path", None) for r in client.app.routes}
-        assert "/api/auth/test-login" in paths
+        this test would pass trivially even if the endpoint were deleted.
+
+        Asserted against `router.routes` rather than `client.app.routes`: how an
+        included router flattens into the composed app's route list is not a
+        stable API (under fastapi 0.138 / starlette 1.3 the sub-router no longer
+        contributes `.path` entries there, so the introspection silently found
+        nothing). The APIRouter's own route objects are the stable seam.
+        """
+        paths = {getattr(r, "path", None) for r in auth_module.router.routes}
+        assert "/test-login" in paths
         monkeypatch.setattr(config, "APP_ENV", "production")
         assert client.post("/api/auth/test-login", json={"user_id": "u"}).status_code == 404
 

--- a/backend/tests/test_auth_test_login.py
+++ b/backend/tests/test_auth_test_login.py
@@ -1,0 +1,328 @@
+"""
+Tests for the test-only session-minting endpoint `POST /api/auth/test-login` (#381).
+
+`GET /api/auth/dev-login` was removed and real Google OAuth is not headless-
+automatable, so pytest and the Playwright global setup need a sanctioned way to
+obtain an authenticated session. This endpoint mints the same HMAC
+`sapling_session` cookie that `services/auth_guard._decode_session` verifies.
+
+The security-critical properties asserted here:
+
+- It returns **404** (not 403) outside `APP_ENV in {"local", "test"}`, with the
+  stock FastAPI "Not Found" body, so it does not advertise its own existence.
+- The allowed set is deliberately NARROWER than `config.IS_LOCAL`
+  (`{local, development, dev, test}`) — `development`/`dev` must 404 too.
+- The gate is evaluated per REQUEST off the live `config` module attribute, so
+  no import-order accident can freeze it open.
+- The minted cookie is not merely string-shaped: it round-trips through the real
+  `auth_guard` decoder.
+- The unified `services.session_tokens.mint_session` is byte-identical to the
+  format the decoder verifies, and the two former copies of that code now
+  delegate to it instead of re-implementing it.
+"""
+import base64
+import hashlib
+import hmac
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+import config
+import routes.auth as auth_module
+from services import auth_guard, session_tokens
+
+SECRET = "test-login-shared-session-secret-at-least-32-bytes"
+FROZEN_NOW = 1_700_000_000
+
+
+def _reference_token(user_id: str, exp: int, secret: str) -> str:
+    """Independent re-implementation of the token format `_decode_session` verifies.
+
+    Deliberately written out longhand (not via session_tokens) so that a change
+    to the canonical helper that broke the wire format would fail this test.
+    """
+    payload = json.dumps({"user_id": user_id, "exp": exp}).encode()
+    payload_b64 = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    sig = hmac.new(secret.encode(), payload_b64.encode(), hashlib.sha256).digest()
+    return f"{payload_b64}.{base64.urlsafe_b64encode(sig).decode().rstrip('=')}"
+
+
+@pytest.fixture
+def secrets_wired(monkeypatch):
+    """Point the minter and the verifier at the same secret, and keep cookies
+    non-Secure so TestClient's (plain http) jar actually stores them."""
+    monkeypatch.setattr(config, "SESSION_SECRET", SECRET)
+    monkeypatch.setattr(config, "SECURE_COOKIES", False)
+    monkeypatch.setattr(auth_guard, "SESSION_SECRET", SECRET)
+
+
+@pytest.fixture
+def client(secrets_wired):
+    """Minimal app: just the auth router plus a probe that runs the REAL decoder.
+
+    conftest's autouse `_bypass_session_auth` stubs `auth_guard._decode_session`
+    for the rest of the suite and stashes the original on `_real_decode_session`;
+    the probe uses the original so the round-trip is genuine.
+    """
+    app = FastAPI()
+    app.include_router(auth_module.router, prefix="/api/auth")
+
+    @app.get("/probe")
+    def _probe(request: Request):
+        return auth_guard._real_decode_session(request)
+
+    return TestClient(app)
+
+
+# ── Production gate ───────────────────────────────────────────────────────────
+
+
+class TestProductionGate:
+    def test_returns_404_under_production(self, client, monkeypatch):
+        monkeypatch.setattr(config, "APP_ENV", "production")
+        resp = client.post("/api/auth/test-login", json={"user_id": "user_alice"})
+        assert resp.status_code == 404
+        # Indistinguishable from a route that does not exist.
+        assert resp.json() == {"detail": "Not Found"}
+        # And nothing was handed out.
+        assert "sapling_session" not in resp.headers.get("set-cookie", "")
+        assert "sapling_session" not in client.cookies
+
+    @pytest.mark.parametrize(
+        "app_env",
+        [
+            "production",
+            "staging",
+            # `development`/`dev` ARE in config.IS_LOCAL. This endpoint uses a
+            # strictly narrower allowlist, so they must still 404.
+            "development",
+            "dev",
+            "",
+            "prod",
+            "localhost",
+            "testing",
+        ],
+    )
+    def test_returns_404_outside_local_and_test(self, client, monkeypatch, app_env):
+        monkeypatch.setattr(config, "APP_ENV", app_env)
+        resp = client.post("/api/auth/test-login", json={"user_id": "user_alice"})
+        assert resp.status_code == 404, f"APP_ENV={app_env!r} must not expose test-login"
+
+    def test_allowlist_is_narrower_than_is_local(self):
+        assert auth_module.TEST_AUTH_ENVS == frozenset({"local", "test"})
+        # Guard the intent: IS_LOCAL is broader, and we must not drift onto it.
+        assert {"development", "dev"} - auth_module.TEST_AUTH_ENVS == {"development", "dev"}
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"json": {}},                                   # missing user_id -> would be 422
+            {"json": {"user_id": ""}},                      # too short -> would be 422
+            {"json": {"user_id": "u", "ttl": "not-an-int"}},  # bad type -> would be 422
+            {"json": []},                                   # not an object
+            {"content": b"not json at all"},                # unparseable body
+            {},                                             # no body at all
+        ],
+    )
+    def test_production_answers_404_for_every_body_shape(self, client, monkeypatch, kwargs):
+        """A 422 from a path that "does not exist" is exactly the disclosure the
+        404 exists to prevent. FastAPI validates *declared* body params before the
+        handler runs, so the gate must be reached before any body parsing."""
+        monkeypatch.setattr(config, "APP_ENV", "production")
+        resp = client.post("/api/auth/test-login", **kwargs)
+        assert resp.status_code == 404, f"leaked {resp.status_code} for {kwargs}"
+        assert resp.json() == {"detail": "Not Found"}
+
+    def test_production_404_matches_a_genuinely_absent_path(self, client, monkeypatch):
+        monkeypatch.setattr(config, "APP_ENV", "production")
+        gated = client.post("/api/auth/test-login", json={"user_id": "u"})
+        absent = client.post("/api/auth/no-such-endpoint", json={"user_id": "u"})
+        assert (gated.status_code, gated.json()) == (absent.status_code, absent.json())
+
+    def test_route_exists_but_is_gated(self, client, monkeypatch):
+        """404 must come from the gate, not from an unmounted route — otherwise
+        this test would pass trivially even if the endpoint were deleted."""
+        paths = {getattr(r, "path", None) for r in client.app.routes}
+        assert "/api/auth/test-login" in paths
+        monkeypatch.setattr(config, "APP_ENV", "production")
+        assert client.post("/api/auth/test-login", json={"user_id": "u"}).status_code == 404
+
+    def test_gate_is_evaluated_at_request_time(self, client, monkeypatch):
+        """`config.APP_ENV` is read at import time by other modules; this gate must
+        not be. Flip it back and forth against a single live app instance."""
+        monkeypatch.setattr(config, "APP_ENV", "production")
+        assert client.post("/api/auth/test-login", json={"user_id": "u"}).status_code == 404
+        monkeypatch.setattr(config, "APP_ENV", "local")
+        assert client.post("/api/auth/test-login", json={"user_id": "u"}).status_code == 200
+        monkeypatch.setattr(config, "APP_ENV", "production")
+        assert client.post("/api/auth/test-login", json={"user_id": "u"}).status_code == 404
+
+    def test_hidden_from_the_openapi_schema(self, client, monkeypatch):
+        monkeypatch.setattr(config, "APP_ENV", "local")
+        assert "/api/auth/test-login" not in client.app.openapi().get("paths", {})
+
+
+# ── Success path ──────────────────────────────────────────────────────────────
+
+
+class TestMintsAcceptedSession:
+    @pytest.mark.parametrize("app_env", ["local", "test", "LOCAL", " Test "])
+    def test_success_under_local_and_test(self, client, monkeypatch, app_env):
+        monkeypatch.setattr(config, "APP_ENV", app_env)
+        resp = client.post("/api/auth/test-login", json={"user_id": "user_alice"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["user_id"] == "user_alice"
+
+    def test_sets_a_cookie_the_real_auth_guard_accepts(self, client, monkeypatch):
+        monkeypatch.setattr(config, "APP_ENV", "test")
+        resp = client.post("/api/auth/test-login", json={"user_id": "user_playwright"})
+        assert resp.status_code == 200
+
+        # The cookie landed in the jar, so a following request is authenticated
+        # with no extra plumbing — this is the pytest ergonomics the issue asks for.
+        assert client.cookies["sapling_session"]
+        probe = client.get("/probe")
+        assert probe.status_code == 200
+        assert probe.json()["user_id"] == "user_playwright"
+
+    def test_cookie_attributes_match_the_real_session_cookie(self, client, monkeypatch):
+        monkeypatch.setattr(config, "APP_ENV", "test")
+        resp = client.post("/api/auth/test-login", json={"user_id": "user_alice"})
+        set_cookie = resp.headers["set-cookie"]
+        assert set_cookie.startswith("sapling_session=")
+        assert "HttpOnly" in set_cookie
+        assert "Path=/" in set_cookie
+        assert "SameSite=lax" in set_cookie
+        assert "Secure" not in set_cookie  # SECURE_COOKIES is False in this fixture
+
+    def test_secure_flag_follows_secure_cookies_config(self, client, monkeypatch):
+        monkeypatch.setattr(config, "APP_ENV", "test")
+        monkeypatch.setattr(config, "SECURE_COOKIES", True)
+        resp = client.post("/api/auth/test-login", json={"user_id": "user_alice"})
+        assert "Secure" in resp.headers["set-cookie"]
+
+    def test_token_is_returned_in_the_body_for_playwright_add_cookies(self, client, monkeypatch):
+        """Playwright global setup injects the token via context.addCookies(), so
+        the body token and the Set-Cookie value must be the same string."""
+        monkeypatch.setattr(config, "APP_ENV", "test")
+        resp = client.post("/api/auth/test-login", json={"user_id": "user_alice"})
+        body = resp.json()
+        assert body["cookie_name"] == "sapling_session"
+        assert body["token"] == client.cookies["sapling_session"]
+        assert body["expires_in"] > 0
+
+        # And that raw token, presented as a cookie by a *different* client,
+        # authenticates — exactly what context.addCookies() does.
+        fresh = TestClient(client.app)
+        fresh.cookies.set("sapling_session", body["token"])
+        assert fresh.get("/probe").json()["user_id"] == "user_alice"
+
+    def test_default_and_custom_ttl(self, client, monkeypatch):
+        monkeypatch.setattr(config, "APP_ENV", "test")
+        default = client.post("/api/auth/test-login", json={"user_id": "u"}).json()
+        assert default["expires_in"] == auth_module.TEST_LOGIN_DEFAULT_TTL_SECONDS
+
+        custom = client.post("/api/auth/test-login", json={"user_id": "u", "ttl": 120}).json()
+        assert custom["expires_in"] == 120
+
+    def test_ttl_is_clamped(self, client, monkeypatch):
+        monkeypatch.setattr(config, "APP_ENV", "test")
+        huge = client.post("/api/auth/test-login", json={"user_id": "u", "ttl": 10**9}).json()
+        assert huge["expires_in"] == auth_module.TEST_LOGIN_MAX_TTL_SECONDS
+        tiny = client.post("/api/auth/test-login", json={"user_id": "u", "ttl": 0}).json()
+        assert tiny["expires_in"] == 30
+
+    @pytest.mark.parametrize("body", [{}, {"user_id": ""}, {"user_id": "   "}, {"user_id": "x" * 300}])
+    def test_rejects_bad_user_id(self, client, monkeypatch, body):
+        monkeypatch.setattr(config, "APP_ENV", "test")
+        assert client.post("/api/auth/test-login", json=body).status_code == 422
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{"json": []}, {"json": "nope"}, {"content": b"not json at all"}, {}],
+    )
+    def test_rejects_non_object_bodies(self, client, monkeypatch, kwargs):
+        monkeypatch.setattr(config, "APP_ENV", "test")
+        assert client.post("/api/auth/test-login", **kwargs).status_code == 422
+
+    def test_rejects_bad_ttl_type(self, client, monkeypatch):
+        monkeypatch.setattr(config, "APP_ENV", "test")
+        resp = client.post("/api/auth/test-login", json={"user_id": "u", "ttl": "soon"})
+        assert resp.status_code == 422
+
+    def test_500_when_session_secret_is_unset(self, client, monkeypatch):
+        """Local dev may legitimately run without SESSION_SECRET (config relaxes the
+        check for IS_LOCAL). Refuse loudly rather than hand out a token signed with
+        an empty key, which the guard would reject anyway."""
+        monkeypatch.setattr(config, "APP_ENV", "local")
+        monkeypatch.setattr(config, "SESSION_SECRET", "")
+        resp = client.post("/api/auth/test-login", json={"user_id": "u"})
+        assert resp.status_code == 500
+        assert "sapling_session" not in resp.headers.get("set-cookie", "")
+
+
+# ── The unified minter ────────────────────────────────────────────────────────
+
+
+class TestUnifiedMintSession:
+    def test_byte_identical_to_the_verified_format(self, monkeypatch):
+        monkeypatch.setattr(session_tokens, "_now", lambda: FROZEN_NOW)
+        minted = session_tokens.mint_session("user_alice", ttl=3600, secret=SECRET)
+        assert minted == _reference_token("user_alice", FROZEN_NOW + 3600, SECRET)
+
+    def test_output_is_accepted_by_the_real_decoder(self, secrets_wired):
+        token = session_tokens.mint_session("user_alice", ttl=3600)
+        scope = {
+            "type": "http", "method": "GET", "path": "/",
+            "headers": [(b"cookie", f"sapling_session={token}".encode())],
+            "query_string": b"",
+        }
+        payload = auth_guard._real_decode_session(Request(scope))
+        assert payload["user_id"] == "user_alice"
+
+    def test_reads_the_secret_from_config_at_call_time(self, monkeypatch):
+        monkeypatch.setattr(session_tokens, "_now", lambda: FROZEN_NOW)
+        monkeypatch.setattr(config, "SESSION_SECRET", SECRET)
+        assert session_tokens.mint_session("u") == _reference_token("u", FROZEN_NOW + 3600, SECRET)
+        monkeypatch.setattr(config, "SESSION_SECRET", "a-completely-different-secret-value")
+        assert session_tokens.mint_session("u") != _reference_token("u", FROZEN_NOW + 3600, SECRET)
+
+    def test_refuses_to_mint_without_a_secret(self, monkeypatch):
+        monkeypatch.setattr(config, "SESSION_SECRET", "")
+        with pytest.raises(RuntimeError, match="SESSION_SECRET"):
+            session_tokens.mint_session("u")
+
+    def test_e2e_staging_helper_is_the_canonical_one(self):
+        """db/e2e_staging_http.py must not keep its own copy (#381)."""
+        from db import e2e_staging_http
+
+        assert e2e_staging_http.mint_session is session_tokens.mint_session
+
+    def test_integration_conftest_delegates_to_the_canonical_one(self, monkeypatch):
+        """tests/integration/conftest.py keeps a thin wrapper (it must not import
+        `config` at module scope, so the .env override still wins), but the token
+        it produces must come from the canonical implementation."""
+        path = Path(__file__).resolve().parent / "integration" / "conftest.py"
+        spec = importlib.util.spec_from_file_location("_integration_conftest_probe", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        source = path.read_text()
+        assert "session_tokens" in source, "integration conftest must delegate, not re-implement"
+        assert "hmac.new(" not in source, "integration conftest still re-implements the HMAC mint"
+
+        monkeypatch.setattr(session_tokens, "_now", lambda: FROZEN_NOW)
+        monkeypatch.setattr(config, "SESSION_SECRET", SECRET)
+        assert module.mint_session("u", 3600) == session_tokens.mint_session("u", 3600)
+
+    def test_routes_auth_redirect_token_uses_the_canonical_minter(self):
+        """The OAuth-callback redirect handoff token is the same wire format; it
+        must not keep a fourth inline copy of the HMAC code."""
+        source = Path(auth_module.__file__).read_text()
+        redirect_block = source[source.index("One-shot HMAC token"):]
+        assert "hmac.new(" not in redirect_block
+        assert "_hmac.new(" not in redirect_block

--- a/docs/local-supabase.md
+++ b/docs/local-supabase.md
@@ -93,6 +93,30 @@ The backend `SESSION_SECRET` **must equal** `frontend/.env.local`'s. Signing in 
 Google creates *your* user (`user_<google-id>`) — a fresh account that goes through
 onboarding — not the seeded `seed-user-demo`; the seed is reference/sample data.
 
+### Automated tests: `POST /api/auth/test-login` (#381)
+
+Google OAuth cannot be driven headlessly, so test harnesses use a separate,
+**test-only** seam instead of a sign-in flow:
+
+```bash
+curl -si -X POST http://localhost:5000/api/auth/test-login \
+  -H 'Content-Type: application/json' \
+  -d '{"user_id": "seed-user-demo"}'
+```
+
+It sets the `sapling_session` cookie (same flags as the real session) **and**
+returns the token in the JSON body, so a Playwright `globalSetup` can inject it
+with `context.addCookies([{ name: 'sapling_session', value: token, url: … }])`
+and pytest can just keep the `TestClient` cookie jar. Optional `ttl` (seconds,
+clamped to `[30, 86400]`) overrides the 1-hour default.
+
+It mints a session for whatever `user_id` you name and performs **no** credential
+check — the only thing protecting it is the environment gate. It exists **only**
+when `APP_ENV` is exactly `local` or `test` (narrower than `IS_LOCAL`, which also
+covers `development`/`dev`); everywhere else it returns a plain `404 Not Found`
+and it is absent from `/openapi.json` in all environments. It does not create
+users, so the `user_id` must already be seeded (`python -m db.seed_local_rich`).
+
 ## Env files
 
 - `backend/.env` — the default env, so `python main.py`, `db.migrate`, and


### PR DESCRIPTION
Closes #381.

`GET /api/auth/dev-login` was removed at `6765f49`, and real Google OAuth is not headless-automatable — so Playwright and the opt-in integration suite had no sanctioned way to obtain an authenticated session. This adds one, and unifies the HMAC minting code it shares with the existing harnesses.

## 1. One canonical `mint_session`

New `backend/services/session_tokens.py` owns the single implementation of the `<payload_b64>.<sig_b64>` wire format that `services/auth_guard._decode_session` verifies, plus the canonical `SESSION_COOKIE_NAME`.

Call sites now import it instead of re-implementing it:

| Site | Before | After |
|---|---|---|
| `backend/db/e2e_staging_http.py:56` | local copy | imports `mint_session` |
| `backend/tests/integration/conftest.py:30` | verbatim copy | thin wrapper delegating to it (the import stays function-local so `config` is not imported before that file's `load_dotenv(override=True)` runs) |
| `backend/routes/auth.py` OAuth redirect handoff (~:528) | inline copy | `mint_session(user_id, ttl=_REDIRECT_TOKEN_TTL_SECONDS, secret=SESSION_SECRET)` |
| `backend/services/auth_guard.py:19` | literal `"sapling_session"` | `SESSION_COOKIE_NAME` |

**On the redirect handoff token** (the judgement call the issue asked for): it *is* the same wire format, and the shared helper produces byte-identical output — same payload key order, same `json.dumps` separators, same HMAC — so this is not a behaviour change. The differing TTL is passed explicitly, and the `if SESSION_SECRET:` guard plus the explicit `secret=` argument are kept, so the path still degrades to "no `auth_token` in the redirect URL" rather than raising, exactly as before. The token's short-TTL/one-shot semantics live entirely in `_REDIRECT_TOKEN_TTL_SECONDS` and the frontend BFF, neither of which this touches. `_clamp_redirect_ttl` / `_parse_redirect_ttl` are untouched and their tests still pass.

`tests/test_auth_session_contract.py::_mint` is deliberately **left** as an independent re-implementation — its whole job is to pin the cross-service format from the outside, which it could not do by calling the code under test. A new test asserts the two agree byte-for-byte.

The OAuth state cookie (`_encode_oauth_cookie`) is a different payload shape (`{n, cv, popup_id}`, no `exp`) with its own unsigned local-dev fallback, so it is **not** routed through the shared minter and is unchanged.

## 2. `POST /api/auth/test-login`

Mounted on the existing auth router. Mints a `sapling_session` for an arbitrary already-seeded user id:

```bash
curl -si -X POST http://localhost:5000/api/auth/test-login \
  -H 'Content-Type: application/json' -d '{"user_id": "seed-user-demo"}'
```

- Sets the cookie with the **same attributes as the real session** (`httponly`, `secure=config.SECURE_COOKIES`, `samesite=lax`, `path=/`), so pytest's `TestClient` jar just works.
- **Also returns the token in the JSON body** (`{ok, user_id, cookie_name, token, expires_in}`) so a Playwright `globalSetup` can inject it with `context.addCookies()`.
- Optional `ttl` (seconds), clamped to `[30, 86400]`; default 1 hour.
- Named `test-login`, not `dev-login`; it is not a sign-in flow and nothing in the frontend links to it.

## SECURITY

This endpoint mints a valid session for **any** user id with **no credential of any kind**. The environment gate is the only thing between a caller and an arbitrary account, so it is built to fail closed:

- **Gate:** `(getattr(config, "APP_ENV", "") or "").strip().lower() in TEST_AUTH_ENVS`, where `TEST_AUTH_ENVS = frozenset({"local", "test"})`.
- **Why not `config.IS_LOCAL`:** `IS_LOCAL` is `{local, development, dev, test}`. `development`/`dev` are plausible values for a real shared deploy, and `IS_LOCAL` already gates unrelated, far less dangerous relaxations (the unsigned OAuth-state fallback, the `SESSION_SECRET` strength check) — so anyone widening `IS_LOCAL` later would silently arm this too. `local` is the developer's own machine, `test` is the pytest/CI harness; nothing else.
- **Fail-closed by default:** `config.APP_ENV` defaults to `"production"` when unset, and a missing/blank attribute also falls outside the allowlist.
- **Evaluated per request** off the live `config` module attribute, never captured at import time — so it is monkeypatchable (i.e. actually testable) and no import-ordering accident can freeze it open.
- **404, not 403**, with the stock FastAPI `{"detail": "Not Found"}` body — the response is byte-identical to a genuinely absent path, so the endpoint does not advertise its own existence. `include_in_schema=False` also keeps it out of `/openapi.json` in *every* environment.
- **No pre-handler disclosure.** FastAPI validates a *declared* body parameter **before** entering the handler, so a malformed body in production would have answered `422` — which discloses that the route exists. The body is therefore parsed and validated by hand, after the gate. A parametrized test covers 6 request shapes (missing field, bad type, non-object, unparseable bytes, no body at all) and asserts every one gets `404`.
- **No DB access.** It does not create users and does not grant approval or roles, so a token minted for a non-seeded id authenticates as an account that does not exist and gets nowhere.
- **Refuses to mint unsigned.** `mint_session` raises rather than signing with an empty key (which `_decode_session` would reject anyway); the endpoint surfaces that as a 500.
- Every mint is logged at WARNING with the user id and `APP_ENV`.

### How the gate is tested (`backend/tests/test_auth_test_login.py`, 47 tests)

- `404` under `APP_ENV=production`, asserting the exact stock body, that no `Set-Cookie` is emitted, and that the response is identical to one for a genuinely absent path.
- `404` for every non-allowlisted env — including `development` and `dev`, which `IS_LOCAL` *would* have permitted — plus `staging`, `prod`, `""`, `localhost`, `testing`.
- The 404 comes from the gate, not an unmounted route: the test asserts `/api/auth/test-login` **is** in `app.routes` and still 404s.
- The gate flips at request time: production → 404, `local` → 200, production → 404 again, against one live app instance.
- Production returns 404 for all 6 malformed-body shapes (this test was verified to fail — 5 of 6 leaking `422` — against a declared-body-param implementation).
- Absent from `openapi()["paths"]`.
- **Round-trip, not string-shape:** the minted cookie is fed to the *real* `auth_guard` decoder (conftest's autouse bypass stashes the original as `_real_decode_session`) and must yield the right `user_id` — both via the `TestClient` jar and via a second client that sets only the body token, mirroring `context.addCookies()`.
- The unified helper is byte-identical to a longhand reference implementation of the verified format, reads the secret from `config` at call time, and refuses to mint without one.
- `db/e2e_staging_http.mint_session is session_tokens.mint_session`; the integration conftest delegates (asserted functionally *and* by the absence of `hmac.new(` in its source); the `routes/auth.py` redirect block contains no inline HMAC.

## Docs / housekeeping

- `SECURITY.md` §1.3 — records this as the one documented exception to "the session cookie is never set by the backend".
- `docs/local-supabase.md` — new "Automated tests" subsection with the curl + Playwright usage.
- `backend/.env.local.example`, `CLAUDE.md` — pointers.
- The stale `dev-login` comment at `backend/.env:19` was fixed locally; that file is gitignored and untracked, so it cannot appear in this diff. The equivalent line in the tracked `backend/.env.local.example` template was already correct and now also mentions the test-login path.

## Verification

```
$ /home/andresl/Projects/sapling/backend/venv/bin/pytest tests/ -q
1020 passed, 5 skipped, 70 warnings, 1 error in 19.46s

$ python -m ruff check .
All checks passed!
```

The single `ERROR tests/test_ocr_pipeline.py::test_save_to_db - RuntimeError: Event loop ...` is **pre-existing and unrelated** — a live-Gemini fixture calling `asyncio.run()` under Python 3.14; it is present identically on the base commit. Run with CI-equivalent env (`SUPABASE_URL` / `SUPABASE_SERVICE_KEY` / `SESSION_SECRET` dummies) since this worktree has no `backend/.env`; without them two `test_storage_service` tests also fail on the base commit for the same reason.

## Follow-up (not in scope here)

Nothing wires Playwright yet — that lands with the browser lane of epic #402. This PR only provides the endpoint it will call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
