### PR TITLE
feat(agents): SAPLING_MODEL_MODE FunctionModel test seam (#391)

### DIFF
--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -18,12 +18,16 @@ the Pro tier for the conversational tutor where reasoning depth matters.
 from __future__ import annotations
 
 import os
-from typing import Literal
+from typing import TYPE_CHECKING, Callable, Literal
 
 from pydantic_ai.models.google import GoogleModel
 from pydantic_ai.providers.google import GoogleProvider
 
 from config import GEMINI_API_KEY
+
+if TYPE_CHECKING:  # keep pydantic-ai's function-model imports out of the prod path
+    from pydantic_ai.messages import ModelMessage, ModelResponse
+    from pydantic_ai.models.function import AgentInfo
 
 
 AgentTask = Literal[
@@ -86,15 +90,112 @@ _DEFAULTS: dict[AgentTask, str] = {
 _provider = GoogleProvider(api_key=GEMINI_API_KEY or "dummy-key-for-import")
 
 
+# ── Test seam: SAPLING_MODEL_MODE (#391) ───────────────────────────────────
+#
+# `model_for` is the single construction point for every agent's model, so it
+# is the only place a deterministic model can be swapped in without stubbing
+# whole agent objects (which leaves the real prompt/tool/output wiring
+# untested). Modes:
+#
+#   real     — GoogleModel. The production default; an unset/empty var is real,
+#              so nothing about the deployed path or the hermetic unit lane
+#              changes.
+#   function — pydantic-ai FunctionModel, driven by a per-task handler a test
+#              registers via `register_function_handler`. Scripted tool calls
+#              run through the REAL tool registration, arg-schema validation,
+#              and retry loop.
+#   cassette — record/replay from tests/evals. Reserved here (issue #391 scope)
+#              but not yet built; raises rather than silently falling through.
+#
+# Why this sits ABOVE the transport guard (#379): a FunctionModel never builds a
+# `google.genai` request, so a function-mode run does not touch the patched
+# `BaseApiClient` and needs no hermetic-guard exemption. If a change ever makes
+# function mode reach the transport, `test_function_mode_rides_above_transport_
+# guard` fails — that is the design invariant, not an accident.
+ModelMode = Literal["real", "function", "cassette"]
+
+# task -> handler(messages, info) -> ModelResponse. Consulted ONLY in function
+# mode (off by default), so it can never affect production or the default lane.
+FunctionModelHandler = Callable[
+    ["list[ModelMessage]", "AgentInfo"], "ModelResponse"
+]
+_FUNCTION_HANDLERS: dict[str, FunctionModelHandler] = {}
+
+
+def _model_mode() -> str:
+    """The active model mode. Unset/blank → 'real'. Normalized for stray
+    case/whitespace so a CI or shell-exported value isn't brittle."""
+    return (os.getenv("SAPLING_MODEL_MODE") or "real").strip().lower()
+
+
+def register_function_handler(task: AgentTask, handler: FunctionModelHandler) -> None:
+    """Register the FunctionModel handler for a task (function mode only).
+
+    The handler has pydantic-ai's FunctionModel signature: it receives the
+    request messages and an `AgentInfo` (carrying the agent's registered tools
+    and output tools) and returns a `ModelResponse`. Tests use this to script
+    tool calls / final output for a specific agent.
+    """
+    _FUNCTION_HANDLERS[task] = handler
+
+
+def unregister_function_handler(task: AgentTask) -> None:
+    _FUNCTION_HANDLERS.pop(task, None)
+
+
+def clear_function_handlers() -> None:
+    """Drop all registered handlers. Tests call this around each case so
+    process-global registrations never leak between them."""
+    _FUNCTION_HANDLERS.clear()
+
+
+def _function_model_for(task: AgentTask) -> GoogleModel:
+    """Build a FunctionModel that dispatches to the task's registered handler at
+    run time. The lookup is deferred to the call (not capture time) so a handler
+    registered after the agent was imported still takes effect."""
+    from pydantic_ai.models.function import FunctionModel
+
+    def _dispatch(messages, info):
+        handler = _FUNCTION_HANDLERS.get(task)
+        if handler is None:
+            raise LookupError(
+                f"SAPLING_MODEL_MODE=function but no handler is registered for "
+                f"task {task!r}. Call agents._providers.register_function_handler("
+                f"{task!r}, ...) before running the agent."
+            )
+        return handler(messages, info)
+
+    # Typed as GoogleModel for the shared return signature; FunctionModel is a
+    # pydantic-ai Model like GoogleModel and agents accept either.
+    return FunctionModel(_dispatch, model_name=f"function:{task}")  # type: ignore[return-value]
+
+
 def model_for(task: AgentTask) -> GoogleModel:
     """Return the configured model for a given pipeline task.
 
-    Reads SAPLING_MODEL_<TASK_UPPER> from env first, falls back to the
-    per-task default. Returns a GoogleModel sharing the project provider.
+    Dispatches on SAPLING_MODEL_MODE (default 'real'). In real mode, reads the
+    per-task SAPLING_MODEL_<TASK_UPPER> override first (ADR 0008), else the
+    per-task default, and returns a GoogleModel sharing the project provider.
+    In function mode, returns a FunctionModel (see the seam notes above).
     """
-    env_key = f"SAPLING_MODEL_{task.upper()}"
-    name = os.getenv(env_key) or _DEFAULTS[task]
-    return GoogleModel(name, provider=_provider)
+    mode = _model_mode()
+    if mode == "real":
+        env_key = f"SAPLING_MODEL_{task.upper()}"
+        name = os.getenv(env_key) or _DEFAULTS[task]
+        return GoogleModel(name, provider=_provider)
+    if mode == "function":
+        return _function_model_for(task)
+    if mode == "cassette":
+        raise NotImplementedError(
+            "SAPLING_MODEL_MODE=cassette (record/replay from tests/evals) is "
+            "reserved by #391 but not yet implemented; use 'function' for "
+            "deterministic agent tests or 'real' for live calls."
+        )
+    raise ValueError(
+        f"unknown SAPLING_MODEL_MODE={mode!r}; expected one of 'real', "
+        f"'function', 'cassette'. An unrecognized mode is a config error, not a "
+        f"silent fall-through to real (which would bill Gemini)."
+    )
 
 
 # Back-compat shim for any caller still using google_model(name).

--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -27,6 +27,7 @@ from config import GEMINI_API_KEY
 
 if TYPE_CHECKING:  # keep pydantic-ai's function-model imports out of the prod path
     from pydantic_ai.messages import ModelMessage, ModelResponse
+    from pydantic_ai.models import Model
     from pydantic_ai.models.function import AgentInfo
 
 
@@ -112,7 +113,6 @@ _provider = GoogleProvider(api_key=GEMINI_API_KEY or "dummy-key-for-import")
 # `BaseApiClient` and needs no hermetic-guard exemption. If a change ever makes
 # function mode reach the transport, `test_function_mode_rides_above_transport_
 # guard` fails — that is the design invariant, not an accident.
-ModelMode = Literal["real", "function", "cassette"]
 
 # task -> handler(messages, info) -> ModelResponse. Consulted ONLY in function
 # mode (off by default), so it can never affect production or the default lane.
@@ -139,17 +139,13 @@ def register_function_handler(task: AgentTask, handler: FunctionModelHandler) ->
     _FUNCTION_HANDLERS[task] = handler
 
 
-def unregister_function_handler(task: AgentTask) -> None:
-    _FUNCTION_HANDLERS.pop(task, None)
-
-
 def clear_function_handlers() -> None:
     """Drop all registered handlers. Tests call this around each case so
     process-global registrations never leak between them."""
     _FUNCTION_HANDLERS.clear()
 
 
-def _function_model_for(task: AgentTask) -> GoogleModel:
+def _function_model_for(task: AgentTask) -> "Model":
     """Build a FunctionModel that dispatches to the task's registered handler at
     run time. The lookup is deferred to the call (not capture time) so a handler
     registered after the agent was imported still takes effect."""
@@ -165,12 +161,10 @@ def _function_model_for(task: AgentTask) -> GoogleModel:
             )
         return handler(messages, info)
 
-    # Typed as GoogleModel for the shared return signature; FunctionModel is a
-    # pydantic-ai Model like GoogleModel and agents accept either.
-    return FunctionModel(_dispatch, model_name=f"function:{task}")  # type: ignore[return-value]
+    return FunctionModel(_dispatch, model_name=f"function:{task}")
 
 
-def model_for(task: AgentTask) -> GoogleModel:
+def model_for(task: AgentTask) -> "Model":
     """Return the configured model for a given pipeline task.
 
     Dispatches on SAPLING_MODEL_MODE (default 'real'). In real mode, reads the

--- a/backend/tests/test_model_mode_seam.py
+++ b/backend/tests/test_model_mode_seam.py
@@ -1,0 +1,303 @@
+"""The SAPLING_MODEL_MODE test seam (#391).
+
+`agents/_providers.py::model_for` is the single place every agent's model is
+built. Until #391 it returned only a `GoogleModel`, so there was no way to
+substitute a deterministic model without stubbing whole agent objects — which
+means today's agent tests never exercise the real prompt, tool registration, or
+output-schema wiring. This module pins the seam:
+
+  - `SAPLING_MODEL_MODE=real` (the default) → `GoogleModel`. Production and the
+    ~976 hermetic unit tests are unchanged: a missing/empty var is `real`.
+  - `SAPLING_MODEL_MODE=function` → pydantic-ai `FunctionModel`, driven by a
+    per-task handler tests register. Scripted tool calls flow through the REAL
+    tool registration, arg-schema validation, and retry loop.
+
+The load-bearing property (issue #391, and the #379 hermetic-guard comment): the
+`FunctionModel` substitutes **above** the google-genai transport. A real agent
+run in `function` mode must NOT trip the autouse `_hermetic_llm_transport` guard
+and needs no exemption marker — because `FunctionModel` never constructs a
+`google.genai` request. `test_function_mode_rides_above_transport_guard` asserts
+exactly that, so a future refactor that accidentally routes function-mode back
+through Gemini fails loudly here.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.models.google import GoogleModel
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+
+from agents._providers import (
+    clear_function_handlers,
+    model_for,
+    register_function_handler,
+)
+from agents.classifier import DocumentClassification, classifier_agent
+from agents.deps import SaplingDeps
+from agents.note_chat import note_chat_agent
+
+
+@pytest.fixture(autouse=True)
+def _clean_function_registry():
+    """Function-mode handlers are process-global; reset around every test so
+    registrations never leak between tests (they can only matter in function
+    mode, which is off by default, but keep the seam pristine regardless)."""
+    clear_function_handlers()
+    yield
+    clear_function_handlers()
+
+
+def _deps() -> SaplingDeps:
+    return SaplingDeps(
+        user_id="seam-user",
+        course_id="seam-course",
+        supabase=None,
+        request_id="seam-req",
+        session_id="seam-note",
+    )
+
+
+# ── Mode dispatch ─────────────────────────────────────────────────────────
+
+
+def test_default_mode_returns_google_model(monkeypatch):
+    """No SAPLING_MODEL_MODE set → real GoogleModel. This is the production
+    default; the ~976 hermetic tests rely on it staying unchanged."""
+    monkeypatch.delenv("SAPLING_MODEL_MODE", raising=False)
+    assert isinstance(model_for("classifier"), GoogleModel)
+
+
+def test_mode_real_explicit_returns_google_model(monkeypatch):
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "real")
+    assert isinstance(model_for("quiz"), GoogleModel)
+
+
+def test_mode_is_case_and_whitespace_insensitive(monkeypatch):
+    """Env vars picked up from shells/CI often carry stray case/whitespace;
+    the mode read must not be brittle to that."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "  Function  ")
+    register_function_handler("classifier", lambda m, i: ModelResponse(parts=[TextPart(content="x")]))
+    assert isinstance(model_for("classifier"), FunctionModel)
+
+
+def test_mode_function_returns_function_model(monkeypatch):
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    register_function_handler("classifier", lambda m, i: ModelResponse(parts=[TextPart(content="x")]))
+    assert isinstance(model_for("classifier"), FunctionModel)
+
+
+def test_real_mode_still_honors_per_task_env_override(monkeypatch):
+    """SAPLING_MODEL_MODE must not clobber the existing per-task model
+    override (ADR 0008) — real mode still reads SAPLING_MODEL_<TASK>."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "real")
+    monkeypatch.setenv("SAPLING_MODEL_QUIZ", "gemini-2.5-pro")
+    m = model_for("quiz")
+    assert isinstance(m, GoogleModel)
+    assert m.model_name == "gemini-2.5-pro"
+
+
+def test_unknown_mode_fails_loudly(monkeypatch):
+    """An unrecognized mode is a configuration error, not a silent fall-through
+    to real — a typo'd SAPLING_MODEL_MODE must never quietly bill Gemini."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "functon")
+    with pytest.raises(ValueError, match="SAPLING_MODEL_MODE"):
+        model_for("classifier")
+
+
+def test_cassette_mode_is_declared_but_not_yet_implemented(monkeypatch):
+    """`cassette` is a recognized mode name (issue #391 scope) but replay is a
+    follow-up; it must raise a pointed NotImplementedError, not dial out."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "cassette")
+    with pytest.raises(NotImplementedError, match="cassette"):
+        model_for("classifier")
+
+
+# ── Registry ──────────────────────────────────────────────────────────────
+
+
+def test_function_mode_without_registered_handler_raises_on_run(monkeypatch):
+    """A FunctionModel is returned eagerly, but running an agent whose task has
+    no registered handler must fail with a pointed error (naming the task), not
+    hang or dial out."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    with classifier_agent.override(model=model_for("classifier")):
+        with pytest.raises(Exception) as exc:
+            classifier_agent.run_sync("some document", deps=_deps())
+    assert "classifier" in str(exc.value)
+
+
+# ── Acceptance criterion: real agent driven by FunctionModel, asserting on
+#    tool-call arguments (issue #391). ─────────────────────────────────────
+
+
+def test_real_agent_driven_by_function_model_asserts_tool_call_args(monkeypatch):
+    """AC: an integration-style test drives a REAL agent with FunctionModel and
+    asserts on tool-call arguments.
+
+    Uses `note_chat_agent` — one of the agents #391 unblocks — because its tools
+    take LLM-chosen arguments (`search_course_materials(query, limit)`), unlike
+    the arg-less quiz/graph readers. The scripted tool call flows through real
+    tool registration and pydantic arg-schema validation before the tool body
+    runs, so recording the query the tool body actually receives proves the
+    whole wiring executed, not just that the model emitted a part.
+    """
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+
+    # Spy on the tool body: records the args the wrapper passes AFTER pydantic
+    # has validated the model's tool-call arguments against the real schema.
+    received: dict = {}
+
+    async def _spy_search(course_id, query, limit=5, *, user_id):
+        received.update(course_id=course_id, query=query, limit=limit, user_id=user_id)
+        return []
+
+    monkeypatch.setattr(
+        "agents.tools.chat_context.search_course_materials", _spy_search
+    )
+
+    seen_tools: dict = {}
+    calls = {"n": 0}
+
+    def handler(messages, info) -> ModelResponse:
+        # Tool registration ran for real: the agent's function tools are visible.
+        seen_tools["names"] = sorted(t.name for t in info.function_tools)
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # First turn: script a call to a real function tool with real args.
+            # The tool is registered under its function name (note_chat.py wires
+            # `search_course_materials_tool` without a name= override).
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="search_course_materials_tool",
+                        args={"query": "gradient descent", "limit": 3},
+                    )
+                ]
+            )
+        # Second turn (after the tool returns): produce the freeform answer.
+        return ModelResponse(
+            parts=[TextPart(content="Gradient descent steps downhill to cut loss.")]
+        )
+
+    register_function_handler("note_chat", handler)
+
+    with note_chat_agent.override(model=model_for("note_chat")):
+        result = note_chat_agent.run_sync("How does gradient descent work?", deps=_deps())
+
+    # The real tools were registered (registration ran through the agent).
+    assert "search_course_materials_tool" in seen_tools["names"]
+    assert "read_active_note" in seen_tools["names"]
+    # The LLM-chosen tool-call arguments were schema-validated and dispatched to
+    # the real tool body with the deps-scoped user/course fields injected.
+    assert received["query"] == "gradient descent"
+    assert received["limit"] == 3
+    assert received["user_id"] == "seam-user"
+    assert received["course_id"] == "seam-course"
+    # The agent looped past the tool call to a final answer.
+    assert "gradient descent" in result.output.lower()
+    assert calls["n"] == 2
+
+
+def test_function_model_output_tool_args_validate_and_retry_loop_runs(monkeypatch):
+    """The retry loop runs for real: a first scripted output with an out-of-range
+    field is rejected by the real DocumentClassification schema, the agent asks
+    the model to retry, and the corrected second response is accepted."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    calls = {"n": 0}
+
+    def handler(messages, info) -> ModelResponse:
+        calls["n"] += 1
+        out_tool = info.output_tools[0].name
+        if calls["n"] == 1:
+            # confidence=5.0 violates the real ge=0/le=1 schema → ModelRetry.
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name=out_tool,
+                        args={
+                            "category": "syllabus",
+                            "is_syllabus": True,
+                            "confidence": 5.0,
+                            "rationale": "schedule + grading rubric present",
+                        },
+                    )
+                ]
+            )
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name=out_tool,
+                    args={
+                        "category": "syllabus",
+                        "is_syllabus": True,
+                        "confidence": 0.9,
+                        "rationale": "schedule + grading rubric present",
+                    },
+                )
+            ]
+        )
+
+    register_function_handler("classifier", handler)
+    with classifier_agent.override(model=model_for("classifier")):
+        result = classifier_agent.run_sync("CS101 syllabus", deps=_deps())
+
+    assert isinstance(result.output, DocumentClassification)
+    assert result.output.confidence == 0.9
+    assert calls["n"] == 2  # the retry actually happened
+
+
+# ── The load-bearing property: function mode is ABOVE the transport guard. ──
+
+
+def test_hermetic_transport_guard_is_installed_in_this_lane():
+    """Sanity: this test carries no exemption marker, so the autouse
+    `_hermetic_llm_transport` guard (#379) must be patched over the google-genai
+    transport. If this ever fails, the next test's 'no egress' claim is vacuous.
+    """
+    from google.genai import _api_client as genai_api_client
+
+    assert getattr(genai_api_client.BaseApiClient.request, "_sapling_llm_guard", False)
+
+
+def test_function_mode_rides_above_transport_guard(monkeypatch):
+    """The core #391 requirement: a real agent runs to completion in function
+    mode in the DEFAULT hermetic lane (no e2e_staging/integration/live_llm
+    marker). It does not trip UnstubbedLLMEgress because FunctionModel never
+    constructs a google-genai request — the substitution is above the transport,
+    not a hole punched through the guard.
+    """
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+
+    def handler(messages, info) -> ModelResponse:
+        out_tool = info.output_tools[0].name
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name=out_tool,
+                    args={
+                        "category": "lecture_notes",
+                        "is_syllabus": False,
+                        "confidence": 0.8,
+                        "rationale": "narrative notes, no schedule",
+                    },
+                )
+            ]
+        )
+
+    register_function_handler("classifier", handler)
+    with classifier_agent.override(model=model_for("classifier")):
+        result = classifier_agent.run_sync("week 1 lecture notes", deps=_deps())
+    assert result.output.category == "lecture_notes"
+
+
+def test_default_real_mode_agent_run_still_trips_the_guard():
+    """Counter-check: without the function seam, a real agent run in the hermetic
+    lane DOES hit the guard. Proves the guard is genuinely in the path and that
+    function mode (above) is what avoids it — not some unrelated exemption.
+
+    UnstubbedLLMEgress subclasses RuntimeError; we match on the message rather
+    than the class so this doesn't depend on whether pytest imported the conftest
+    as `conftest` or `tests.conftest` (they are distinct module objects, so the
+    class identities differ)."""
+    with pytest.raises(RuntimeError, match="unstubbed LLM egress"):
+        classifier_agent.run_sync("anything", deps=_deps())

--- a/docs/decisions/0019-sapling-model-mode-functionmodel-test-seam.md
+++ b/docs/decisions/0019-sapling-model-mode-functionmodel-test-seam.md
@@ -1,0 +1,74 @@
+# 0019: SAPLING_MODEL_MODE FunctionModel test seam
+
+- Status: accepted
+- Date: 2026-07-23
+- Supersedes: none (extends 0008 per-task model routing)
+
+## Context
+
+Epic #402 (the E2E regression suite) needs agent journeys — the tutor, quiz,
+notes, and document paths — to run deterministically in tests while exercising
+the *real* prompt, tool registration, arg-schema validation, and retry loop. Two
+constraints made that hard. First, `agents/_providers.py::model_for(task)` was
+the single construction point for every agent's model but had no injection seam:
+it always returned `GoogleModel(name, provider=_provider)`, so tests could only
+stub whole agent objects (`patch("<agent>.run")`), which leaves all the wiring
+under test untested — the exact failure mode the epic is fighting. Second, #379
+installed an autouse `_hermetic_llm_transport` guard that patches
+`google.genai._api_client.BaseApiClient` at the class level so any unstubbed LLM
+call raises `UnstubbedLLMEgress`; pydantic-ai's `GoogleModel` wraps a
+`google.genai.Client`, so the agents lane already rides that guard. A test seam
+that needed the guard *disabled* to work would be substituting at the wrong
+layer. This is issue #391.
+
+## Decision
+
+Add a `SAPLING_MODEL_MODE` dispatch inside `model_for`, defaulting to `real`.
+
+- `real` (default; unset/blank/`"real"`) → `GoogleModel`, still honoring the
+  per-task `SAPLING_MODEL_<TASK>` override from ADR 0008. Production and the
+  default hermetic unit lane are byte-for-byte unchanged.
+- `function` → a pydantic-ai `FunctionModel` bound to a per-task handler that
+  tests register via `register_function_handler(task, handler)` /
+  `clear_function_handlers()`. The handler resolution is deferred to run time
+  (a closure, not capture time), so a handler registered *after* the agent
+  module was imported still takes effect — necessary because agents build their
+  model at import (`model=model_for(...)` on a module-level `Agent`).
+- `cassette` is a recognized mode name (issue #391 scope) but raises
+  `NotImplementedError`; record/replay from `tests/evals` is a deliberate
+  follow-up, not silently stubbed.
+- Any other value raises `ValueError` — a typo'd mode is a config error, never a
+  silent fall-through to `real` that would bill Gemini.
+
+The load-bearing property: `FunctionModel` never constructs a `google.genai`
+request, so a `function`-mode run substitutes **above** the transport guard. It
+needs no hermetic-guard exemption marker and runs clean in the default lane;
+`test_function_mode_rides_above_transport_guard` pins that invariant, and
+`test_default_real_mode_agent_run_still_trips_the_guard` is the counter-check
+proving the guard is genuinely in the path. Tests drive a real agent by pairing
+the mode with `Agent.override(model=model_for(task))`, the pydantic-ai-blessed
+per-run injection (cf. ADR 0013's per-call `model=` layer).
+
+## Consequences
+
+- (+) Agent tests can exercise the real prompt, tool registration, arg schemas,
+  and retry loop deterministically and offline — the AC drives `note_chat_agent`
+  with a scripted `search_course_materials_tool` call and asserts on the
+  LLM-chosen arguments after schema validation, plus a classifier retry-loop
+  test that watches an out-of-range field get rejected then corrected.
+- (+) Zero production-path change: `real` is the default and the deployed code
+  never reads a handler registry. The ~976-test hermetic lane is untouched
+  (+13 new tests, no regressions).
+- (+) The seam sits above the transport guard by construction, so it composes
+  with #379 instead of fighting it — no fourth guard, no bypass.
+- (−) `FunctionModel` does **not** enforce Gemini's structured-output
+  schema-complexity limits (see `docs/attempts/2026-05-03-orchestrator-schema-
+  complexity.md`). A schema that passes in `function` mode can still be rejected
+  by the real `GoogleModel`. The seam gives confidence about *wiring*, not about
+  whether Gemini will accept an output schema — keep the eval cassettes for that.
+- (−) `cassette` mode is declared but unbuilt; a follow-up issue tracks it.
+- (−) Because agents capture their model at import, `function` mode reaches an
+  already-imported agent only via `Agent.override(...)` or by setting the env
+  before import. Full-journey E2E lanes (#392/#393/#399) that drive real routes
+  must set `SAPLING_MODEL_MODE=function` at process start so every agent builds
+  as a `FunctionModel`, then register per-task handlers.


### PR DESCRIPTION
## Description
`agents/_providers.py::model_for()` was the single construction point for every agent's model but had no injection seam — so agent tests could only stub whole agent objects, leaving the real prompt / tool registration / output-schema wiring untested. This adds a `SAPLING_MODEL_MODE` dispatch so a deterministic `FunctionModel` can be substituted **above** the #379 transport guard, unblocking deterministic tutor/quiz/notes journeys (Chapter 1 of epic #402).

## Changes Made
- `model_for()` dispatches on `SAPLING_MODEL_MODE` (default `real`, so production and the hermetic unit lane are byte-for-byte unchanged):
  - `real` → `GoogleModel`, still honoring the per-task `SAPLING_MODEL_<TASK>` override from ADR 0008.
  - `function` → pydantic-ai `FunctionModel` bound to a per-task handler tests register via `register_function_handler()` / `clear_function_handlers()`. Handler lookup is deferred to run time so a handler registered after the agent was imported still takes effect.
  - `cassette` → recognized (issue scope) but raises `NotImplementedError` — deferred to a follow-up, not silently stubbed.
  - any other value → `ValueError` (a typo'd mode never silently falls through to `real` and bills Gemini).
- `docs/decisions/0019-sapling-model-mode-functionmodel-test-seam.md` — ADR recording the decision.
- `tests/test_model_mode_seam.py` — 13 tests.

## Related Issues
Closes #391

## Testing
- [x] Tested locally — `pytest tests/test_model_mode_seam.py` → 13 passed. Full CI-ignore lane **976 → 989 passed, 5 skipped**, no regressions. `ruff check .` clean.
- [x] Added/updated tests

Written test-first: the acceptance test drives the **real** `note_chat_agent` with a `FunctionModel`, scripts a `search_course_materials_tool` call, and asserts on the LLM-chosen `query`/`limit` arguments **after** they pass real pydantic arg-schema validation and reach the tool body (spied). A second test proves the retry loop runs for real (out-of-range `confidence` rejected by the real `DocumentClassification` schema, then corrected). Two guard tests pin the load-bearing property: a function-mode run does **not** trip `UnstubbedLLMEgress` in the default lane (no exemption marker), while a real-mode run still does — proving the substitution is above the transport, not a hole in the guard.

## Notes for Reviewers
- **Design invariant:** `FunctionModel` never constructs a `google.genai` request, so it rides above the #379 hermetic transport guard with **no** exemption marker and no fourth guard. Verified against the CI-pinned deps (`requirements.lock`: pydantic-ai 1.107.0, google-genai 2.9.0), not just a local venv.
- **Deviation from issue scope, flagged:** the issue lists `cassette` mode; I implemented `real` + `function` (which the AC requires) and left `cassette` as a loud `NotImplementedError`, keeping this diff single-purpose. Follow-up issue to track cassette replay.
- **Known limitation (in the ADR):** `FunctionModel` does not enforce Gemini's structured-output schema-complexity limits (cf. `docs/attempts/2026-05-03-orchestrator-schema-complexity.md`), so the seam proves *wiring*, not that Gemini will accept an output schema — the eval cassettes remain the guard for that.

---
_Generated by [Claude Code](https://claude.ai/code/session_018b3MtMEu2htdGVBGRcrmzX)_