### PR TITLE
test(backend): migration order pins + encryption round-trip suite + e2e→subcutaneous rename (Part of #398)

### DIFF
--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -56,7 +56,7 @@ mocked per-test, not globally.
 | `test_shared_course_context.py` | Course context service, system prompt building, quiz prompt augmentation |
 | `test_ocr_pipeline.py` | Mocked agent-path unit tests **plus** live-Gemini **integration** tests gated on `GEMINI_API_KEY` (the DB layer is stubbed by the hermetic fixture) |
 | `test_supabase.py` | **Connectivity script** — verifies env vars and table access. Run manually: `python tests/test_supabase.py` |
-| `test_e2e_staging.py` | **Opt-in staging E2E** — drives live routes against the REAL staging DB; skipped unless `RUN_STAGING_E2E=1` (see below) |
+| `test_subcutaneous_staging.py` | **Opt-in staging subcutaneous test** — drives live routes against the REAL staging DB; skipped unless `RUN_STAGING_E2E=1` (see below) |
 
 The table highlights the load-bearing suites; the directory holds ~70 `test_*.py`
 files covering routes, services, encryption, and auth scoping.
@@ -70,12 +70,13 @@ files covering routes, services, encryption, and auth scoping.
   of that module stays fully mocked. No `--ignore` needed. (Their DB layer is
   stubbed by the hermetic conftest fixture, so they no longer write to a real
   project.)
-- **Staging E2E** — `test_e2e_staging.py` (marker `e2e_staging`) drives the live
-  routes against the REAL staging DB and is skipped unless `RUN_STAGING_E2E=1`.
-  It intentionally bypasses the hermetic DB + auth-bypass fixtures:
+- **Staging subcutaneous** — `test_subcutaneous_staging.py` (marker `e2e_staging`)
+  drives the live routes against the REAL staging DB and is skipped unless
+  `RUN_STAGING_E2E=1`. It intentionally bypasses the hermetic DB + auth-bypass
+  fixtures:
 
   ```bash
-  RUN_STAGING_E2E=1 dotenv -f .env.staging run -- python -m pytest tests/test_e2e_staging.py -v
+  RUN_STAGING_E2E=1 dotenv -f .env.staging run -- python -m pytest tests/test_subcutaneous_staging.py -v
   ```
 
 ---

--- a/backend/tests/integration/test_encryption_roundtrip.py
+++ b/backend/tests/integration/test_encryption_roundtrip.py
@@ -1,0 +1,103 @@
+"""Encryption-at-rest + decrypt-integrity across every encrypted column (#398).
+
+The epic's highest-value check: a silent decrypt regression corrupts data
+invisibly. Using the #397 raw-SQL seam, we read the *seeded* baseline rows
+directly with psycopg and assert two things per encrypted column:
+
+  1. the raw stored bytes are ciphertext (NOT the known plaintext), and
+  2. the app's decrypt helper round-trips them back to the expected value.
+
+Reading the seed (rather than writing fresh rows) keeps the assertion anchored to
+known-constant plaintext across all three flavours — text (`decrypt_if_present`),
+numeric (`decrypt_numeric`, for `assignments.points_*`), and JSON
+(`decrypt_json`, for `sessions.summary_json`). The route-level encrypt-on-write
+path is covered separately by the flagship note test in test_local_stack.py.
+
+Plaintext constants mirror db/seed_local_rich (kept as literals here for the same
+import-ordering reason the conftest documents).
+"""
+import pytest
+
+from services.encryption import decrypt_if_present, decrypt_json, decrypt_numeric
+
+pytestmark = pytest.mark.integration
+
+
+# (label, table, id_column, id_value, column, expected_plaintext)
+_TEXT_COLUMNS = [
+    ("user_profiles.name", "user_profiles", "user_id", "rich-user-active", "name", "Rich Active"),
+    ("user_profiles.first_name", "user_profiles", "user_id", "rich-user-active", "first_name", "Rich"),
+    ("notes.title", "notes", "id", "rich-note-cs-week1", "title", "Week 1 — Variables"),
+    ("notes.body", "notes", "id", "rich-note-cs-week1", "body",
+     "A variable binds a name to a value. Types: int, str, bool, float."),
+    ("documents.summary", "documents", "id", "rich-doc-cs-syllabus", "summary",
+     "CS101 syllabus: weekly homework, one midterm, final project."),
+    ("documents.extracted_text", "documents", "id", "rich-doc-cs-syllabus", "extracted_text",
+     "CS101 — Introduction to Computer Science. Weekly homework due Fridays..."),
+    ("messages.content", "messages", "id", "rich-msg-cs-recursion-1", "content",
+     "Can you explain recursion?"),
+    ("room_messages.text", "room_messages", "id",
+     "11111111-1111-4111-8111-000000000001", "text",
+     "Anyone up for reviewing recursion before the midterm?"),
+]
+
+# (label, id_value, column, expected_number)
+_NUMERIC_COLUMNS = [
+    ("assignments.points_possible", "rich-asg-cs-f25-hw1", "points_possible", 100.0),
+    ("assignments.points_earned", "rich-asg-cs-f25-hw1", "points_earned", 88.0),
+]
+
+
+def _raw(db_conn, table: str, id_col: str, id_val: str, column: str):
+    row = db_conn.execute(
+        f'SELECT "{column}" FROM "{table}" WHERE "{id_col}" = %s', (id_val,)
+    ).fetchone()
+    assert row is not None, f"seed row {table}.{id_col}={id_val!r} is missing"
+    return row[column]
+
+
+@pytest.mark.parametrize(
+    "label,table,id_col,id_val,column,expected",
+    _TEXT_COLUMNS,
+    ids=[c[0] for c in _TEXT_COLUMNS],
+)
+def test_text_column_is_ciphertext_at_rest_and_decrypts(
+    db_conn, label, table, id_col, id_val, column, expected
+):
+    raw = _raw(db_conn, table, id_col, id_val, column)
+    assert raw is not None, f"{label} is NULL — seed did not populate it"
+    assert raw != expected, f"{label} stored as PLAINTEXT — encryption-at-rest regressed"
+    assert decrypt_if_present(raw) == expected, f"{label} ciphertext does not round-trip"
+
+
+@pytest.mark.parametrize(
+    "label,id_val,column,expected",
+    _NUMERIC_COLUMNS,
+    ids=[c[0] for c in _NUMERIC_COLUMNS],
+)
+def test_numeric_column_is_ciphertext_at_rest_and_decrypts(
+    db_conn, label, id_val, column, expected
+):
+    raw = _raw(db_conn, "assignments", "id", id_val, column)
+    assert raw is not None, f"{label} is NULL — seed did not populate it"
+    assert str(raw) != str(expected), f"{label} stored as PLAINTEXT — encryption-at-rest regressed"
+    assert decrypt_numeric(raw) == expected, f"{label} does not decrypt to the seeded number"
+
+
+def test_sessions_summary_json_is_ciphertext_at_rest_and_decrypts(db_conn):
+    """summary_json needs the JSON pair (encrypt_json/decrypt_json), not the text
+    pair — a column that's easy to enumerate with the wrong helper (#398 comment)."""
+    raw = _raw(db_conn, "sessions", "id", "rich-sess-cs-recursion", "summary_json")
+    assert raw is not None, "sessions.summary_json is NULL — seed did not populate it"
+    decoded = decrypt_json(raw)
+    assert isinstance(decoded, dict) and "bullets" in decoded
+    assert "Discussed base cases" in decoded["bullets"]
+
+
+def test_documents_concept_notes_uses_json_encryption(db_conn):
+    """documents.concept_notes is stored via encrypt_json (a list of concepts)."""
+    raw = _raw(db_conn, "documents", "id", "rich-doc-cs-syllabus", "concept_notes")
+    assert raw is not None, "documents.concept_notes is NULL — seed did not populate it"
+    decoded = decrypt_json(raw)
+    assert isinstance(decoded, list) and decoded
+    assert any(c.get("name") == "Variables" for c in decoded)

--- a/backend/tests/integration/test_migrations_ledger.py
+++ b/backend/tests/integration/test_migrations_ledger.py
@@ -1,0 +1,25 @@
+"""Migration ledger consistency against the real local stack (#398).
+
+The offline apply-order pins live in tests/test_migrations.py. This is the
+DB-backed half: on the running stack, every migration file on disk must be
+recorded in the schema_migrations ledger — a file present but unrecorded means
+the DB is behind, or a file was added without `python -m db.migrate`.
+"""
+from pathlib import Path
+
+import pytest
+
+from db.migrate import discover_migrations
+
+pytestmark = pytest.mark.integration
+
+
+def test_schema_migrations_ledger_records_every_file(db_conn):
+    on_disk = {p.name for p in discover_migrations(Path("db/migrations"))}
+    rows = db_conn.execute("SELECT filename FROM schema_migrations").fetchall()
+    recorded = {r["filename"] for r in rows}
+    missing = on_disk - recorded
+    assert not missing, (
+        f"migrations on disk but not applied to the local stack: {sorted(missing)} "
+        "(run `python -m db.migrate`)"
+    )

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,89 @@
+"""Migration ledger + apply-order pins (#398).
+
+The runner applies migrations in `sorted(glob("*.sql"))` order — pure
+lexicographic by filename (`db/migrate.py::discover_migrations`). Three prefixes
+carry TWO files each (0019 / 0020 / 0021), so the numeric prefix alone does not
+determine order — the suffix does, and a rename could silently flip it.
+
+The 0021 pair is load-bearing: `0021_gradebook.sql` DROPs and re-CREATEs the
+enrollment-keyed `assignments` table, and `0021_gradebook_curve.sql` then ALTERs
+it to add the `curve_*` columns. So gradebook MUST apply before gradebook_curve —
+otherwise the curve columns are added to the old table and then dropped when
+gradebook recreates it, and `routes/gradebook.py` reads columns that don't exist.
+
+These order pins are pure filename logic (no database) so they gate in the
+default lane. The ledger-consistency check needs the real local stack and is
+marked `integration`.
+
+NOTE (issue #398 comment, corrected): the comment states the 0021 pair "sorts
+gradebook_curve BEFORE gradebook under filesystem sort, which is the opposite of
+the numeric intent." That is not what the runner does. `sorted()` compares
+`"0021_gradebook.sql"` vs `"0021_gradebook_curve.sql"` and, because `.` (0x2E) <
+`_` (0x5F), applies **gradebook first** — which is exactly the required
+dependency order. `test_gradebook_applies_before_curve` pins that.
+"""
+import re
+from pathlib import Path
+
+from db.migrate import discover_migrations
+
+MIGRATIONS_DIR = "db/migrations"
+
+# Duplicate-prefix pairs and the order the runner MUST keep (first, then second).
+_PINNED_PAIRS = [
+    ("0019_conventions_terms_schools.sql", "0019_gradebook_drops.sql"),
+    ("0020_academics_split.sql", "0020_gradescope.sql"),
+    ("0021_gradebook.sql", "0021_gradebook_curve.sql"),
+]
+
+
+def _order() -> list[str]:
+    return [p.name for p in discover_migrations(Path(MIGRATIONS_DIR))]
+
+
+# ── Offline: apply-order pins (pure filename logic) ─────────────────────────
+
+
+def test_every_migration_has_a_four_digit_numeric_prefix():
+    """A file without the NNNN_ prefix sorts unpredictably and breaks ordering."""
+    bad = [n for n in _order() if not re.match(r"^\d{4}_.*\.sql$", n)]
+    assert bad == [], f"migrations without a NNNN_ prefix: {bad}"
+
+
+def test_migration_filenames_are_unique():
+    """The runner keys the ledger on basename; a duplicate basename would make
+    one migration silently shadow another."""
+    names = _order()
+    assert len(names) == len(set(names))
+
+
+def test_duplicate_prefix_pairs_apply_in_pinned_order():
+    """The three NNNN pairs must apply in the pinned order — a rename that flips
+    the lexicographic suffix would reorder them silently, so pin it."""
+    order = _order()
+    for first, second in _PINNED_PAIRS:
+        assert first in order and second in order, f"missing {first!r}/{second!r}"
+        assert order.index(first) < order.index(second), (
+            f"{first} must apply before {second}, got "
+            f"{order.index(first)} vs {order.index(second)}"
+        )
+
+
+def test_gradebook_applies_before_curve():
+    """Load-bearing: 0021_gradebook CREATEs `assignments`; 0021_gradebook_curve
+    ALTERs it. Reversed, the curve columns would be dropped on recreate. This is
+    the pin that contradicts the #398 comment's 'curve before gradebook' claim."""
+    order = _order()
+    assert order.index("0021_gradebook.sql") < order.index("0021_gradebook_curve.sql")
+
+
+def test_discover_is_sorted_lexicographically():
+    """Pin the runner's contract: apply order == sorted(filenames). If the runner
+    ever switches to numeric-aware or ctime sorting, these pins must be revisited."""
+    order = _order()
+    assert order == sorted(order)
+
+
+# The DB-backed counterpart — that the schema_migrations ledger records every
+# file on disk — needs the real stack and lives in the integration lane
+# (tests/integration/test_migrations_ledger.py).

--- a/backend/tests/test_subcutaneous_staging.py
+++ b/backend/tests/test_subcutaneous_staging.py
@@ -1,10 +1,11 @@
-"""Opt-in HTTP end-to-end test against the REAL staging database.
+"""Opt-in subcutaneous HTTP test against the REAL staging database.
 
-This is NOT a normal unit test: it drives the live FastAPI routes against staging
-and writes a throwaway fixture (cleaned up afterward). It is skipped by default so
-the regular suite / CI never touches staging. To run it:
+This is a subcutaneous test, not a browser E2E (hence the rename off `e2e_` in
+#398): it drives the live FastAPI routes against staging over HTTP and writes a
+throwaway fixture (cleaned up afterward), below the UI. It is skipped by default
+so the regular suite / CI never touches staging. To run it:
 
-    RUN_STAGING_E2E=1 dotenv -f .env.staging run -- python -m pytest tests/test_e2e_staging.py -v
+    RUN_STAGING_E2E=1 dotenv -f .env.staging run -- python -m pytest tests/test_subcutaneous_staging.py -v
 
 The `e2e_staging` marker tells conftest to leave the live Supabase client + the real
 auth guard in place (the hermetic mock + auth bypass are skipped for this test only).


### PR DESCRIPTION
## Description
A **partial** delivery of the #398 subcutaneous write-path suite — the pieces that are provable, or low-risk, without a running Supabase stack. The remaining pure DB-behavior suites need the stack (see *Remaining scope*), so **this does not close #398.**

## Changes Made
- **`tests/test_migrations.py`** (default lane, **verified**) — pins the runner's apply order (`sorted(glob())`). The **0021 pair is load-bearing**: `0021_gradebook.sql` DROP/CREATEs the enrollment-keyed `assignments` table and `0021_gradebook_curve.sql` then `ALTER`s it to add the `curve_*` columns, so gradebook **must** apply first. `sorted()` does exactly that because `'.'` (0x2E) < `'_'` (0x5F). **This also corrects the issue comment**, which states the sort yields "gradebook_curve before gradebook" — it does not; the pin guards against a future rename flipping it.
- **`tests/integration/test_encryption_roundtrip.py`** — the epic's "highest-value" check. Reads every encrypted column from the seeded baseline via the #397 raw-SQL seam and asserts **ciphertext at rest + decrypt round-trip** across text (`decrypt_if_present`), numeric (`decrypt_numeric`, `assignments.points_*`), and JSON (`decrypt_json`, `sessions.summary_json`) — the silent-decrypt-regression sentinel.
- **`tests/integration/test_migrations_ledger.py`** — DB-backed half of the migration check (the `schema_migrations` ledger records every file on disk).
- **Renamed** `test_e2e_staging.py` → `test_subcutaneous_staging.py` (it drives HTTP routes below the UI — not a browser E2E). The `e2e_staging` **marker is unchanged**; README + the file's self-reference updated.

## Related Issues
Part of #398 (does **not** close it — see below).

## Testing
- [x] Tested locally — `ruff check .` clean; default CI lane **1002 → 1007 passed, 23 skipped**, no regressions. The 5 migration order-pin tests pass in the default lane; the 17 integration tests collect and skip cleanly without `RUN_INTEGRATION`.
- [x] Added/updated tests

## Notes for Reviewers
> [!IMPORTANT]
> Same environment limitation as #397: the Docker image CDNs are `403`-blocked here, so the DB-backed tests (`test_encryption_roundtrip.py`, `test_migrations_ledger.py`) **were not executed** — I lack `actions:write` to dispatch the integration workflow too. They're written against `seed_local_rich`'s proven column values and the #397 seam, but that is reasoning, not a green run. The **migration order-pins are fully verified offline** and gate in CI.

**Remaining #398 scope (needs the local stack, tracked on #398):**
- `test_postgrest_semantics.py` — `.in_([])`, `.single()` vs 0/2 rows, `.eq()` vs NULL, upsert `on_conflict`.
- `test_constraints.py` — FK / unique / NOT-NULL violations → assert 4xx, not a 500 leaking psycopg.
- `test_authz_real_rows.py` — port `test_calendar_export_idor.py` + `test_extract_auth_bounds.py` negatives to real rows owned by `other_user_client`.
- The **run-to-find-bugs** deliverable — those failures are the point of the issue and require executing the lane against a real DB.

I found **no bugs to file** because I could not run the DB lane; the one factual finding (the corrected 0021 sort claim) is a positive, pinned in `test_migrations.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018b3MtMEu2htdGVBGRcrmzX)_