### PR TITLE
test(e2e): journey — quiz answer → mastery update (UI + DB) (#393)

### DIFF
--- a/backend/agents/function_handlers_e2e.py
+++ b/backend/agents/function_handlers_e2e.py
@@ -29,7 +29,7 @@ handlers here rather than growing parallel modules.
 
 from __future__ import annotations
 
-from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
 
 from agents._providers import register_function_handler
 
@@ -46,3 +46,53 @@ def _chat_tutor_handler(messages, info) -> ModelResponse:
 
 
 register_function_handler("chat_tutor", _chat_tutor_handler)
+
+
+# ── Quiz (#393) ────────────────────────────────────────────────────────────
+#
+# Fixed three-question quiz. The correct options sit at indexes 1, 2, 0;
+# routes/quiz.py assigns wire labels in options order, so the correct labels
+# are B, C, A. frontend/e2e/quiz.spec.ts clicks exactly that sequence and
+# backend/tests/test_e2e_function_handlers.py pins it — KEEP ALL THREE IN
+# SYNC (E2E_QUIZ_CORRECT_LABELS is that contract, exported like
+# E2E_TUTOR_REPLY above). The count deliberately ignores the requested
+# num_questions: the route stores whatever the agent returns, and a fixed
+# count keeps the journey's mastery math (3 correct × +0.03 = +0.09)
+# byte-stable across runs. The `concept` field is fixed too (the route
+# derives mastery from the DB node it looked up, never from this field).
+#
+# The single ToolCallPart below is the agent's OUTPUT tool (the structured
+# Quiz result) — not a function tool, so the no-tool-calls constraint above
+# holds. `quiz_context` stays deliberately unregistered: submit_quiz updates
+# it in a BackgroundTask wrapped in `except Exception: pass`, so an
+# unscripted handler fails fast with no post-response DB write racing the
+# next test's truncate + re-seed.
+
+E2E_QUIZ_CORRECT_LABELS = ("B", "C", "A")
+
+_E2E_QUIZ_QUESTIONS = [
+    {
+        "question": f"E2E deterministic question {n}: which option is marked correct?",
+        "type": "multiple_choice",
+        "difficulty": "medium",
+        "options": [f"Q{n} option A", f"Q{n} option B", f"Q{n} option C", f"Q{n} option D"],
+        "correct_answer": f"Q{n} option {label}",
+        "explanation": f"Scripted E2E fixture: option {label} is the marked answer for question {n}.",
+        "concept": "Recursion",
+    }
+    for n, label in zip((1, 2, 3), E2E_QUIZ_CORRECT_LABELS)
+]
+
+
+def _quiz_handler(messages, info) -> ModelResponse:
+    return ModelResponse(
+        parts=[
+            ToolCallPart(
+                tool_name=info.output_tools[0].name,
+                args={"questions": _E2E_QUIZ_QUESTIONS},
+            )
+        ]
+    )
+
+
+register_function_handler("quiz", _quiz_handler)

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -138,10 +138,19 @@ def _resolve_model_pref(model_pref: str | None):
     """
     if not model_pref:
         return None
+    from agents._providers import _model_mode, google_model
+    if _model_mode() != "real":
+        # #391 seam: the per-request fast/smart override must not bypass
+        # SAPLING_MODEL_MODE by constructing a live GoogleModel. Same fix as
+        # routes/learn.py (#392) — there the browser always sends a pref;
+        # the quiz UI does not send one today, but any client that did would
+        # silently put live Gemini back in the function-mode path. Fall
+        # through to the agent's default model, which model_for("quiz")
+        # already built for the active mode.
+        return None
     name = _PREF_MODEL_NAMES.get(model_pref)
     if not name:
         return None
-    from agents._providers import google_model
     return google_model(name)
 
 

--- a/backend/tests/test_e2e_function_handlers.py
+++ b/backend/tests/test_e2e_function_handlers.py
@@ -23,7 +23,12 @@ import agents._providers as providers
 from agents._providers import clear_function_handlers, model_for
 from agents.chat_tutor import socratic_agent
 from agents.deps import SaplingDeps
+from agents.quiz import quiz_agent
 from routes.learn import _resolve_model_pref
+from routes.quiz import (
+    _agent_question_to_wire,
+    _resolve_model_pref as _resolve_quiz_model_pref,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -149,3 +154,75 @@ def test_resolve_model_pref_still_builds_override_in_real_mode(monkeypatch):
     assert isinstance(m, GoogleModel)
     assert m.model_name == "gemini-2.5-flash-lite"
     assert _resolve_model_pref(None) is None
+
+
+# ── Quiz journey contract (#393) ──────────────────────────────────────────
+#
+# frontend/e2e/quiz.spec.ts drives the real /quiz UI against a uvicorn booted
+# with the two env vars and answers B, C, A expecting a 3/3 score. That is
+# only deterministic while the env-registered quiz handler keeps producing
+# exactly that quiz — through the REAL quiz_agent (output-tool schema
+# validation included) and the REAL routes/quiz.py wire mapping. Pinned here
+# so drift in the handler, the Quiz schema, or the wire mapping fails in CI
+# instead of mid-browser-run.
+
+
+def test_env_module_quiz_handler_produces_the_scripted_quiz(monkeypatch):
+    """Full E2E-boot contract for the quiz task: function mode + the env-named
+    module give a real quiz_agent run the fixed three-question quiz, with no
+    handler registered by the test itself."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv(
+        "SAPLING_FUNCTION_HANDLERS", "agents.function_handlers_e2e"
+    )
+
+    with quiz_agent.override(model=model_for("quiz")):
+        result = quiz_agent.run_sync("Generate 5 medium questions.", deps=_deps())
+
+    quiz = result.output
+    assert len(quiz.questions) == 3
+    # Correct options at indexes 1, 2, 0 → wire labels B, C, A.
+    assert [q.options.index(q.correct_answer) for q in quiz.questions] == [1, 2, 0]
+    assert all(q.question.startswith("E2E deterministic question") for q in quiz.questions)
+
+
+def test_quiz_handler_wire_labels_match_the_browser_spec(monkeypatch):
+    """Through the route's real wire mapping, the correct labels are exactly
+    E2E_QUIZ_CORRECT_LABELS — the click sequence frontend/e2e/quiz.spec.ts
+    hardcodes. Changing the ordering means updating the spec in the same PR
+    (testids are API, and so is this sequence)."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv(
+        "SAPLING_FUNCTION_HANDLERS", "agents.function_handlers_e2e"
+    )
+
+    with quiz_agent.override(model=model_for("quiz")):
+        result = quiz_agent.run_sync("Generate 5 medium questions.", deps=_deps())
+
+    from agents.function_handlers_e2e import E2E_QUIZ_CORRECT_LABELS
+
+    labels = []
+    for i, q in enumerate(result.output.questions):
+        wire = _agent_question_to_wire(q, i + 1)
+        assert wire is not None  # correct_answer appears verbatim in options
+        labels.append(next(o["label"] for o in wire["options"] if o["correct"]))
+    assert labels == list(E2E_QUIZ_CORRECT_LABELS)
+
+
+def test_quiz_resolve_model_pref_returns_none_in_function_mode(monkeypatch):
+    """The quiz half of the same bypass fixed in routes/learn.py: a fast/smart
+    pref must not produce a live GoogleModel override in any non-real mode.
+    The quiz UI sends no pref today, but any client that did would silently
+    put live Gemini back in the function-mode path."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    assert _resolve_quiz_model_pref("fast") is None
+    assert _resolve_quiz_model_pref("smart") is None
+
+
+def test_quiz_resolve_model_pref_still_builds_override_in_real_mode(monkeypatch):
+    """Default lane unchanged: real mode keeps the quiz per-request override."""
+    monkeypatch.delenv("SAPLING_MODEL_MODE", raising=False)
+    m = _resolve_quiz_model_pref("smart")
+    assert isinstance(m, GoogleModel)
+    assert m.model_name == "gemini-2.5-pro"
+    assert _resolve_quiz_model_pref(None) is None

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -153,6 +153,7 @@ route:
 | `quiz-explain-concept` | "Explain this" |
 | `quiz-next` | "Next question" / "See results" |
 | `quiz-results-score` | the score percentage |
+| `quiz-results-mastery` | the "X / Y correct · mastery B% → A%" line |
 | `quiz-retake` | "Retake" |
 | `quiz-done` | "Done" |
 

--- a/frontend/e2e/quiz.spec.ts
+++ b/frontend/e2e/quiz.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * Journey (#393): answer a quiz through the UI → mastery updates in the UI
+ * AND in the database.
+ *
+ * Mastery is the append-only `node_mastery_events` table since migration
+ * 0023 (never a `mastery_events` column): submitting a quiz routes through
+ * services/graph_service.py::apply_graph_update, which bumps
+ * `graph_nodes.mastery_score` and INSERTs one event row. The UI writes
+ * through the real routes; every DB assertion here reads back over the
+ * raw-SQL seam (support/db.ts::queryRows) — a different layer than the one
+ * that wrote, so the test proves the write hit the database, not the echo.
+ *
+ * MONOTONICITY — the property no mocked test can falsify: a correct answer
+ * never lowers a score. The scoring math in routes/quiz.py is
+ * `delta = score*0.03 - (total-score)*0.02`; an all-correct submission must
+ * therefore never decrease mastery. Asserted three ways below: on the UI's
+ * rendered before→after, on `graph_nodes.mastery_score`, and on the event's
+ * `delta` sign.
+ *
+ * Determinism: the stack boots with SAPLING_MODEL_MODE=function and
+ * SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e (#391/#392 /
+ * ADR 0019), so /api/quiz/generate runs the real quiz_agent against the
+ * scripted handler in backend/agents/function_handlers_e2e.py — a fixed
+ * three-question quiz whose correct labels are B, C, A
+ * (E2E_QUIZ_CORRECT_LABELS). That sequence is pinned by
+ * backend/tests/test_e2e_function_handlers.py; KEEP IN SYNC.
+ */
+import { queryRaw } from "./support/db";
+import { expect, test } from "./support/fixtures";
+
+/** db/seed_local_rich.py: "Recursion" for rich-user-active on CS101 —
+ * seeded at mastery 0.25 with NO seeded mastery events, so the baseline
+ * event count is exactly zero after the per-test reset. */
+const NODE_ID = "rich-node-cs-recursion";
+const SEEDED_MASTERY = 0.25;
+
+/** Correct option labels, in question order — the e2e_function_handlers.py
+ * contract (correct options at indexes 1, 2, 0 → wire labels B, C, A). */
+const CORRECT_LABELS = ["B", "C", "A"] as const;
+
+/** routes/quiz.py: 3 correct of 3 → delta = 3 × 0.03 = +0.09. */
+const EXPECTED_DELTA = 3 * 0.03;
+
+test("quiz journey: all-correct answers raise mastery in UI and DB, monotonically", async ({
+  page,
+}) => {
+  // Generation includes a best-effort RAG grounding call server-side (below
+  // the model seam) before the scripted FunctionModel runs; give the journey
+  // room without ever sleeping — every wait below is locator/event-based.
+  test.setTimeout(180_000);
+
+  // ── Baseline (post-reset seed), read over the raw-SQL seam ──────────────
+  const nodeBefore = await queryRaw(
+    "SELECT mastery_score, times_studied FROM graph_nodes WHERE id = $1",
+    [NODE_ID],
+  );
+  expect(nodeBefore).toHaveLength(1);
+  const masteryBefore = Number(nodeBefore[0].mastery_score);
+  expect(masteryBefore).toBeCloseTo(SEEDED_MASTERY, 10);
+
+  const eventsBefore = await queryRaw(
+    "SELECT id FROM node_mastery_events WHERE node_id = $1",
+    [NODE_ID],
+  );
+  expect(eventsBefore).toHaveLength(0);
+
+  // ── Take the quiz through the UI ────────────────────────────────────────
+  // The AI-disclaimer modal (DisclaimerModal.tsx) opens over /quiz for any
+  // browser that has never acknowledged it and intercepts every click.
+  // Pre-ack it exactly the way a returning user's browser carries the ack —
+  // the disclaimer is unrelated chrome, not part of this journey's scope.
+  // (Scoped here rather than in global-setup.ts, which stays verbatim-
+  // identical to the #386 branch by sibling-convergence agreement.)
+  await page.addInitScript(() => {
+    window.localStorage.setItem("sapling_disclaimer_ack", "true");
+  });
+
+  // Deep link preselects the course AND the concept (quizSelection.ts), so
+  // the select phase arrives ready to start.
+  await page.goto(`/quiz?concept=${NODE_ID}`);
+  await expect(page.getByTestId("quiz-panel")).toBeVisible();
+
+  const start = page.getByTestId("quiz-start");
+  await expect(start).toBeEnabled();
+  await start.click();
+
+  // /api/quiz/generate round trip (agent + attempt insert) → active phase.
+  await expect(page.getByTestId("quiz-answer-options")).toBeVisible({
+    timeout: 60_000,
+  });
+
+  // Loud mode guard: the scripted fixture's question text proves the backend
+  // booted with SAPLING_MODEL_MODE=function. A stack accidentally in `real`
+  // mode would serve a live-Gemini quiz and fail HERE with a clear signal,
+  // not three steps later on a coin-flip verdict.
+  await expect(page.getByTestId("quiz-panel")).toContainText(
+    "E2E deterministic question 1",
+  );
+
+  for (const label of CORRECT_LABELS) {
+    await page.getByTestId(`quiz-answer-option-${label}`).click();
+    await page.getByTestId("quiz-submit-answer").click();
+    // The scripted quiz makes every chosen label the correct one — a
+    // "Not quite." here means the handler/spec label contract drifted.
+    await expect(page.getByTestId("quiz-review-verdict")).toHaveText(
+      "Correct.",
+    );
+    await page.getByTestId("quiz-next").click();
+  }
+
+  // The final "See results" click fires /api/quiz/submit; the results phase
+  // renders only after the response, so once the score is visible the
+  // synchronous mastery write (apply_graph_update) has been committed.
+  await expect(page.getByTestId("quiz-results-score")).toHaveText("100%", {
+    timeout: 30_000,
+  });
+
+  // ── UI mastery: parse the rendered before → after ───────────────────────
+  const masteryLine = page.getByTestId("quiz-results-mastery");
+  await expect(masteryLine).toContainText("3 / 3 correct");
+  const lineText = (await masteryLine.textContent()) ?? "";
+  const match = lineText.match(/mastery\s+(\d+)%\s*→\s*(\d+)%/);
+  expect(match, `unparsable mastery line: ${JSON.stringify(lineText)}`).not.toBeNull();
+  const uiBefore = Number(match![1]);
+  const uiAfter = Number(match![2]);
+
+  // MONOTONICITY (UI): a fully correct quiz never lowers the score.
+  expect(uiAfter).toBeGreaterThanOrEqual(uiBefore);
+  expect(uiBefore).toBe(Math.round(masteryBefore * 100));
+
+  // ── DB: node score moved, and UI and DB agree ───────────────────────────
+  const nodeAfter = await queryRaw(
+    "SELECT mastery_score, times_studied, last_studied_at FROM graph_nodes WHERE id = $1",
+    [NODE_ID],
+  );
+  expect(nodeAfter).toHaveLength(1);
+  const masteryAfter = Number(nodeAfter[0].mastery_score);
+
+  // MONOTONICITY (DB): the persisted score did not drop…
+  expect(masteryAfter).toBeGreaterThanOrEqual(masteryBefore);
+  // …and moved by exactly the all-correct delta (0.25 → 0.34, no clamp).
+  expect(masteryAfter).toBeCloseTo(SEEDED_MASTERY + EXPECTED_DELTA, 10);
+  // UI ↔ DB agreement: the percentages the student saw are the DB state.
+  expect(uiAfter).toBe(Math.round(masteryAfter * 100));
+
+  // apply_graph_update also bumps the study counters.
+  expect(Number(nodeAfter[0].times_studied)).toBe(1);
+  expect(nodeAfter[0].last_studied_at).not.toBeNull();
+
+  // ── DB: exactly ONE append-only mastery event, with a non-negative delta ─
+  const eventsAfter = await queryRaw(
+    "SELECT delta, reason FROM node_mastery_events WHERE node_id = $1 ORDER BY created_at",
+    [NODE_ID],
+  );
+  expect(eventsAfter).toHaveLength(1);
+  // MONOTONICITY (event): a correct-only submission records a delta ≥ 0.
+  expect(Number(eventsAfter[0].delta)).toBeGreaterThanOrEqual(0);
+  expect(Number(eventsAfter[0].delta)).toBeCloseTo(EXPECTED_DELTA, 10);
+  expect(eventsAfter[0].reason).toBe("Quiz: 3/3 correct");
+
+  // ── DB: the attempt row was completed through the app ───────────────────
+  // Scoped to rows the JOURNEY created: the rich seed also has a completed
+  // baseline attempt on this node (rich-qa-cs-recursion-1). Seeded ids are
+  // namespaced rich-*; the route mints uuid4 ids, so the NOT LIKE filter
+  // isolates the app-written row.
+  const attempts = await queryRaw(
+    "SELECT score, total, completed_at FROM quiz_attempts WHERE concept_node_id = $1 AND id NOT LIKE 'rich-%'",
+    [NODE_ID],
+  );
+  expect(attempts).toHaveLength(1);
+  expect(Number(attempts[0].score)).toBe(3);
+  expect(Number(attempts[0].total)).toBe(3);
+  expect(attempts[0].completed_at).not.toBeNull();
+});

--- a/frontend/src/components/QuizPanel.tsx
+++ b/frontend/src/components/QuizPanel.tsx
@@ -371,7 +371,7 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
           <div data-testid="quiz-results-score" className="h-serif" style={{ fontSize: 32 }}>
             {Math.round((results.score / Math.max(1, results.total)) * 100)}%
           </div>
-          <div style={{ fontSize: 13, color: "var(--text-dim)" }}>
+          <div data-testid="quiz-results-mastery" style={{ fontSize: 13, color: "var(--text-dim)" }}>
             {results.score} / {results.total} correct · mastery{" "}
             <span style={{ color: results.mastery_after >= results.mastery_before ? "var(--accent)" : "var(--err)", fontWeight: 600 }}>
               {Math.round(results.mastery_before * 100)}% → {Math.round(results.mastery_after * 100)}%

--- a/frontend/src/components/QuizPanel.tsx
+++ b/frontend/src/components/QuizPanel.tsx
@@ -33,7 +33,10 @@ interface QuizQuestion {
 
 interface QuizAnswer {
   question_id: number | string;
-  selected: string;
+  // Wire name per backend models.AnswerItem — the shell revamp renamed this
+  // to `selected` and every UI submission 422'd (caught by the #393 E2E
+  // journey). The RESPONSE items (QuizResult below) do use `selected`.
+  selected_label: string;
 }
 
 interface QuizResult {
@@ -133,7 +136,7 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
     if (!currentQuestion || !currentSelection) return;
     const chosen = currentQuestion.options.find(o => o.label === currentSelection);
     setLastCorrect(!!chosen?.correct);
-    setAnswers(a => [...a, { question_id: currentQuestion.id, selected: currentSelection }]);
+    setAnswers(a => [...a, { question_id: currentQuestion.id, selected_label: currentSelection }]);
     setPhase("review");
   };
 


### PR DESCRIPTION
## Summary

Browser journey for the quiz → mastery path (#393): sign in as the seeded `rich-user-active` (storageState), deep-link to `/quiz?concept=rich-node-cs-recursion`, answer a deterministic three-question quiz through the real UI, and assert the mastery change **in the UI and in the database**:

- `graph_nodes.mastery_score` moves 0.25 → 0.34 (3 correct × +0.03), `times_studied` bumps 0 → 1, `last_studied_at` set;
- exactly **one** new row appends to `node_mastery_events` (the 0023 table — never a `mastery_events` column) with `delta ≈ +0.09` and reason `Quiz: 3/3 correct`;
- the journey's `quiz_attempts` row completes (`score=3, total=3, completed_at` set; scoped `id NOT LIKE 'rich-%'` because the seed carries a completed baseline attempt on the same node);
- the percentages the student *saw* (`quiz-results-mastery`) equal the DB state read back over the raw-SQL seam — writes go through the app, assertions never ride the layer that wrote.

**Monotonicity** — the property no mocked test can falsify — is pinned three ways: a fully correct submission must never lower the rendered score (`uiAfter >= uiBefore`), the persisted score (`masteryAfter >= masteryBefore`), or the event delta sign (`delta >= 0`). If the scoring math in `routes/quiz.py` ever regresses to subtract on correct answers, this journey fails.

## Product bugs found (2, both fixed here)

1. **Every UI quiz submission has 422'd since the shell revamp.** `QuizPanel` submits `{question_id, selected}`; backend `models.AnswerItem` requires `selected_label`. Introduced by `399eae3` ("frontend: ship revamp shell, screens, and API client"), which dropped the old `selected_label` payload; verified live on `origin/main`. No mocked test on either side could catch it — backend tests construct `AnswerItem` directly, frontend tests mock `fetch`. The journey caught it on its first live run (`POST /api/quiz/submit -> 422`, `.e2e/backend.log`). Fixed by renaming the request field to the backend contract (the response items keep their separate `selected` key). Distinct from the known #129 scoring bug, which this journey does not exercise (single submit per answer, well-formed items).
2. **The quiz half of the #392-discovered seam bypass.** `routes/quiz.py::_resolve_model_pref` built a live `GoogleModel` for a `fast`/`smart` pref regardless of `SAPLING_MODEL_MODE` — same bug the #392 sibling fixed in `routes/learn.py`, deliberately left to this PR. The quiz UI sends no pref today (`generateQuiz` omits `model_pref`, which is why this journey's runs stayed deterministic regardless), but any client that did would silently dial Gemini in function mode. Fixed with the same pattern + the same test shape as learn's.

## Seam findings (#391 / ADR 0019 / #392 convergence)

- **Quiz generation IS covered by the FunctionModel seam** — it does not route through `gemini_service.call_gemini_json`; `/api/quiz/generate` runs `agents/quiz.py::quiz_agent` built via `model_for("quiz")`. Verified with evidence, not assumption: the spec's mode guard asserts the scripted fixture's question text before answering (a real-Gemini stack fails loudly there), generate round-trips in ~530 ms (`.e2e/backend.log`), and the only Gemini egress in a full run is the one below-seam embedding call (next bullet).
- **Env propagation confirmed:** `SAPLING_MODEL_MODE=function SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e make e2e-up` reaches uvicorn by plain env inheritance; `load_dotenv` (main.py, config.py) never overrides exported vars. No script changes needed.
- **Handler registration converged on #392's mechanism — now upstream.** After #434 merged (including the review-found latch fix in `_load_env_handlers_module` and its dispatch-twice regression test), this branch was rebased onto it: the shared seam files (`_providers.py`, `learn.py`, `db.ts`, `global-setup.ts`) collapsed into main entirely, and the PR diff is down to the quiz-specific surface — the quiz handler **appended** to `agents/function_handlers_e2e.py` (per that module's own instruction) and the quiz contract tests appended to its test file. The scripted quiz contract (labels B, C, A = `E2E_QUIZ_CORRECT_LABELS`) is pinned hermetically through the real agent + real wire mapping.
- **Below-the-seam egress (follow-up candidate):** `/api/quiz/generate`'s best-effort RAG grounding (`_course_material_block` → `retrieve_chunks` → `_embed_query`) sits below the model seam: with a real key in `backend/.env` each generate makes one live `gemini-embedding-001:batchEmbedContents` call even in function mode (observed in `.e2e/backend.log`). It cannot affect the journey's outcome (the scripted handler ignores prompt content; `course_chunks` is empty post-reset; failures are swallowed by design) but it is incidental egress and a bounded (60 s) latency source the spec budgets for. Worth a follow-up to short-circuit grounding in non-real modes.
- **`quiz_context` deliberately unregistered:** `submit_quiz`'s background context update runs in `try/except pass`; without a handler it fails fast with no post-response DB write racing the next test's truncate + re-seed.

## 10-run tally

**10/10 consecutive local runs green** in one lock-held cycle (fresh `SAPLING_MODEL_MODE=function SAPLING_FUNCTION_HANDLERS=agents.function_handlers_e2e make e2e-up` boot, `make e2e-down` after; cycle exit rc=0):

```
RUN  1/10  1 passed (7.9s)      RUN  6/10  1 passed (6.6s)
RUN  2/10  1 passed (6.2s)      RUN  7/10  1 passed (6.2s)
RUN  3/10  1 passed (6.4s)      RUN  8/10  1 passed (5.2s)
RUN  4/10  1 passed (6.7s)      RUN  9/10  1 passed (6.7s)
RUN  5/10  1 passed (6.6s)      RUN 10/10  1 passed (5.4s)
```

The consecutive greens double as isolation proof: every run asserts the seeded 0.25 baseline before playing, which would fail if the prior run's 0.34 write leaked past the per-test truncate + re-seed.

**Post-rebase confirmation** (after re-syncing onto main's merged #434 seam, incl. the latch fix): fresh lock-held cycle, **3/3 green** — 8.4 s / 6.9 s / 6.8 s.

## Harness changes (additive)

- `frontend/e2e/quiz.spec.ts` — the journey. Zero `waitForTimeout`; locator/event waits only. Pre-acks the AI disclaimer via `addInitScript` (the modal intercepts every click for a browser that never acked; scoped to the spec so `global-setup.ts` stays byte-identical to the #386/#394 content already on main).
- `frontend/src/components/QuizPanel.tsx` + `docs/frontend-testids.md` — one new testid on the existing `quiz` surface, `quiz-results-mastery` (inventory row appended; the file is already in the eslint `files` array), plus the `selected_label` fix above. DB readback uses main's `queryRaw` helper (merged with #434) — no harness-file changes remain in this diff.

Backend hermetic suite: 1080 passed, 23 skipped on the rebased branch. Frontend: tsc clean, eslint 0 errors, vitest 204 passed.

Part of #402, closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)
