### PR TITLE
test(infra): one-command local stack boot — make e2e-up / e2e-down (#384)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ Thumbs.db
 # ---- Worktrees ----
 .worktrees/
 
+# ---- Local E2E stack run dir (PIDs + logs, scripts/e2e-up.sh, #384) ----
+.e2e/
+
 # ---- Superpowers brainstorm sessions ----
 .superpowers/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# Sapling — repo-level entry points.
+#
+# E2E stack (#384): one command to boot / tear down the whole local test stack —
+# Supabase (rootless Podman or Docker) → migrations → seed → uvicorn backend →
+# test-profile Next production build — health-checked end to end.
+# See docs/local-supabase.md ("One-command E2E stack").
+
+.PHONY: e2e-up e2e-down
+
+e2e-up:
+	scripts/e2e-up.sh
+
+e2e-down:
+	scripts/e2e-down.sh

--- a/docs/local-supabase.md
+++ b/docs/local-supabase.md
@@ -233,6 +233,32 @@ Notes:
   still serves the full build from `.next/` (pages, `/api/*` rewrites, the
   session route, and middleware all verified working).
 
+## One-command E2E stack (`make e2e-up` / `make e2e-down`, #384)
+
+Everything above in one command. From the repo root:
+
+```bash
+make e2e-up      # supabase start → migrate → buckets → NOTIFY pgrst →
+                 # seed (demo + rich) → uvicorn on :5000 →
+                 # `npm run build:test && npm run start:test` on :3000
+make e2e-down    # stop uvicorn + next (tracked PIDs), then `supabase stop`
+```
+
+`e2e-up` health-checks all four services (Postgres, PostgREST, backend
+`/api/health`, frontend `/`) and fails loudly with a log tail if one doesn't
+come up. Server PIDs and logs live in `.e2e/` at the repo root (gitignored).
+It's idempotent: re-running restarts the app servers and re-applies the
+skip-if-done migrations/seeds. The rich dataset (#363) seeds by default so
+`POST /api/auth/test-login` has its `rich-*` users — `SEED_RICH=0 make e2e-up`
+skips it. The backend runs without `--reload` (a mid-test file-watcher restart
+would make E2E runs nondeterministic).
+
+First-time machine setup is the same as `scripts/local-up.sh` (backend `.env`
+from `.env.local.example`, backend venv, `cd frontend && npm ci`); the script
+preflights each piece and fails fast with the exact command if one is missing.
+Rootless Podman is the documented runtime; Docker is auto-detected as a
+fallback (`$CONTAINER_CMD` overrides the choice).
+
 ## Troubleshooting
 
 - **`supabase start` hangs on health checks** — usually the analytics/vector
@@ -248,4 +274,3 @@ Notes:
   version-agnostic and verified to replay on 17; keep new migrations portable.
 - **Ports 54321–54327 already in use** — another project's `supabase start` is
   running; `supabase stop` in that project (or `podman ps` to find it).
-```

--- a/scripts/e2e-down.sh
+++ b/scripts/e2e-down.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Tear down the LOCAL E2E stack booted by scripts/e2e-up.sh (#384).
+#
+#   make e2e-down                     # stop uvicorn + next, then `supabase stop`
+#   scripts/e2e-down.sh --apps-only   # stop only the tracked app servers, keep
+#                                     # Supabase up (e2e-up.sh uses this so
+#                                     # re-runs start from clean processes)
+#
+# Server PIDs are tracked in .e2e/*.pid. Each server was started under setsid,
+# so the recorded PID is its process-group leader and one group signal takes
+# down the whole tree (npm → next-server, etc.). Stale or missing PID files are
+# cleaned up silently — safe to run any time. LOCAL ONLY.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+# Point the Supabase CLI at the rootless podman socket only when podman exists;
+# under Docker leave DOCKER_HOST alone so the default daemon socket is used.
+if command -v podman >/dev/null 2>&1; then
+  export DOCKER_HOST="${DOCKER_HOST:-unix:///run/user/$(id -u)/podman/podman.sock}"
+fi
+
+E2E_DIR="$REPO_ROOT/.e2e"
+APPS_ONLY=0
+[ "${1:-}" = "--apps-only" ] && APPS_ONLY=1
+
+# Stop the process group recorded in a PID file: SIGTERM, wait up to 10s for a
+# graceful exit, then SIGKILL. Tolerates stale/missing PID files.
+stop_tracked() { # name pidfile
+  local name="$1" pidfile="$2" pid
+  [ -f "$pidfile" ] || return 0
+  pid="$(cat "$pidfile" 2>/dev/null)"
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    echo "▶ Stopping $name (pid $pid)…"
+    kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
+    for _ in $(seq 1 10); do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 1
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "  still running — sending SIGKILL"
+      kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
+    fi
+  fi
+  rm -f "$pidfile"
+}
+
+stop_tracked "frontend (next start)" "$E2E_DIR/frontend.pid"
+stop_tracked "backend (uvicorn)" "$E2E_DIR/backend.pid"
+
+[ "$APPS_ONLY" = "1" ] && exit 0
+
+echo "▶ Stopping local Supabase…"
+supabase stop || { echo "✗ supabase stop failed"; exit 1; }
+
+echo "✅ E2E stack is down. Logs from the last run are kept in .e2e/."

--- a/scripts/e2e-up.sh
+++ b/scripts/e2e-up.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# One-command LOCAL E2E stack boot (#384).
+#
+#   make e2e-up          # or: scripts/e2e-up.sh
+#   make e2e-down        # tear down — scripts/e2e-down.sh
+#
+# Sequence: supabase start → db.migrate → ensure Storage buckets →
+# NOTIFY pgrst 'reload schema' → PostgREST poll → seed (demo + rich) →
+# uvicorn backend on :5000 → test-profile Next production build
+# (`npm run build:test && npm run start:test`, #380) on :3000 →
+# health-check all four services (Postgres, PostgREST, backend, frontend).
+#
+# Idempotent — re-running restarts the app servers and re-applies the
+# skip-if-done migrations/seeds. LOCAL ONLY — never touches staging/prod.
+#
+# First-time setup on a new machine (same as scripts/local-up.sh):
+#   cp backend/.env.local.example backend/.env       # then fill in GEMINI_API_KEY
+#   python -m venv backend/venv && backend/venv/bin/pip install -r backend/requirements.txt
+#   cd frontend && npm ci
+#
+# Rootless Podman is the documented runtime; Docker also works — the runtime is
+# auto-detected in scripts/lib/local-common.sh ($CONTAINER_CMD overrides).
+#
+# The servers run detached (setsid, so each PID is its process-group leader);
+# PIDs and logs live in .e2e/ at the repo root. E2E harnesses sign in via
+# POST /api/auth/test-login (#381) with the seeded rich-* users.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+# Point the Supabase CLI at the rootless podman socket only when podman exists;
+# under Docker leave DOCKER_HOST alone so the default daemon socket is used.
+if command -v podman >/dev/null 2>&1; then
+  export DOCKER_HOST="${DOCKER_HOST:-unix:///run/user/$(id -u)/podman/podman.sock}"
+fi
+
+LOCAL_DB_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+DB_CONTAINER="supabase_db_sapling"
+
+# Shared migrate → ensure buckets → reload PostgREST → seed sequence (#10),
+# plus $CONTAINER_CMD (podman/docker) detection.
+source "$REPO_ROOT/scripts/lib/local-common.sh"
+
+E2E_DIR="$REPO_ROOT/.e2e"
+BACKEND_PORT="$(grep -E '^PORT=' backend/.env 2>/dev/null | head -n1 | cut -d= -f2-)"
+BACKEND_PORT="${BACKEND_PORT:-5000}"
+FRONTEND_PORT=3000
+
+# Poll a URL until it returns HTTP 200 (same curl style as local-common.sh),
+# failing the boot with a log tail if it never comes up.
+wait_for_http() { # name url attempts logfile [extra curl args…]
+  local name="$1" url="$2" attempts="$3" logfile="$4" code=000
+  shift 4
+  for _ in $(seq 1 "$attempts"); do
+    code="$(curl -s -o /dev/null -w '%{http_code}' "$@" "$url")"
+    [ "$code" = "200" ] && { echo "  ✓ $name"; return 0; }
+    sleep 1
+  done
+  echo "✗ $name did not become healthy (last HTTP $code from $url)"
+  if [ -n "$logfile" ] && [ -f "$logfile" ]; then
+    echo "  last lines of $logfile:"
+    tail -n 20 "$logfile" | sed 's/^/    /'
+  fi
+  exit 1
+}
+
+# ── Preflight ────────────────────────────────────────────────────────────────
+# Fail fast with the exact fix before touching anything, so a clean machine
+# gets one actionable message instead of a half-up stack.
+echo "▶ Preflight…"
+command -v supabase >/dev/null 2>&1 \
+  || { echo "✗ supabase CLI not found. Install it first (Arch: paru -S supabase-bin) — see docs/local-supabase.md"; exit 1; }
+[ -f backend/.env ] \
+  || { echo "✗ backend/.env not found. Create it first: cp backend/.env.local.example backend/.env  (then fill in GEMINI_API_KEY)"; exit 1; }
+[ -x backend/venv/bin/python ] \
+  || { echo "✗ backend/venv not found. Create it first: python -m venv backend/venv && backend/venv/bin/pip install -r backend/requirements.txt"; exit 1; }
+[ -d frontend/node_modules ] \
+  || { echo "✗ frontend/node_modules not found. Install first: cd frontend && npm ci"; exit 1; }
+# build:test/start:test hardcode BACKEND_URL=http://localhost:5000 (#380), so a
+# nonstandard backend port would silently break the Next → FastAPI proxy.
+[ "$BACKEND_PORT" = "5000" ] \
+  || { echo "✗ backend/.env sets PORT=$BACKEND_PORT, but the test-profile frontend proxies to :5000. Unset PORT (or set it to 5000) for E2E."; exit 1; }
+# The E2E sign-in seam POST /api/auth/test-login (#381) only exists when
+# APP_ENV is exactly local or test — warn, the stack still boots without it.
+grep -qE '^APP_ENV=(local|test)$' backend/.env \
+  || echo "  ⚠ backend/.env APP_ENV is not local/test — /api/auth/test-login will 404 for E2E harnesses"
+
+mkdir -p "$E2E_DIR"
+
+# Stop any servers a previous e2e-up left running (keeps re-runs clean).
+"$REPO_ROOT/scripts/e2e-down.sh" --apps-only
+
+# With our own tracked servers gone, the ports must be free — anything still
+# listening is someone else's dev server and uvicorn/next would fail to bind.
+if command -v ss >/dev/null 2>&1; then
+  for port in "$BACKEND_PORT" "$FRONTEND_PORT"; do
+    if ss -ltn 2>/dev/null | grep -q ":$port "; then
+      echo "✗ port $port is already in use by an untracked process — stop your dev server first"
+      exit 1
+    fi
+  done
+fi
+
+# ── Database stack ───────────────────────────────────────────────────────────
+echo "▶ Starting local Supabase (no-op if already running)…"
+if ! supabase start; then
+  # A stale project (containers left 'exited', e.g. after a reboot) makes the
+  # CLI claim it's "already running" and then fail — stop and retry once.
+  # `supabase stop` keeps the DB volume, so no data is lost.
+  echo "  ⚠ supabase start failed — retrying once after supabase stop"
+  supabase stop >/dev/null 2>&1 || true
+  supabase start || { echo "✗ supabase start failed"; exit 1; }
+fi
+
+# Seed the rich dataset by default (#363): E2E harnesses sign in via
+# /api/auth/test-login, which needs the seeded rich-* users. SEED_RICH=0 skips.
+export SEED_RICH="${SEED_RICH:-1}"
+migrate_reload_seed
+
+# ── Backend (uvicorn) ────────────────────────────────────────────────────────
+# Same app entry as `python main.py` but without --reload: a file-watcher
+# restarting mid-test would make E2E runs nondeterministic.
+echo "▶ Starting backend (uvicorn on :$BACKEND_PORT, log: .e2e/backend.log)…"
+# `setsid <simple command> &` is load-bearing: bash fork+execs the simple
+# command directly, so $! is setsid's PID, which becomes the new session's
+# process-group leader — the PID e2e-down.sh kills as a group. (Backgrounding a
+# `cd … && setsid …` list instead records a wrapper-subshell PID and teardown
+# would orphan the server.)
+(
+  cd backend || exit 1
+  setsid venv/bin/python -m uvicorn main:app --host 0.0.0.0 --port "$BACKEND_PORT" \
+    >"$E2E_DIR/backend.log" 2>&1 &
+  echo $! >"$E2E_DIR/backend.pid"
+) || { echo "✗ could not start backend"; exit 1; }
+wait_for_http "backend (uvicorn :$BACKEND_PORT)" \
+  "http://127.0.0.1:$BACKEND_PORT/api/health" 30 "$E2E_DIR/backend.log"
+
+# ── Frontend (test-profile production build, #380) ───────────────────────────
+# `start:test` prints a "next start does not work with output: standalone"
+# warning — expected and harmless, see docs/local-supabase.md.
+echo "▶ Building test-profile frontend (npm run build:test, log: .e2e/frontend-build.log)…"
+( cd frontend && npm run build:test ) >"$E2E_DIR/frontend-build.log" 2>&1 \
+  || { echo "✗ frontend build failed"; tail -n 20 "$E2E_DIR/frontend-build.log" | sed 's/^/    /'; exit 1; }
+
+echo "▶ Starting frontend (next start on :$FRONTEND_PORT, log: .e2e/frontend.log)…"
+# Same setsid-simple-command shape as the backend launch above.
+(
+  cd frontend || exit 1
+  setsid npm run start:test >"$E2E_DIR/frontend.log" 2>&1 &
+  echo $! >"$E2E_DIR/frontend.pid"
+) || { echo "✗ could not start frontend"; exit 1; }
+
+# ── Health-check all four services ───────────────────────────────────────────
+echo "▶ Health-checking all services…"
+if "$CONTAINER_CMD" exec "$DB_CONTAINER" pg_isready -U postgres -d postgres >/dev/null 2>&1; then
+  echo "  ✓ Postgres (:54322)"
+else
+  echo "✗ Postgres health check failed ($CONTAINER_CMD exec $DB_CONTAINER pg_isready)"
+  exit 1
+fi
+KEY="$(grep -E '^SUPABASE_SERVICE_KEY=' backend/.env | head -n1 | cut -d= -f2-)"
+wait_for_http "Supabase REST / PostgREST (:54321)" \
+  "http://127.0.0.1:54321/rest/v1/terms?select=id&limit=1" 30 "" \
+  -H "apikey: $KEY" -H "Authorization: Bearer $KEY"
+wait_for_http "backend (uvicorn :$BACKEND_PORT)" \
+  "http://127.0.0.1:$BACKEND_PORT/api/health" 15 "$E2E_DIR/backend.log"
+wait_for_http "frontend (next start :$FRONTEND_PORT)" \
+  "http://127.0.0.1:$FRONTEND_PORT/" 60 "$E2E_DIR/frontend.log" -L
+
+cat <<DONE
+
+✅ E2E stack is up.
+     frontend  http://localhost:$FRONTEND_PORT   (test-profile production build)
+     backend   http://localhost:$BACKEND_PORT   (health: /api/health)
+     Supabase  http://127.0.0.1:54321  (Studio: http://127.0.0.1:54323)
+   PIDs + logs: .e2e/          Tear down: make e2e-down
+   Harness sign-in: POST /api/auth/test-login with a seeded rich-* user (#381).
+DONE

--- a/scripts/lib/local-common.sh
+++ b/scripts/lib/local-common.sh
@@ -1,16 +1,28 @@
 # Shared helpers for the LOCAL Sapling dev scripts.
 #
-# Sourced (never executed) by scripts/local-up.sh and scripts/local-db-reset.sh
-# so the identical "migrate → ensure buckets → reload PostgREST → seed" sequence
-# lives in exactly one place (#10). LOCAL ONLY — never touches staging/prod.
+# Sourced (never executed) by scripts/local-up.sh, scripts/local-db-reset.sh and
+# scripts/e2e-up.sh so the identical "migrate → ensure buckets → reload
+# PostgREST → seed" sequence lives in exactly one place (#10). LOCAL ONLY —
+# never touches staging/prod.
 #
 # The caller is expected to have already:
 #   • set -uo pipefail
 #   • cd'd to the repo root
-#   • exported DOCKER_HOST (rootless podman socket)
+#   • exported DOCKER_HOST (rootless podman socket) when running under podman
 #   • defined LOCAL_DB_URL and DB_CONTAINER
 #
 # No shebang / +x needed — this file is meant to be `source`d.
+
+# Container runtime used to `exec` into the Supabase DB container: rootless
+# Podman is the documented default, Docker also works (#384). An explicit
+# $CONTAINER_CMD wins; otherwise prefer podman, falling back to docker.
+if [ -z "${CONTAINER_CMD:-}" ]; then
+  if command -v podman >/dev/null 2>&1; then
+    CONTAINER_CMD=podman
+  else
+    CONTAINER_CMD=docker
+  fi
+fi
 
 # Ensure the Supabase Storage buckets the app expects exist locally, plus a
 # blunt LOCAL-ONLY RLS policy so anon-key frontend uploads work (#2).
@@ -48,7 +60,7 @@ CREATE POLICY "local dev storage open"
   WITH CHECK (bucket_id IN ('cosmetic-assets', 'issues-media-files'));
 SQL
 )"
-  if podman exec "$DB_CONTAINER" psql -U postgres -d postgres \
+  if "$CONTAINER_CMD" exec "$DB_CONTAINER" psql -U postgres -d postgres \
        -v ON_ERROR_STOP=1 -c "$sql" >/dev/null 2>&1; then
     echo "  ensured storage buckets"
   else
@@ -77,7 +89,7 @@ migrate_reload_seed() {
   ensure_storage_buckets
 
   echo "▶ Reloading PostgREST schema cache…"
-  podman exec "$DB_CONTAINER" psql -U postgres -d postgres \
+  "$CONTAINER_CMD" exec "$DB_CONTAINER" psql -U postgres -d postgres \
     -c "NOTIFY pgrst, 'reload schema';" >/dev/null 2>&1 || true
 
   echo "▶ Waiting for PostgREST to expose the schema…"


### PR DESCRIPTION
## Summary

One command now boots (and tears down) the entire local test stack, per #384:

- **`make e2e-up`** → `scripts/e2e-up.sh`: preflight (supabase CLI, `backend/.env`, backend venv, `frontend/node_modules`, port sanity — fails fast with the exact bootstrap command) → `supabase start` (with a stop-and-retry-once fallback for stale `exited` containers, e.g. after a reboot) → `migrate_reload_seed()` from `scripts/lib/local-common.sh` (migrate → Storage buckets → `NOTIFY pgrst, 'reload schema'` → PostgREST poll → `db.seed_staging`, plus `db.seed_local_rich` — `SEED_RICH` defaults to `1` here so `POST /api/auth/test-login` (#381) has its `rich-*` users; `SEED_RICH=0` skips) → uvicorn backend on :5000 (no `--reload`, deterministic for E2E) → test-profile Next production build `npm run build:test && npm run start:test` (#380/#421) on :3000 → health-checks all four services (Postgres `pg_isready`, PostgREST REST probe, backend `/api/health`, frontend `/`), failing loudly with a log tail if one doesn't come up.
- **`make e2e-down`** → `scripts/e2e-down.sh`: SIGTERM (then SIGKILL after 10 s) to the tracked process groups, then `supabase stop`. Servers are launched with `setsid` as a *simple command*, so each recorded PID in `.e2e/*.pid` is its session/process-group leader and one group signal takes the whole tree (npm → next-server). `--apps-only` stops just the app servers (used by `e2e-up` to make re-runs clean).
- PIDs + logs live in `.e2e/` at the repo root (gitignored).
- `scripts/lib/local-common.sh` now detects the container runtime (`$CONTAINER_CMD`: podman preferred, docker fallback, explicit value wins) instead of hardcoding `podman exec` — the only change needed for Docker support; `local-up.sh`/`local-db-reset.sh` behavior on Podman machines is unchanged.
- New root `Makefile` (none existed) with the two entry points; docs section added to `docs/local-supabase.md` (plus removed a stray trailing code fence).

## Verified (rootless Podman, this machine)

- `shellcheck -x` clean on `e2e-up.sh` / `e2e-down.sh` / `local-common.sh` (shellcheck 0.11.0; the two remaining SC2164 warnings are pre-existing in the untouched `local-up.sh`/`local-db-reset.sh`).
- **Full cold cycle**: from everything stopped, `make e2e-up` ran end-to-end (supabase cold start → 0 pending migrations → buckets → PostgREST ready → both seeds no-op idempotent → backend healthy → `build:test` → `start:test` → all four health checks ✓, exit 0).
- **Stack exercised**: `POST /api/auth/test-login` with `rich-user-main` returned 200 + `sapling_session` cookie; frontend `/` → 200; same-origin proxy `:3000/api/health` → 200.
- **Teardown**: `make e2e-down` left zero app processes (verified the npm→next-server tree dies with the group), zero containers, ports 3000/5000/54321/54322 free, PID files removed.
- **PID bookkeeping**: verified via `ps` that recorded PIDs are session/PG leaders (`pid == pgid == sid`). An earlier draft recorded a wrapper-subshell PID (which would have orphaned uvicorn on teardown) — caught and fixed during live testing.
- **Stale-state resilience**: the first live run hit `supabase start` failing on containers left `exited` ("is already running" + "container is not running: exited"); the stop-and-retry fallback now recovers this automatically (exercised live).

## Not verified

- **Docker**: no Docker daemon on this machine — the Docker path (podman absent → `CONTAINER_CMD=docker`, no forced podman `DOCKER_HOST`) is code-reviewed only, not executed. Needs a run on a Docker machine to check the box in #384.
- **True clean machine**: this machine already had the supabase images, backend venv, `backend/.env`, and `frontend/node_modules` (the worktree borrowed the primary checkout's venv/.env and a hardlink copy of `node_modules` — Turbopack rejects out-of-root symlinks, so a plain symlinked `node_modules` does *not* work). First-ever-boot (image pulls, fresh `.env`) wasn't reproducible here; the preflight fails fast with the exact bootstrap command for each missing piece.
- `next start`'s `output: standalone` warning is expected and intentionally left alone (documented in #421's docs section).

Part of #402, closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)