### PR TITLE
test(e2e): journey — seeded session → dashboard (#386)

### DIFF
--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -74,6 +74,7 @@ renders the element.
 | Knowledge graph | `graph` | `frontend/src/components/KnowledgeGraph.tsx` (wrapper only — not the 2D/3D internals) |
 | App shell | `app` | `frontend/src/components/ShellFrame.tsx` (the authed layout frame every `(shell)` route renders inside) |
 | Study rooms | `social` | `frontend/src/components/screens/Social.tsx` (rooms sidebar, chat, overview, study match, directory — added with the #394 two-context journey) |
+| Dashboard | `dashboard` | `frontend/src/components/screens/Dashboard.tsx` (rendered by `(shell)/dashboard/page.tsx`) |
 
 Two surfaces do **not** carry their testids in the screen file named by the
 route:
@@ -203,6 +204,13 @@ route:
 | `social-member-kick-{userId}` | "Kick" on that member row (leader only) |
 | `social-match-run` | "Find matches" on the study-match tab |
 
+### `dashboard`
+
+| testid | element |
+| --- | --- |
+| `dashboard-courses-key-toggle` | expand/collapse toggle of the "My courses" key overlay on the graph panel (default sidebar layout; the key starts collapsed) |
+| `dashboard-course-code` | a course row's code/name label inside the expanded key — repeated per course with **no suffix** (deliberate deviation from the suffix rule above: journeys select a row by seeded content, `getByTestId(…).filter({ hasText })`, so no per-row identity is exposed) |
+
 ## Enforcement
 
 `frontend/eslint.config.mjs` has a per-file `no-restricted-syntax` block scoped
@@ -238,6 +246,13 @@ It is intentionally narrow:
 There is no lint coverage on `signin-trigger` in `src/app/(public)/page.tsx` —
 the landing page has dozens of buttons that are not part of any browser test, so
 that file stays out of the `files` list. The trigger is documented here instead.
+
+`screens/Dashboard.tsx` joined the `files` list with the `dashboard` surface
+(#386) carrying 25 pre-existing untagged intrinsic elements; those are
+baselined in `eslint-suppressions.json` (the repo's legacy-debt mechanism —
+see the header of `eslint.config.mjs`), so only **new** interactive elements
+in the file must carry a testid. Tag baselined elements as they get browser
+coverage and regenerate with `npm run lint:baseline`.
 
 ### Adding a surface
 

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -5,15 +5,16 @@
  * /dashboard → assert a known seeded course is visible. Deliberately nothing
  * else is asserted — smoke.spec.ts already owns the URL/shell proof.
  *
- * The course: `rich-course-math210` (MATH210 — "Linear Algebra") from
- * db/seed_local_rich.py, which rich-user-active takes via the spring-2026
- * offering. Spring 2026 is the current term under the frozen test-mode clock
- * (2026-03-11), so the enrollment always sits in the current (not Archive)
- * bucket of the "My courses" key on the default sidebar dashboard layout.
- * The key starts collapsed; its toggle is reached by accessible name and the
- * course by seeded text — the dashboard is not a #382 testid surface, and
- * per the issue a seeded-data text/role assertion is preferred over minting
- * one for it.
+ * Selectors anchor on the `dashboard` testid surface (docs/frontend-testids.md,
+ * minted with this journey): the "My courses" key on the default sidebar
+ * layout starts collapsed, so the spec opens it via
+ * `dashboard-courses-key-toggle`, then asserts the seeded course inside the
+ * `dashboard-course-code` row labels. The course itself is asserted by seeded
+ * DATA, not copy: `rich-course-math210` ("MATH210" — Linear Algebra,
+ * db/seed_local_rich.py) is rich-user-active's spring-2026 enrollment, and
+ * spring 2026 is the current term under the frozen test-mode clock
+ * (2026-03-11), so its row always renders in the current — never Archive —
+ * bucket of the key.
  */
 import { expect, test } from "./support/fixtures";
 
@@ -22,14 +23,15 @@ test("seeded session lands on dashboard with a seeded course visible", async ({
 }) => {
   await page.goto("/dashboard");
 
-  // Expand the "My courses" key overlay (collapsed by default). The button
+  // Expand the "My courses" key overlay (collapsed by default). The toggle
   // only mounts once enrollments have loaded, so Playwright's auto-wait on
   // the click doubles as the "dashboard data arrived" gate.
-  await page.getByRole("button", { name: "Expand courses key" }).click();
+  await page.getByTestId("dashboard-courses-key-toggle").click();
 
-  // The row label renders the seeded course_code (course_code wins over
-  // course_name throughout the dashboard). Exact match keeps the locator
-  // unique: the "Where you left off" panel mentions MATH210 too, but only
-  // inside a longer "MATH210 · expository · …" string.
-  await expect(page.getByText("MATH210", { exact: true })).toBeVisible();
+  // One row label carries the seeded course code (course_code wins over
+  // course_name in the row renderer). `dashboard-course-code` repeats per
+  // course, so filter down to the seeded MATH210 row.
+  await expect(
+    page.getByTestId("dashboard-course-code").filter({ hasText: "MATH210" }),
+  ).toBeVisible();
 });

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Journey #386 — seeded session → dashboard. The smallest journey in the
+ * chapter-1 lane and the known-good base every other journey builds on:
+ * inject the session cookie (storageState minted by global-setup) → land on
+ * /dashboard → assert a known seeded course is visible. Deliberately nothing
+ * else is asserted — smoke.spec.ts already owns the URL/shell proof.
+ *
+ * The course: `rich-course-math210` (MATH210 — "Linear Algebra") from
+ * db/seed_local_rich.py, which rich-user-active takes via the spring-2026
+ * offering. Spring 2026 is the current term under the frozen test-mode clock
+ * (2026-03-11), so the enrollment always sits in the current (not Archive)
+ * bucket of the "My courses" key on the default sidebar dashboard layout.
+ * The key starts collapsed; its toggle is reached by accessible name and the
+ * course by seeded text — the dashboard is not a #382 testid surface, and
+ * per the issue a seeded-data text/role assertion is preferred over minting
+ * one for it.
+ */
+import { expect, test } from "./support/fixtures";
+
+test("seeded session lands on dashboard with a seeded course visible", async ({
+  page,
+}) => {
+  await page.goto("/dashboard");
+
+  // Expand the "My courses" key overlay (collapsed by default). The button
+  // only mounts once enrollments have loaded, so Playwright's auto-wait on
+  // the click doubles as the "dashboard data arrived" gate.
+  await page.getByRole("button", { name: "Expand courses key" }).click();
+
+  // The row label renders the seeded course_code (course_code wins over
+  // course_name throughout the dashboard). Exact match keeps the locator
+  // unique: the "Where you left off" panel mentions MATH210 too, but only
+  // inside a longer "MATH210 · expository · …" string.
+  await expect(page.getByText("MATH210", { exact: true })).toBeVisible();
+});

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -87,6 +87,9 @@
     }
   },
   "src/components/screens/Dashboard.tsx": {
+    "no-restricted-syntax": {
+      "count": 25
+    },
     "react/no-unescaped-entities": {
       "count": 2
     }

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -60,6 +60,7 @@ const eslintConfig = [
       "src/components/KnowledgeGraph.tsx",
       "src/components/ShellFrame.tsx",
       "src/components/screens/Social.tsx",
+      "src/components/screens/Dashboard.tsx",
     ],
     rules: {
       "no-restricted-syntax": [

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -1358,6 +1358,7 @@ function CoursesKey({
             onClick={() => setCollapsed(c => !c)}
             aria-label={collapsed ? "Expand courses key" : "Collapse courses key"}
             style={paddedIconBtn}
+            data-testid="dashboard-courses-key-toggle"
           >
             <Icon name={collapsed ? "plus" : "x"} size={13} />
           </button>
@@ -1380,7 +1381,10 @@ function CoursesKey({
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 5, gap: 8 }}>
                   <span style={{ display: "inline-flex", alignItems: "center", gap: 8, minWidth: 0 }}>
                     <span style={{ width: 11, height: 11, borderRadius: "50%", background: baseColor, flexShrink: 0, ...legibleDot }} />
-                    <strong style={{ fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", ...legibleText }}>
+                    <strong
+                      data-testid="dashboard-course-code"
+                      style={{ fontSize: 13, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", ...legibleText }}
+                    >
                       {course.course_code || course.course_name}
                     </strong>
                   </span>


### PR DESCRIPTION
## Summary

The smallest browser journey (#386), the known-good base for the rest of the chapter-1 lane: storageState session → `/dashboard` → one assertion that a known seeded course is visible.

- **`frontend/e2e/dashboard.spec.ts`** (new) — opens the "My courses" key via `dashboard-courses-key-toggle` (it starts collapsed on the default sidebar layout), then asserts the seeded course inside the testid-anchored row labels: `getByTestId("dashboard-course-code").filter({ hasText: "MATH210" })`. MATH210 (Linear Algebra, `rich-course-math210` from `db/seed_local_rich.py`) is `rich-user-active`'s spring-2026 enrollment, and spring 2026 is the current term under the frozen test-mode clock (2026-03-11), so its row always sits in the current — not Archive — bucket. Nothing else is asserted — smoke.spec.ts owns the URL/shell proof. Zero `waitForTimeout`; the click's auto-wait doubles as the data-arrived gate.
- **`frontend/e2e/global-setup.ts`** (harness fix, additive) — the minted storageState now also carries the `sapling_user` localStorage entry (mirroring exactly what `setActiveUser` persists on real sign-in). The cookie alone is not a signed-in browser: `UserContext` reads identity from localStorage only, so every authed screen rendered its shell but never fetched user data — this journey found `/dashboard` stuck on its skeleton for the full test timeout. Every sibling journey needs this, so it belongs in the shared setup rather than per-spec boilerplate.

## Testids — `dashboard` surface minted (review follow-up)

Per `docs/frontend-testids.md` "Adding a surface" (review flagged that the doc's testid-anchor rule is blanket, and #428 set the precedent):

- `dashboard-courses-key-toggle` on the key's expand/collapse button; `dashboard-course-code` on each course-row label (repeated, **no suffix** — a documented deviation from the suffix rule: journeys select rows by seeded content, so no per-row identity is exposed).
- Registry table row + `### dashboard` inventory added to `docs/frontend-testids.md`.
- `src/components/screens/Dashboard.tsx` added to the eslint enforcement `files` array. That surfaced **25 pre-existing untagged intrinsic elements**; instead of a blind testid sweep they are absorbed by the repo's documented legacy-debt mechanism — the ESLint bulk-suppressions baseline (`eslint-suppressions.json`, regenerated via `npm run lint:baseline`; see the header comment in `eslint.config.mjs`). The baseline diff is exactly one entry (`no-restricted-syntax: 25` for Dashboard.tsx), so any NEW interactive element in the file still fails CI without a testid. The doc's enforcement section records this (mirroring the existing landing-page note). `npm run lint` and `tsc --noEmit` pass; Dashboard unit tests pass.

## Verification — fresh 10 consecutive local runs of the spec as it will merge, all green

Full cycle under the shared stack lock (`make e2e-up` → 10 × `npx playwright test e2e/dashboard.spec.ts` → `make e2e-down`, exit 0), run **after** the testid rework:

| Run | Result |
| --- | --- |
| 1/10 | 1 passed (6.7s) |
| 2/10 | 1 passed (4.8s) |
| 3/10 | 1 passed (3.8s) |
| 4/10 | 1 passed (4.0s) |
| 5/10 | 1 passed (4.1s) |
| 6/10 | 1 passed (4.4s) |
| 7/10 | 1 passed (4.8s) |
| 8/10 | 1 passed (4.9s) |
| 9/10 | 1 passed (4.7s) |
| 10/10 | 1 passed (4.8s) |

History: cycle 1 failed run 1 with the skeleton hang described above (which surfaced the global-setup gap); cycle 2 (text/role anchors) was 10/10 green; cycle 3 (the tally above) is the reworked, merge-state spec.

## Product observation (reported, not papered over)

A browser holding a **valid `sapling_session` cookie but no `sapling_user` localStorage** renders `/dashboard` as an infinite skeleton: middleware lets the request through, but `UserContext` only bootstraps identity from localStorage (written solely by the sign-in flows) and never falls back to cookie-based `/api/auth/me` — even though that endpoint can identify the user from the cookie alone (the auth callback already calls it without `user_id`). Real-world shape: any state where the HttpOnly cookie outlives localStorage. Worth a follow-up issue; this PR only mirrors the real sign-in state in the harness rather than changing app behavior.

Part of #402, closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)