### PR TITLE
feat(frontend): NEXT_PUBLIC_TEST_MODE determinism flag (#383)

### DIFF
--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -9,6 +9,7 @@ import HowItWorks from '@/components/HowItWorks';
 import SignInModal from '@/components/SignInModal';
 import { BRAND_FOREST } from '@/lib/brand';
 import { Button } from "@/components/ui";
+import { IS_TEST_MODE, random, now } from '@/lib/testMode';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5000';
 
@@ -138,7 +139,9 @@ export default function LandingPage() {
     let animId = 0;
 
     const reduceMotion = window.matchMedia(REDUCED_MOTION_QUERY);
-    let animating = !reduceMotion.matches;
+    // Test mode parks the loop on its single deterministic frame, same
+    // as prefers-reduced-motion.
+    let animating = !IS_TEST_MODE && !reduceMotion.matches;
 
     // #3e6f8a mirrors --info (globals.css); literal because canvas can't resolve var().
     const palette = [
@@ -147,7 +150,7 @@ export default function LandingPage() {
       { c: '#9CA3AF', w: 0.10 }, { c: '#D1D5DB', w: 0.07 },
     ];
     function randColor() {
-      let r = Math.random(), s = 0;
+      let r = random(), s = 0;
       for (const p of palette) { s += p.w; if (r <= s) return p.c; }
       return palette[0].c;
     }
@@ -163,21 +166,21 @@ export default function LandingPage() {
     ];
     const spread = 280;
     const bgNodes = Array.from({ length: 220 }, () => {
-      const cl = clusters[Math.floor(Math.random() * clusters.length)];
+      const cl = clusters[Math.floor(random() * clusters.length)];
       return {
-        ox: cl.x + (Math.random() - 0.5) * spread,
-        oy: cl.y + (Math.random() - 0.5) * spread,
-        oz: cl.z + (Math.random() - 0.5) * spread,
+        ox: cl.x + (random() - 0.5) * spread,
+        oy: cl.y + (random() - 0.5) * spread,
+        oz: cl.z + (random() - 0.5) * spread,
         color: randColor(),
-        radius: 1 + Math.random() * 4,
-        seed: Math.random() * 100,
+        radius: 1 + random() * 4,
+        seed: random() * 100,
         clusterIndex: undefined as number | undefined,
       };
     });
     const clusterNodes = CLUSTER_INIT_POS.map((pos, i) => ({
       ox: pos.ox, oy: pos.oy, oz: pos.oz,
       color: CLUSTER_COLORS[i],
-      radius: 2.5 + Math.random() * 1.5,
+      radius: 2.5 + random() * 1.5,
       seed: CLUSTER_SEEDS_BG[i],
       clusterIndex: i as number | undefined,
     }));
@@ -200,7 +203,7 @@ export default function LandingPage() {
       if (!ctx) return;
       ctx.clearRect(0, 0, width, height);
       rotAngle += 0.0008;
-      const fl = 1000, cx = width / 2, cy = height / 2, t = Date.now() * 0.001;
+      const fl = 1000, cx = width / 2, cy = height / 2, t = now() * 0.001;
       const mx = mouseRef.current.x, my = mouseRef.current.y;
 
       const proj = nodes.map(n => {
@@ -248,7 +251,7 @@ export default function LandingPage() {
     // Toggling the OS preference mid-session either parks the loop on a
     // static frame or restarts it; `draw` self-schedules only when animating.
     const onMotionPrefChange = () => {
-      const next = !reduceMotion.matches;
+      const next = !IS_TEST_MODE && !reduceMotion.matches;
       if (next === animating) return;
       animating = next;
       cancelAnimationFrame(animId);
@@ -337,7 +340,7 @@ export default function LandingPage() {
 
     const reduceMotion = window.matchMedia(REDUCED_MOTION_QUERY);
     let animId = 0;
-    let animating = !reduceMotion.matches;
+    let animating = !IS_TEST_MODE && !reduceMotion.matches;
 
     function paint() {
       const t = Date.now();
@@ -355,7 +358,7 @@ export default function LandingPage() {
     }
 
     const onMotionPrefChange = () => {
-      const next = !reduceMotion.matches;
+      const next = !IS_TEST_MODE && !reduceMotion.matches;
       if (next === animating) return;
       animating = next;
       cancelAnimationFrame(animId);

--- a/frontend/src/app/(shell)/notetaker/page.tsx
+++ b/frontend/src/app/(shell)/notetaker/page.tsx
@@ -25,6 +25,7 @@ import type {
   LinkedConcept as ApiLinkedConcept,
   GraphNode,
 } from "@/lib/types";
+import { now } from "@/lib/testMode";
 
 type Mastery = "mastered" | "learning" | "struggling" | "unexplored";
 
@@ -66,7 +67,7 @@ function normalizeMastery(tier: string): Mastery {
 }
 
 function relTime(d: Date) {
-  const diff = Date.now() - d.getTime();
+  const diff = now() - d.getTime();
   const mins = Math.round(diff / 60000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;
@@ -93,7 +94,7 @@ function apiNoteToNote(n: ApiNote): Note {
     title: n.title || "",
     body: n.body || "",
     courseId: n.course_id,
-    updatedAt: new Date(n.updated_at || Date.now()),
+    updatedAt: new Date(n.updated_at || now()),
     tags: n.tags || [],
     linkedConcepts: [],
     lastSummary: n.last_summary || null,

--- a/frontend/src/components/AtmosphericBackdrop.tsx
+++ b/frontend/src/components/AtmosphericBackdrop.tsx
@@ -19,6 +19,7 @@
  */
 
 import React from "react";
+import { IS_TEST_MODE, random } from "@/lib/testMode";
 
 type Orb = {
   x: number; y: number; z: number;
@@ -44,14 +45,14 @@ function makeOrbs(width: number, height: number): Orb[] {
   const orbs: Orb[] = [];
   for (let i = 0; i < count; i++) {
     orbs.push({
-      x: Math.random() * width,
-      y: Math.random() * height,
-      z: 0.35 + Math.random() * 0.65,    // pseudo-depth 0.35..1
-      vx: (Math.random() - 0.5) * 0.12,  // very slow horizontal drift
-      vy: (Math.random() - 0.5) * 0.08,  // even slower vertical
-      r: 180 + Math.random() * 260,      // big, soft radial glows
+      x: random() * width,
+      y: random() * height,
+      z: 0.35 + random() * 0.65,    // pseudo-depth 0.35..1
+      vx: (random() - 0.5) * 0.12,  // very slow horizontal drift
+      vy: (random() - 0.5) * 0.08,  // even slower vertical
+      r: 180 + random() * 260,      // big, soft radial glows
       color: PALETTE[i % PALETTE.length],
-      phase: Math.random() * Math.PI * 2,
+      phase: random() * Math.PI * 2,
     });
   }
   return orbs;
@@ -71,8 +72,10 @@ export function AtmosphericBackdrop() {
     if (!ctx) return;
 
     const mql = window.matchMedia?.("(prefers-reduced-motion: reduce)");
-    reducedMotionRef.current = !!mql?.matches;
-    const onReducedChange = () => { reducedMotionRef.current = !!mql?.matches; };
+    // Test mode paints one still frame with seeded orbs — same path as
+    // prefers-reduced-motion.
+    reducedMotionRef.current = IS_TEST_MODE || !!mql?.matches;
+    const onReducedChange = () => { reducedMotionRef.current = IS_TEST_MODE || !!mql?.matches; };
     mql?.addEventListener?.("change", onReducedChange);
 
     const resize = () => {

--- a/frontend/src/components/HowItWorks.tsx
+++ b/frontend/src/components/HowItWorks.tsx
@@ -7,8 +7,15 @@ import {
   useTransform,
   useMotionValueEvent,
   MotionValue,
+  MotionGlobalConfig,
 } from 'framer-motion';
 import { BRAND_FOREST } from '@/lib/brand';
+import { IS_TEST_MODE } from '@/lib/testMode';
+
+// Deterministic DOM for browser tests (#383): framer-motion's own test
+// seam jumps every animation straight to its final keyframe. No-op in
+// production builds (flag inlined to false at build time).
+if (IS_TEST_MODE) MotionGlobalConfig.skipAnimations = true;
 
 // ─── Graph data (shared by step 2 & 3) ───────────────────────────────────────
 

--- a/frontend/src/components/KnowledgeGraph2D.testmode.test.tsx
+++ b/frontend/src/components/KnowledgeGraph2D.testmode.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+/**
+ * NEXT_PUBLIC_TEST_MODE determinism for KnowledgeGraph2D (#383).
+ *
+ * With the flag on the component must (a) seed its initial node
+ * positions from the deterministic PRNG instead of Math.random(), and
+ * (b) take the reduced-motion path so the d3-force simulation settles
+ * synchronously with a fixed tick count. Together those pin the
+ * acceptance criterion: two consecutive loads of the graph view render
+ * identical node coordinates.
+ *
+ * Module-loading strategy: the flag is captured when `@/lib/testMode`
+ * first evaluates, so we stub the env at file scope and import the
+ * component lazily in beforeAll. No `vi.resetModules()` — that would
+ * fork a second React copy and break hooks against the test renderer's
+ * react-dom. A "fresh page load" is simulated with `resetTestRng()`,
+ * which rewinds the seeded sequence to its module-init state.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import React from "react";
+import type { GraphEdge, GraphNode } from "@/lib/data";
+
+vi.stubEnv("NEXT_PUBLIC_TEST_MODE", "1");
+
+let KnowledgeGraph2D: (typeof import("./KnowledgeGraph2D"))["KnowledgeGraph2D"];
+let resetTestRng: (typeof import("@/lib/testMode"))["resetTestRng"];
+
+beforeAll(async () => {
+  ({ resetTestRng } = await import("@/lib/testMode"));
+  ({ KnowledgeGraph2D } = await import("./KnowledgeGraph2D"));
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const NODES: GraphNode[] = [
+  { id: "root", name: "Math", subject: "Math", color: "#7a874f", is_subject_root: true, mastery_tier: "learning", mastery_score: 0, course_id: "c1" },
+  { id: "a", name: "Limits", subject: "Math", color: "#7a874f", mastery_tier: "learning", mastery_score: 0.4, course_id: "c1" },
+  { id: "b", name: "Derivatives", subject: "Math", color: "#7a874f", mastery_tier: "struggling", mastery_score: 0.2, course_id: "c1" },
+  { id: "c", name: "Integrals", subject: "Math", color: "#7a874f", mastery_tier: "unexplored", mastery_score: 0, course_id: "c1" },
+  { id: "d", name: "Series", subject: "Math", color: "#7a874f", mastery_tier: "mastered", mastery_score: 0.9, course_id: "c1" },
+];
+
+const EDGES: GraphEdge[] = [
+  { source: "root", target: "a", strength: 0.8 },
+  { source: "a", target: "b", strength: 0.6 },
+  { source: "b", target: "c", strength: 0.5 },
+  { source: "a", target: "d", strength: 0.7 },
+];
+
+/** Every rendered circle + edge coordinate, as attribute strings. */
+function snapshot(container: HTMLElement): string[] {
+  const svg = container.querySelector("svg");
+  expect(svg).not.toBeNull();
+  const circles = Array.from(svg!.querySelectorAll("circle")).map(
+    (c) => `c:${c.getAttribute("cx")},${c.getAttribute("cy")},${c.getAttribute("r")}`,
+  );
+  const lines = Array.from(svg!.querySelectorAll("line")).map(
+    (l) => `l:${l.getAttribute("x1")},${l.getAttribute("y1")},${l.getAttribute("x2")},${l.getAttribute("y2")}`,
+  );
+  return [...circles, ...lines];
+}
+
+describe("KnowledgeGraph2D — test-mode determinism", () => {
+  it("two consecutive loads render identical node coordinates", () => {
+    const first = render(
+      <KnowledgeGraph2D nodes={NODES} edges={EDGES} width={600} height={480} />,
+    );
+    const snap1 = snapshot(first.container);
+    // The simulation must have actually laid out and rendered content.
+    expect(snap1.length).toBeGreaterThan(0);
+    expect(snap1.some((s) => s.startsWith("l:"))).toBe(true);
+    for (const s of snap1) {
+      expect(s).not.toMatch(/NaN|null|undefined/);
+    }
+    cleanup();
+
+    // Fresh "page load": module state rewound, brand-new mount.
+    resetTestRng();
+    const second = render(
+      <KnowledgeGraph2D nodes={NODES} edges={EDGES} width={600} height={480} />,
+    );
+    expect(snapshot(second.container)).toEqual(snap1);
+  });
+
+  it("nodes settle into a spread-out layout, not a degenerate point", () => {
+    resetTestRng();
+    const { container } = render(
+      <KnowledgeGraph2D nodes={NODES} edges={EDGES} width={600} height={480} />,
+    );
+    const centers = new Set(
+      Array.from(container.querySelectorAll("circle")).map(
+        (c) => `${c.getAttribute("cx")},${c.getAttribute("cy")}`,
+      ),
+    );
+    // 5 nodes must occupy at least 5 distinct positions once settled.
+    expect(centers.size).toBeGreaterThanOrEqual(NODES.length);
+  });
+});

--- a/frontend/src/components/KnowledgeGraph2D.tsx
+++ b/frontend/src/components/KnowledgeGraph2D.tsx
@@ -13,6 +13,7 @@ import {
   type SimulationLinkDatum,
 } from "d3-force";
 import { hashSeed, type GraphEdge, type GraphNode } from "@/lib/data";
+import { IS_TEST_MODE, random } from "@/lib/testMode";
 
 export type GraphVariant = "orb" | "constellation" | "organism";
 
@@ -159,11 +160,11 @@ function KnowledgeGraph2DImpl({
         Object.assign(prev, n);
         return prev;
       }
-      const hubSeed = n.is_subject_root ? 0 : Math.random();
+      const hubSeed = n.is_subject_root ? 0 : random();
       return {
         ...n,
-        x: width / 2 + (Math.random() - 0.5) * 40,
-        y: height / 2 + (Math.random() - 0.5) * 40,
+        x: width / 2 + (random() - 0.5) * 40,
+        y: height / 2 + (random() - 0.5) * 40,
         vx: 0,
         vy: 0,
         index: undefined,
@@ -205,8 +206,12 @@ function KnowledgeGraph2DImpl({
       .force("x", forceX<SimNode>(width / 2).strength(0.02))
       .force("y", forceY<SimNode>(height / 2).strength(0.02));
 
-    const reducedMotion = typeof window !== "undefined"
-      && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    // Test mode rides the reduced-motion path: the simulation settles
+    // synchronously (fixed tick count) instead of animating on rAF, so
+    // node coordinates are identical on every load.
+    const reducedMotion = IS_TEST_MODE
+      || (typeof window !== "undefined"
+        && window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
     if (reducedMotion) {
       sim.alpha(1).tick(200).alpha(0).stop();
       forceRerender();

--- a/frontend/src/components/KnowledgeGraph3D.testmode.test.tsx
+++ b/frontend/src/components/KnowledgeGraph3D.testmode.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+/**
+ * NEXT_PUBLIC_TEST_MODE determinism for KnowledgeGraph3D (#383).
+ *
+ * Test mode must force `cooldownTicks={0}` even when the OS reports no
+ * reduced-motion preference — the same ready-made seam the
+ * prefers-reduced-motion path uses, so the WebGL layout renders its
+ * deterministic initial arrangement without a physics warm-up.
+ *
+ * Mocks mirror KnowledgeGraph3D.test.tsx (props-capturing stub for
+ * react-force-graph-3d, passthrough next/dynamic). The component is
+ * imported lazily in beforeAll so the file-scope env stub is visible
+ * when `@/lib/testMode` first evaluates.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import React from "react";
+import type { GraphNode } from "@/lib/data";
+
+vi.stubEnv("NEXT_PUBLIC_TEST_MODE", "1");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let lastProps: Record<string, any> | null = null;
+
+vi.mock("react-force-graph-3d", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: (props: any) => {
+    lastProps = props;
+    return null;
+  },
+}));
+
+vi.mock("next/dynamic", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: (loader: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let Resolved: any = () => null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Promise.resolve(loader()).then((mod: any) => {
+      Resolved = mod?.default ?? mod;
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const Wrapper = (props: any) => {
+      const C = Resolved;
+      return C ? C(props) : null;
+    };
+    return Wrapper;
+  },
+}));
+
+let KnowledgeGraph3D: (typeof import("./KnowledgeGraph3D"))["KnowledgeGraph3D"];
+
+beforeAll(async () => {
+  ({ KnowledgeGraph3D } = await import("./KnowledgeGraph3D"));
+});
+
+function installNoPreferenceMatchMedia() {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false, // OS reports NO reduced-motion preference
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+const NODE: GraphNode = {
+  id: "n1",
+  name: "Node 1",
+  subject: "Math",
+  color: "#88aa55",
+  mastery_tier: "learning",
+  mastery_score: 0.5,
+  course_id: "c1",
+};
+
+beforeEach(() => {
+  lastProps = null;
+  installNoPreferenceMatchMedia();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("KnowledgeGraph3D — test-mode determinism", () => {
+  it("forces cooldownTicks to 0 even without a reduced-motion preference", () => {
+    render(<KnowledgeGraph3D nodes={[NODE]} edges={[]} />);
+    expect(lastProps).not.toBeNull();
+    expect(lastProps!.cooldownTicks).toBe(0);
+  });
+});

--- a/frontend/src/components/KnowledgeGraph3D.tsx
+++ b/frontend/src/components/KnowledgeGraph3D.tsx
@@ -16,6 +16,7 @@
 import React from "react";
 import dynamic from "next/dynamic";
 import { hashSeed, type GraphEdge, type GraphNode } from "@/lib/data";
+import { IS_TEST_MODE } from "@/lib/testMode";
 
 // `react-force-graph-3d`'s default export touches `document` at
 // module evaluation, so it can't be SSR'd. ssr: false ensures the
@@ -220,7 +221,7 @@ export function KnowledgeGraph3D({
         }}
         backgroundColor="rgba(0,0,0,0)"
         showNavInfo={false}
-        cooldownTicks={reducedMotion ? 0 : 120}
+        cooldownTicks={reducedMotion || IS_TEST_MODE ? 0 : 120}
         enableNodeDrag={false}
         onNodeClick={handleNodeClick}
       />

--- a/frontend/src/components/screens/Calendar.tsx
+++ b/frontend/src/components/screens/Calendar.tsx
@@ -26,6 +26,7 @@ import {
   type EnrolledCourse,
   type GoogleEvent,
 } from "@/lib/api";
+import { now } from "@/lib/testMode";
 
 type View = "month" | "week" | "day" | "table";
 
@@ -52,9 +53,9 @@ function dateKey(d: Date) {
 }
 
 function dueLabel(date: string) {
-  const now = Date.now();
+  const nowMs = now();
   const due = new Date(date).getTime();
-  const diffMs = due - now;
+  const diffMs = due - nowMs;
   const diffHours = diffMs / (1000 * 60 * 60);
   if (diffHours <= 0) return { label: "overdue", cls: "chip--err" };
   if (diffHours <= 24) return { label: "due soon", cls: "chip--err" };
@@ -72,7 +73,7 @@ export function Calendar() {
   const [assignments, setAssignments] = React.useState<Assignment[]>([]);
   const [courses, setCourses] = React.useState<EnrolledCourse[]>([]);
   const [view, setView] = React.useState<View>("month");
-  const [cursor, setCursor] = React.useState(new Date());
+  const [cursor, setCursor] = React.useState(() => new Date(now()));
   const [googleConnected, setGoogleConnected] = React.useState(false);
   const [uploadOpen, setUploadOpen] = React.useState(false);
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
@@ -116,7 +117,7 @@ export function Calendar() {
   }, [search, router, toast, load]);
 
   const today = React.useMemo(() => {
-    const d = new Date(); d.setHours(0, 0, 0, 0); return d;
+    const d = new Date(now()); d.setHours(0, 0, 0, 0); return d;
   }, []);
 
   const byDate = React.useMemo(() => {
@@ -206,7 +207,7 @@ export function Calendar() {
           <button className="btn btn--sm" onClick={() => shift(setCursor, view, -1)}>
             <Icon name="chev" size={12} /> Prev
           </button>
-          <button className="btn btn--sm" onClick={() => setCursor(new Date())}>Today</button>
+          <button className="btn btn--sm" onClick={() => setCursor(new Date(now()))}>Today</button>
           <button className="btn btn--sm" onClick={() => shift(setCursor, view, 1)}>
             Next <Icon name="chev" size={12} />
           </button>

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -26,6 +26,7 @@ import {
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
 import { apiToGraphNode, type GraphNode, type GraphEdge } from "@/lib/data";
 import { partitionCurrentAndArchive } from "@/lib/semesters";
+import { IS_TEST_MODE, now } from "@/lib/testMode";
 
 const QUOTES = [
   "Learning is the only thing the mind never exhausts, never fears, and never regrets. — da Vinci",
@@ -252,8 +253,10 @@ export function Dashboard() {
     const d = new Date(0); d.setHours(0, 0, 0, 0); return d;
   });
   React.useEffect(() => {
-    setQuote(QUOTES[Math.floor(Math.random() * QUOTES.length)]);
-    const t = new Date(); t.setHours(0, 0, 0, 0); setToday(t);
+    // Test mode freezes the quote to index 0 and the clock to the fixed
+    // test instant so the hero copy is byte-stable across loads.
+    setQuote(IS_TEST_MODE ? QUOTES[0] : QUOTES[Math.floor(Math.random() * QUOTES.length)]);
+    const t = new Date(now()); t.setHours(0, 0, 0, 0); setToday(t);
   }, []);
   const weekDays = React.useMemo(() => getWeekDays(today), [today]);
 
@@ -324,7 +327,7 @@ export function Dashboard() {
   const firstName = userName ? userName.split(" ")[0] : "";
   const [greetingPrefix, setGreetingPrefix] = React.useState<string>("Welcome back");
   React.useEffect(() => {
-    setGreetingPrefix(getGreetingPrefix(new Date()));
+    setGreetingPrefix(getGreetingPrefix(new Date(now())));
   }, []);
   const greetingText = firstName ? `${greetingPrefix}, ${firstName}` : "Welcome back";
   const [greetingDone, setGreetingDone] = React.useState(false);
@@ -516,7 +519,7 @@ export function Dashboard() {
 
   const relTime = (iso: string | null | undefined) => {
     if (!iso) return "—";
-    const diff = Date.now() - new Date(iso).getTime();
+    const diff = now() - new Date(iso).getTime();
     const mins = Math.round(diff / 60000);
     if (mins < 1) return "just now";
     if (mins < 60) return `${mins}m ago`;
@@ -648,7 +651,7 @@ export function Dashboard() {
           <div style={{ fontSize: 12, color: "var(--text-muted)" }}>No upcoming assignments.</div>
         )}
         {assignments.slice(0, 4).map((a) => {
-          const diffMs = new Date(a.due_date).getTime() - Date.now();
+          const diffMs = new Date(a.due_date).getTime() - now();
           const hours = diffMs / (1000 * 60 * 60);
           const days = Math.ceil(diffMs / 86400000);
           let chipClass = "chip--info";
@@ -824,7 +827,7 @@ export function Dashboard() {
           <div style={{ fontSize: 12, color: "var(--text-muted)" }}>No upcoming assignments.</div>
         )}
         {assignments.slice(0, 4).map((a) => {
-          const diffMs = new Date(a.due_date).getTime() - Date.now();
+          const diffMs = new Date(a.due_date).getTime() - now();
           const hours = diffMs / (1000 * 60 * 60);
           const days = Math.ceil(diffMs / 86400000);
           let chipClass = "chip--info";

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -2,7 +2,13 @@
 import React from "react";
 import dynamic from "next/dynamic";
 import { useSearchParams } from "next/navigation";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, MotionGlobalConfig } from "framer-motion";
+import { IS_TEST_MODE } from "@/lib/testMode";
+
+// Deterministic DOM for browser tests (#383): framer-motion's own test
+// seam jumps every animation straight to its final keyframe. No-op in
+// production builds (flag inlined to false at build time).
+if (IS_TEST_MODE) MotionGlobalConfig.skipAnimations = true;
 import { TopBar } from "../TopBar";
 import { AIDisclaimerChip } from "../AIDisclaimerChip";
 import { Icon } from "../Icon";

--- a/frontend/src/lib/testMode.test.ts
+++ b/frontend/src/lib/testMode.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for the NEXT_PUBLIC_TEST_MODE determinism seams (#383).
+ *
+ * The flag is read at module-evaluation time (NEXT_PUBLIC_ vars are
+ * build-time inlined in the app), so each case stubs the env and
+ * re-imports the module through a fresh registry.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+type TestModeModule = typeof import("./testMode");
+
+async function load(flag: string): Promise<TestModeModule> {
+  vi.resetModules();
+  vi.stubEnv("NEXT_PUBLIC_TEST_MODE", flag);
+  return import("./testMode");
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  globalThis.__SAPLING_TEST_NOW__ = undefined;
+});
+
+describe("mulberry32", () => {
+  it("same seed produces the same sequence; different seed diverges", async () => {
+    const { mulberry32 } = await load("0");
+    const a = mulberry32(42);
+    const b = mulberry32(42);
+    const seqA = Array.from({ length: 16 }, () => a());
+    const seqB = Array.from({ length: 16 }, () => b());
+    expect(seqA).toEqual(seqB);
+    for (const v of seqA) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+    const c = mulberry32(43);
+    const seqC = Array.from({ length: 16 }, () => c());
+    expect(seqC).not.toEqual(seqA);
+  });
+});
+
+describe("flag on", () => {
+  it("IS_TEST_MODE is true for '1' and 'true'", async () => {
+    expect((await load("1")).IS_TEST_MODE).toBe(true);
+    expect((await load("true")).IS_TEST_MODE).toBe(true);
+  });
+
+  it("random() is seeded: resetTestRng() rewinds to the page-load sequence", async () => {
+    const m = await load("1");
+    const first = Array.from({ length: 8 }, () => m.random());
+    m.resetTestRng();
+    const second = Array.from({ length: 8 }, () => m.random());
+    expect(second).toEqual(first);
+    for (const v of first) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("two fresh module loads (≈ two page loads) draw identical sequences", async () => {
+    const m1 = await load("1");
+    const seq1 = Array.from({ length: 8 }, () => m1.random());
+    const m2 = await load("1");
+    const seq2 = Array.from({ length: 8 }, () => m2.random());
+    expect(seq2).toEqual(seq1);
+  });
+
+  it("now() returns the fixed mid-semester weekday-noon instant", async () => {
+    const m = await load("1");
+    expect(m.now()).toBe(m.TEST_NOW_MS);
+    const d = new Date(m.TEST_NOW_MS);
+    expect(d.getUTCDay()).toBe(3); // Wednesday
+    expect(d.getUTCHours()).toBe(12); // noon UTC
+    expect(d.toISOString()).toBe("2026-03-11T12:00:00.000Z");
+  });
+
+  it("now() honors an injected clock via globalThis.__SAPLING_TEST_NOW__", async () => {
+    const m = await load("1");
+    globalThis.__SAPLING_TEST_NOW__ = 1234567890;
+    expect(m.now()).toBe(1234567890);
+    globalThis.__SAPLING_TEST_NOW__ = undefined;
+    expect(m.now()).toBe(m.TEST_NOW_MS);
+  });
+});
+
+describe("flag off", () => {
+  it("IS_TEST_MODE is false for unset-ish values", async () => {
+    expect((await load("")).IS_TEST_MODE).toBe(false);
+    expect((await load("0")).IS_TEST_MODE).toBe(false);
+    expect((await load("false")).IS_TEST_MODE).toBe(false);
+  });
+
+  it("random() passes through to Math.random()", async () => {
+    const m = await load("0");
+    const spy = vi.spyOn(Math, "random").mockReturnValue(0.42);
+    expect(m.random()).toBe(0.42);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("now() passes through to Date.now() and ignores the injected clock", async () => {
+    const m = await load("0");
+    const spy = vi.spyOn(Date, "now").mockReturnValue(111222333);
+    globalThis.__SAPLING_TEST_NOW__ = 987654321;
+    expect(m.now()).toBe(111222333);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/testMode.ts
+++ b/frontend/src/lib/testMode.ts
@@ -1,0 +1,77 @@
+/**
+ * NEXT_PUBLIC_TEST_MODE determinism seams (#383).
+ *
+ * Browser-test (Playwright) builds set NEXT_PUBLIC_TEST_MODE=1 so the
+ * DOM becomes deterministic: seeded PRNG instead of Math.random(), a
+ * frozen clock instead of Date.now(), rAF loops parked, framer-motion
+ * animations skipped, and force-graph cooldowns zeroed.
+ *
+ * NEXT_PUBLIC_ vars are inlined at build time, so with the flag off
+ * every test-mode branch below is statically false — production
+ * bundles keep the exact Math.random()/Date.now() behavior.
+ */
+
+export const IS_TEST_MODE =
+  process.env.NEXT_PUBLIC_TEST_MODE === "1" ||
+  process.env.NEXT_PUBLIC_TEST_MODE === "true";
+
+/**
+ * mulberry32 — tiny 32-bit seeded PRNG. Same seed ⇒ same sequence,
+ * values in [0, 1) like Math.random().
+ */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), a | 1);
+    t = (t + Math.imul(t ^ (t >>> 7), t | 61)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const TEST_SEED = 0x5eed_383; // arbitrary but fixed (383 = the issue)
+
+let testRng = mulberry32(TEST_SEED);
+
+/**
+ * Drop-in Math.random() replacement. Seeded + deterministic when the
+ * flag is on; passthrough to Math.random() otherwise. The sequence
+ * restarts on every page load (module init), so two consecutive loads
+ * of the same view draw identical values.
+ */
+export function random(): number {
+  return IS_TEST_MODE ? testRng() : Math.random();
+}
+
+/**
+ * Rewind the seeded sequence to its page-load state. Only meaningful
+ * in test mode; unit tests use it to simulate a fresh page load
+ * without tearing down the module registry.
+ */
+export function resetTestRng(): void {
+  testRng = mulberry32(TEST_SEED);
+}
+
+/**
+ * The frozen test-mode instant: Wednesday 2026-03-11T12:00:00Z — a
+ * mid-semester weekday noon. Local-time renderings of it (greeting,
+ * calendar "today") are stable as long as the browser test pins its
+ * timezone (Playwright: `timezoneId`).
+ */
+export const TEST_NOW_MS = Date.UTC(2026, 2, 11, 12, 0, 0);
+
+declare global {
+  var __SAPLING_TEST_NOW__: number | undefined;
+}
+
+/**
+ * Drop-in Date.now() replacement. In test mode returns TEST_NOW_MS,
+ * unless the harness injects a clock by setting
+ * `globalThis.__SAPLING_TEST_NOW__` (e.g. via Playwright addInitScript)
+ * to pick a different frozen instant per scenario.
+ */
+export function now(): number {
+  if (!IS_TEST_MODE) return Date.now();
+  const injected = globalThis.__SAPLING_TEST_NOW__;
+  return typeof injected === "number" ? injected : TEST_NOW_MS;
+}


### PR DESCRIPTION
## Summary

Adds a build-time `NEXT_PUBLIC_TEST_MODE` flag that makes the DOM deterministic for browser tests, with zero effect on production builds (flag off = passthrough behavior).

**New helper — `frontend/src/lib/testMode.ts`:**
- `IS_TEST_MODE` — `process.env.NEXT_PUBLIC_TEST_MODE === '1' || === 'true'` (build-time inlined, so flag-off branches dead-code-eliminate).
- `random()` — drop-in `Math.random()` replacement backed by a mulberry32 PRNG with a fixed seed; the sequence restarts on every page load so two consecutive loads draw identical values. `resetTestRng()` rewinds it for unit tests.
- `now()` — drop-in `Date.now()` replacement frozen at **2026-03-11T12:00:00Z** (mid-semester Wednesday noon); injectable per-scenario via `globalThis.__SAPLING_TEST_NOW__` (e.g. Playwright `addInitScript`). Local-time renderings additionally need the browser test to pin `timezoneId`.

**Gated seams (flag on only):**
- `KnowledgeGraph2D` — seeded initial node positions + forced reduced-motion path (synchronous fixed-tick d3-force settle) → identical coordinates on every load (d3-force's internal jiggle is already a deterministic LCG).
- `KnowledgeGraph3D` — `cooldownTicks={reducedMotion || IS_TEST_MODE ? 0 : 120}` (the existing reduced-motion seam).
- Landing page (`(public)/page.tsx`) — seeded point-cloud generation; hero-canvas and floating-card rAF loops park on a static frame (same as `prefers-reduced-motion`); the static frame's time read routes through `now()`.
- `AtmosphericBackdrop` — seeded orbs, single still frame.
- `HowItWorks` / `Study` — `MotionGlobalConfig.skipAnimations = true` (framer-motion's own test seam; animations jump to their final keyframe).
- `Dashboard` — quote frozen to `QUOTES[0]`; greeting, week strip, and due/relative labels routed through `now()`.
- `Calendar` — `dueLabel`, month cursor, `today`, and the Today button routed through `now()`.
- Notetaker page — `relTime` + `updatedAt` fallback routed through `now()`.

**Deliberately un-gated** (transient or non-asserted): the landing hero text-scramble and stat counters (both converge to final text/values), and `Math.random()`/`Date.now()` used purely for opaque ID generation (DocumentUploadModal, Admin upload path, Social temp IDs) and the CSV download filename in Calendar.

## Tests

- `src/lib/testMode.test.ts` — mulberry32 same-seed reproducibility; flag-on: seeded sequence, reset/fresh-load equivalence, frozen + injectable clock; flag-off: passthrough to `Math.random()`/`Date.now()`.
- `src/components/KnowledgeGraph2D.testmode.test.tsx` — pins the acceptance criterion: two consecutive loads of the graph render identical circle/edge coordinates, and the layout actually settles (no NaN, distinct positions).
- `src/components/KnowledgeGraph3D.testmode.test.tsx` — `cooldownTicks === 0` in test mode even with no reduced-motion preference.

## Verified

- `npx tsc --noEmit` — clean.
- `npm test` (vitest) — 23 files, 204 tests, all pass (includes the 3 new test files).
- `BACKEND_URL=… npm run build` (production, flag off) — succeeds.
- `eslint` on all touched files — 0 errors; remaining warnings are pre-existing (`no-img-element`, an unused `t` param, an unused disable directive).

Part of #402, closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)