### PR TITLE
ci: run the integration lane on every push to main (#402)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,6 +2,8 @@ name: integration (local supabase)
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
 
 jobs:
   integration:


### PR DESCRIPTION
The subcutaneous suite (#396–#398) currently runs only on manual `workflow_dispatch` — CI has never exercised it automatically, so a misspelled column or broken encryption round-trip would land silently. This adds `push: branches: [main]` (keeping manual dispatch), per epic #402 open decision 3's lean: run on main first, promote to a PR gate once the #388 stability bar holds.

Two-line workflow change; no job content touched.

Part of #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)