### PR TITLE
test(e2e): journey — study room with two browser contexts (#394)

### DIFF
--- a/backend/db/migrations/0032_rooms_missing_columns.sql
+++ b/backend/db/migrations/0032_rooms_missing_columns.sql
@@ -1,0 +1,24 @@
+-- 0032: add the rooms columns routes/social.py already reads (#405).
+--
+-- `rooms` was created in 0001 with only id/name/invite_code/created_by/
+-- created_at, but social.py selects `topic, course, owner_id, updated_at,
+-- is_public` in four places (join-by-invite, list-my-rooms, room overview,
+-- kick authorization). On any schema that replays purely from migrations
+-- (local Supabase, the E2E stack) PostgREST rejects the select with 42703
+-- ("column rooms.topic does not exist") and every one of those endpoints
+-- 500s — which blocks the study-room E2E journey (#394).
+--
+-- This migration only reconciles the schema with the column list the code
+-- reads. The columns stay nullable and unpopulated: deciding their semantics
+-- (owner_id vs created_by, is_public default, and populating them in
+-- create_room) remains open product work tracked in #405.
+--
+-- IF NOT EXISTS keeps this a no-op on any environment where the columns
+-- already exist via historical dashboard DDL drift.
+
+ALTER TABLE rooms
+    ADD COLUMN IF NOT EXISTS topic      TEXT,
+    ADD COLUMN IF NOT EXISTS course     TEXT,
+    ADD COLUMN IF NOT EXISTS owner_id   TEXT,
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS is_public  BOOLEAN;

--- a/backend/db/migrations/0033_realtime_publish_room_messages.sql
+++ b/backend/db/migrations/0033_realtime_publish_room_messages.sql
@@ -1,0 +1,36 @@
+-- 0033: publish room_messages on the supabase_realtime publication.
+--
+-- Study-room chat propagation (frontend/src/components/screens/Social.tsx)
+-- rides Supabase Realtime `postgres_changes` on `room_messages`: a foreign
+-- INSERT/UPDATE event is treated as a "something changed" signal and the
+-- client re-fetches through the decrypting REST endpoint (#124 — the payload
+-- itself carries ciphertext `text`). Realtime only emits `postgres_changes`
+-- for tables in the `supabase_realtime` publication, and no migration ever
+-- added `room_messages` — the deployed environments got it via dashboard
+-- configuration (the observed production behavior #124 fixed proves it is
+-- published there). On a migrations-only schema (local Supabase, the E2E
+-- stack) the events never fire, so cross-client chat propagation silently
+-- does not happen. Needed by the #394 two-context study-room journey.
+--
+-- Guarded to be idempotent and safe everywhere:
+--   * publication missing (bare Postgres without Realtime) -> no-op;
+--   * table already published (hosted projects configured via dashboard)
+--     -> no-op.
+--
+-- room_reactions stays unpublished on purpose: its realtime handlers were
+-- removed as dead code in #231 pending the RLS/Realtime-authorization work.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime')
+       AND NOT EXISTS (
+           SELECT 1
+             FROM pg_publication_tables
+            WHERE pubname = 'supabase_realtime'
+              AND schemaname = 'public'
+              AND tablename = 'room_messages'
+       ) THEN
+        ALTER PUBLICATION supabase_realtime ADD TABLE public.room_messages;
+    END IF;
+END
+$$;

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -73,6 +73,7 @@ renders the element.
 | Quiz | `quiz` | `frontend/src/components/QuizPanel.tsx` (rendered by `screens/Quiz.tsx`) |
 | Knowledge graph | `graph` | `frontend/src/components/KnowledgeGraph.tsx` (wrapper only — not the 2D/3D internals) |
 | App shell | `app` | `frontend/src/components/ShellFrame.tsx` (the authed layout frame every `(shell)` route renders inside) |
+| Study rooms | `social` | `frontend/src/components/screens/Social.tsx` (rooms sidebar, chat, overview, study match, directory — added with the #394 two-context journey) |
 
 Two surfaces do **not** carry their testids in the screen file named by the
 route:
@@ -165,6 +166,42 @@ route:
 | testid | element |
 | --- | --- |
 | `app-shell` | authed shell root — the scrolling `<main id="main-content">` in `ShellFrame.tsx`, present in both (top-nav and sidebar) layout variants; the Playwright harness smoke spec (#385) anchors on it as the "authed shell mounted" signal |
+
+### `social`
+
+| testid | element |
+| --- | --- |
+| `social-create-room` | sidebar "Create" (opens the room-name input) |
+| `social-join-room` | sidebar "Join" (opens the invite-code input) |
+| `social-create-join-input` | shared create/join text input |
+| `social-create-join-submit` | "Go" |
+| `social-room-item-{roomId}` | a room in the sidebar list (stable seeded/domain id) |
+| `social-room-name` | active room title in the header |
+| `social-invite-copy` | invite-code copy chip in the header |
+| `social-directory-open` | sidebar "Browse directory" |
+| `social-directory-search` | directory search input |
+| `social-chat-messages` | chat scroll log (the "messages render here" container) |
+| `social-chat-message-{messageId}` | one message row (server UUID suffix) |
+| `social-chat-load-earlier` | "Load earlier messages" |
+| `social-chat-input` | message composer `<textarea>` |
+| `social-chat-send` | send button |
+| `social-chat-attach` | attach-image button |
+| `social-chat-image-input` | hidden `<input type="file">` (use `setInputFiles`) |
+| `social-chat-reply-cancel` | × on the "Replying to…" bar |
+| `social-chat-mention-{userId}` | an @mention autocomplete option |
+| `social-chat-message-react` | per-message menu: open emoji picker (one menu open at a time) |
+| `social-chat-message-reply` | per-message menu: reply |
+| `social-chat-message-edit` | per-message menu: edit (own messages) |
+| `social-chat-message-delete` | per-message menu: delete (own messages) |
+| `social-chat-emoji-{emoji}` | an option in the emoji picker grid |
+| `social-chat-reaction-{emoji}` | an existing reaction chip on a message (scope by the message row) |
+| `social-chat-edit-input` | inline edit input |
+| `social-chat-edit-save` | inline edit "Save" |
+| `social-chat-edit-cancel` | inline edit cancel |
+| `social-room-leave` | overview "Leave room" |
+| `social-member-{userId}` | a member row on the overview |
+| `social-member-kick-{userId}` | "Kick" on that member row (leader only) |
+| `social-match-run` | "Find matches" on the study-match tab |
 
 ## Enforcement
 

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -65,7 +65,28 @@ export default async function globalSetup(): Promise<void> {
         sameSite: "Lax" as const,
       },
     ],
-    origins: [],
+    // The cookie alone is not a signed-in browser: the client identity lives
+    // in localStorage (`UserContext` reads `sapling_user`; only the sign-in
+    // flows write it via setActiveUser). Without it every authed screen
+    // renders its shell but never fetches user data — the #386 journey found
+    // /dashboard stuck on its skeleton forever. Mirror exactly what
+    // setActiveUser persists for the primary seeded user (name per
+    // db/seed_local_rich.py).
+    origins: [
+      {
+        origin: FRONTEND_URL,
+        localStorage: [
+          {
+            name: "sapling_user",
+            value: JSON.stringify({
+              id: USER_ACTIVE,
+              name: "Rich Active",
+              avatar: "",
+            }),
+          },
+        ],
+      },
+    ],
   };
 
   fs.mkdirSync(path.dirname(STORAGE_STATE), { recursive: true });

--- a/frontend/e2e/study-room.spec.ts
+++ b/frontend/e2e/study-room.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * Journey #394 — study room with two browser contexts.
+ *
+ * Study rooms are the only multi-user surface, and `room_messages.text` is
+ * column-encrypted at rest — two signed-in contexts are the only honest way
+ * to observe propagation end-to-end (write → encrypt → realtime signal →
+ * decrypting re-fetch → render).
+ *
+ * Room existence: the journey uses the SEEDED room `rich-room-study-group`
+ * (db/seed_local_rich.py) — both rich-user-active and rich-user-second are
+ * members and three encrypted messages exist. This is the most robust path:
+ * no create/join UI dance, deterministic ids, and the per-test reset restores
+ * it. (Creating a room via UI/API is covered by the routes, not this journey.)
+ *
+ * Propagation mechanics (frontend/src/components/screens/Social.tsx):
+ * the client subscribes to Supabase Realtime `postgres_changes` on
+ * `room_messages` over a websocket. A FOREIGN insert event carries ciphertext
+ * `text` (#124), so the client treats it purely as a "something changed"
+ * signal and re-fetches through the decrypting REST endpoint
+ * (GET /api/social/rooms/{id}/messages). Own sends render optimistically and
+ * reconcile from the POST response. There is NO polling fallback — realtime
+ * is the only cross-client path, which is why this spec waits for each
+ * context's postgres_changes subscription to be confirmed (the server's
+ * "Subscribed to PostgreSQL" system frame) before any cross-context send:
+ * an insert landing before the receiver's subscription is live would never
+ * be delivered. All waits are event-based; zero waitForTimeout.
+ *
+ * Prerequisites added with this spec (previously the journey was impossible
+ * on a migrations-only schema):
+ *   - migration 0032: rooms drift columns (topic/course/owner_id/updated_at/
+ *     is_public) that routes/social.py selects — without them every room
+ *     listing endpoint 500s (bug #405, verified reproducing locally);
+ *   - migration 0033: `room_messages` added to the supabase_realtime
+ *     publication — without it postgres_changes never fire locally.
+ */
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "./support/fixtures";
+import { mintStorageState } from "./support/session";
+import { USER_SECOND } from "./support/stack";
+
+/** Seeded study room both users belong to (db/seed_local_rich.py). */
+const ROOM_ID = "rich-room-study-group";
+
+/** A seeded, column-encrypted message — rendering it proves the decrypting
+ * read path (not just that rows exist). */
+const SEEDED_MESSAGE = "Anyone up for reviewing recursion before the midterm?";
+
+/**
+ * Resolves once this page's Realtime postgres_changes subscription for the
+ * given room is CONFIRMED live by the server. The confirmation is the
+ * Phoenix "system" frame `Subscribed to PostgreSQL` on the channel topic
+ * `room:<roomId>` — the moment from which WAL events are guaranteed to be
+ * delivered. Must be armed BEFORE navigating so no websocket is missed.
+ */
+function waitForRoomRealtime(
+  page: Page,
+  roomId: string,
+  timeoutMs = 30_000,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `Realtime postgres_changes for room ${roomId} was not confirmed ` +
+            `within ${timeoutMs}ms — is room_messages in the ` +
+            "supabase_realtime publication (migration 0033)?",
+        ),
+      );
+    }, timeoutMs);
+    page.on("websocket", (ws) => {
+      if (!ws.url().includes("realtime")) return;
+      ws.on("framereceived", (frame) => {
+        const text =
+          typeof frame.payload === "string"
+            ? frame.payload
+            : frame.payload.toString("utf-8");
+        if (
+          text.includes(`room:${roomId}`) &&
+          text.includes("Subscribed to PostgreSQL")
+        ) {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+  });
+}
+
+/** Navigate a signed-in page into the seeded room's chat and wait until both
+ * the decrypted seeded history is rendered AND realtime is confirmed live. */
+async function enterStudyRoom(page: Page): Promise<void> {
+  const realtimeReady = waitForRoomRealtime(page, ROOM_ID);
+  // Handled at the `await` below; this guard only silences an early timeout
+  // rejection from surfacing as an unhandled rejection mid-navigation.
+  realtimeReady.catch(() => {});
+
+  await page.goto("/social");
+  // Explicitly select the seeded room — the sidebar auto-picks the first room
+  // in an unordered listing, and both seeded users belong to two rooms.
+  await page.getByTestId(`social-room-item-${ROOM_ID}`).click();
+  await expect(page.getByTestId("social-room-name")).toHaveText(
+    "CS101 Study Group",
+  );
+
+  // Seeded history renders decrypted (room_messages.text is encrypted at
+  // rest; the REST read path decrypts).
+  await expect(page.getByTestId("social-chat-messages")).toContainText(
+    SEEDED_MESSAGE,
+  );
+
+  await realtimeReady;
+}
+
+test("study room: chat propagates across two contexts and both graphs render", async ({
+  page,
+  browser,
+}) => {
+  // Two contexts, several navigations, and two realtime round-trips — give
+  // the whole journey more room than the 30s default without ever sleeping.
+  test.setTimeout(120_000);
+
+  // Context A is the default fixture page (rich-user-active via the
+  // global-setup storageState). Context B signs in rich-user-second through
+  // the same #381 test-login seam, minted fresh inside the test.
+  const contextB = await browser.newContext({
+    storageState: await mintStorageState(USER_SECOND, "Sam Second"),
+  });
+  try {
+    const pageB = await contextB.newPage();
+
+    await enterStudyRoom(page);
+    await enterStudyRoom(pageB);
+
+    const logA = page.getByTestId("social-chat-messages");
+    const logB = pageB.getByTestId("social-chat-messages");
+
+    // A → B. Unique per-direction markers that cannot collide with seeded copy.
+    const fromA = "E2E propagation check: ping from Rich Active";
+    await page.getByTestId("social-chat-input").fill(fromA);
+    await page.getByTestId("social-chat-send").click();
+    // Sender renders its own message (optimistic + POST reconciliation)…
+    await expect(logA).toContainText(fromA);
+    // …and the OTHER context receives it: realtime insert event → decrypting
+    // REST re-fetch → rendered, attributed to the sender.
+    await expect(logB).toContainText(fromA, { timeout: 15_000 });
+    await expect(
+      logB.getByTestId(/^social-chat-message-/).filter({ hasText: fromA }),
+    ).toContainText("Rich Active");
+
+    // B → A, the reverse direction.
+    const fromB = "E2E propagation check: pong from Sam Second";
+    await pageB.getByTestId("social-chat-input").fill(fromB);
+    await pageB.getByTestId("social-chat-send").click();
+    await expect(logB).toContainText(fromB);
+    await expect(logA).toContainText(fromB, { timeout: 15_000 });
+    await expect(
+      logA.getByTestId(/^social-chat-message-/).filter({ hasText: fromB }),
+    ).toContainText("Sam Second");
+
+    // Both knowledge graphs render — one per signed-in user. rich-user-active
+    // has seeded nodes/edges; rich-user-second renders the (empty) graph
+    // container, which is still the "graph surface works" signal (#382's
+    // graph-container is the registered anchor).
+    await page.goto("/dashboard");
+    await expect(page.getByTestId("graph-container")).toBeVisible();
+
+    await pageB.goto("/dashboard");
+    await expect(pageB.getByTestId("graph-container")).toBeVisible();
+  } finally {
+    await contextB.close();
+  }
+});

--- a/frontend/e2e/support/session.ts
+++ b/frontend/e2e/support/session.ts
@@ -1,0 +1,99 @@
+/**
+ * Per-test session minting for ADDITIONAL seeded users (#394).
+ *
+ * global-setup mints exactly one storageState (USER_ACTIVE) that every spec
+ * starts from. Multi-user journeys need a second signed-in browser context,
+ * so this helper repeats the same #381 test-login flow in-process and returns
+ * a Playwright `storageState` OBJECT (not a file) for
+ * `browser.newContext({ storageState })`.
+ *
+ * Kept deliberately in lock-step with e2e/global-setup.ts:
+ *   - mint through the frontend origin (proves the same-origin /api proxy);
+ *   - cookie flags mirror the real `sapling_session` (HttpOnly/Lax, and
+ *     secure:true — Chromium accepts Secure cookies on http://localhost);
+ *   - the cookie alone is NOT a signed-in browser: client identity lives in
+ *     localStorage (`UserContext` reads `sapling_user`, written only by the
+ *     sign-in flows' setActiveUser) — without it authed screens render their
+ *     shell but never fetch user data (found by the #386 journey), so the
+ *     storageState carries the same origins entry global-setup writes;
+ *   - the token is stateless HMAC, so the per-test TRUNCATE + re-seed can
+ *     never invalidate it — the re-seed restores the same rich-* user row.
+ */
+import { FRONTEND_URL } from "./stack";
+
+type StorageState = {
+  cookies: Array<{
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    expires: number;
+    httpOnly: boolean;
+    secure: boolean;
+    sameSite: "Strict" | "Lax" | "None";
+  }>;
+  origins: Array<{
+    origin: string;
+    localStorage: Array<{ name: string; value: string }>;
+  }>;
+};
+
+/** Mint a session for a seeded rich-* user and return it as storageState.
+ * `displayName` mirrors what setActiveUser would persist after a real
+ * sign-in (the user's profile name per db/seed_local_rich.py). */
+export async function mintStorageState(
+  userId: string,
+  displayName: string,
+): Promise<StorageState> {
+  const res = await fetch(`${FRONTEND_URL}/api/auth/test-login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id: userId }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `POST /api/auth/test-login failed for ${userId} (HTTP ${res.status}). ` +
+        "A 404 means the backend is not running with APP_ENV=local|test — " +
+        "check backend/.env and re-run `make e2e-up`.",
+    );
+  }
+  const body = (await res.json()) as { token?: string; expires_in?: number };
+  if (!body.token) {
+    throw new Error(
+      `test-login returned no token for ${userId}: ` +
+        JSON.stringify(body).slice(0, 200),
+    );
+  }
+
+  const { hostname } = new URL(FRONTEND_URL);
+  return {
+    cookies: [
+      {
+        name: "sapling_session",
+        value: body.token,
+        domain: hostname,
+        path: "/",
+        expires: Math.floor(Date.now() / 1000) + (body.expires_in ?? 3600),
+        httpOnly: true,
+        secure: true,
+        sameSite: "Lax",
+      },
+    ],
+    origins: [
+      {
+        origin: FRONTEND_URL,
+        localStorage: [
+          {
+            name: "sapling_user",
+            value: JSON.stringify({
+              id: userId,
+              name: displayName,
+              avatar: "",
+            }),
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/frontend/e2e/support/stack.ts
+++ b/frontend/e2e/support/stack.ts
@@ -17,6 +17,12 @@ export const BACKEND_URL =
  * integration fixtures' USER_ACTIVE. */
 export const USER_ACTIVE = "rich-user-active";
 
+/** The second seeded user (db/seed_local_rich.py, "Sam Second") — approved,
+ * onboarded, and a member of the seeded study room alongside USER_ACTIVE.
+ * Multi-user journeys (#394) sign this user into a second browser context
+ * via support/session.ts. */
+export const USER_SECOND = "rich-user-second";
+
 async function isUp(url: string): Promise<boolean> {
   try {
     const res = await fetch(url, { signal: AbortSignal.timeout(3_000) });

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -59,6 +59,7 @@ const eslintConfig = [
       "src/components/QuizPanel.tsx",
       "src/components/KnowledgeGraph.tsx",
       "src/components/ShellFrame.tsx",
+      "src/components/screens/Social.tsx",
     ],
     rules: {
       "no-restricted-syntax": [

--- a/frontend/src/components/screens/Social.tsx
+++ b/frontend/src/components/screens/Social.tsx
@@ -115,10 +115,10 @@ function CreateJoinBar({ onDone }: { onDone: () => void }) {
   if (mode === "idle") {
     return (
       <div style={{ display: "flex", gap: 6, marginTop: 10 }}>
-        <button className="btn btn--sm btn--primary" style={{ flex: 1 }} onClick={() => setMode("create")}>
+        <button data-testid="social-create-room" className="btn btn--sm btn--primary" style={{ flex: 1 }} onClick={() => setMode("create")}>
           <Icon name="plus" size={12} /> Create
         </button>
-        <button className="btn btn--sm" style={{ flex: 1 }} onClick={() => setMode("join")}>Join</button>
+        <button data-testid="social-join-room" className="btn btn--sm" style={{ flex: 1 }} onClick={() => setMode("join")}>Join</button>
       </div>
     );
   }
@@ -126,6 +126,7 @@ function CreateJoinBar({ onDone }: { onDone: () => void }) {
   return (
     <div style={{ display: "flex", gap: 6, marginTop: 10 }}>
       <input
+        data-testid="social-create-join-input"
         autoFocus
         value={value}
         onChange={(e) => setValue(e.target.value)}
@@ -137,7 +138,7 @@ function CreateJoinBar({ onDone }: { onDone: () => void }) {
           fontSize: 12, background: "var(--bg-panel)",
         }}
       />
-      <button className="btn btn--sm btn--primary" onClick={submit}>Go</button>
+      <button data-testid="social-create-join-submit" className="btn btn--sm btn--primary" onClick={submit}>Go</button>
     </div>
   );
 }
@@ -432,11 +433,12 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
       </div>
       <div
         ref={scrollRef}
+        data-testid="social-chat-messages"
         style={{ flex: 1, overflowY: "auto", padding: "12px 24px", display: "flex", flexDirection: "column", gap: 14 }}
       >
         {hasMore && (
           <div style={{ textAlign: "center" }}>
-            <button className="btn btn--ghost btn--sm" onClick={loadEarlier} disabled={loadingEarlier}>
+            <button data-testid="social-chat-load-earlier" className="btn btn--ghost btn--sm" onClick={loadEarlier} disabled={loadingEarlier}>
               {loadingEarlier ? "Loading…" : "Load earlier messages"}
             </button>
           </div>
@@ -449,7 +451,7 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
           const isMenuOpen = menu === m.id;
           const isEditing = editing === m.id;
           return (
-            <div key={m.id} style={{ display: "flex", gap: 10, alignSelf: self ? "flex-end" : "flex-start", maxWidth: "72%", position: "relative" }} className="fade-in">
+            <div key={m.id} data-testid={`social-chat-message-${m.id}`} style={{ display: "flex", gap: 10, alignSelf: self ? "flex-end" : "flex-start", maxWidth: "72%", position: "relative" }} className="fade-in">
               {!self && <Avatar name={m.user_name} size={32} />}
               <div style={{ position: "relative" }}>
                 {!self && <div style={{ fontSize: 11, color: "var(--text-dim)", fontWeight: 600, marginBottom: 2 }}>{m.user_name}</div>}
@@ -465,6 +467,7 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
                 ) : isEditing ? (
                   <div style={{ display: "flex", gap: 6 }}>
                     <input
+                      data-testid="social-chat-edit-input"
                       autoFocus
                       value={editValue}
                       onChange={e => setEditValue(e.target.value)}
@@ -477,8 +480,8 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
                         borderRadius: "var(--r-sm)", fontSize: 13, background: "var(--bg-panel)",
                       }}
                     />
-                    <button className="btn btn--sm btn--primary" onClick={() => handleEditSave(m.id)}>Save</button>
-                    <button className="btn btn--sm btn--ghost" onClick={() => { setEditing(null); setEditValue(""); }}>
+                    <button data-testid="social-chat-edit-save" className="btn btn--sm btn--primary" onClick={() => handleEditSave(m.id)}>Save</button>
+                    <button data-testid="social-chat-edit-cancel" className="btn btn--sm btn--ghost" onClick={() => { setEditing(null); setEditValue(""); }}>
                       <Icon name="x" size={11} />
                     </button>
                   </div>
@@ -505,6 +508,7 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
                     {m.reactions.map((r) => (
                       <button
                         key={r.emoji}
+                        data-testid={`social-chat-reaction-${r.emoji}`}
                         onClick={() => handleReaction(m.id, r.emoji)}
                         style={{
                           fontSize: 11, padding: "2px 8px",
@@ -520,18 +524,18 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
                 )}
                 {isMenuOpen && !m.is_deleted && (
                   <div style={{ position: "absolute", top: -32, right: 0, display: "flex", gap: 4, background: "var(--bg-panel)", border: "1px solid var(--border-strong)", borderRadius: "var(--r-full)", padding: 4, boxShadow: "var(--shadow-md)" }}>
-                    <button className="btn btn--ghost btn--sm" title="React" onClick={(e) => { e.stopPropagation(); setPicker(m.id); }}>
+                    <button data-testid="social-chat-message-react" className="btn btn--ghost btn--sm" title="React" onClick={(e) => { e.stopPropagation(); setPicker(m.id); }}>
                       😊
                     </button>
-                    <button className="btn btn--ghost btn--sm" title="Reply" onClick={(e) => { e.stopPropagation(); setReplyTo(m); setMenu(null); inputRef.current?.focus(); }}>
+                    <button data-testid="social-chat-message-reply" className="btn btn--ghost btn--sm" title="Reply" onClick={(e) => { e.stopPropagation(); setReplyTo(m); setMenu(null); inputRef.current?.focus(); }}>
                       ↪
                     </button>
                     {self && (
                       <>
-                        <button className="btn btn--ghost btn--sm" title="Edit" onClick={(e) => { e.stopPropagation(); setEditing(m.id); setEditValue(m.text || ""); setMenu(null); }}>
+                        <button data-testid="social-chat-message-edit" className="btn btn--ghost btn--sm" title="Edit" onClick={(e) => { e.stopPropagation(); setEditing(m.id); setEditValue(m.text || ""); setMenu(null); }}>
                           <Icon name="pencil" size={11} />
                         </button>
-                        <button className="btn btn--ghost btn--sm" title="Delete" onClick={(e) => { e.stopPropagation(); handleDelete(m); setMenu(null); }}>
+                        <button data-testid="social-chat-message-delete" className="btn btn--ghost btn--sm" title="Delete" onClick={(e) => { e.stopPropagation(); handleDelete(m); setMenu(null); }}>
                           <Icon name="x" size={11} />
                         </button>
                       </>
@@ -541,7 +545,7 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
                 {picker === m.id && (
                   <div style={{ position: "absolute", top: 20, right: 0, zIndex: 20, background: "var(--bg-panel)", border: "1px solid var(--border-strong)", borderRadius: "var(--r-md)", padding: 10, boxShadow: "var(--shadow-lg)", display: "grid", gridTemplateColumns: "repeat(10, 1fr)", gap: 4, width: 340 }}>
                     {EMOJI_50.map((e) => (
-                      <button key={e} onClick={() => handleReaction(m.id, e)} style={{ fontSize: 16, padding: 4, borderRadius: 4 }}>{e}</button>
+                      <button key={e} data-testid={`social-chat-emoji-${e}`} onClick={() => handleReaction(m.id, e)} style={{ fontSize: 16, padding: 4, borderRadius: 4 }}>{e}</button>
                     ))}
                   </div>
                 )}
@@ -556,7 +560,7 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
           <div style={{ color: "var(--text-dim)" }}>
             Replying to <strong>{replyTo.user_name}</strong>: {replyTo.text?.slice(0, 80) || "(attachment)"}
           </div>
-          <button className="btn btn--ghost btn--sm" onClick={() => setReplyTo(null)}>
+          <button data-testid="social-chat-reply-cancel" className="btn btn--ghost btn--sm" onClick={() => setReplyTo(null)}>
             <Icon name="x" size={11} />
           </button>
         </div>
@@ -568,6 +572,7 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
             {filteredMentions.map((m, i) => (
               <button
                 key={m.user_id}
+                data-testid={`social-chat-mention-${m.user_id}`}
                 onClick={() => applyMention(m.name)}
                 style={{
                   display: "block", width: "100%", textAlign: "left",
@@ -583,6 +588,7 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
         <div style={{ display: "flex", gap: 8, alignItems: "center", background: "var(--bg-subtle)", borderRadius: "var(--r-full)", padding: "6px 14px", border: "1px solid var(--border)" }}>
           <textarea
             ref={inputRef}
+            data-testid="social-chat-input"
             value={input}
             rows={1}
             onChange={(e) => onInputChange(e.target.value)}
@@ -607,6 +613,7 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
           />
           <input
             ref={fileRef}
+            data-testid="social-chat-image-input"
             type="file"
             accept="image/*"
             hidden
@@ -616,10 +623,10 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
               e.target.value = "";
             }}
           />
-          <button className="btn btn--ghost btn--sm" onClick={() => fileRef.current?.click()} title="Attach image">
+          <button data-testid="social-chat-attach" className="btn btn--ghost btn--sm" onClick={() => fileRef.current?.click()} title="Attach image">
             <Icon name="doc" size={13} />
           </button>
-          <button className="btn btn--primary btn--sm" onClick={send} disabled={!input.trim()}>
+          <button data-testid="social-chat-send" className="btn btn--primary btn--sm" onClick={send} disabled={!input.trim()}>
             <Icon name="send" size={13} />
           </button>
         </div>
@@ -719,6 +726,7 @@ function RoomOverview({ roomId, onChange }: { roomId: string; onChange: () => vo
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
           <div className="label-micro">Members</div>
           <button
+            data-testid="social-room-leave"
             className={`btn btn--sm ${leave.armed ? "btn--danger" : ""}`}
             onClick={leave.trigger}
             style={leave.armed ? { background: "var(--err-soft)", color: "var(--err)" } : undefined}
@@ -778,7 +786,7 @@ function MemberRow({
 }) {
   const kick = useConfirm(onKick);
   return (
-    <div style={{
+    <div data-testid={`social-member-${member.user_id}`} style={{
       display: "flex", alignItems: "center", gap: 10,
       padding: "10px 0", borderBottom: last ? "none" : "1px solid var(--border)",
     }}>
@@ -797,6 +805,7 @@ function MemberRow({
       </Link>
       {canKick && (
         <button
+          data-testid={`social-member-kick-${member.user_id}`}
           className={`btn btn--sm ${kick.armed ? "btn--danger" : "btn--ghost"}`}
           onClick={kick.trigger}
           style={kick.armed ? { background: "var(--err-soft)", color: "var(--err)" } : undefined}
@@ -841,7 +850,7 @@ function StudyMatch({ roomId }: { roomId: string }) {
           <div style={{ color: "var(--text-dim)", marginBottom: 20 }}>
             We&apos;ll pair you with members whose knowledge complements yours.
           </div>
-          <button className="btn btn--primary" onClick={run} disabled={loading}>
+          <button data-testid="social-match-run" className="btn btn--primary" onClick={run} disabled={loading}>
             {loading ? "Finding…" : "Find matches"}
           </button>
         </div>
@@ -942,6 +951,7 @@ function SchoolDirectory() {
             <div className="h-serif" style={{ fontSize: 22 }}>Students at your school</div>
           </div>
           <input
+            data-testid="social-directory-search"
             value={q}
             onChange={e => setQ(e.target.value)}
             placeholder="Search by name, course, concept"
@@ -1041,7 +1051,7 @@ export function Social() {
           <>
             <div style={{ padding: "18px 24px", borderBottom: "1px solid var(--border)", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
               <div>
-                <div className="h-serif" style={{ fontSize: 22, fontWeight: 500 }}>{active.name}</div>
+                <div data-testid="social-room-name" className="h-serif" style={{ fontSize: 22, fontWeight: 500 }}>{active.name}</div>
                 <div style={{ fontSize: 11, color: "var(--text-muted)", display: "flex", alignItems: "center", gap: 8, marginTop: 2 }}>
                   <CopyChip code={active.invite_code} />
                   <span>{active.member_count} members</span>
@@ -1078,6 +1088,7 @@ export function Social() {
           <div className="h-serif" style={{ fontSize: 18, fontWeight: 500 }}>Study Rooms</div>
           <CreateJoinBar onDone={load} />
           <button
+            data-testid="social-directory-open"
             className="btn btn--sm"
             style={{ marginTop: 8, width: "100%" }}
             onClick={() => setTab("directory")}
@@ -1095,6 +1106,7 @@ export function Social() {
           {!loading && rooms.map((r) => (
             <button
               key={r.id}
+              data-testid={`social-room-item-${r.id}`}
               onClick={() => { setActiveId(r.id); setTab("chat"); }}
               style={{
                 width: "100%", padding: "10px 12px",
@@ -1128,7 +1140,7 @@ function CopyChip({ code }: { code: string }) {
     }
   };
   return (
-    <button className="chip" onClick={copy} title="Copy invite code">
+    <button data-testid="social-invite-copy" className="chip" onClick={copy} title="Copy invite code">
       {copied ? "Copied!" : code}
     </button>
   );


### PR DESCRIPTION
## Summary

Two-context study-room journey: `rich-user-active` and `rich-user-second` sign into separate Playwright browser contexts, meet in the seeded `rich-room-study-group`, and **each context asserts receipt of the other's message** (attributed to the sender by display name) plus its own knowledge-graph render (`graph-container` on `/dashboard` for both users). `room_messages.text` is column-encrypted at rest, so the assertions prove the full write → encrypt → realtime signal → decrypting re-fetch → render loop. Zero `waitForTimeout` — every wait is event-based.

- `frontend/e2e/study-room.spec.ts` — the journey.
- `frontend/e2e/support/session.ts` — NEW additive helper minting a second user's `storageState` via `POST /api/auth/test-login` (same flow as `global-setup.ts`, returned as an object for `browser.newContext`). It carries both the `sapling_session` cookie AND the `sapling_user` localStorage identity `UserContext` requires; `global-setup.ts` takes the `test/386-journey-dashboard` branch's localStorage fix **verbatim** so the sibling PRs converge on identical content.
- `USER_SECOND` appended to `e2e/support/stack.ts`.
- `Social.tsx` joins the #382 `data-testid` convention per the registry's "Adding a surface" process: full `social-*` sweep, inventory appended to `docs/frontend-testids.md`, file appended to the eslint enforcement array.

## Room creation — chosen path

The journey uses the **seeded room** (`db/seed_local_rich.py`: `rich-room-study-group`, both users members, 3 encrypted messages) rather than creating one via UI/API. Most robust: no create/join dance, deterministic ids, and the per-test truncate + re-seed restores it. Rendering the seeded history doubles as proof of the decrypting read path. UI create/join stays reachable via the new `social-create-room` / `social-join-room` testids for later specs.

## Propagation mechanism — findings

Room chat propagates via **Supabase Realtime `postgres_changes`** over a websocket — not polling, not SSE. `Social.tsx` subscribes on `room_messages` filtered by room; a FOREIGN insert event carries **ciphertext** `text` (#124), so the client treats it purely as a "something changed" signal and re-fetches through the decrypting REST endpoint (`GET /api/social/rooms/{id}/messages`). Own sends render optimistically and reconcile from the POST response. There is **no polling fallback** — realtime is the only cross-client path — so the spec waits for each context's server-side subscription confirmation (the `Subscribed to PostgreSQL` frame on the room topic) before any cross-context send: an insert landing before the receiver's subscription is live would never be delivered.

## Bugs found → unblocking migrations

1. **#405 confirmed live on the local schema** (verified at runtime pre-migration, not assumed): `rooms` had only `id/name/invite_code/created_by/created_at`, and the wide select `routes/social.py` uses returned PostgREST `42703 — column rooms.topic does not exist`, so every room-listing endpoint 500'd and the journey was impossible. **Migration 0032** adds the five drift columns (`ADD COLUMN IF NOT EXISTS`, nullable, unpopulated) — schema reconciliation only; `create_room` population semantics stay open in #405.
2. **New finding, same drift family:** the `supabase_realtime` publication existed but published **zero tables** locally (verified: `pg_publication_tables` empty) — nothing in the repo ever added `room_messages`, the deployed environments got it via dashboard configuration (the production behavior #124 fixed proves it's published there). Without it, `postgres_changes` never fire and cross-client chat silently does not propagate at all on a migrations-only stack. **Migration 0033** publishes it, guarded to no-op where the publication is absent or the table already published. `room_reactions` deliberately stays unpublished (#231).

## Verification — 10 consecutive local runs green

Single lock hold: pre-migration evidence capture → `make e2e-up` (applies 0032/0033) → 10 runs → `make e2e-down`.

| run | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| result | pass 11.9s | pass 10.3s | pass 10.7s | pass 10.6s | pass 10.3s | pass 10.7s | pass 9.7s | pass 10.6s | pass 10.6s | pass 9.9s |

Post-migration state checks: `rooms` carries all selected columns; `pg_publication_tables` lists `supabase_realtime → room_messages`. `npm run typecheck`, `eslint` (incl. the new enforcement on `Social.tsx`), and the `Social.realtime.test.ts` vitest suite all pass.

Part of #402, closes #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)