### PR TITLE
ci(e2e): node 22 — fix the engine-strict npm pin failure from e2e.yml's first run

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,10 @@ jobs:
           cache-dependency-path: backend/requirements.txt
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # node 22 to match ci.yml's frontend lane: node 20 bundles npm 10.8,
+          # under the repo's npm >=10.9 <11 engine-strict pin, and the
+          # kv-asset-handler transitive dep needs >=22 anyway.
+          node-version: '22'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - uses: supabase/setup-cli@v1


### PR DESCRIPTION
First live run of e2e.yml (run 30332031352) failed at `npm ci`: node 20 runners bundle npm 10.8.2, under the repo's `npm >=10.9 <11` engine-strict pin. Same fix ci.yml's frontend lane already documents — node 22 (whose bundled npm satisfies the pin, and the kv-asset-handler transitive dep wants ≥22 anyway). One-line version bump + comment.

Fix-forward for #389/#440; part of #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)