### PR TITLE
test(backend): integration fixtures — psycopg raw-SQL seam, truncate isolation, seeded users (#397)

### DIFF
--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,11 +1,24 @@
-"""Fixtures for the opt-in integration suite (#362) — real local Supabase.
+"""Fixtures for the opt-in integration suite (#362, #397) — real local Supabase.
 
-Runs ONLY when RUN_INTEGRATION=1 and SUPABASE_URL is local. Loads backend/.env
+Runs ONLY when RUN_INTEGRATION=1 and the local stack is up. Loads backend/.env
 with override so the seed's ENCRYPTION_KEY / SESSION_SECRET / SUPABASE_* win over
 the root conftest's hermetic test defaults (else decryption silently mismatches).
+
+The defining constraint of this lane (#397): **writes go through the app; raw-SQL
+assertions read back through a direct psycopg connection**, never through the same
+`db.connection.table()` (PostgREST) layer that made the write — asserting through
+the layer under test proves the echo, not the database. `db_conn` is that seam.
+
+Safety (non-negotiable, #397): the autouse truncate runs over a direct Postgres
+connection on SUPABASE_DB_URL, bypassing PostgREST entirely. That variable is
+independent of SUPABASE_URL (which `_require_local_stack` checks) and .env.staging
+/ .env.production both hold live direct-Postgres strings. `_require_local_db_url`
+asserts SUPABASE_DB_URL is local and **raises loudly rather than skipping** before
+any connection opens — a silent skip would read as "safe" while wiping real data.
 """
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 
@@ -17,9 +30,58 @@ if _RUN:
     load_dotenv(Path(__file__).resolve().parents[2] / ".env", override=True)
 
 
+# Ids mirror db/seed_local_rich. Kept as literals so importing that module — and
+# transitively `config` — stays deferred to fixture bodies, preserving the
+# load_dotenv(override=True) ordering the header depends on.
+USER_ACTIVE = "rich-user-active"
+USER_SECOND = "rich-user-second"
+COURSE_CS = "rich-course-cs101"
+
+
 def _is_local() -> bool:
     url = (os.getenv("SUPABASE_URL") or "").strip()
     return "127.0.0.1" in url or "localhost" in url
+
+
+# ── The direct-Postgres safety gate (#397) ─────────────────────────────────
+
+_LOCAL_DB_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def _db_url_is_local(url: str) -> bool:
+    """True iff SUPABASE_DB_URL points at the local stack.
+
+    Parses the host and requires an EXACT match against loopback names —
+    deliberately stricter than a substring check, so a hostile or fat-fingered
+    URL like ``postgresql://…@127.0.0.1.evil.com/…`` (which *contains* the string
+    ``127.0.0.1``) is correctly rejected rather than treated as local.
+    """
+    if not url:
+        return False
+    try:
+        host = (urlparse(url).hostname or "").strip().lower()
+    except ValueError:
+        return False
+    return host in _LOCAL_DB_HOSTS
+
+
+def _require_local_db_url(url: str) -> None:
+    """Fail LOUDLY (raise, never skip) unless SUPABASE_DB_URL is local.
+
+    This is the last line of defense before the truncate fixture opens a psycopg
+    connection that bypasses PostgREST. `_require_local_stack` only inspects
+    SUPABASE_URL — an independent variable — so the session gate can pass while
+    SUPABASE_DB_URL still points at staging/production. A `skip` here would read
+    as "safe" while a misconfigured var TRUNCATEs real customer data on every run.
+    """
+    if not _db_url_is_local(url):
+        raise RuntimeError(
+            "REFUSING to open the integration psycopg connection: SUPABASE_DB_URL "
+            f"host is not local (got {url!r}). The truncate fixture bypasses "
+            "PostgREST and would wipe whatever this points at. Point SUPABASE_DB_URL "
+            "at the local stack (postgresql://postgres:postgres@127.0.0.1:54322/postgres) "
+            "before running the integration lane."
+        )
 
 
 def mint_session(user_id: str, ttl: int = 3600) -> str:
@@ -33,6 +95,49 @@ def mint_session(user_id: str, ttl: int = 3600) -> str:
     return _mint_session(user_id, ttl)
 
 
+# ── Truncate isolation (#397) ──────────────────────────────────────────────
+#
+# Preserve the reference/catalog layer; truncate everything else and restore the
+# rich baseline before each test, so tests are order-independent. The denylist
+# holds (a) the migration ledger and (b) tables seeded by MIGRATIONS that
+# `seed_local_rich` does not restore, plus the catalog hierarchy (schools /
+# courses / course_offerings) which the seed re-upserts idempotently and which —
+# verified against the schema — carry no FK to `users`, so no CASCADE from a
+# truncated user table can ever reach them. Adding a new migration-seeded
+# reference table means adding it here, or its rows vanish on the first reset.
+_TRUNCATE_DENYLIST = frozenset({
+    "schema_migrations",
+    "terms", "roles", "achievements", "achievement_triggers", "cosmetics",
+    "schools", "courses", "course_offerings",
+})
+
+
+def _public_tables(conn) -> list[str]:
+    rows = conn.execute(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+    ).fetchall()
+    return [r["tablename"] for r in rows]
+
+
+def _truncate_mutable(conn) -> None:
+    targets = [t for t in _public_tables(conn) if t not in _TRUNCATE_DENYLIST]
+    if not targets:
+        return
+    idents = ", ".join(f'"{t}"' for t in targets)
+    # One statement so mutual FKs among the targets truncate together; CASCADE
+    # only ever reaches children of the targets, all of which are themselves
+    # targets (the denylist is catalog-parents-only, checked above).
+    conn.execute(f"TRUNCATE {idents} RESTART IDENTITY CASCADE")
+
+
+def _reseed_baseline() -> None:
+    from db import seed_local_rich
+    seed_local_rich.main()
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _require_local_stack():
     if not _RUN:
@@ -40,20 +145,102 @@ def _require_local_stack():
     if not _is_local():
         pytest.skip(f"integration suite: SUPABASE_URL is not local ({os.getenv('SUPABASE_URL')!r})")
     # Ensure the rich dataset is present (idempotent, additive).
-    from db import seed_local_rich
-    seed_local_rich.main()
+    _reseed_baseline()
+    yield
+
+
+@pytest.fixture(scope="session")
+def db_conn():
+    """Session-scoped raw psycopg connection on SUPABASE_DB_URL — the raw-SQL
+    assertion seam (#397). autocommit so each read sees the app's just-committed
+    PostgREST writes; dict rows so assertions read columns by name. Refuses to
+    open against a non-local SUPABASE_DB_URL (raises, never skips)."""
+    import psycopg
+    from psycopg.rows import dict_row
+
+    url = (os.getenv("SUPABASE_DB_URL") or "").strip()
+    _require_local_db_url(url)
+    conn = psycopg.connect(url, autocommit=True, row_factory=dict_row)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_between_tests(db_conn):
+    """Truncate all mutable tables and restore the rich baseline BEFORE each test,
+    so a prior test's writes (or a crash) cannot leak forward — making the suite
+    pass under `-p no:randomly` and in reversed/shuffled order alike (#397)."""
+    _truncate_mutable(db_conn)
+    _reseed_baseline()
     yield
 
 
 @pytest.fixture
-def client():
-    from main import app
+def seeded_user():
+    """Factory minting distinct, approved users on demand (#397). Each call
+    returns a fresh unique id; the autouse reset removes them between tests, so
+    no manual cleanup is needed. Ownership/IDOR negatives need real second rows —
+    this is how tests get them beyond the two baseline users."""
+    import uuid
+
+    from db.connection import table
+    from services.encryption import encrypt_if_present
+
+    def _make(*, approved: bool = True, onboarding_completed: bool = True,
+              name: str = "Seeded User") -> str:
+        uid = f"it-user-{uuid.uuid4().hex[:12]}"
+        table("users").insert({
+            "id": uid,
+            "email": encrypt_if_present(f"{uid}@integration.test"),
+            "is_approved": approved,
+            "onboarding_completed": onboarding_completed,
+            "auth_provider": "google",
+        })
+        table("user_profiles").insert({
+            "user_id": uid,
+            "name": encrypt_if_present(name),
+        })
+        return uid
+
+    return _make
+
+
+def _client_for(user_id: str):
     from fastapi.testclient import TestClient
+
+    from main import app
+    c = TestClient(app)
+    c.cookies.set("sapling_session", mint_session(user_id))
+    return c
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+
+    from main import app
     return TestClient(app)
 
 
 @pytest.fixture
 def anon_client():
-    from main import app
     from fastapi.testclient import TestClient
+
+    from main import app
     return TestClient(app)
+
+
+@pytest.fixture
+def authed_client():
+    """A TestClient authenticated as the primary baseline user (rich-user-active).
+    Absorbs the per-test `cookies.set(..., mint_session(...))` boilerplate."""
+    return _client_for(USER_ACTIVE)
+
+
+@pytest.fixture
+def other_user_client():
+    """A TestClient authenticated as a DIFFERENT baseline user (rich-user-second)
+    — the counterparty for ownership/IDOR negatives against real rows (#397)."""
+    return _client_for(USER_SECOND)

--- a/backend/tests/integration/test_local_stack.py
+++ b/backend/tests/integration/test_local_stack.py
@@ -1,9 +1,14 @@
-"""Opt-in integration tests against the real local Supabase (#362).
+"""Opt-in integration tests against the real local Supabase (#362, #397).
 
 Run: RUN_INTEGRATION=1 dotenv -f .env run -- \
-     /home/andresl/Projects/sapling/backend/venv/bin/python -m pytest -m integration -q
+     python -m pytest -m integration -q
 (from backend/, local stack up). The conftest also loads .env, so plain
 `RUN_INTEGRATION=1 pytest -m integration` works too.
+
+The lane's rule (#397): **writes go through the app; assertions read back with
+raw SQL** via the session `db_conn` (psycopg), never through the same PostgREST
+`table()` layer that made the write. Auth comes from `authed_client` /
+`other_user_client`; isolation comes from the autouse truncate + reseed.
 """
 import pytest
 
@@ -11,44 +16,86 @@ from db.connection import table
 from services.encryption import (
     decrypt_if_present, decrypt_numeric, encrypt_if_present,
 )
-from tests.integration.conftest import mint_session
+from tests.integration.conftest import COURSE_CS, USER_ACTIVE, USER_SECOND
 
 pytestmark = pytest.mark.integration
 
-_ACTIVE = "rich-user-active"
+# Seeded offering ids (mirror db/seed_local_rich; literals keep config imports
+# deferred — see the conftest header).
+OFF_CS_F25 = "rich-off-cs101-f25"
+OFF_CS_S26 = "rich-off-cs101-s26"
 
 
-def test_db_roundtrip_write_read_delete():
-    """A real insert → select → delete through db.connection.table()."""
+# ── The raw-SQL seam: write via the app, assert with psycopg (#397) ─────────
+
+
+def test_note_created_via_app_is_encrypted_at_rest(authed_client, db_conn):
+    """The flagship pattern: POST a note through the real route, then read the
+    raw `body` column with psycopg. The write went through PostgREST; the
+    assertion does NOT — so a broken encrypt-on-write or a wrong column would be
+    caught, where a table()-both-ways round-trip would only prove the echo."""
+    secret = "raw-sql-secret ✓ gradient descent minimizes loss"
+    res = authed_client.post(
+        "/api/notes",
+        json={
+            "user_id": USER_ACTIVE,
+            "course_id": COURSE_CS,
+            "title": "Encrypted-at-rest note",
+            "body": secret,
+            "tags": ["it-raw-sql"],
+        },
+    )
+    assert res.status_code == 200, res.text
+    note_id = res.json()["id"]
+
+    row = db_conn.execute(
+        "SELECT body FROM notes WHERE id = %s", (note_id,)
+    ).fetchone()
+    assert row is not None, "note the app claims to have written is absent in raw SQL"
+    raw_body = row["body"]
+    assert raw_body != secret, "body stored as plaintext — encryption-on-write regressed"
+    assert decrypt_if_present(raw_body) == secret, "ciphertext does not round-trip back"
+
+
+def test_db_roundtrip_write_read_delete(db_conn):
+    """Low-level insert/delete via table(), but every assertion reads through raw
+    SQL (psycopg) rather than table() — so this exercises the database, not the
+    PostgREST echo of the write."""
     rid = "rich-it-school-roundtrip"
     try:
         table("schools").upsert(
             {"id": rid, "name": "IT Roundtrip", "slug": rid}, on_conflict="id"
         )
-        rows = table("schools").select("id,slug", filters={"id": f"eq.{rid}"})
-        assert rows and rows[0]["slug"] == rid
+        row = db_conn.execute(
+            "SELECT slug FROM schools WHERE id = %s", (rid,)
+        ).fetchone()
+        assert row is not None and row["slug"] == rid
     finally:
         table("schools").delete({"id": f"eq.{rid}"})
-    assert table("schools").select("id", filters={"id": f"eq.{rid}"}) == []
+    gone = db_conn.execute("SELECT id FROM schools WHERE id = %s", (rid,)).fetchall()
+    assert gone == []
 
 
-def test_encryption_roundtrip_text_and_numeric():
-    """Write encrypted → read raw → decrypt; both text and numeric paths."""
+def test_encryption_roundtrip_text_and_numeric(db_conn):
+    """Write an encrypted note via table(), then read the raw ciphertext column
+    with psycopg: the stored bytes must be ciphertext, and must decrypt back."""
     nid = "rich-it-note-enc"
     secret = "integration-secret-body-✓"
     try:
         table("notes").upsert(
             {
                 "id": nid,
-                "user_id": _ACTIVE,
-                "offering_id": "rich-off-cs101-s26",
+                "user_id": USER_ACTIVE,
+                "offering_id": OFF_CS_S26,
                 "title": encrypt_if_present("IT note"),
                 "body": encrypt_if_present(secret),
                 "tags": ["it"],
             },
             on_conflict="id",
         )
-        raw = table("notes").select("body", filters={"id": f"eq.{nid}"})[0]["body"]
+        raw = db_conn.execute(
+            "SELECT body FROM notes WHERE id = %s", (nid,)
+        ).fetchone()["body"]
         assert raw != secret                       # stored ciphertext, not plaintext
         assert decrypt_if_present(raw) == secret   # round-trips back
         # numeric path via decrypt_numeric — this is the unit-level check; the
@@ -60,27 +107,38 @@ def test_encryption_roundtrip_text_and_numeric():
         table("notes").delete({"id": f"eq.{nid}"})
 
 
-def test_route_e2e_auth_me(client, anon_client):
+# ── Auth fixtures replace the per-test cookie boilerplate (#397) ────────────
+
+
+def test_route_e2e_auth_me(authed_client, anon_client):
     """Full route E2E: real auth guard + real DB + real decryption."""
     anon = anon_client.get("/api/auth/me")
     assert anon.status_code == 401             # no cookie → unauthenticated
 
-    client.cookies.set("sapling_session", mint_session(_ACTIVE))
-    res = client.get("/api/auth/me")
+    res = authed_client.get("/api/auth/me")
     assert res.status_code == 200
     data = res.json()
-    assert data["user_id"] == _ACTIVE
+    assert data["user_id"] == USER_ACTIVE
     assert data["is_approved"] is True
     assert isinstance(data["name"], str) and data["name"]   # decrypted display name
 
 
-def test_route_e2e_gradebook_decrypt_numeric(client):
+def test_authed_and_other_user_are_distinct(authed_client, other_user_client):
+    """authed_client and other_user_client must resolve to genuinely different
+    real users — the precondition for every ownership/IDOR negative (#397)."""
+    me = authed_client.get("/api/auth/me").json()
+    them = other_user_client.get("/api/auth/me").json()
+    assert me["user_id"] == USER_ACTIVE
+    assert them["user_id"] == USER_SECOND
+    assert me["user_id"] != them["user_id"]
+
+
+def test_route_e2e_gradebook_decrypt_numeric(authed_client):
     """Gradebook route returns decrypt_numeric'd points end-to-end."""
-    client.cookies.set("sapling_session", mint_session(_ACTIVE))
     # rich-user-active is enrolled in CS101 spring-2026 with graded assignments.
-    res = client.get(
+    res = authed_client.get(
         "/api/gradebook/courses/rich-course-cs101",
-        params={"user_id": _ACTIVE, "semester": "Spring 2026"},
+        params={"user_id": USER_ACTIVE, "semester": "Spring 2026"},
     )
     assert res.status_code == 200, res.text
     body = res.json()
@@ -89,3 +147,58 @@ def test_route_e2e_gradebook_decrypt_numeric(client):
     for a in graded:
         assert isinstance(a["points_earned"], (int, float))     # decrypted numeric
         assert isinstance(a["points_possible"], (int, float))
+
+
+# ── seeded_user factory (#397) ─────────────────────────────────────────────
+
+
+def test_seeded_user_factory_makes_distinct_approved_users(seeded_user, db_conn):
+    """Each call mints a distinct, approved user with a real row."""
+    a = seeded_user(name="Alice IT")
+    b = seeded_user(name="Bob IT")
+    assert a != b
+    rows = db_conn.execute(
+        "SELECT id, is_approved FROM users WHERE id = ANY(%s)", ([a, b],)
+    ).fetchall()
+    assert {r["id"] for r in rows} == {a, b}
+    assert all(r["is_approved"] for r in rows)
+
+
+# ── Truncate isolation, proven order-independently (#397) ───────────────────
+#
+# Both tests insert a note with the SAME fixed id. If the autouse reset did not
+# run between them, the second insert to run would either see a leaked row or
+# collide on the PK. `_second` asserts the id is absent at entry, so it proves
+# isolation whichever order the two run in (default, reversed, or shuffled).
+_ISO_NOTE_ID = "it-iso-note-fixed-id"
+
+
+def _insert_iso_note() -> None:
+    table("notes").insert(
+        {
+            "id": _ISO_NOTE_ID,
+            "user_id": USER_ACTIVE,
+            "offering_id": OFF_CS_F25,
+            "tags": ["iso"],
+        }
+    )
+
+
+def test_truncate_isolation_first(db_conn):
+    _insert_iso_note()
+    rows = db_conn.execute(
+        "SELECT id FROM notes WHERE id = %s", (_ISO_NOTE_ID,)
+    ).fetchall()
+    assert len(rows) == 1
+
+
+def test_truncate_isolation_second(db_conn):
+    pre = db_conn.execute(
+        "SELECT id FROM notes WHERE id = %s", (_ISO_NOTE_ID,)
+    ).fetchall()
+    assert pre == [], "reset did not run: a prior test's row leaked into this one"
+    _insert_iso_note()
+    rows = db_conn.execute(
+        "SELECT id FROM notes WHERE id = %s", (_ISO_NOTE_ID,)
+    ).fetchall()
+    assert len(rows) == 1

--- a/backend/tests/test_integration_db_guard.py
+++ b/backend/tests/test_integration_db_guard.py
@@ -1,0 +1,48 @@
+"""The integration truncate's direct-Postgres safety gate (#397), proven in the
+DEFAULT hermetic lane.
+
+This is pure URL logic with no database, so it runs in normal CI (not the opt-in
+integration lane) — which is exactly where we want the guard proven: the autouse
+truncate fixture opens a psycopg connection on SUPABASE_DB_URL that bypasses
+PostgREST, and `_require_local_stack` only checks the *independent* SUPABASE_URL.
+`backend/.env.staging` / `.env.production` both carry live direct-Postgres
+strings, so a misconfigured SUPABASE_DB_URL would TRUNCATE real data. The gate
+must RAISE (never skip) on anything non-local. A skip would read as "safe".
+"""
+import pytest
+
+from tests.integration.conftest import _db_url_is_local, _require_local_db_url
+
+_LOCAL_URLS = [
+    "postgresql://postgres:postgres@127.0.0.1:54322/postgres",
+    "postgresql://postgres:postgres@localhost:54322/postgres",
+    "postgres://postgres:postgres@[::1]:54322/postgres",
+]
+
+_NON_LOCAL_URLS = [
+    "postgresql://postgres:pw@db.abcdefgh.supabase.co:5432/postgres",
+    "postgresql://postgres:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres",
+    # The substring trap: contains "127.0.0.1"/"localhost" but resolves elsewhere.
+    "postgresql://postgres:pw@127.0.0.1.evil.com:5432/postgres",
+    "postgresql://postgres:pw@localhost.attacker.net:5432/postgres",
+    "",
+]
+
+
+@pytest.mark.parametrize("url", _LOCAL_URLS)
+def test_local_db_urls_are_accepted(url):
+    assert _db_url_is_local(url) is True
+    _require_local_db_url(url)  # must not raise
+
+
+@pytest.mark.parametrize("url", _NON_LOCAL_URLS)
+def test_non_local_db_urls_are_classified_non_local(url):
+    assert _db_url_is_local(url) is False
+
+
+@pytest.mark.parametrize("url", _NON_LOCAL_URLS)
+def test_guard_raises_not_skips_on_non_local_url(url):
+    """The AC: refuses a non-local SUPABASE_DB_URL by RAISING (a skip would be a
+    silent false-safe). RuntimeError, not pytest.skip.Exception."""
+    with pytest.raises(RuntimeError, match="SUPABASE_DB_URL"):
+        _require_local_db_url(url)


### PR DESCRIPTION
## Description
The integration lane existed but did not test the database: two tests round-tripped through `db.connection.table()` (PostgREST) **both ways** — proving the echo, not the DB — and two asserted only on the app's own JSON. This adds the raw-SQL assertion seam the lane was missing, the autouse truncate isolation, and the seeded-user / auth fixtures that #398 builds on. **The defining rule: writes go through the app; assertions read back with raw SQL (psycopg), never through the layer that made the write.**

## Changes Made
- **`db_conn`** — session-scoped psycopg connection on `SUPABASE_DB_URL` (dict rows, autocommit so reads see the app's committed writes). The raw-SQL seam; not a PostgREST read.
- **`_require_local_db_url`** — the non-negotiable safety gate. `SUPABASE_DB_URL` is independent of the `SUPABASE_URL` that `_require_local_stack` checks, and `.env.staging`/`.env.production` both hold live direct-Postgres strings, so a misconfigured var would `TRUNCATE` a real project. It parses the host (strict — `127.0.0.1.evil.com` is rejected, unlike a substring check) and **raises, never skips** on anything non-local.
- **`_reset_between_tests`** — autouse `TRUNCATE ... RESTART IDENTITY CASCADE` of every mutable table + reseed of the rich baseline before each test → order-independence. The denylist preserves the migration-seeded reference layer (`terms`, `roles`, `achievements`, `achievement_triggers`, `cosmetics`) + the catalog hierarchy (`schools`, `courses`, `course_offerings`), which I verified against the schema carry **no FK to `users`**, so no CASCADE from a truncated user table can ever reach them.
- **`seeded_user`** factory (distinct, approved users) and **`authed_client`** / **`other_user_client`**, replacing the per-test `cookies.set(..., mint_session(...))` boilerplate.
- **`test_local_stack.py`** refactored onto the fixtures: the flagship test POSTs a note through the real route and asserts the ciphertext at rest via raw SQL; a truncate-isolation pair proves ordering-independence; distinct-users and seeded_user tests cover the new fixtures.
- **`tests/test_integration_db_guard.py`** — proves the safety gate in the DEFAULT hermetic lane (pure URL logic, no DB), so it gates every PR.

## Related Issues
Closes #397

## Testing
- [x] Tested locally (hermetic lane) — `ruff check .` clean; default CI lane **976 → 989 passed, 10 skipped**, no regressions. The safety-gate test (13 cases) passes in the default lane. The 9 DB-backed integration tests **collect and skip** cleanly without `RUN_INTEGRATION`.
- [x] Added/updated tests

## Notes for Reviewers
> [!IMPORTANT]
> **The 9 DB-backed tests could not be executed in the authoring environment** — this cloud session's egress proxy returns `403` on the Docker image CDNs, so `supabase start` cannot pull `supabase/postgres`/PostgREST and no local stack can come up. I verified everything provable offline (safety gate + default-lane green + collection), and I'm dispatching the `integration (local supabase)` workflow on this branch to exercise the DB-backed lane against a real stack. **Merge is gated on that run being green**, in addition to the default `Backend (pytest)` check.

- **Safety first:** the truncate runs over raw psycopg on `SUPABASE_DB_URL`, bypassing PostgREST. The `_require_local_db_url` gate raising (not skipping) on non-local is the load-bearing invariant — a silent skip would read as "safe" while wiping real data. It's proven in the always-on lane.
- **Truncate denylist is a documented drift point:** adding a new migration-seeded reference table means adding it to `_TRUNCATE_DENYLIST`, or its rows vanish on the first reset. Called out in the conftest comment.
- **Import ordering preserved:** all `config`-touching imports (seed, encryption, `main`, session tokens) stay function-local, exactly as the pre-existing conftest did, so `load_dotenv(override=True)` still wins over the root conftest's hermetic keys.

---
_Generated by [Claude Code](https://claude.ai/code/session_018b3MtMEu2htdGVBGRcrmzX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded local integration coverage for authentication, authorization isolation, gradebook decryption, and encrypted note storage.
  * Added checks confirming encrypted data is not stored as readable plaintext.
  * Improved test data isolation with deterministic reset and reseeding between tests.
  * Added safety checks to prevent integration tests from connecting to or modifying non-local databases.
  * Added coverage for distinct seeded users and authenticated versus unauthenticated access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->