### PR TITLE
test(e2e): journey — tutor conversation persists to messages (#392)

### DIFF
--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -155,8 +155,10 @@ def clear_function_handlers() -> None:
 # process start ... then register per-task handlers". SAPLING_FUNCTION_HANDLERS
 # names a module (e.g. `agents.function_handlers_e2e`) whose import registers
 # handlers. It is consulted lazily, once, and ONLY on a dispatch miss — so the
-# pytest lane (which registers explicitly and never sets the var) is unchanged,
-# and a test that forgot to register a handler still gets the loud LookupError.
+# normal (hermetic) pytest lane, which registers explicitly and does not set
+# the var, is unchanged, and a test that forgot to register a handler still
+# gets the loud LookupError. (The seam's own tests DO set the var, resetting
+# the latch around each case.)
 
 _ENV_HANDLERS_LOADED = False
 
@@ -164,17 +166,20 @@ _ENV_HANDLERS_LOADED = False
 def _load_env_handlers_module() -> None:
     """Import the SAPLING_FUNCTION_HANDLERS module (once per process).
 
-    A bad module path raises ImportError loudly at first dispatch — a broken
-    E2E boot must fail the run, never silently fall through to LookupError
-    with the wrong story.
+    A bad module path raises ImportError loudly at EVERY dispatch, not just
+    the first — a broken E2E boot must fail the run, never silently fall
+    through to LookupError with the wrong story. That is why the latch is
+    set only after a successful import (or when there is nothing to load):
+    latching before the import would permanently cache the failure as
+    "loaded" and downgrade every later dispatch to the generic LookupError.
     """
     global _ENV_HANDLERS_LOADED
     if _ENV_HANDLERS_LOADED:
         return
-    _ENV_HANDLERS_LOADED = True
     module = (os.getenv("SAPLING_FUNCTION_HANDLERS") or "").strip()
     if module:
-        importlib.import_module(module)
+        importlib.import_module(module)  # raises before the latch on failure
+    _ENV_HANDLERS_LOADED = True
 
 
 def _function_model_for(task: AgentTask) -> "Model":

--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -17,6 +17,7 @@ the Pro tier for the conversational tutor where reasoning depth matters.
 
 from __future__ import annotations
 
+import importlib
 import os
 from typing import TYPE_CHECKING, Callable, Literal
 
@@ -145,6 +146,37 @@ def clear_function_handlers() -> None:
     _FUNCTION_HANDLERS.clear()
 
 
+# ── Boot-time handler registration for out-of-process runs (#392) ──────────
+#
+# `register_function_handler` covers in-process tests, but the E2E browser lane
+# boots the backend as a separate uvicorn process (`SAPLING_MODEL_MODE=function
+# make e2e-up`) where no pytest fixture can reach the registry. ADR 0019
+# anticipated this: full-journey lanes "must set SAPLING_MODEL_MODE=function at
+# process start ... then register per-task handlers". SAPLING_FUNCTION_HANDLERS
+# names a module (e.g. `agents.function_handlers_e2e`) whose import registers
+# handlers. It is consulted lazily, once, and ONLY on a dispatch miss — so the
+# pytest lane (which registers explicitly and never sets the var) is unchanged,
+# and a test that forgot to register a handler still gets the loud LookupError.
+
+_ENV_HANDLERS_LOADED = False
+
+
+def _load_env_handlers_module() -> None:
+    """Import the SAPLING_FUNCTION_HANDLERS module (once per process).
+
+    A bad module path raises ImportError loudly at first dispatch — a broken
+    E2E boot must fail the run, never silently fall through to LookupError
+    with the wrong story.
+    """
+    global _ENV_HANDLERS_LOADED
+    if _ENV_HANDLERS_LOADED:
+        return
+    _ENV_HANDLERS_LOADED = True
+    module = (os.getenv("SAPLING_FUNCTION_HANDLERS") or "").strip()
+    if module:
+        importlib.import_module(module)
+
+
 def _function_model_for(task: AgentTask) -> "Model":
     """Build a FunctionModel that dispatches to the task's registered handler at
     run time. The lookup is deferred to the call (not capture time) so a handler
@@ -154,10 +186,16 @@ def _function_model_for(task: AgentTask) -> "Model":
     def _dispatch(messages, info):
         handler = _FUNCTION_HANDLERS.get(task)
         if handler is None:
+            # Out-of-process runs (E2E uvicorn) register via the env-named
+            # module; loaded lazily on the first miss, no-op when unset.
+            _load_env_handlers_module()
+            handler = _FUNCTION_HANDLERS.get(task)
+        if handler is None:
             raise LookupError(
                 f"SAPLING_MODEL_MODE=function but no handler is registered for "
                 f"task {task!r}. Call agents._providers.register_function_handler("
-                f"{task!r}, ...) before running the agent."
+                f"{task!r}, ...) before running the agent (or point "
+                f"SAPLING_FUNCTION_HANDLERS at a module that does)."
             )
         return handler(messages, info)
 

--- a/backend/agents/function_handlers_e2e.py
+++ b/backend/agents/function_handlers_e2e.py
@@ -6,9 +6,11 @@ loaded ONLY when the backend boots with both
     SAPLING_MODEL_MODE=function
     SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e
 
-(see `_providers._load_env_handlers_module`). Production and the pytest lane
-never import it: the env vars are unset there, and pytest registers its own
-scripted handlers explicitly per test.
+(see `_providers._load_env_handlers_module`). Production and the normal
+(hermetic) pytest lane never import it: the env vars are unset there, and
+pytest registers its own scripted handlers explicitly per test. The seam's
+own tests (`tests/test_e2e_function_handlers.py`) are the one exception —
+they set the vars deliberately to exercise this module.
 
 Design constraints for every handler in this file:
 

--- a/backend/agents/function_handlers_e2e.py
+++ b/backend/agents/function_handlers_e2e.py
@@ -1,0 +1,46 @@
+"""Deterministic FunctionModel handlers for the E2E browser lane (#392).
+
+Importing this module registers per-task handlers on the #391 seam. It is
+loaded ONLY when the backend boots with both
+
+    SAPLING_MODEL_MODE=function
+    SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e
+
+(see `_providers._load_env_handlers_module`). Production and the pytest lane
+never import it: the env vars are unset there, and pytest registers its own
+scripted handlers explicitly per test.
+
+Design constraints for every handler in this file:
+
+- **Fixed output.** Replies are constants the Playwright specs assert on
+  verbatim (rendered in the UI and decrypted out of the database). Echoing
+  request content back would couple the constant to route-side prompt
+  assembly (RAG prefixes, constraint suffixes) — keep it fixed.
+- **No tool calls.** Scripted tool calls belong in the pytest seam tests
+  (`tests/test_model_mode_seam.py`), where the side effects are spied. A
+  browser journey wants zero model-driven writes beyond what the route
+  itself persists, so `graph_update` / `mastery_changes` stay empty.
+
+Journeys for other tasks (quiz, notes, documents) should append their
+handlers here rather than growing parallel modules.
+"""
+
+from __future__ import annotations
+
+from pydantic_ai.messages import ModelResponse, TextPart
+
+from agents._providers import register_function_handler
+
+# Asserted verbatim by frontend/e2e/tutor.spec.ts (rendered reply + decrypted
+# messages.content readback). Keep the two literals in sync.
+E2E_TUTOR_REPLY = (
+    "[e2e-function-model] Deterministic tutor reply: every recursive function "
+    "needs a base case so it can stop calling itself."
+)
+
+
+def _chat_tutor_handler(messages, info) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content=E2E_TUTOR_REPLY)])
+
+
+register_function_handler("chat_tutor", _chat_tutor_handler)

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -87,10 +87,18 @@ def _resolve_model_pref(model_pref: str | None):
     """
     if not model_pref:
         return None
+    from agents._providers import _model_mode, google_model
+    if _model_mode() != "real":
+        # #391 seam: the per-request fast/smart override must not bypass
+        # SAPLING_MODEL_MODE by constructing a live GoogleModel — the browser
+        # always sends a model_pref (ModelToggle defaults to "fast"), so
+        # without this the E2E function-mode lane would silently dial Gemini
+        # on every tutor turn. Fall through to the agent's default model,
+        # which model_for("chat_tutor") already built for the active mode.
+        return None
     name = _PREF_MODEL_NAMES.get(model_pref)
     if not name:
         return None
-    from agents._providers import google_model
     return google_model(name)
 
 

--- a/backend/tests/test_e2e_function_handlers.py
+++ b/backend/tests/test_e2e_function_handlers.py
@@ -93,6 +93,24 @@ def test_bad_env_module_path_fails_loudly(monkeypatch):
     assert "no_such_module" in str(exc.value)
 
 
+def test_bad_env_module_path_fails_loudly_on_every_dispatch(monkeypatch):
+    """Regression (#434 review): the latch must not cache a FAILED import as
+    loaded. Two dispatches within one latch lifetime (no fixture reset in
+    between) must BOTH surface the module path — the original code latched
+    before importing, so the second dispatch silently downgraded to the
+    generic LookupError and the broken-boot story disappeared."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv("SAPLING_FUNCTION_HANDLERS", "agents.no_such_module")
+
+    with socratic_agent.override(model=model_for("chat_tutor")):
+        for attempt in (1, 2):
+            with pytest.raises(Exception) as exc:
+                socratic_agent.run_sync("What is recursion?", deps=_deps())
+            assert "no_such_module" in str(exc.value), (
+                f"dispatch {attempt} lost the bad-module story: {exc.value}"
+            )
+
+
 def test_explicit_registration_wins_over_env_module(monkeypatch):
     """The env module is a dispatch-miss fallback only: a handler registered
     in-process (the pytest pattern) is never shadowed by it."""

--- a/backend/tests/test_e2e_function_handlers.py
+++ b/backend/tests/test_e2e_function_handlers.py
@@ -1,0 +1,133 @@
+"""Boot-time function-handler registration for the E2E lane (#392).
+
+The #391 seam registers handlers in-process; the browser E2E lane boots the
+backend as a separate uvicorn process, so #392 adds `SAPLING_FUNCTION_HANDLERS`
+— a module path imported lazily (once) on the first dispatch miss — plus
+`agents/function_handlers_e2e.py`, the module the E2E stack points it at.
+
+Also pins the route-side gap that made the env module necessary but not
+sufficient: `routes.learn._resolve_model_pref` used to build a live
+GoogleModel for the browser's fast/smart preference, silently bypassing the
+seam on every tutor turn (the ModelToggle default is "fast", so the browser
+ALWAYS sends a pref). In any non-real mode it must return None.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from pydantic_ai.models.google import GoogleModel
+
+import agents._providers as providers
+from agents._providers import clear_function_handlers, model_for
+from agents.chat_tutor import socratic_agent
+from agents.deps import SaplingDeps
+from routes.learn import _resolve_model_pref
+
+
+@pytest.fixture(autouse=True)
+def _clean_function_registry(monkeypatch):
+    """Reset the process-global registry AND the once-only env-module latch so
+    each case observes a cold seam (same posture as test_model_mode_seam.py)."""
+    clear_function_handlers()
+    monkeypatch.setattr(providers, "_ENV_HANDLERS_LOADED", False)
+    sys.modules.pop("agents.function_handlers_e2e", None)
+    yield
+    clear_function_handlers()
+    sys.modules.pop("agents.function_handlers_e2e", None)
+
+
+def _deps() -> SaplingDeps:
+    return SaplingDeps(
+        user_id="e2e-user",
+        course_id="e2e-course",
+        supabase=None,
+        request_id="e2e-req",
+        session_id="e2e-session",
+    )
+
+
+# ── SAPLING_FUNCTION_HANDLERS autoload ────────────────────────────────────
+
+
+def test_env_module_registers_chat_tutor_handler_on_dispatch(monkeypatch):
+    """The full E2E-boot contract: function mode + the env-named module give a
+    real chat_tutor agent run the module's fixed deterministic reply — through
+    the real agent wiring, with no handler registered by the test itself."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv(
+        "SAPLING_FUNCTION_HANDLERS", "agents.function_handlers_e2e"
+    )
+
+    with socratic_agent.override(model=model_for("chat_tutor")):
+        result = socratic_agent.run_sync("What is recursion?", deps=_deps())
+
+    from agents.function_handlers_e2e import E2E_TUTOR_REPLY
+
+    assert result.output == E2E_TUTOR_REPLY
+
+
+def test_unset_env_module_still_raises_pointed_lookup_error(monkeypatch):
+    """Without SAPLING_FUNCTION_HANDLERS the #391 posture is unchanged: a
+    missing handler is a loud LookupError naming the task — the autoload hook
+    must not soften it."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.delenv("SAPLING_FUNCTION_HANDLERS", raising=False)
+
+    with socratic_agent.override(model=model_for("chat_tutor")):
+        with pytest.raises(Exception) as exc:
+            socratic_agent.run_sync("What is recursion?", deps=_deps())
+    assert "chat_tutor" in str(exc.value)
+
+
+def test_bad_env_module_path_fails_loudly(monkeypatch):
+    """A typo'd module path must surface as ImportError at first dispatch —
+    a broken E2E boot fails the run rather than quietly running handler-less."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv("SAPLING_FUNCTION_HANDLERS", "agents.no_such_module")
+
+    with socratic_agent.override(model=model_for("chat_tutor")):
+        with pytest.raises(Exception) as exc:
+            socratic_agent.run_sync("What is recursion?", deps=_deps())
+    assert "no_such_module" in str(exc.value)
+
+
+def test_explicit_registration_wins_over_env_module(monkeypatch):
+    """The env module is a dispatch-miss fallback only: a handler registered
+    in-process (the pytest pattern) is never shadowed by it."""
+    from pydantic_ai.messages import ModelResponse, TextPart
+
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv(
+        "SAPLING_FUNCTION_HANDLERS", "agents.function_handlers_e2e"
+    )
+    providers.register_function_handler(
+        "chat_tutor",
+        lambda m, i: ModelResponse(parts=[TextPart(content="explicit wins")]),
+    )
+
+    with socratic_agent.override(model=model_for("chat_tutor")):
+        result = socratic_agent.run_sync("What is recursion?", deps=_deps())
+    assert result.output == "explicit wins"
+
+
+# ── routes.learn model_pref override respects the mode ────────────────────
+
+
+def test_resolve_model_pref_returns_none_in_function_mode(monkeypatch):
+    """In function mode the browser's fast/smart pref must NOT produce a live
+    GoogleModel override — that would put real Gemini back in the path the
+    seam exists to remove (the browser always sends a pref)."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    assert _resolve_model_pref("fast") is None
+    assert _resolve_model_pref("smart") is None
+
+
+def test_resolve_model_pref_still_builds_override_in_real_mode(monkeypatch):
+    """Default lane unchanged: real mode keeps the per-request override."""
+    monkeypatch.delenv("SAPLING_MODEL_MODE", raising=False)
+    m = _resolve_model_pref("fast")
+    assert isinstance(m, GoogleModel)
+    assert m.model_name == "gemini-2.5-flash-lite"
+    assert _resolve_model_pref(None) is None

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -69,7 +69,7 @@ renders the element.
 | Sign-in | `signin` | `frontend/src/components/SignInModal.tsx` (+ the trigger in `src/app/(public)/page.tsx`) |
 | Approval gate | `pending` | `frontend/src/app/pending/page.tsx` |
 | Upload modal | `upload-modal` | `frontend/src/components/DocumentUploadModal.tsx` |
-| Tutor | `tutor` | `frontend/src/components/ChatPanel.tsx` (rendered by `screens/Learn.tsx`) |
+| Tutor | `tutor` | `frontend/src/components/ChatPanel.tsx` (rendered by `screens/Learn.tsx`; + the session-resume rows in `src/components/screens/Learn.tsx` itself) |
 | Quiz | `quiz` | `frontend/src/components/QuizPanel.tsx` (rendered by `screens/Quiz.tsx`) |
 | Knowledge graph | `graph` | `frontend/src/components/KnowledgeGraph.tsx` (wrapper only — not the 2D/3D internals) |
 | App shell | `app` | `frontend/src/components/ShellFrame.tsx` (the authed layout frame every `(shell)` route renders inside) |
@@ -136,7 +136,7 @@ route:
 | `tutor-action-hint` | "Hint" |
 | `tutor-action-confused` | "I'm confused" |
 | `tutor-action-skip` | "Skip" |
-| `tutor-session-resume-{sessionId}` | a "Recent sessions" row's resume button (`screens/Learn.tsx`) — suffixed with the session's own id per the stable-domain-id rule; the #392 journey targets a seeded `rich-sess-*` id |
+| `tutor-session-resume-{sessionId}` | a "Recent sessions" row's resume button (`screens/Learn.tsx`), suffixed with the session's own id per the stable-domain-id rule |
 
 ### `quiz`
 
@@ -255,10 +255,9 @@ see the header of `eslint.config.mjs`), so only **new** interactive elements
 in the file must carry a testid. Tag baselined elements as they get browser
 coverage and regenerate with `npm run lint:baseline`.
 
-The same exception covers `tutor-session-resume-{sessionId}` in
-`src/components/screens/Learn.tsx` (#392): the Learn screen has ~20 intrinsic
-interactive elements outside any browser journey, so the file stays out of the
-`files` list and the one tested control is documented here instead.
+`src/components/screens/Learn.tsx` (the session-resume rows, #392) is in the
+`files` list with the same treatment: its 21 pre-existing untagged elements are
+baselined, so only NEW interactive elements there must carry a testid.
 
 ### Adding a surface
 

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -136,6 +136,7 @@ route:
 | `tutor-action-hint` | "Hint" |
 | `tutor-action-confused` | "I'm confused" |
 | `tutor-action-skip` | "Skip" |
+| `tutor-session-resume-{sessionId}` | a "Recent sessions" row's resume button (`screens/Learn.tsx`) — suffixed with the session's own id per the stable-domain-id rule; the #392 journey targets a seeded `rich-sess-*` id |
 
 ### `quiz`
 
@@ -253,6 +254,11 @@ baselined in `eslint-suppressions.json` (the repo's legacy-debt mechanism —
 see the header of `eslint.config.mjs`), so only **new** interactive elements
 in the file must carry a testid. Tag baselined elements as they get browser
 coverage and regenerate with `npm run lint:baseline`.
+
+The same exception covers `tutor-session-resume-{sessionId}` in
+`src/components/screens/Learn.tsx` (#392): the Learn screen has ~20 intrinsic
+interactive elements outside any browser journey, so the file stays out of the
+`files` list and the one tested control is documented here instead.
 
 ### Adding a surface
 

--- a/frontend/e2e/support/db.ts
+++ b/frontend/e2e/support/db.ts
@@ -144,3 +144,17 @@ export async function resetDb(): Promise<void> {
   await truncateMutable();
   await reseedBaseline();
 }
+
+/**
+ * Raw-SQL readback for journey assertions (#392): journeys write through the
+ * app and assert directly against Postgres (the #397 posture), so the read
+ * must bypass PostgREST/the API entirely. Parameterized ($1, $2, …) SELECTs
+ * only — mutations stay the fixtures' job. Runs behind the same
+ * loopback-host guard as the reset.
+ */
+export async function queryRaw(
+  sql: string,
+  params: unknown[] = [],
+): Promise<Record<string, unknown>[]> {
+  return withDb(async (client) => (await client.query(sql, params)).rows);
+}

--- a/frontend/e2e/support/decrypt.ts
+++ b/frontend/e2e/support/decrypt.ts
@@ -1,0 +1,72 @@
+/**
+ * Decrypt seam for raw-SQL readbacks (#392).
+ *
+ * Encrypted columns (`messages.content` here) must be asserted two ways:
+ * ciphertext at rest, AND decrypting to the expected plaintext. The decrypt
+ * half cannot be reimplemented in TS — the AES-GCM wire format and the
+ * ENCRYPTION_KEY belong to `backend/services/encryption.py` — so this shells
+ * out to the backend venv's python with cwd=backend/ (backend/.env supplies
+ * ENCRYPTION_KEY via config's load_dotenv), exactly like
+ * `support/db.ts::reseedBaseline` runs the seeder. Same python override env
+ * var (E2E_SEED_PYTHON) on purpose: one knob points the harness at one venv.
+ *
+ * Mirrors the assertion pattern of
+ * `backend/tests/integration/test_encryption_roundtrip.py` — note that
+ * `decrypt_if_present` falls back to returning its input on undecryptable
+ * values (legacy-plaintext tolerance), so a "decrypts to X" check is only
+ * meaningful alongside the separate ciphertext-at-rest (`raw != plaintext`)
+ * assertion. Specs must always make both.
+ */
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+// Values travel on stdin / stdout as JSON arrays, so ciphertext never hits
+// argv (length limits, shell-quoting hazards).
+const PY_DECRYPT = `
+import json, sys
+from dotenv import load_dotenv
+load_dotenv()  # services.encryption reads ENCRYPTION_KEY straight from env
+from services.encryption import decrypt_if_present
+values = json.load(sys.stdin)
+sys.stdout.write(json.dumps([decrypt_if_present(v) for v in values]))
+`;
+
+/** Decrypt a batch of raw column values via the backend's own helper. */
+export function decryptTexts(values: string[]): Promise<string[]> {
+  const repoRoot = path.resolve(__dirname, "..", "..", "..");
+  const backendDir = path.join(repoRoot, "backend");
+  const python =
+    process.env.E2E_SEED_PYTHON?.trim() ||
+    path.join(backendDir, "venv", "bin", "python");
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(python, ["-c", PY_DECRYPT], {
+      cwd: backendDir,
+      timeout: 30_000,
+    });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", (d) => (err += d));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`decrypt helper exited ${code} (${python}):\n${err}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(out) as string[]);
+      } catch (e) {
+        reject(new Error(`decrypt helper returned non-JSON: ${out}\n${e}`));
+      }
+    });
+    child.stdin.write(JSON.stringify(values));
+    child.stdin.end();
+  });
+}
+
+/** Decrypt one raw column value. */
+export async function decryptText(value: string): Promise<string> {
+  const [plain] = await decryptTexts([value]);
+  return plain;
+}

--- a/frontend/e2e/tutor.spec.ts
+++ b/frontend/e2e/tutor.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Journey (#392): a tutor conversation persists to `messages`, encrypted.
+ *
+ * Flow: resume the seeded "Understanding Recursion" session → send a message
+ * through the real composer → assert the deterministic reply renders → raw-SQL
+ * readback of the two new `messages` rows proving the encryption boundary
+ * (`content` at rest is ciphertext, and decrypts to exactly what was sent).
+ *
+ * Determinism: the stack must be booted with
+ *
+ *   SAPLING_MODEL_MODE=function \
+ *   SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e make e2e-up
+ *
+ * so `model_for("chat_tutor")` builds a FunctionModel (#391) and the backend
+ * self-registers the fixed-reply handler at first dispatch (#392). The spec
+ * enters the chat by RESUMING a seeded session — deliberately not via
+ * "Start learning": `POST /api/learn/start-session` still runs on the legacy
+ * `call_gemini_multiturn` path (routes/learn.py), which the seam does not
+ * cover, and this journey must never depend on live Gemini.
+ *
+ * No token streaming: `sendChat` (src/lib/api.ts) is a plain fetch returning
+ * the full `{ reply, ... }` object, so the assertions wait on the rendered
+ * reply locator — no SSE handling, no waitForTimeout.
+ */
+import { expect, test } from "./support/fixtures";
+import { queryRaw } from "./support/db";
+import { decryptTexts } from "./support/decrypt";
+
+/** Seeded by db/seed_local_rich.py for rich-user-active (4 prior messages). */
+const SESSION_ID = "rich-sess-cs-recursion";
+const SEEDED_MESSAGE_COUNT = 4;
+
+/** What the student types — asserted verbatim against the decrypted user row. */
+const STUDENT_MESSAGE =
+  "Why does infinite recursion crash the program? (e2e #392)";
+
+/** Must match backend/agents/function_handlers_e2e.py::E2E_TUTOR_REPLY. */
+const TUTOR_REPLY =
+  "[e2e-function-model] Deterministic tutor reply: every recursive function " +
+  "needs a base case so it can stop calling itself.";
+
+test("tutor turn renders a reply and persists encrypted to messages", async ({
+  page,
+}) => {
+  // The per-browser AI-disclosure modal (DisclaimerModal) is a fixed overlay
+  // that would swallow the composer clicks. Model a returning user who has
+  // already acknowledged it — the disclaimer is not this journey's subject,
+  // and its "Got it" control carries no testid to dismiss it by.
+  await page.addInitScript(() => {
+    localStorage.setItem("sapling_disclaimer_ack", "true");
+  });
+
+  // ── Reach an active chat by resuming the seeded session ──────────────────
+  await page.goto("/learn");
+  await page.getByTestId(`tutor-session-resume-${SESSION_ID}`).click();
+
+  // The conversation log mounts with the seeded history (proves resume
+  // actually loaded this session's decrypted turns, not an empty chat).
+  const log = page.getByTestId("tutor-messages");
+  await expect(log).toBeVisible();
+  await expect(log).toContainText("Can you explain recursion?");
+
+  // ── Send a message through the real composer ─────────────────────────────
+  await page.getByTestId("tutor-input").fill(STUDENT_MESSAGE);
+  await page.getByTestId("tutor-send").click();
+
+  // The user turn renders immediately; the deterministic FunctionModel reply
+  // replaces the "Thinking…" placeholder when POST /api/learn/chat returns.
+  await expect(log).toContainText(STUDENT_MESSAGE);
+  await expect(log).toContainText(TUTOR_REPLY);
+
+  // ── Raw-SQL readback: the turn persisted, encrypted (#397 posture) ───────
+  const rows = (await queryRaw(
+    `SELECT role, content FROM messages
+      WHERE session_id = $1
+      ORDER BY created_at ASC`,
+    [SESSION_ID],
+  )) as { role: string; content: string }[];
+
+  // Exactly the seeded baseline plus this turn's user + assistant rows.
+  expect(rows).toHaveLength(SEEDED_MESSAGE_COUNT + 2);
+  const [userRow, assistantRow] = rows.slice(-2);
+  expect(userRow.role).toBe("user");
+  expect(assistantRow.role).toBe("assistant");
+
+  // At rest the content column is CIPHERTEXT — never the sent plaintext.
+  expect(userRow.content).not.toBe(STUDENT_MESSAGE);
+  expect(assistantRow.content).not.toBe(TUTOR_REPLY);
+
+  // And it decrypts (via the backend's own helper) to exactly what was sent
+  // and exactly what rendered. Both checks are required: decrypt_if_present
+  // echoes plaintext input back, so decrypt-equality alone can't prove
+  // encryption — the ciphertext assertions above close that hole.
+  const [userPlain, assistantPlain] = await decryptTexts([
+    userRow.content,
+    assistantRow.content,
+  ]);
+  expect(userPlain).toBe(STUDENT_MESSAGE);
+  expect(assistantPlain).toBe(TUTOR_REPLY);
+});

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -97,6 +97,9 @@
   "src/components/screens/Learn.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
+    },
+    "no-restricted-syntax": {
+      "count": 21
     }
   },
   "src/components/screens/Library.tsx": {

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -61,6 +61,7 @@ const eslintConfig = [
       "src/components/ShellFrame.tsx",
       "src/components/screens/Social.tsx",
       "src/components/screens/Dashboard.tsx",
+      "src/components/screens/Learn.tsx",
     ],
     rules: {
       "no-restricted-syntax": [

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -1307,6 +1307,11 @@ function SessionRow({ s, onResume, onDelete, onRename }: {
         </div>
       ) : (
         <button
+          // Keyed on the session id (a stable domain id per
+          // docs/frontend-testids.md) — the E2E tutor journey (#392) resumes a
+          // seeded `rich-sess-*` session to reach an active chat without the
+          // Gemini-backed start-session call.
+          data-testid={`tutor-session-resume-${s.id}`}
           onClick={() => onResume(s)}
           style={{
             flex: 1,


### PR DESCRIPTION
## Summary

Browser journey for the tutor chat (#392): resume the seeded `rich-sess-cs-recursion` session on `/learn`, send a message through the real composer (`tutor-input` → `tutor-send`), assert the deterministic reply renders in `tutor-messages`, then raw-SQL readback of `messages` proving the encryption boundary:

- exactly 2 new rows for the session (seeded 4 → 6; a double-write from an accidental legacy fallback would fail the count),
- `content` at rest is **ciphertext** (≠ the sent plaintext / rendered reply), and
- both rows **decrypt** — via the backend's own `decrypt_if_present`, shelled through the backend venv — to exactly the sent text and the deterministic reply. Both directions are asserted because `decrypt_if_present` echoes plaintext input back (legacy tolerance), so decrypt-equality alone can't prove encryption.

No SSE handling and zero `waitForTimeout`: `sendChat` is a plain fetch returning the full `{ reply, … }` object; assertions wait on the rendered reply locator.

### Boot contract

```
SAPLING_MODEL_MODE=function SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e make e2e-up
```

`scripts/e2e-up.sh` does not scrub the environment — exported vars flow through `make` into the `setsid venv/bin/python -m uvicorn` launch, and `backend/.env` doesn't define `SAPLING_*`, so no sanctioned-passing workaround was needed. The second var is new (see below).

## Seam findings (#391 coverage of the tutor path)

1. **`POST /api/learn/chat` IS covered by the seam** — it runs `chat_tutor` (pydantic-ai) via `_chat_via_agent`, whose model comes from `model_for("chat_tutor")`.
2. **…but the browser could never reach the seam before this PR.** `routes/learn.py::_resolve_model_pref` built a live `GoogleModel` via `google_model(name)` for the per-request fast/smart pref, passed as `agent.run(model=…)` — overriding the FunctionModel. The frontend **always** sends a pref (`ModelToggle`'s `useModelPref` defaults to `"fast"`), so in function mode every browser tutor turn would still have dialed real Gemini. Fixed here: in any non-real mode the pref resolves to `None` (the agent default, already mode-correct). `real` mode is byte-for-byte unchanged.
   - **Same bypass exists in `routes/quiz.py::_resolve_model_pref` (lines ~127–145)** — left untouched (out of scope), flagged for the #393 quiz journey.
3. **`POST /api/learn/start-session` is NOT covered** — it still runs the legacy `services/gemini_service.py::call_gemini_multiturn` path (explicit `TODO(refactor-3 follow-up)` in the route). The journey therefore enters the chat by **resuming a seeded session**, never via "Start learning". Same applies to `/action` and `/mode-switch` (both legacy).
4. **Handler registration for out-of-process runs did not exist.** #391's `register_function_handler` is in-process only; ADR 0019 anticipated E2E lanes would "set the env at process start, then register per-task handlers" but shipped no mechanism for a separate uvicorn process. Added additively: `SAPLING_FUNCTION_HANDLERS=<module>` is imported lazily, **once, only on a dispatch miss** — the pytest lane (env unset, explicit registration) is unchanged, a missing handler still raises the pointed `LookupError`, explicit registrations always win, and a typo'd module path fails loudly (ImportError) instead of running handler-less. `agents/function_handlers_e2e.py` holds the fixed-reply `chat_tutor` handler; other journeys should append theirs there.
5. **Residual live-Gemini *attempt* (not a dependency): RAG query embedding.** `_chat_via_agent` calls `rag_service.retrieve_chunks` whenever the session's course has a `course_code` (seeded CS101 does), and `_embed_query` hits `gemini-embedding-001` outside any seam. `retrieve_chunks` swallows every exception and returns `[]`, so the journey's outcome does not depend on it — but each E2E tutor turn still *attempts* one billed embedding call when `backend/.env` carries a real key. Worth a follow-up (seam or env kill-switch for embeddings).

## Verification

- **10 consecutive local runs green** (single lock hold, fresh function-mode stack boot from this branch's worktree): runs 1–10 all `1 passed`, 4.5–5.9s each, zero failed/flaky/retried, clean teardown. Boot line used: the contract above.
- Backend unit suite in the worktree: **1075 passed, 1 skipped** (includes 6 new tests in `tests/test_e2e_function_handlers.py`: env-module autoload end-to-end through the real `socratic_agent`, unset-var LookupError posture, bad-module loud failure, explicit-registration precedence, and `_resolve_model_pref` mode behavior both ways). `ruff check` clean on changed files.
- `tsc --noEmit` and `eslint` clean on changed frontend files (one pre-existing baselined warning in `Learn.tsx`).
- Encrypt→decrypt round-trip of the exact helper snippet verified against the local stack's `ENCRYPTION_KEY` before the runs.

## Testid note (deviation, with precedent)

The journey needs one new testid, `tutor-session-resume-{sessionId}`, on the Learn screen's session rows — but `screens/Learn.tsx` has ~20 intrinsic interactive elements outside any browser journey, so adding it to the eslint `files` array would force testids on all of them. Followed the documented `signin-trigger` exception instead: testid added + inventoried in `docs/frontend-testids.md` with the exception noted, file stays out of the lint block.

The AI-disclosure `DisclaimerModal` (fixed overlay, no testids) is pre-acked via `addInitScript` (models a returning user); dismissing it by copy would violate the no-copy-anchoring rule and tagging it was out of scope.

## Cross-PR convergence notes

- `frontend/e2e/global-setup.ts` gained the `sapling_user` localStorage entry **copied verbatim from `test/386-journey-dashboard`** (per the harness-owner heads-up): the cookie-only storageState never populates `UserContext` (it bootstraps identity solely from that localStorage key), so the Learn screen's session list — which this journey resumes from — stays empty without it. Identical content on both branches, so the merge is clean whichever lands first.
- At least one sibling journey PR boots with the same `SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e` contract and will carry its own version of the handlers module / `_providers.py` autoload. These were authored in isolated worktrees — whoever merges second should converge to one module (append handlers per task) rather than duplicate the mechanism.

## Files

- `frontend/e2e/tutor.spec.ts` — the journey (new)
- `frontend/e2e/support/decrypt.ts` — backend-venv decrypt seam (new)
- `frontend/e2e/support/db.ts` — additive `queryRaw` (parameterized SELECTs behind the existing loopback guard)
- `frontend/src/components/screens/Learn.tsx` — `tutor-session-resume-{sessionId}`
- `docs/frontend-testids.md` — inventory + lint-exception note (append-only)
- `backend/agents/_providers.py` — `SAPLING_FUNCTION_HANDLERS` lazy autoload on dispatch miss
- `backend/agents/function_handlers_e2e.py` — deterministic `chat_tutor` handler (new)
- `backend/routes/learn.py` — `_resolve_model_pref` respects `SAPLING_MODEL_MODE`
- `backend/tests/test_e2e_function_handlers.py` — 6 unit tests (new)

Part of #402, closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading function-mode tutor handlers during startup and dispatch.
  * Added deterministic tutor behavior for end-to-end testing.
  * Added a test identifier for resuming recent tutor sessions.

* **Bug Fixes**
  * Prevented live model overrides from being created in non-real modes.
  * Improved missing or invalid handler errors.

* **Tests**
  * Added coverage for handler loading, routing, session persistence, and encrypted message storage.

* **Documentation**
  * Updated tutor end-to-end testing and test-identifier guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->