### PR TITLE
test(e2e): journey — upload → SSE → document appears (#387)

### DIFF
--- a/backend/agents/function_handlers_e2e.py
+++ b/backend/agents/function_handlers_e2e.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
 
-from agents._providers import register_function_handler
+from agents._providers import FunctionModelHandler, register_function_handler
 
 # Asserted verbatim by frontend/e2e/tutor.spec.ts (rendered reply + decrypted
 # messages.content readback). Keep the two literals in sync.
@@ -96,3 +96,90 @@ def _quiz_handler(messages, info) -> ModelResponse:
 
 
 register_function_handler("quiz", _quiz_handler)
+
+
+# ── Document upload pipeline (#387) ─────────────────────────────────────────
+#
+# The SSE /api/documents/upload journey runs: classifier → (summary ∥
+# concepts) → graph merge → persist. The classifier is scripted as a
+# NON-syllabus category so syllabus extraction never runs and no assignment
+# side effects fire. `course_summary` covers the post-roll
+# update_course_context task so it completes through the real agent instead
+# of its template fallback.
+#
+# These agents have structured `output_type`s, so each handler emits its
+# fixed payload through the agent's OUTPUT tool (`info.output_tools[0]`) —
+# the same channel a Gemini structured response uses, validated by the real
+# output schema. That stays within this module's no-tool-calls constraint:
+# no *function* tools are invoked and the model drives zero writes; the
+# route itself performs the graph merge and persistence.
+
+E2E_DOC_CATEGORY = "lecture_notes"
+E2E_DOC_HEADLINE = "Deterministic E2E lecture notes on gradient descent."
+# Asserted (as a substring, rendered + decrypted-readback) by
+# frontend/e2e/upload.spec.ts. Keep the literals in sync.
+E2E_DOC_ABSTRACT = (
+    "These lecture notes introduce gradient descent as an iterative "
+    "optimization procedure. They define the loss surface, derive the "
+    "parameter update rule, and discuss how the learning rate governs "
+    "convergence. The treatment is deterministic fixture content for the "
+    "E2E upload journey."
+)
+E2E_DOC_KEY_POINTS = [
+    "Gradient descent iteratively steps against the gradient of the loss.",
+    "The learning rate controls the size of each update step.",
+    "Convergence behavior depends on the shape of the loss surface.",
+]
+E2E_DOC_CONCEPTS = [
+    ("Gradient Descent", "Iterative optimization that steps against the loss gradient.", 0.9),
+    ("Learning Rate", "Step-size hyperparameter governing each descent update.", 0.7),
+]
+
+
+def _structured_output(args: dict) -> FunctionModelHandler:
+    """Handler emitting `args` through the agent's registered output tool, so
+    the REAL output schema validates the payload before the agent returns."""
+
+    def handler(messages, info) -> ModelResponse:
+        return ModelResponse(
+            parts=[ToolCallPart(tool_name=info.output_tools[0].name, args=args)]
+        )
+
+    return handler
+
+
+register_function_handler(
+    "classifier",
+    _structured_output({
+        "category": E2E_DOC_CATEGORY,
+        "is_syllabus": False,
+        "confidence": 0.95,
+        "rationale": "Scripted E2E classification: narrative notes, no schedule.",
+    }),
+)
+register_function_handler(
+    "summary",
+    _structured_output({
+        "headline": E2E_DOC_HEADLINE,
+        "abstract": E2E_DOC_ABSTRACT,
+        "key_points": E2E_DOC_KEY_POINTS,
+    }),
+)
+register_function_handler(
+    "concepts",
+    _structured_output({
+        "concepts": [
+            {"name": name, "description": desc, "importance": imp}
+            for name, desc, imp in E2E_DOC_CONCEPTS
+        ],
+    }),
+)
+register_function_handler(
+    "course_summary",
+    _structured_output({
+        "summary": (
+            "Scripted E2E course summary: the class is progressing "
+            "steadily; review the struggling concepts listed above."
+        ),
+    }),
+)

--- a/backend/main.py
+++ b/backend/main.py
@@ -208,7 +208,17 @@ app.include_router(academics.router,   prefix="/api", tags=["academics"])
 
 @app.get("/api/health")
 def health():
-    return {"status": "ok", "service": "sapling-backend"}
+    # model_mode surfaces the #391 seam state (real | function | cassette) so
+    # E2E journeys that must never hit live Gemini (#387) can fail fast with a
+    # pointed message when the stack was booted in real mode, instead of
+    # silently billing the API. Not a secret: it names a mode, not a key.
+    from agents._providers import _model_mode
+
+    return {
+        "status": "ok",
+        "service": "sapling-backend",
+        "model_mode": _model_mode(),
+    }
 
 
 @app.get("/api/users")

--- a/backend/main.py
+++ b/backend/main.py
@@ -209,9 +209,11 @@ app.include_router(academics.router,   prefix="/api", tags=["academics"])
 @app.get("/api/health")
 def health():
     # model_mode surfaces the #391 seam state (real | function | cassette) so
-    # E2E journeys that must never hit live Gemini (#387) can fail fast with a
-    # pointed message when the stack was booted in real mode, instead of
-    # silently billing the API. Not a secret: it names a mode, not a key.
+    # E2E journeys (#387) can fail fast with a pointed message when the stack
+    # was booted in real mode, instead of running agent stages against live
+    # Gemini. (The RAG embed path sits below the seam — #439 — so "function"
+    # here vouches for the agent stages, not every byte of egress.) Not a
+    # secret: it names a mode, not a key.
     from agents._providers import _model_mode
 
     return {

--- a/backend/tests/test_e2e_function_handlers.py
+++ b/backend/tests/test_e2e_function_handlers.py
@@ -22,8 +22,10 @@ from pydantic_ai.models.google import GoogleModel
 import agents._providers as providers
 from agents._providers import clear_function_handlers, model_for
 from agents.chat_tutor import socratic_agent
+from agents.classifier import classifier_agent
 from agents.deps import SaplingDeps
 from agents.quiz import quiz_agent
+from agents.summary import summary_agent
 from routes.learn import _resolve_model_pref
 from routes.quiz import (
     _agent_question_to_wire,
@@ -226,3 +228,48 @@ def test_quiz_resolve_model_pref_still_builds_override_in_real_mode(monkeypatch)
     assert isinstance(m, GoogleModel)
     assert m.model_name == "gemini-2.5-pro"
     assert _resolve_quiz_model_pref(None) is None
+
+
+# ── Upload-pipeline handlers (#387) ───────────────────────────────────────
+
+
+def test_env_module_registers_upload_pipeline_handlers_on_dispatch(monkeypatch):
+    """#387's boot contract on the same once-per-process autoload: a real
+    classifier run gets the module's scripted structured output — emitted
+    through the agent's REAL output tool, so the DocumentClassification
+    schema validated it — and that single import also registered the
+    parallel workers (summary, concepts) and the post-roll course_summary."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv(
+        "SAPLING_FUNCTION_HANDLERS", "agents.function_handlers_e2e"
+    )
+
+    with classifier_agent.override(model=model_for("classifier")):
+        result = classifier_agent.run_sync("week 3 lecture notes", deps=_deps())
+
+    from agents.function_handlers_e2e import E2E_DOC_CATEGORY
+
+    assert result.output.category == E2E_DOC_CATEGORY
+    assert result.output.is_syllabus is False
+    for task in ("classifier", "summary", "concepts", "course_summary"):
+        assert task in providers._FUNCTION_HANDLERS
+
+
+def test_env_module_summary_handler_passes_real_output_schema(monkeypatch):
+    """The scripted summary payload must satisfy the Summary output tool's
+    real schema (headline <= 140 chars, 3-8 key points): drift between the
+    module constants and the schema fails here, in the hermetic lane, not
+    three phases into a browser run."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv(
+        "SAPLING_FUNCTION_HANDLERS", "agents.function_handlers_e2e"
+    )
+
+    with summary_agent.override(model=model_for("summary")):
+        result = summary_agent.run_sync("some document text", deps=_deps())
+
+    from agents.function_handlers_e2e import E2E_DOC_ABSTRACT, E2E_DOC_HEADLINE
+
+    assert result.output.headline == E2E_DOC_HEADLINE
+    assert result.output.abstract == E2E_DOC_ABSTRACT
+    assert 3 <= len(result.output.key_points) <= 8

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -75,6 +75,7 @@ renders the element.
 | App shell | `app` | `frontend/src/components/ShellFrame.tsx` (the authed layout frame every `(shell)` route renders inside) |
 | Study rooms | `social` | `frontend/src/components/screens/Social.tsx` (rooms sidebar, chat, overview, study match, directory — added with the #394 two-context journey) |
 | Dashboard | `dashboard` | `frontend/src/components/screens/Dashboard.tsx` (rendered by `(shell)/dashboard/page.tsx`) |
+| Library | `library` | `frontend/src/components/screens/Library.tsx` (the `/library` document screen — upload trigger, document cards/rows, filters, detail panel) |
 
 Two surfaces do **not** carry their testids in the screen file named by the
 route:
@@ -212,6 +213,25 @@ route:
 | --- | --- |
 | `dashboard-courses-key-toggle` | expand/collapse toggle of the "My courses" key overlay on the graph panel (default sidebar layout; the key starts collapsed) |
 | `dashboard-course-code` | a course row's code/name label inside the expanded key — repeated per course with **no suffix** (deliberate deviation from the suffix rule above: journeys select a row by seeded content, `getByTestId(…).filter({ hasText })`, so no per-row identity is exposed) |
+
+### `library`
+
+Added with the upload → SSE → library journey (#387).
+
+| testid | element |
+| --- | --- |
+| `library-upload` | TopBar "Upload" button that opens the upload modal (disabled with zero courses) |
+| `library-search` | TopBar "Search documents…" input |
+| `library-course-scan` | TopBar "Scan <course>" button (only while a course filter is active) |
+| `library-doc-{docId}` | one document card (grid view) / row (list view), suffixed with the document's id |
+| `library-course-filter-all` | sidebar "All" course filter |
+| `library-course-filter-uncategorized` | sidebar "Uncategorized" course filter |
+| `library-course-filter-{courseId}` | sidebar per-course filter row |
+| `library-detail-close` | detail panel × close |
+| `library-detail-scan` | detail panel "Scan" / "Re-scan" concept-scan button |
+| `library-detail-delete` | detail panel "Delete document" (click-twice confirm) |
+| `library-concepts-toggle-all` | detail panel "Expand all" / "Collapse all" |
+| `library-concept-toggle-{idx}` | one concept accordion toggle (render index) |
 
 ## Enforcement
 

--- a/frontend/e2e/fixtures/upload-journey.pdf
+++ b/frontend/e2e/fixtures/upload-journey.pdf
@@ -1,0 +1,40 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 293 >>
+stream
+BT /F1 12 Tf 72 720 Td 16 TL
+(Sapling E2E fixture: Lecture 3 notes on gradient descent.) Tj
+T*
+(Gradient descent iteratively updates parameters against the) Tj
+T*
+(gradient of the loss with a fixed learning rate until the) Tj
+T*
+(updates converge to a local minimum of the loss surface.) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000311 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+655
+%%EOF

--- a/frontend/e2e/upload.spec.ts
+++ b/frontend/e2e/upload.spec.ts
@@ -21,9 +21,13 @@
  *   SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e make e2e-up
  *
  * which swaps deterministic FunctionModel handlers in above the transport
- * (ADR 0019) — zero live Gemini calls. The spec fail-fasts via
- * /api/health's `model_mode` before uploading so a real-mode stack can
- * never be silently billed. Scripted outputs (category, abstract, concept
+ * (ADR 0019) — every AGENT stage (classifier/summary/concepts/
+ * course_summary) is scripted. One pre-existing path sits below the seam:
+ * the fire-and-forget RAG post-roll embed (#439) may still attempt a live
+ * embedding call; its failures are swallowed, so determinism holds — run
+ * verification with a dummy GEMINI_API_KEY so it cannot bill. The spec
+ * fail-fasts via /api/health's `model_mode` before uploading so a
+ * real-mode stack is caught before the agent stages run. Scripted outputs (category, abstract, concept
  * names) come from backend/agents/function_handlers_e2e.py; asserting
  * their exact values below is what proves the SSE result payload and the
  * persisted row came from the scripted pipeline, not a fallback path.

--- a/frontend/e2e/upload.spec.ts
+++ b/frontend/e2e/upload.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Journey: upload → SSE → document appears (#387).
+ *
+ * Drives the REAL streaming pipeline end to end through the UI: pick a
+ * fixture PDF in the upload modal (upload-modal testids, #382), start the
+ * upload, ride the SSE stream (frontend/src/lib/sse.ts::streamSSE under
+ * uploadDocumentStream) to its terminal `done` event, then assert the
+ * document appears in the library AND the row exists in Postgres via
+ * raw-SQL readback (support/db.ts::query).
+ *
+ * LLM-dependence (the #387 "known hard part"): the SSE pipeline's happy
+ * path is agent-driven — classifier → (summary ∥ concepts) → graph merge —
+ * and the documents row is only persisted AFTER those stages, so the
+ * journey cannot complete without model responses. The #391 seam covers
+ * every one of these agents (they all build via `model_for`); its
+ * boot-time half (#392's SAPLING_FUNCTION_HANDLERS autoload, which this
+ * PR extends with the upload-pipeline handlers) means the stack MUST be
+ * booted with
+ *
+ *   SAPLING_MODEL_MODE=function \
+ *   SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e make e2e-up
+ *
+ * which swaps deterministic FunctionModel handlers in above the transport
+ * (ADR 0019) — zero live Gemini calls. The spec fail-fasts via
+ * /api/health's `model_mode` before uploading so a real-mode stack can
+ * never be silently billed. Scripted outputs (category, abstract, concept
+ * names) come from backend/agents/function_handlers_e2e.py; asserting
+ * their exact values below is what proves the SSE result payload and the
+ * persisted row came from the scripted pipeline, not a fallback path.
+ *
+ * Waiting is event-based only (no waitForTimeout): every wait is an
+ * auto-retrying expect() on UI state that a pipeline event flips.
+ */
+import path from "node:path";
+
+import { queryRaw } from "./support/db";
+import { expect, test } from "./support/fixtures";
+import { BACKEND_URL, USER_ACTIVE } from "./support/stack";
+
+const FIXTURE_PDF = path.join(__dirname, "fixtures", "upload-journey.pdf");
+const FIXTURE_NAME = "upload-journey.pdf";
+
+// Mirrors backend/agents/function_handlers_e2e.py — the scripted pipeline
+// output this journey asserts on. Keep in sync with that module.
+const SCRIPTED_CATEGORY = "lecture_notes";
+const SCRIPTED_ABSTRACT_SNIPPET = "deterministic fixture content";
+const SCRIPTED_CONCEPTS = ["Gradient Descent", "Learning Rate"];
+
+test("upload → SSE → document appears in library and Postgres", async ({
+  page,
+}) => {
+  // Guard: never run this journey against a real-mode stack — the pipeline
+  // would dial live Gemini (slow, nondeterministic, billed). /api/health
+  // surfaces the #391 seam mode precisely for this fail-fast.
+  const health = (await (await fetch(`${BACKEND_URL}/api/health`)).json()) as {
+    model_mode?: string;
+  };
+  expect(
+    health.model_mode,
+    "Stack is not in deterministic model mode. Reboot it with:\n" +
+      "  SAPLING_MODEL_MODE=function " +
+      "SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e make e2e-up",
+  ).toBe("function");
+
+  // ── Upload through the UI ─────────────────────────────────────────────
+  await page.goto("/library");
+  await expect(page.getByTestId("app-shell")).toBeVisible();
+
+  // Enabled only once the courses fetch lands (the seeded rich-user-active
+  // has enrollments), so this wait also covers the library's initial load.
+  const uploadButton = page.getByTestId("library-upload");
+  await expect(uploadButton).toBeEnabled();
+  await uploadButton.click();
+
+  await expect(page.getByTestId("upload-modal")).toBeVisible();
+  await page.getByTestId("upload-modal-file-input").setInputFiles(FIXTURE_PDF);
+
+  const fileRow = page.getByTestId("upload-modal-file-row-0");
+  await expect(fileRow).toBeVisible();
+  await expect(fileRow).toContainText(FIXTURE_NAME);
+
+  await page.getByTestId("upload-modal-submit").click();
+
+  // ── Ride the SSE stream to completion ─────────────────────────────────
+  // The "Done" footer button only replaces "Start upload" once every row
+  // left the uploading state — i.e. once streamSSE consumed the terminal
+  // `status: done` event and uploadDocumentStream resolved with the
+  // persisted document. Event-based wait; generous budget for the OCR +
+  // pipeline round trips, but it normally flips in a few seconds.
+  const doneButton = page.getByTestId("upload-modal-done");
+  await expect(doneButton).toBeVisible({ timeout: 60_000 });
+
+  // The row rendered the orchestrator result from the SSE `result` event:
+  // the scripted summary abstract and concept chips — proof the stream
+  // delivered the full DocumentProcessingResult, not an error/fallback.
+  await expect(fileRow).toContainText(SCRIPTED_ABSTRACT_SNIPPET);
+  for (const concept of SCRIPTED_CONCEPTS) {
+    await expect(fileRow).toContainText(concept);
+  }
+
+  // ── Postgres readback (raw SQL) ───────────────────────────────────────
+  const docs = await queryRaw(
+    `SELECT id, user_id, offering_id, category, summary
+       FROM documents
+      WHERE file_name = $1
+        AND deleted_at IS NULL`,
+    [FIXTURE_NAME],
+  );
+  expect(docs).toHaveLength(1);
+  const doc = docs[0] as {
+    id: string;
+    user_id: string;
+    offering_id: string | null;
+    category: string;
+    summary: string | null;
+  };
+  expect(doc.user_id).toBe(USER_ACTIVE);
+  expect(doc.category).toBe(SCRIPTED_CATEGORY);
+  // Documents key on the offering (0025) — resolve_offering(create=True)
+  // must have attached one.
+  expect(doc.offering_id).toBeTruthy();
+  // `documents.summary` is column-encrypted at rest: present, but the
+  // stored value must be ciphertext, never the plaintext abstract.
+  expect(doc.summary ?? "").not.toBe("");
+  expect(doc.summary ?? "").not.toContain(SCRIPTED_ABSTRACT_SNIPPET);
+  expect(doc.summary ?? "").not.toContain("gradient descent");
+
+  // Phase-3 side effect: the scripted concepts were merged into the
+  // course knowledge graph (plaintext columns — safe to assert exactly).
+  const nodes = await queryRaw(
+    `SELECT concept_name
+       FROM graph_nodes
+      WHERE user_id = $1
+        AND concept_name = ANY($2::text[])`,
+    [USER_ACTIVE, SCRIPTED_CONCEPTS],
+  );
+  expect(nodes.map((n) => n.concept_name as string).sort()).toEqual(
+    [...SCRIPTED_CONCEPTS].sort(),
+  );
+
+  // ── Document appears in the library ───────────────────────────────────
+  // Closing via Done triggers the library refetch (onComplete → load()).
+  await doneButton.click();
+  await expect(page.getByTestId("upload-modal")).toBeHidden();
+
+  const card = page.getByTestId(`library-doc-${doc.id}`);
+  await expect(card).toBeVisible();
+  await expect(card).toContainText(FIXTURE_NAME);
+  // The card renders the decrypted summary — the encryption round-trip
+  // (encrypt at persist, decrypt at read) closed correctly.
+  await expect(card).toContainText(SCRIPTED_ABSTRACT_SNIPPET);
+});

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -62,6 +62,7 @@ const eslintConfig = [
       "src/components/screens/Social.tsx",
       "src/components/screens/Dashboard.tsx",
       "src/components/screens/Learn.tsx",
+      "src/components/screens/Library.tsx",
     ],
     rules: {
       "no-restricted-syntax": [

--- a/frontend/src/components/screens/Library.tsx
+++ b/frontend/src/components/screens/Library.tsx
@@ -147,6 +147,7 @@ export function Library() {
             <>
               <div style={{ position: "relative" }}>
                 <input
+                  data-testid="library-search"
                   value={query}
                   onChange={e => setQuery(e.target.value)}
                   placeholder="Search documents…"
@@ -159,6 +160,7 @@ export function Library() {
               </div>
               {courseScanCourseId && (
                 <button
+                  data-testid="library-course-scan"
                   className="btn btn--sm"
                   onClick={runCourseScan}
                   disabled={courseScanning}
@@ -169,6 +171,7 @@ export function Library() {
                 </button>
               )}
               <button
+                data-testid="library-upload"
                 className="btn btn--sm btn--primary"
                 onClick={() => setUploadOpen(true)}
                 disabled={courses.length === 0}
@@ -228,6 +231,7 @@ export function Library() {
                   return (
                     <button
                       key={d.id}
+                      data-testid={`library-doc-${d.id}`}
                       onClick={() => setDetail(d)}
                       className="card"
                       style={{
@@ -281,6 +285,7 @@ export function Library() {
                   return (
                     <button
                       key={d.id}
+                      data-testid={`library-doc-${d.id}`}
                       onClick={() => setDetail(d)}
                       style={{
                         width: "100%", display: "flex", alignItems: "center", gap: 16,
@@ -341,12 +346,14 @@ export function Library() {
         }}>
           <div className="label-micro" style={{ marginBottom: 10 }}>Courses</div>
           <CourseRow
+            testid="library-course-filter-all"
             label="All"
             count={groupedByCourse.all || 0}
             active={courseFilter === "all"}
             onClick={() => setCourseFilter("all")}
           />
           <CourseRow
+            testid="library-course-filter-uncategorized"
             label="Uncategorized"
             count={groupedByCourse.uncategorized || 0}
             active={courseFilter === "uncategorized"}
@@ -355,6 +362,7 @@ export function Library() {
           {courses.map(c => (
             <CourseRow
               key={c.course_id}
+              testid={`library-course-filter-${c.course_id}`}
               label={c.course_code || c.course_name}
               subLabel={c.course_code ? c.course_name : undefined}
               color={c.color || undefined}
@@ -419,13 +427,15 @@ export function Library() {
 }
 
 function CourseRow({
-  label, subLabel, color, count, active, onClick,
+  testid, label, subLabel, color, count, active, onClick,
 }: {
+  testid: string;
   label: string; subLabel?: string; color?: string;
   count: number; active: boolean; onClick: () => void;
 }) {
   return (
     <button
+      data-testid={testid}
       onClick={onClick}
       style={{
         width: "100%", display: "flex", alignItems: "center", gap: 8,
@@ -502,7 +512,7 @@ function DetailPanel({
     <aside style={container}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
         <span className="chip">{doc.category.replace("_", " ")}</span>
-        <button className="btn btn--ghost btn--sm" onClick={onClose} aria-label="Close">
+        <button data-testid="library-detail-close" className="btn btn--ghost btn--sm" onClick={onClose} aria-label="Close">
           <Icon name="x" size={12} />
         </button>
       </div>
@@ -538,6 +548,7 @@ function DetailPanel({
             </div>
           </div>
           <button
+            data-testid="library-detail-scan"
             onClick={runScan}
             disabled={scanState === "scanning"}
             className="btn btn--sm"
@@ -554,6 +565,7 @@ function DetailPanel({
       </div>
 
       <button
+        data-testid="library-detail-delete"
         onClick={del.trigger}
         className={`btn ${del.armed ? "btn--danger" : ""}`}
         style={{ width: "100%", background: del.armed ? "var(--err-soft)" : undefined, color: del.armed ? "var(--err)" : undefined }}
@@ -584,6 +596,7 @@ function ConceptList({ notes }: { notes: ConceptNote[] }) {
       >
         <div className="label-micro">Key concepts ({notes.length})</div>
         <button
+          data-testid="library-concepts-toggle-all"
           onClick={toggleAll}
           className="btn btn--ghost btn--sm"
           style={{ fontSize: 11 }}
@@ -605,6 +618,7 @@ function ConceptList({ notes }: { notes: ConceptNote[] }) {
               }}
             >
               <button
+                data-testid={`library-concept-toggle-${i}`}
                 onClick={() => setOpen(prev => ({ ...prev, [i]: !prev[i] }))}
                 aria-expanded={isOpen}
                 style={{


### PR DESCRIPTION
## Summary

Browser journey for the document pipeline (#387): upload a fixture PDF through the real UI (`upload-modal` testids), ride the SSE stream (`streamSSE` under `uploadDocumentStream`) to its terminal `done` event, then assert the document appears in the library **and** the row exists in Postgres via raw-SQL readback.

- `frontend/e2e/upload.spec.ts` — the journey. Event-based waiting only (auto-retrying `expect()`s on UI state; zero `waitForTimeout`). Asserts: SSE completion (`upload-modal-done` replaces submit only after the terminal event), the scripted result payload rendered in the row (summary abstract + concept chips), the Postgres `documents` row (plaintext columns: `user_id`, `category`, `offering_id`; `summary` asserted **ciphertext-not-plaintext**), the phase-3 `graph_nodes` merge, and the library card (decrypted summary round-trip).
- `frontend/e2e/fixtures/upload-journey.pdf` — hand-assembled 838-byte single-page PDF with a real text layer (232 chars extract natively via pypdf, so backend extraction never reaches the OCR engines).
- Postgres readback uses `queryRaw` from `frontend/e2e/support/db.ts` (landed with #434; this PR adds no db.ts changes).
- `frontend/src/components/screens/Library.tsx` + `docs/frontend-testids.md` + `frontend/eslint.config.mjs` — Library registered as a testid surface per the "Adding a surface" procedure (doc row, inventory, eslint files array; every intrinsic interactive element tagged).

## LLM-dependence finding (the issue's "known hard part")

**The SSE completion event and the `documents` row itself require model responses — there is no LLM-free scoping that can honestly assert "document appears".** Trace of `POST /api/documents/upload` (`backend/routes/documents.py`):

1. The happy path is agent-driven: `classifier_agent` → (`summary_agent` ∥ `concept_extraction_agent`) → graph merge → `_persist_document`. **Persistence happens only after the agent stages**, so without a model there is no row, no `done` event, no library entry. Option (2) from the issue (assert "upload accepted + row created" without an LLM) is factually impossible on this pipeline.
2. Any agent failure falls back to `_legacy_upload_pipeline` → `services/gemini_service.py::call_gemini_json` → **real Gemini** (the #391 seam does not cover `gemini_service`); if that also fails, the stream ends `error/failed` + `done "Failed."` with **no row persisted**.
3. The #391 seam **does** cover every agent in the happy path (all build via `model_for`), but it originally had no boot-time half: handlers could only be registered by an in-process Python caller, which a separately booted uvicorn doesn't have. Booting `SAPLING_MODEL_MODE=function make e2e-up` alone would make every agent raise a handler-miss `LookupError` → legacy fallback → live Gemini. #434 (tutor) landed the canonical boot-time half on main — the `SAPLING_FUNCTION_HANDLERS` once-per-process autoload with its failure-latch ordering — and this PR (rebased onto it) **adopts that seam wholesale** and appends on top of it:
   - `backend/agents/function_handlers_e2e.py` — the upload-pipeline handlers appended to main's module per its own "append here" guidance: deterministic scripted outputs for `classifier` (→ `lecture_notes`), `summary`, `concepts`, plus post-roll `course_summary`. These agents have structured `output_type`s, so each handler emits through the agent's **output tool** — the real output schema validates the payload; no function tools, zero model-driven writes (within the module's stated constraints).
   - `/api/health` now surfaces `model_mode`, and the spec **fail-fasts** against a real-mode stack instead of silently billing Gemini.
   - `backend/tests/test_e2e_function_handlers.py` — two appended cases pinning the upload handlers under the canonical once-latch design: one autoload dispatch registers the whole pipeline and drives the real classifier; the scripted summary payload passes the real `Summary` output schema in the hermetic lane.
4. Residual egress note: post-roll `_index_document_chunks` embeds via `services/rag_service.py` (a direct `google.genai` client — not covered by the seam). It is fire-and-forget and swallowed on failure, so the journey doesn't depend on it, but for the 10-run tally the stack ran with a **dummy `GEMINI_API_KEY`** so even that attempt fails fast without billing. `update_course_context` is covered (its `course_summary` agent goes through the seam) and degrades to a template string if unregistered.

**Boot contract for this spec:**

```
SAPLING_MODEL_MODE=function SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e make e2e-up
```

## Verification

- **10 consecutive local runs green** under a single stack-lock hold (one `make e2e-up` in function mode, 10× `npx playwright test e2e/upload.spec.ts`, `make e2e-down`; exit 0):

  | run | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
  | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
  | result | pass 7.8s | pass 6.4s | pass 6.2s | pass 6.1s | pass 6.3s | pass 6.2s | pass 6.5s | pass 6.1s | pass 6.4s | pass 6.2s |
- Zero `waitForTimeout` calls — every wait is an auto-retrying `expect()` on state an event flips (the only grep hit for the string is the header comment stating the rule).
- Post-rebase confirmation (converged onto main's #434 seam): **3/3 consecutive runs green** under one lock hold — pass 7.4s / pass 6.1s / pass 7.1s, exit 0, clean teardown. The 10/10 pre-rebase tally stands as acceptance evidence; this cycle proves the seam swap changed no behavior.
- Backend after rebase: `pytest tests/ -q` → 1088 passed, 23 skipped, 1 **pre-existing** error (`tests/test_ocr_pipeline.py::test_save_to_db`, "RuntimeError: Event loop is closed" — reproduces identically on an untouched `main` checkout; unrelated to this change).
- Frontend after rebase: `eslint .` 0 errors (Library.tsx now under the testid enforcement block), `tsc --noEmit` clean, `vitest run` 204 passed.

Part of #402, closes #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
