### PR TITLE
feat(frontend): test environment profile with same-origin API proxy (#380)

### DIFF
--- a/docs/local-supabase.md
+++ b/docs/local-supabase.md
@@ -184,6 +184,55 @@ These bypass the hermetic mocks and hit the real local Supabase (real Postgres,
 encryption round-trips, migrated schema). Skipped by default. The suite seeds the
 rich dataset (idempotent) on first run and never resets your DB.
 
+## Test-profile production build (`build:test` / `start:test`, #380)
+
+`npm run dev` is fine for hand-testing, but browser E2E (Playwright) should run
+against a real production build. The test profile builds one that targets the
+**local** stack with **all API traffic same-origin** through the Next proxy:
+
+```bash
+# 1. Local backend up (from backend/, APP_ENV=local so /api/auth/test-login exists)
+python main.py                                # uvicorn on :5000
+
+# 2. Build + serve the test-profile frontend (from frontend/)
+npm run build:test && npm run start:test      # Next production server on :3000
+```
+
+What the profile bakes in (build-time, inlined by `next build`):
+
+- `NEXT_PUBLIC_API_URL=` **empty** — every client fetch is same-origin `/api/...`,
+  so the `sapling_session` cookie always rides along (a cross-origin value drops
+  it → 401). Explicitly empty matters: some callers fall back to
+  `http://localhost:5000` when the var is *unset*.
+- `BACKEND_URL=http://localhost:5000` — the `/api/:path*` rewrite proxies to the
+  local FastAPI (port 5000 = `backend/config.py` default). This also satisfies
+  `next.config.ts`'s production-build guard, which requires an explicit
+  `BACKEND_URL`.
+- Local Supabase URL + demo anon key — the lazy `lib/supabase.ts` client (used by
+  `/social` realtime) initializes instead of throwing.
+
+`start:test` supplies the runtime side: `BACKEND_URL` for the middleware session
+check and the fixed local `SESSION_SECRET` (must equal the backend's, which it
+does by default — both come from the `.env.local.example` values).
+
+Notes:
+
+- All values are the committed-safe local defaults from `.env.local.example`.
+  They're inlined in the npm scripts, and real process env beats `.env*` files in
+  Next — so the profile builds the same output even if your `frontend/.env.local`
+  points elsewhere. No env file is required.
+- Zero cross-origin API requests by construction: the browser only ever talks to
+  `http://localhost:3000`; the Next server proxies `/api/*` to `:5000`.
+- The build runs with `NODE_ENV=production`, so the session cookie is set with
+  `Secure`. Browsers (and Playwright's bundled browsers) accept Secure cookies on
+  `http://localhost`, so sign-in works unchanged.
+- `npm run build` (the deploy build) is untouched — the profile is additive npm
+  scripts only.
+- `start:test` prints `⚠ "next start" does not work with "output: standalone"` —
+  ignore it. The warning is about the *standalone deploy packaging*; `next start`
+  still serves the full build from `.next/` (pages, `/api/*` rewrites, the
+  session route, and middleware all verified working).
+
 ## Troubleshooting
 
 - **`supabase start` hangs on health checks** — usually the analytics/vector

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "build:test": "NEXT_PUBLIC_API_URL= BACKEND_URL=http://localhost:5000 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0 next build",
+    "start:test": "BACKEND_URL=http://localhost:5000 SESSION_SECRET=sapling-local-dev-session-secret-change-only-if-you-know-why next start",
     "lint": "eslint .",
     "lint:baseline": "eslint --suppress-all",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Adds a test environment profile — `npm run build:test` / `npm run start:test` — that produces a real production Next build routing **all** API traffic same-origin through the Next proxy to the local FastAPI backend (`:5000`, the `backend/config.py` default), for browser E2E against a production build (epic #402 browser lane).

- **`build:test`** inlines the committed-safe local defaults from `.env.local.example` directly in the npm script (zero new dependencies):
  - `NEXT_PUBLIC_API_URL=` **explicitly empty** — every client fetch is same-origin so the `sapling_session` cookie always rides along. Explicitly empty matters: `src/app/(public)/page.tsx` falls back to cross-origin `http://localhost:5000` when the var is merely *unset*.
  - `BACKEND_URL=http://localhost:5000` — bakes the `/api/:path*` rewrite destination and satisfies `next.config.ts`'s production-build guard (which fails builds without an explicit `BACKEND_URL`).
  - Local Supabase URL (`http://127.0.0.1:54321`) + demo anon key — the lazy `lib/supabase.ts` client initializes instead of throwing.
- **`start:test`** supplies the runtime side: `BACKEND_URL` for the middleware session check and the fixed local `SESSION_SECRET` for the session route.
- Real process env beats `.env*` files in Next, so the profile builds the same output even if a dev's `frontend/.env.local` points elsewhere; no env file is required.
- `middleware.ts` untouched (stays edge middleware — no Node `proxy` reintroduction). Production `npm run build` untouched (additive scripts + docs only).
- Recipe documented in `docs/local-supabase.md`.

## Verified

- `npm run build:test` — succeeds (exit 0).
- `npx tsc --noEmit` — passes.
- `npm test` (vitest) — 192/192 passing.
- Build output inspection: `routes-manifest.json` rewrite destination baked as `http://localhost:5000/api/:path*`; local Supabase URL inlined in client chunks; **zero** client chunks contain the `http://localhost:5000` literal (the cross-origin fallback in `(public)/page.tsx` was constant-folded away — the browser bundle cannot make a cross-origin API call).
- Live `start:test` smoke against a stub HTTP server on `:5000`:
  - `GET /` → 200 from the production server on `:3000`.
  - `GET :3000/api/graph/smoke-user` with a `sapling_session` cookie → proxied to `:5000` **with the cookie intact** (stub echoed it back).
  - `POST :3000/api/auth/session` same-origin → 400 `authToken required` (i.e. not 403 cross-origin-rejected, not 500 missing-`SESSION_SECRET`); with `Origin: http://evil.example` → 403 (CSRF guard active, same-origin passes it).
  - Unauthenticated `GET /dashboard` → 307 to `http://localhost:5000/api/auth/google` (edge middleware reads runtime `BACKEND_URL` correctly).
- Not verified: a smoke against the **real** running FastAPI + local Supabase stack (the container stack isn't up in this environment) — the `:5000` end of the proxy was a stub. `next start` prints a `"next start" does not work with "output: standalone"` warning; it demonstrably serves the full build (documented in the recipe).

Part of #402, closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added test-profile commands for building and serving a production frontend locally.
  - Enabled end-to-end testing against a real production build using same-origin API routing and local session handling.

- **Documentation**
  - Added setup instructions covering local backend startup, environment configuration, cookies, Supabase initialization, and common local testing considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->