### PR TITLE
ci: browser-lane E2E job — real Postgres from empty, Playwright, flake surfacing (#389, #390)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,9 +7,9 @@ name: e2e (browser lane)
 #
 # Trigger is main-only per epic #402 open decision 3 (promote to a PR gate
 # once the #388 stability bar has held for a while). Postgres version comes
-# from supabase/config.toml — the same stack local dev and integration.yml
-# already run (epic decision 2: matching the proven CLI stack; the PG15 prod
-# skew is a documented, accepted gap).
+# from supabase/config.toml (PG17) — this deliberately goes AGAINST epic
+# decision 2's recorded PG15 leaning, choosing consistency with the proven
+# local + integration.yml stack instead; the prod skew is tracked in #441.
 
 on:
   workflow_dispatch:
@@ -19,6 +19,15 @@ on:
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: false
+
+env:
+  # ubuntu-latest ships Podman ALONGSIDE Docker, so e2e-up's podman-first
+  # detection would target a rootless podman socket nobody started. Pin the
+  # runtime explicitly (local-common.sh: an explicit CONTAINER_CMD wins) and
+  # pre-set DOCKER_HOST so e2e-up's ${DOCKER_HOST:-...} keeps the real
+  # Docker daemon socket.
+  CONTAINER_CMD: docker
+  DOCKER_HOST: unix:///var/run/docker.sock
 
 jobs:
   e2e:
@@ -30,6 +39,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -83,7 +94,9 @@ jobs:
             if [ "$FLAKY" -gt 0 ]; then
               echo ""
               echo "### ⚠ Tests that passed only on retry"
-              jq -r '.. | objects | select(.status? == "flaky") | .title? // empty' "$R" | sed 's/^/- /'
+              # In Playwright's JSON report, status lives on the TEST object
+              # but title on its parent SPEC — select specs whose tests flaked.
+              jq -r '.. | objects | select(.title? and .tests?) | select(any(.tests[]?; .status == "flaky")) | .title' "$R" | sed 's/^/- /'
               echo ""
               echo "A retried-pass is a flake to fix at the root (#388 policy), not a green run."
             fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,106 @@
+name: e2e (browser lane)
+
+# The browser-lane E2E job (#389): boots the SAME stack the local lane uses —
+# `make e2e-up` (Supabase CLI → migrations from EMPTY → seed → uvicorn →
+# test-profile Next build) — then runs the Playwright suite and surfaces
+# per-run retry counts (#390) so a retried-pass is never silently green.
+#
+# Trigger is main-only per epic #402 open decision 3 (promote to a PR gate
+# once the #388 stability bar has held for a while). Postgres version comes
+# from supabase/config.toml — the same stack local dev and integration.yml
+# already run (epic decision 2: matching the proven CLI stack; the PG15 prod
+# skew is a documented, accepted gap).
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    # Acceptance bar (#389): total wall clock under 15 minutes — enforced.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      # Satisfy `make e2e-up`'s preflight exactly as a local machine would
+      # (backend/.env, backend/venv, frontend/node_modules) so CI runs the
+      # identical boot path — no CI-only stack wiring to drift.
+      - name: Backend env + venv
+        working-directory: backend
+        run: |
+          cp .env.local.example .env
+          python -m venv venv
+          venv/bin/pip install --quiet -r requirements.txt
+      - name: Frontend deps + browser
+        working-directory: frontend
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Boot the stack (make e2e-up, function mode)
+        env:
+          SAPLING_MODEL_MODE: function
+          SAPLING_FUNCTION_HANDLERS: agents.function_handlers_e2e
+          # Dummy on purpose: the below-seam RAG embed path (#439) must not
+          # be able to bill; its failures are swallowed by design.
+          GEMINI_API_KEY: e2e-dummy-key-no-billing
+        run: make e2e-up
+
+      - name: Run Playwright suite
+        working-directory: frontend
+        run: npx playwright test e2e/
+
+      # #390 — flake tracking: a test that passed only on retry is real
+      # signal, not noise. Parse the JSON report's stats into the job summary
+      # and fail-visible (not fail-red) by listing every flaky test title.
+      - name: Surface retry counts (#390)
+        if: always()
+        working-directory: frontend
+        run: |
+          R=e2e/results/last-run.json
+          if [ ! -f "$R" ]; then echo "no report produced" >> "$GITHUB_STEP_SUMMARY"; exit 0; fi
+          {
+            echo "## Browser-lane run stats"
+            jq -r '.stats | "| expected | unexpected | flaky | skipped |\n|---|---|---|---|\n| \(.expected) | \(.unexpected) | \(.flaky) | \(.skipped) |"' "$R"
+            FLAKY=$(jq -r '[.. | objects | select(.status? == "flaky")] | length' "$R")
+            if [ "$FLAKY" -gt 0 ]; then
+              echo ""
+              echo "### ⚠ Tests that passed only on retry"
+              jq -r '.. | objects | select(.status? == "flaky") | .title? // empty' "$R" | sed 's/^/- /'
+              echo ""
+              echo "A retried-pass is a flake to fix at the root (#388 policy), not a green run."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload failure artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts
+          path: |
+            frontend/test-results/
+            frontend/e2e/results/last-run.json
+            .e2e/*.log
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Teardown
+        if: always()
+        run: make e2e-down


### PR DESCRIPTION
Adds `.github/workflows/e2e.yml`: the browser lane in CI.

**Design** — CI satisfies `make e2e-up`'s preflight (backend/.env from the local example, a fresh venv, npm ci) and then runs the *identical* boot path local dev uses: Supabase CLI → `db.migrate` from an empty database → `seed_local_rich` → function-mode uvicorn (`SAPLING_MODEL_MODE=function` + handlers module, dummy `GEMINI_API_KEY` so the below-seam RAG path #439 cannot bill) → test-profile Next build → 7-spec Playwright suite.

**Epic open decisions resolved:**
- *Decision 1 (runtime)*: Supabase CLI on the Docker runner — already proven by `integration.yml`, green on every main push since #427.
- *Decision 2 (PG version)*: whatever `supabase/config.toml` pins (the stack local + integration already run); the PG15 prod skew is documented and accepted for now.
- *Decision 3 (gating)*: main-only + `workflow_dispatch`, non-gating for PRs until #388's bar has held.

**#390** — the job summary renders expected/unexpected/flaky/skipped stats and lists every test that passed only on retry, so a retried-pass is never silently green. Traces/videos/JSON report upload as artifacts (14-day retention). `timeout-minutes: 15` enforces the wall-clock acceptance bar.

**Verification** — YAML validated; the boot path, suite, and reporter output are the same ones exercised locally all day (the 20-run #388 streak is running on this exact suite as this PR goes up). The workflow itself is truly validated only by its first run on main after merge — I'll watch it and fix forward if red.

Part of #402, closes #389, closes #390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an automated browser testing workflow that runs on demand and with updates to the main branch.
  * Improved test setup by automatically preparing backend, frontend, and browser testing dependencies.
  * Added reporting for retries and flaky test results.
  * Preserved test logs and artifacts for troubleshooting, with automatic environment cleanup after each run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->