### PR TITLE
feat(e2e): deterministic oracle module — python -m e2e_oracles (#400)

### DIFF
--- a/backend/e2e_oracles/__init__.py
+++ b/backend/e2e_oracles/__init__.py
@@ -1,0 +1,4 @@
+"""Pure, hermetic oracle modules for the #400 E2E Chapter 2 explore/judge tooling.
+
+No DB, no HTTP, no service imports — stdlib only.
+"""

--- a/backend/e2e_oracles/__main__.py
+++ b/backend/e2e_oracles/__main__.py
@@ -1,0 +1,114 @@
+"""`python -m e2e_oracles` — the #400 E2E Chapter 2 oracle CLI.
+
+Invocation (from `backend/`):
+
+    venv/bin/python -m e2e_oracles [--json] [--check NAME]... [--user ID] \\
+        [--base-url URL] [--log PATH]
+
+Check names: `graph`, `counts`, `ciphertext`, `logscan`, `orphans` — default
+is all five, in that (sorted) order. `--check` may repeat to select a subset.
+
+Exit codes: 0 clean / 1 findings / 2 infra error — a check that raises
+becomes a single `Finding(oracle="oracle-error", ...)` and FORCES exit 2,
+even if every other check came back clean (an infra failure means the run's
+other results can't be trusted either).
+
+`CHECKS` is a thin registry (`name -> Callable[[argparse.Namespace],
+tuple[list[Finding], int]]`) over `gather.run_<name>`; tests monkeypatch this
+dict wholesale with fakes, so `main()` itself never opens a DB connection or
+makes an HTTP call in the hermetic suite. `gather` carries no top-level side
+effects (see its module docstring), so importing it here — needed to build
+`CHECKS` at module scope, before `main()` runs — never trips the
+`load_dotenv`-before-`services.*` ordering the deferred-import pattern
+protects.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from e2e_oracles import gather
+from e2e_oracles.findings import Finding, render_json, render_text
+
+# backend/e2e_oracles/__main__.py -> parents[1] = backend, parents[2] = repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_LOG = _REPO_ROOT / ".e2e" / "backend.log"
+
+CHECKS: dict[str, Callable[[argparse.Namespace], tuple[list[Finding], int]]] = {
+    "graph": lambda args: gather.run_graph(args),
+    "counts": lambda args: gather.run_counts(args),
+    "ciphertext": lambda args: gather.run_ciphertext(args),
+    "logscan": lambda args: gather.run_logscan(args),
+    "orphans": lambda args: gather.run_orphans(args),
+}
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m e2e_oracles",
+        description="Run the #400 E2E Chapter 2 oracles against the local stack.",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    parser.add_argument(
+        "--check",
+        action="append",
+        dest="checks",
+        choices=sorted(CHECKS),
+        help="check to run (repeatable); default: all five",
+    )
+    parser.add_argument("--user", default="rich-user-active", help="user id to check")
+    parser.add_argument(
+        "--base-url", default="http://localhost:5000", help="local backend base URL"
+    )
+    parser.add_argument("--log", default=str(_DEFAULT_LOG), help="backend log path for logscan")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    from dotenv import load_dotenv
+
+    # Must run before any real check imports config/services: populates
+    # SUPABASE_DB_URL / SESSION_SECRET / ENCRYPTION_KEY etc. from backend/.env
+    # (no override — an already-exported shell var still wins) so those
+    # modules see real values instead of freezing empty defaults at import
+    # time. Mirrors tests/integration/conftest.py's load-env-before-services
+    # ordering.
+    load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+    args = _parse_args(argv)
+    selected = args.checks or sorted(CHECKS)
+
+    findings: list[Finding] = []
+    suppressed = 0
+    infra_error = False
+
+    try:
+        for name in selected:
+            check = CHECKS[name]
+            try:
+                check_findings, check_suppressed = check(args)
+            except Exception as exc:  # a crashing check is itself a finding
+                infra_error = True
+                findings.append(
+                    Finding(oracle="oracle-error", summary=f"{name} crashed: {exc}")
+                )
+                continue
+            findings.extend(check_findings)
+            suppressed += check_suppressed
+    finally:
+        gather.close_conn()
+
+    output = render_json(findings, suppressed) if args.json else render_text(findings, suppressed)
+    print(output)
+
+    if infra_error:
+        return 2
+    if findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/e2e_oracles/__main__.py
+++ b/backend/e2e_oracles/__main__.py
@@ -8,10 +8,12 @@ Invocation (from `backend/`):
 Check names: `graph`, `counts`, `ciphertext`, `logscan`, `orphans` — default
 is all five, in that (sorted) order. `--check` may repeat to select a subset.
 
-Exit codes: 0 clean / 1 findings / 2 infra error — a check that raises
-becomes a single `Finding(oracle="oracle-error", ...)` and FORCES exit 2,
-even if every other check came back clean (an infra failure means the run's
-other results can't be trusted either).
+Exit codes: 0 clean / 1 findings / 2 infra error — ANY `Finding(oracle=
+"oracle-error", ...)` FORCES exit 2, even if every other check came back
+clean (an infra failure means the run's other results can't be trusted
+either). A check can produce that finding two ways: by raising (`main()`
+catches it and synthesizes the finding itself) or by returning one directly
+(e.g. `gather.run_logscan`'s missing-log-file case) — both are checked.
 
 `CHECKS` is a thin registry (`name -> Callable[[argparse.Namespace],
 tuple[list[Finding], int]]`) over `gather.run_<name>`; tests monkeypatch this
@@ -97,6 +99,13 @@ def main(argv: list[str] | None = None) -> int:
                 continue
             findings.extend(check_findings)
             suppressed += check_suppressed
+            if any(f.oracle == "oracle-error" for f in check_findings):
+                # A check can signal an infra failure by RETURNING an
+                # oracle-error finding (e.g. run_logscan's missing-log-file
+                # case) rather than raising. Either way it forces exit 2 —
+                # an oracle-error means the run's other results can't be
+                # trusted.
+                infra_error = True
     finally:
         gather.close_conn()
 

--- a/backend/e2e_oracles/findings.py
+++ b/backend/e2e_oracles/findings.py
@@ -1,0 +1,30 @@
+"""Finding record + rendering shared by every #400 oracle."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass
+class Finding:
+    oracle: str  # "graph" | "counts" | "ciphertext" | "logscan" | "orphans" | "oracle-error"
+    summary: str
+    evidence: dict = field(default_factory=dict)
+
+
+def render_text(findings: list[Finding], suppressed: int = 0) -> str:
+    lines = [f"{len(findings)} finding(s), {suppressed} suppressed (allowlisted)."]
+    for f in findings:
+        lines.append(f"[{f.oracle}] {f.summary}")
+        for k, v in f.evidence.items():
+            lines.append(f"    {k}: {v}")
+    return "\n".join(lines)
+
+
+def render_json(findings: list[Finding], suppressed: int = 0) -> str:
+    return json.dumps(
+        {"count": len(findings), "suppressed": suppressed, "findings": [asdict(f) for f in findings]},
+        indent=2,
+        default=str,
+    )

--- a/backend/e2e_oracles/gather.py
+++ b/backend/e2e_oracles/gather.py
@@ -1,0 +1,285 @@
+"""IO gatherers for the #400 E2E Chapter 2 oracle CLI.
+
+Wires the pure judges (`judges.py`) to the live LOCAL stack: one shared
+psycopg connection (opened lazily, on the first check that needs it) and
+plain `httpx` calls authenticated via a minted `sapling_session` cookie
+(`services.session_tokens.mint_session`) — never a hand-rolled token.
+
+Hermetic-safety contract: this module must be importable with no DB, no
+network, and no service imports at module scope. `psycopg`, `httpx`, and
+every `services.*` import are function-local, mirroring
+`tests/integration/conftest.py`'s deferred-import pattern (so the
+`load_dotenv()` call in `__main__.main()` always wins the ordering race
+against `config`/`services` freezing env vars at import time). `gather`
+itself carries no top-level side effects, so importing it eagerly from
+`__main__.py` (to build the `CHECKS` registry) never trips this contract.
+
+Both DB and HTTP entry points refuse anything but the local stack
+(`require_local`, copied semantics from
+`tests/integration/conftest.py:48-84`'s `_db_url_is_local`/
+`_require_local_db_url`): exact-hostname loopback matching so a URL that
+merely *contains* "127.0.0.1" (e.g. `127.0.0.1.evil.com`) is rejected, not
+waved through by a substring check. This CLI runs against a developer's own
+local Supabase stack ONLY — never staging or production.
+
+Decisions baked into the checks below (Task 3, #400):
+
+- `counts` covers BOTH `documents` (`GET /api/documents/user/{id}`) and
+  `notes` (`GET /api/notes/user/{id}`) — `routes/notes.py::list_user_notes`
+  DOES expose a plain per-user list (`{"notes": [...]}`, soft-deleted via
+  `deleted_at`), a shape directly comparable to the documents list, so the
+  brief's documents-only fallback wasn't needed.
+- `orphans` ships all six FK-shaped checks the brief specifies verbatim; every
+  table/column name was verified against `db/migrations/0001_baseline_schema.sql`,
+  `0021_gradebook.sql`, `0023_graph_integrity.sql`, `0025_study_integrity.sql`
+  and `db/seed_local_rich.py` — no renames or drops were needed. Every one of
+  these FKs is DB-enforced today, so a live run should always find zero rows;
+  the checks exist as a defense-in-depth oracle against pre-FK data, partial
+  migrations, or a future schema drift that removes the constraint.
+"""
+
+from __future__ import annotations
+
+import argparse
+from urllib.parse import urlparse
+
+from e2e_oracles import judges
+from e2e_oracles.findings import Finding
+from e2e_oracles.logscan import scan_file
+
+_LOCAL_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+# One shared psycopg connection per CLI run (module-global; a fresh process
+# per invocation, so this never leaks across runs). Opened lazily by the
+# first DB-backed check; closed by `close_conn()` in `__main__.main()`'s
+# `finally`.
+_conn = None
+
+
+def require_local(url: str, label: str) -> None:
+    """Raise `RuntimeError` unless `url`'s hostname is an EXACT loopback match.
+
+    Guards both `SUPABASE_DB_URL` (before any psycopg connect) and
+    `--base-url` (before any HTTP call) — this CLI only ever talks to a
+    developer's own local stack. `label` names the offending setting in the
+    error so a misconfigured env var or flag is easy to trace.
+    """
+    try:
+        host = (urlparse(url).hostname or "").strip().lower()
+    except ValueError:
+        host = ""
+    if host not in _LOCAL_HOSTS:
+        raise RuntimeError(
+            f"REFUSING to use non-local {label} ({url!r}): host {host!r} is not "
+            "one of 127.0.0.1 / localhost / ::1. This CLI only targets a local "
+            "stack, never staging or production."
+        )
+
+
+def _db_conn():
+    """Return the shared psycopg connection, opening it on first use."""
+    global _conn
+    if _conn is None:
+        import os
+
+        import psycopg
+        from psycopg.rows import dict_row
+
+        url = (os.environ.get("SUPABASE_DB_URL") or "").strip()
+        require_local(url, "SUPABASE_DB_URL")
+        _conn = psycopg.connect(url, autocommit=True, row_factory=dict_row)
+    return _conn
+
+
+def close_conn() -> None:
+    """Close the shared connection if one was opened. Safe to call unconditionally."""
+    global _conn
+    if _conn is not None:
+        _conn.close()
+        _conn = None
+
+
+def _authed_get(args: argparse.Namespace, path: str) -> dict:
+    """GET `path` off `args.base_url`, authenticated as `args.user`."""
+    import httpx
+
+    from services.session_tokens import SESSION_COOKIE_NAME, mint_session
+
+    require_local(args.base_url, "--base-url")
+    resp = httpx.get(
+        f"{args.base_url}{path}",
+        cookies={SESSION_COOKIE_NAME: mint_session(args.user)},
+        timeout=15.0,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def run_graph(args: argparse.Namespace) -> tuple[list[Finding], int]:
+    """`graph`: `GET /api/graph/{user}` payload vs the DB (#355 oracle)."""
+    payload = _authed_get(args, f"/api/graph/{args.user}")
+    conn = _db_conn()
+
+    db_nodes = conn.execute(
+        "SELECT id, course_id FROM graph_nodes WHERE user_id = %s", (args.user,)
+    ).fetchall()
+    db_edges = conn.execute(
+        "SELECT id, source_node_id, target_node_id, relationship_type "
+        "FROM graph_edges WHERE user_id = %s",
+        (args.user,),
+    ).fetchall()
+    enrolled_rows = conn.execute(
+        "SELECT DISTINCT co.course_id FROM enrollments e "
+        "JOIN course_offerings co ON co.id = e.offering_id "
+        "WHERE e.user_id = %s",
+        (args.user,),
+    ).fetchall()
+    enrolled_course_ids = {r["course_id"] for r in enrolled_rows}
+
+    findings = judges.graph_findings(payload, db_nodes, db_edges, enrolled_course_ids)
+    return findings, 0
+
+
+def run_counts(args: argparse.Namespace) -> tuple[list[Finding], int]:
+    """`counts`: API-reported list lengths vs the DB's own counts.
+
+    Covers `documents` (`routes/documents.py:370` filters `deleted_at IS
+    NULL`) and `notes` (`routes/notes.py::list_user_notes`, same soft-delete
+    shape) — see the module docstring for why notes wasn't dropped.
+    """
+    conn = _db_conn()
+    findings: list[Finding] = []
+
+    docs_payload = _authed_get(args, f"/api/documents/user/{args.user}")
+    api_doc_count = len(docs_payload.get("documents", []))
+    db_doc_count = conn.execute(
+        "SELECT count(*) AS n FROM documents WHERE user_id = %s AND deleted_at IS NULL",
+        (args.user,),
+    ).fetchone()["n"]
+    findings.extend(judges.count_findings("documents", api_doc_count, db_doc_count))
+
+    notes_payload = _authed_get(args, f"/api/notes/user/{args.user}")
+    api_notes_count = len(notes_payload.get("notes", []))
+    db_notes_count = conn.execute(
+        "SELECT count(*) AS n FROM notes WHERE user_id = %s AND deleted_at IS NULL",
+        (args.user,),
+    ).fetchone()["n"]
+    findings.extend(judges.count_findings("notes", api_notes_count, db_notes_count))
+
+    return findings, 0
+
+
+# (table, pk_col, column) manifest — hardcoded, so identifiers never come from
+# user input; every value is read via a parameterized `%s`, never interpolated.
+_CIPHERTEXT_MANIFEST: tuple[tuple[str, str, str], ...] = (
+    ("users", "id", "email"),
+    ("user_profiles", "user_id", "name"),
+    ("user_profiles", "user_id", "first_name"),
+    ("user_profiles", "user_id", "last_name"),
+    ("messages", "id", "content"),
+    ("room_messages", "id", "text"),
+    ("sessions", "id", "summary_json"),
+    ("documents", "id", "summary"),
+    ("documents", "id", "concept_notes"),
+    ("documents", "id", "extracted_text"),
+    ("notes", "id", "title"),
+    ("notes", "id", "body"),
+    ("notes", "id", "last_summary"),
+    ("assignments", "id", "notes"),
+    ("assignments", "id", "points_possible"),
+    ("assignments", "id", "points_earned"),
+)
+
+
+def run_ciphertext(args: argparse.Namespace) -> tuple[list[Finding], int]:
+    """`ciphertext`: sample rows off `_CIPHERTEXT_MANIFEST`, decrypt-and-compare."""
+    from services.encryption import decrypt
+
+    conn = _db_conn()
+    findings: list[Finding] = []
+    for table, pk_col, column in _CIPHERTEXT_MANIFEST:
+        # Identifiers come only from the hardcoded manifest above, never from
+        # user input — safe to interpolate directly into SQL text.
+        rows = conn.execute(
+            f'SELECT "{pk_col}", "{column}" FROM "{table}" '
+            f'WHERE "{column}" IS NOT NULL LIMIT 50'
+        ).fetchall()
+        pairs = [(r[pk_col], r[column]) for r in rows]
+        findings.extend(judges.ciphertext_findings(table, column, pairs, decrypt))
+    return findings, 0
+
+
+# (check_name, SQL) — each a LEFT JOIN selecting up to 20 orphaned parent-row
+# ids whose referenced row is missing. Verified against
+# db/migrations/{0001_baseline_schema,0021_gradebook,0023_graph_integrity,
+# 0025_study_integrity}.sql and db/seed_local_rich.py's _SUMMARY_ORDER.
+_ORPHAN_CHECKS: tuple[tuple[str, str], ...] = (
+    (
+        "graph_edges->graph_nodes",
+        "SELECT ge.id AS id FROM graph_edges ge "
+        "LEFT JOIN graph_nodes gs ON gs.id = ge.source_node_id "
+        "LEFT JOIN graph_nodes gt ON gt.id = ge.target_node_id "
+        "WHERE gs.id IS NULL OR gt.id IS NULL LIMIT 20",
+    ),
+    (
+        "node_mastery_events->graph_nodes",
+        "SELECT nme.id AS id FROM node_mastery_events nme "
+        "LEFT JOIN graph_nodes n ON n.id = nme.node_id "
+        "WHERE n.id IS NULL LIMIT 20",
+    ),
+    (
+        "messages->sessions",
+        "SELECT m.id AS id FROM messages m "
+        "LEFT JOIN sessions s ON s.id = m.session_id "
+        "WHERE s.id IS NULL LIMIT 20",
+    ),
+    (
+        "enrollments->course_offerings",
+        "SELECT e.id AS id FROM enrollments e "
+        "LEFT JOIN course_offerings co ON co.id = e.offering_id "
+        "WHERE co.id IS NULL LIMIT 20",
+    ),
+    (
+        "documents->users",
+        "SELECT d.id AS id FROM documents d "
+        "LEFT JOIN users u ON u.id = d.user_id "
+        "WHERE u.id IS NULL LIMIT 20",
+    ),
+    (
+        "room_messages->rooms",
+        "SELECT rm.id AS id FROM room_messages rm "
+        "LEFT JOIN rooms r ON r.id = rm.room_id "
+        "WHERE r.id IS NULL LIMIT 20",
+    ),
+)
+
+
+def run_orphans(args: argparse.Namespace) -> tuple[list[Finding], int]:
+    """`orphans`: dangling-FK sweeps over `_ORPHAN_CHECKS`."""
+    conn = _db_conn()
+    findings: list[Finding] = []
+    for check_name, sql in _ORPHAN_CHECKS:
+        rows = conn.execute(sql).fetchall()
+        orphan_ids = [r["id"] for r in rows]
+        findings.extend(judges.orphan_findings(check_name, orphan_ids))
+    return findings, 0
+
+
+def run_logscan(args: argparse.Namespace) -> tuple[list[Finding], int]:
+    """`logscan`: scan `args.log` for 5xx responses and tracebacks.
+
+    A missing log file is itself an `oracle-error` finding — most likely
+    the local stack isn't up rather than a real logscan result.
+    """
+    from pathlib import Path
+
+    log_path = Path(args.log)
+    if not log_path.exists():
+        return [
+            Finding(
+                oracle="oracle-error",
+                summary=f"logscan: log file not found at {log_path} (is the stack up?)",
+                evidence={"path": str(log_path)},
+            )
+        ], 0
+    return scan_file(log_path)

--- a/backend/e2e_oracles/judges.py
+++ b/backend/e2e_oracles/judges.py
@@ -1,0 +1,181 @@
+"""Pure judges for the #400 E2E Chapter 2 oracle module.
+
+No IO, no service imports at module level — every judge is a plain function
+over already-gathered data (payload dict / DB rows / counts) that returns
+`Finding`s. Task 3 wires these to SQL/HTTP gatherers; the ciphertext judge
+takes `decrypt_fn` as a parameter so this module never imports
+`services.encryption` (or any other service) itself.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable
+
+from e2e_oracles.findings import Finding
+
+
+def _duplicates(ids: list[str]) -> dict[str, int]:
+    return {k: v for k, v in Counter(ids).items() if v > 1}
+
+
+def graph_findings(
+    payload: dict,
+    db_nodes: list[dict],
+    db_edges: list[dict],
+    enrolled_course_ids: set[str],
+) -> list[Finding]:
+    """Check `GET /api/graph/{user_id}` payload shape against the DB (#355 oracle).
+
+    `payload` is `{"nodes": [...], "edges": [...], "stats": {...}}`. Synthesized
+    subject roots are `subject_root__{course_id}`; spokes are
+    `subject_edge__subject_root__{course_id}__{node_id}`.
+    """
+    findings: list[Finding] = []
+
+    payload_nodes = payload.get("nodes", [])
+    payload_edges = payload.get("edges", [])
+    payload_node_ids = [n["id"] for n in payload_nodes]
+    payload_edge_ids = [e["id"] for e in payload_edges]
+
+    node_id_dupes = _duplicates(payload_node_ids)
+    if node_id_dupes:
+        findings.append(
+            Finding(
+                oracle="graph",
+                summary=f"Duplicate payload node ids: {sorted(node_id_dupes)}",
+                evidence={"duplicates": node_id_dupes},
+            )
+        )
+
+    edge_id_dupes = _duplicates(payload_edge_ids)
+    if edge_id_dupes:
+        findings.append(
+            Finding(
+                oracle="graph",
+                summary=f"Duplicate payload edge ids: {sorted(edge_id_dupes)}",
+                evidence={"duplicates": edge_id_dupes},
+            )
+        )
+
+    db_node_ids = {n["id"] for n in db_nodes}
+    expected_node_count = len(db_nodes) + len(enrolled_course_ids)
+    payload_node_count = len(payload_nodes)
+    if payload_node_count != expected_node_count:
+        findings.append(
+            Finding(
+                oracle="graph",
+                summary=(
+                    f"Node count mismatch: payload={payload_node_count} "
+                    f"expected={expected_node_count}"
+                ),
+                evidence={"payload": payload_node_count, "expected": expected_node_count},
+            )
+        )
+
+    drawable = sum(
+        1
+        for e in db_edges
+        if e["source_node_id"] in db_node_ids and e["target_node_id"] in db_node_ids
+    )
+    spokes = sum(1 for n in db_nodes if n.get("course_id") in enrolled_course_ids)
+    expected_edge_count = drawable + spokes
+    payload_edge_count = len(payload_edges)
+    if payload_edge_count != expected_edge_count:
+        findings.append(
+            Finding(
+                oracle="graph",
+                summary=(
+                    f"Edge count mismatch: payload={payload_edge_count} "
+                    f"expected={expected_edge_count}"
+                ),
+                evidence={"payload": payload_edge_count, "expected": expected_edge_count},
+            )
+        )
+
+    root_counts = Counter(n for n in payload_node_ids if n.startswith("subject_root__"))
+    for course_id in sorted(enrolled_course_ids):
+        root_id = f"subject_root__{course_id}"
+        count = root_counts.get(root_id, 0)
+        if count != 1:
+            findings.append(
+                Finding(
+                    oracle="graph",
+                    summary=f"{root_id} appears {count} times (expected 1)",
+                    evidence={"root_id": root_id, "count": count},
+                )
+            )
+
+    return findings
+
+
+def ciphertext_findings(
+    table: str,
+    column: str,
+    rows: list[tuple],
+    decrypt_fn: Callable[[str], str],
+) -> list[Finding]:
+    """Flag rows in `table.column` that are not encrypted at rest.
+
+    `rows` are `(pk, value)`. A value is "encrypted at rest" iff
+    `decrypt_fn(value)` succeeds AND the plaintext differs from the raw value.
+    Non-str values are findings too. Evidence truncates the raw value to 32
+    chars so a possibly-plaintext value is never fully leaked into reports.
+    """
+    findings: list[Finding] = []
+    for pk, value in rows:
+        if not isinstance(value, str):
+            findings.append(
+                Finding(
+                    oracle="ciphertext",
+                    summary=f"{table}.{column} non-string value at rest (pk={pk})",
+                    evidence={"pk": pk, "value_prefix": str(value)[:32]},
+                )
+            )
+            continue
+        try:
+            plain = decrypt_fn(value)
+        except Exception:
+            findings.append(
+                Finding(
+                    oracle="ciphertext",
+                    summary=f"{table}.{column} not encrypted at rest (pk={pk})",
+                    evidence={"pk": pk, "value_prefix": value[:32]},
+                )
+            )
+            continue
+        if plain == value:
+            findings.append(
+                Finding(
+                    oracle="ciphertext",
+                    summary=f"{table}.{column} not encrypted at rest (pk={pk})",
+                    evidence={"pk": pk, "value_prefix": value[:32]},
+                )
+            )
+    return findings
+
+
+def count_findings(name: str, api_count: int, db_count: int) -> list[Finding]:
+    """Flag a mismatch between an API-reported count and the DB's own count."""
+    if api_count == db_count:
+        return []
+    return [
+        Finding(
+            oracle="counts",
+            summary=f"{name} count mismatch: api={api_count} db={db_count}",
+            evidence={"api_count": api_count, "db_count": db_count},
+        )
+    ]
+
+
+def orphan_findings(check_name: str, orphan_ids: list) -> list[Finding]:
+    """Flag rows whose foreign key points nowhere, e.g. `graph_edges→graph_nodes`."""
+    if not orphan_ids:
+        return []
+    return [
+        Finding(
+            oracle="orphans",
+            summary=f"{check_name}: {len(orphan_ids)} orphaned row(s)",
+            evidence={"sample_ids": orphan_ids},
+        )
+    ]

--- a/backend/e2e_oracles/judges.py
+++ b/backend/e2e_oracles/judges.py
@@ -134,17 +134,10 @@ def ciphertext_findings(
             )
             continue
         try:
-            plain = decrypt_fn(value)
+            not_encrypted = decrypt_fn(value) == value
         except Exception:
-            findings.append(
-                Finding(
-                    oracle="ciphertext",
-                    summary=f"{table}.{column} not encrypted at rest (pk={pk})",
-                    evidence={"pk": pk, "value_prefix": value[:32]},
-                )
-            )
-            continue
-        if plain == value:
+            not_encrypted = True
+        if not_encrypted:
             findings.append(
                 Finding(
                     oracle="ciphertext",

--- a/backend/e2e_oracles/logscan.py
+++ b/backend/e2e_oracles/logscan.py
@@ -30,11 +30,16 @@ _PLAIN_TRACEBACK_START_RE = re.compile(r"^[\s|+]*Traceback \(most recent call la
 _BLOCK_START_SUBSTRINGS = ("Exception in ASGI application", "Exception Group Traceback")
 
 # A line that unambiguously starts a *new* log record — closes an open block.
-NEW_LOG_LINE_RE = re.compile(r"^(INFO|ERROR|WARNING|DEBUG|CRITICAL):|^\d{4}-\d{2}-\d{2} ")
+# The third alternative is the post-ANSI-strip shape of the pre-request log line
+# (e.g. "22:17:08.488 GET /api/health") — scanning runs after ANSI stripping.
+NEW_LOG_LINE_RE = re.compile(
+    r"^(INFO|ERROR|WARNING|DEBUG|CRITICAL):|^\d{4}-\d{2}-\d{2} |^\d{2}:\d{2}:\d{2}\.\d+ "
+)
 
-# The line within a traceback block that names the exception, e.g. "ValueError: boom"
-# or "    | KeyError: 'z'" (ExceptionGroup gutter prefix).
-KEY_RE = re.compile(r"^[\s|+]*\w+(\.\w+)*(Error|Exception|Interrupt|Exit)\b.*")
+# The line within a traceback block that names the exception, e.g. "ValueError: boom",
+# a bare "Exception: boom", or "    | KeyError: 'z'" (ExceptionGroup gutter prefix).
+# The class-name prefix is optional so bare Error:/Exception:/etc. lines still match.
+KEY_RE = re.compile(r"^[\s|+]*(?:\w+(?:\.\w+)*)?(?:Error|Exception|Interrupt|Exit)\b.*")
 
 # #439 by-design noise: RAG indexing failures are retried and logged loudly but
 # don't represent a user-facing bug. Suppressed (counted, not reported).

--- a/backend/e2e_oracles/logscan.py
+++ b/backend/e2e_oracles/logscan.py
@@ -1,0 +1,166 @@
+"""Backend-log scanner for the #400 E2E Chapter 2 oracle module.
+
+Scans `.e2e/backend.log` (uvicorn's combined stdout+stderr) for two signal
+shapes: 5xx responses (uvicorn access log or the app's ADR-0009 request
+logger) and tracebacks (plain, uvicorn ASGI, or ExceptionGroup/TaskGroup
+form). Identical signals are aggregated by key so a flaky retry loop
+produces one Finding, not a thousand. Pure stdlib, streaming — never
+slurps the whole file.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import deque
+from collections.abc import Iterable
+from pathlib import Path
+
+from e2e_oracles.findings import Finding
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+# Uvicorn access log: 'INFO:     1.2.3.4:5 - "POST /path HTTP/1.1" 500 ...'
+ACCESS_RE = re.compile(r'"(?P<method>[A-Z]+) (?P<path>\S+) HTTP/[^"]*" (?P<status>5\d\d)')
+
+# App request logger (ADR 0009): '... [ERROR] sapling.request: [<id>] GET /path -> 500 (23.0ms)'
+REQLOG_RE = re.compile(r"\] (?P<method>[A-Z]+) (?P<path>\S+) -> (?P<status>5\d\d) ")
+
+# Traceback block start.
+_PLAIN_TRACEBACK_START_RE = re.compile(r"^[\s|+]*Traceback \(most recent call last\):")
+_BLOCK_START_SUBSTRINGS = ("Exception in ASGI application", "Exception Group Traceback")
+
+# A line that unambiguously starts a *new* log record — closes an open block.
+NEW_LOG_LINE_RE = re.compile(r"^(INFO|ERROR|WARNING|DEBUG|CRITICAL):|^\d{4}-\d{2}-\d{2} ")
+
+# The line within a traceback block that names the exception, e.g. "ValueError: boom"
+# or "    | KeyError: 'z'" (ExceptionGroup gutter prefix).
+KEY_RE = re.compile(r"^[\s|+]*\w+(\.\w+)*(Error|Exception|Interrupt|Exit)\b.*")
+
+# #439 by-design noise: RAG indexing failures are retried and logged loudly but
+# don't represent a user-facing bug. Suppressed (counted, not reported).
+ALLOWLIST = (re.compile(r"\[RAG\] _index_document_chunks failed"),)
+
+_MAX_EXCERPT_LINES = 20
+_CONTEXT_LINES = 5
+
+
+def _clean(raw_line: str) -> str:
+    return ANSI_RE.sub("", raw_line).rstrip("\n")
+
+
+def _is_block_start(line: str) -> bool:
+    if _PLAIN_TRACEBACK_START_RE.match(line):
+        return True
+    return any(sub in line for sub in _BLOCK_START_SUBSTRINGS)
+
+
+def _block_key(block_lines: list[str]) -> str:
+    key = None
+    for line in block_lines:
+        if KEY_RE.match(line):
+            key = line
+    if key is None:
+        key = block_lines[0] if block_lines else ""
+    return key
+
+
+def _block_summary(key: str, count: int) -> str:
+    clean_key = re.sub(r"^[\s|+]*", "", key).strip()
+    return f"Traceback: {clean_key} ({count}×)"
+
+
+def scan_lines(lines: Iterable[str]) -> tuple[list[Finding], int]:
+    """Scan an iterable of raw log lines for 5xx responses and tracebacks.
+
+    Returns (findings, suppressed_count). Aggregates repeated identical
+    signals (same route+status, or same exception key) into a single
+    Finding with a `count` in evidence.
+    """
+    fivexx: dict[tuple[str, str, str], dict] = {}
+    blocks: dict[str, dict] = {}
+    suppressed_count = 0
+    context: deque[str] = deque(maxlen=_CONTEXT_LINES)
+
+    in_block = False
+    block_lines: list[str] = []
+    block_start_line_no = 0
+
+    def close_block() -> None:
+        nonlocal in_block, block_lines, block_start_line_no, suppressed_count
+        if not in_block:
+            return
+        block_text = "\n".join(block_lines)
+        allowlisted = any(rx.search(block_text) for rx in ALLOWLIST) or any(
+            rx.search(ctx_line) for ctx_line in context for rx in ALLOWLIST
+        )
+        if allowlisted:
+            suppressed_count += 1
+        else:
+            key = _block_key(block_lines)
+            agg = blocks.setdefault(
+                key,
+                {"count": 0, "first_line": block_start_line_no, "lines": list(block_lines)},
+            )
+            agg["count"] += 1
+        in_block = False
+        block_lines = []
+
+    for line_no, raw_line in enumerate(lines, start=1):
+        stripped = _clean(raw_line)
+
+        if in_block:
+            if NEW_LOG_LINE_RE.match(stripped):
+                close_block()
+                # fall through: this line is re-processed normally below —
+                # it may itself start the next block.
+            else:
+                block_lines.append(stripped)
+                continue
+
+        if _is_block_start(stripped):
+            in_block = True
+            block_lines = [stripped]
+            block_start_line_no = line_no
+            continue
+
+        match = ACCESS_RE.search(stripped) or REQLOG_RE.search(stripped)
+        if match:
+            key = (match.group("method"), match.group("path"), match.group("status"))
+            agg = fivexx.setdefault(key, {"count": 0, "first_line": line_no})
+            agg["count"] += 1
+
+        context.append(stripped)
+
+    close_block()
+
+    findings: list[Finding] = []
+
+    for (method, path, status), agg in fivexx.items():
+        findings.append(
+            Finding(
+                oracle="logscan",
+                summary=f"{status} on {method} {path} ({agg['count']}×)",
+                evidence={"count": agg["count"], "first_line": agg["first_line"]},
+            )
+        )
+
+    for key, agg in blocks.items():
+        findings.append(
+            Finding(
+                oracle="logscan",
+                summary=_block_summary(key, agg["count"]),
+                evidence={
+                    "count": agg["count"],
+                    "first_line": agg["first_line"],
+                    "excerpt": agg["lines"][:_MAX_EXCERPT_LINES],
+                },
+            )
+        )
+
+    return findings, suppressed_count
+
+
+def scan_file(path: str | Path) -> tuple[list[Finding], int]:
+    """Stream `path` line-by-line through `scan_lines`. Never slurps the file."""
+    with Path(path).open("r", errors="replace") as f:
+        return scan_lines(f)

--- a/backend/services/encryption.py
+++ b/backend/services/encryption.py
@@ -20,10 +20,15 @@ ROLLOUT NOTES
        assignments.points_earned   NUMERIC -> TEXT
        documents.concept_notes     JSONB   -> TEXT
    These migrations are tracked separately and are NOT part of this rollout.
-3. The following fields are referenced in the spec but were NOT marked in the
-   prior pass and are therefore not encrypted yet: messages.content (text),
-   room_messages.text, sessions.summary_json. Add markers + wire encryption in
-   a follow-up before any compliance review.
+3. messages.content, room_messages.text, and sessions.summary_json ARE
+   encrypted — this note previously claimed otherwise, which was stale
+   documentation rather than a real gap. All three are wired at write time
+   (see the "🔒" markers in db/seed_local_rich.py, which calls
+   encrypt_if_present for messages.content/room_messages.text and
+   encrypt_json for sessions.summary_json) and are listed as encrypted in
+   the root CLAUDE.md Gotchas section. frontend/e2e/tutor.spec.ts and
+   frontend/e2e/study-room.spec.ts additionally assert ciphertext-at-rest
+   for messages.content and room_messages.text against the live stack.
 """
 from __future__ import annotations
 

--- a/backend/tests/test_e2e_oracles_cli.py
+++ b/backend/tests/test_e2e_oracles_cli.py
@@ -1,0 +1,63 @@
+"""Hermetic tests for the #400 CLI: registry wiring, guards, exit codes."""
+
+import pytest
+
+from e2e_oracles import __main__ as cli
+from e2e_oracles.findings import Finding
+from e2e_oracles.gather import require_local
+
+
+def test_require_local_accepts_loopback_hosts():
+    require_local("postgresql://postgres:postgres@127.0.0.1:54322/postgres", "db")
+    require_local("http://localhost:5000", "base-url")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "postgresql://u:p@db.abcdef.supabase.co:5432/postgres",
+        "postgresql://u:p@127.0.0.1.evil.com/postgres",
+        "http://sapling.example.com",
+    ],
+)
+def test_require_local_rejects_non_loopback(url):
+    with pytest.raises(RuntimeError):
+        require_local(url, "db")
+
+
+def _fake_check(findings, suppressed=0):
+    def run(args):
+        return findings, suppressed
+
+    return run
+
+
+def test_exit_zero_when_all_checks_clean(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "CHECKS", {"logscan": _fake_check([])})
+    assert cli.main(["--check", "logscan"]) == 0
+    assert "0 finding" in capsys.readouterr().out
+
+
+def test_exit_one_with_findings_and_json_output(monkeypatch, capsys):
+    f = Finding(oracle="graph", summary="node count 18 != 17", evidence={"payload": 18})
+    monkeypatch.setattr(cli, "CHECKS", {"graph": _fake_check([f])})
+    assert cli.main(["--check", "graph", "--json"]) == 1
+    import json
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["count"] == 1
+    assert payload["findings"][0]["summary"].startswith("node count")
+
+
+def test_exit_two_when_a_check_raises(monkeypatch, capsys):
+    def boom(args):
+        raise RuntimeError("db unreachable")
+
+    monkeypatch.setattr(cli, "CHECKS", {"orphans": boom})
+    assert cli.main(["--check", "orphans"]) == 2
+    assert "oracle-error" in capsys.readouterr().out
+
+
+def test_unknown_check_name_rejected():
+    with pytest.raises(SystemExit):
+        cli.main(["--check", "nope"])

--- a/backend/tests/test_e2e_oracles_cli.py
+++ b/backend/tests/test_e2e_oracles_cli.py
@@ -58,6 +58,17 @@ def test_exit_two_when_a_check_raises(monkeypatch, capsys):
     assert "oracle-error" in capsys.readouterr().out
 
 
+def test_exit_two_when_a_check_returns_oracle_error_finding(monkeypatch, capsys):
+    # A check can RETURN an oracle-error finding (e.g. logscan's missing-log-
+    # file case) instead of raising. That must force exit 2 too — an
+    # oracle-error means the run's other results can't be trusted, whether
+    # the check signaled it via an exception or via its own return value.
+    f = Finding(oracle="oracle-error", summary="logscan: log file not found (is the stack up?)")
+    monkeypatch.setattr(cli, "CHECKS", {"logscan": _fake_check([f])})
+    assert cli.main(["--check", "logscan"]) == 2
+    assert "oracle-error" in capsys.readouterr().out
+
+
 def test_unknown_check_name_rejected():
     with pytest.raises(SystemExit):
         cli.main(["--check", "nope"])

--- a/backend/tests/test_e2e_oracles_judges.py
+++ b/backend/tests/test_e2e_oracles_judges.py
@@ -1,0 +1,81 @@
+"""Hermetic tests for the #400 pure judges."""
+
+from e2e_oracles.judges import (
+    ciphertext_findings,
+    count_findings,
+    graph_findings,
+    orphan_findings,
+)
+
+COURSES = {"c-cs", "c-math"}
+DB_NODES = [
+    {"id": "n1", "course_id": "c-cs"},
+    {"id": "n2", "course_id": "c-cs"},
+    {"id": "n3", "course_id": "c-math"},
+]
+DB_EDGES = [
+    {"source_node_id": "n1", "target_node_id": "n2", "relationship_type": "prerequisite"},
+    {"source_node_id": "n1", "target_node_id": "ghost", "relationship_type": "related"},
+]
+
+
+def _correct_payload():
+    nodes = [{"id": n["id"]} for n in DB_NODES]
+    nodes += [{"id": "subject_root__c-cs"}, {"id": "subject_root__c-math"}]
+    edges = [{"id": "e1"}]  # the one drawable db edge (n1->n2)
+    edges += [
+        {"id": "subject_edge__subject_root__c-cs__n1"},
+        {"id": "subject_edge__subject_root__c-cs__n2"},
+        {"id": "subject_edge__subject_root__c-math__n3"},
+    ]
+    return {"nodes": nodes, "edges": edges, "stats": {}}
+
+
+def test_correct_payload_yields_no_findings():
+    assert graph_findings(_correct_payload(), DB_NODES, DB_EDGES, COURSES) == []
+
+
+def test_355_shape_duplicate_root_and_spokes_all_reported():
+    p = _correct_payload()
+    p["nodes"].append({"id": "subject_root__c-cs"})  # dup hub
+    p["edges"] += [
+        {"id": "subject_edge__subject_root__c-cs__n1"},
+        {"id": "subject_edge__subject_root__c-cs__n2"},
+    ]
+    fs = graph_findings(p, DB_NODES, DB_EDGES, COURSES)
+    summaries = " | ".join(f.summary for f in fs)
+    assert "subject_root__c-cs" in summaries          # dup id named
+    assert any("node count" in f.summary.lower() for f in fs)
+    assert any("edge count" in f.summary.lower() for f in fs)
+    assert all(f.oracle == "graph" for f in fs)
+
+
+def test_missing_subject_root_reported():
+    p = _correct_payload()
+    p["nodes"] = [n for n in p["nodes"] if n["id"] != "subject_root__c-math"]
+    fs = graph_findings(p, DB_NODES, DB_EDGES, COURSES)
+    assert any("subject_root__c-math" in f.summary for f in fs)
+
+
+def test_ciphertext_judge_flags_plaintext_and_passes_real_ciphertext():
+    from services.encryption import decrypt, encrypt
+
+    rows = [("row1", encrypt("hello")), ("row2", "just plaintext"), ("row3", {"a": 1})]
+    fs = ciphertext_findings("notes", "body", rows, decrypt)
+    assert len(fs) == 2
+    pks = {f.evidence["pk"] for f in fs}
+    assert pks == {"row2", "row3"}
+    # Raw value must be truncated in evidence, never full
+    assert all(len(str(f.evidence.get("value_prefix", ""))) <= 32 for f in fs)
+
+
+def test_count_judge():
+    assert count_findings("documents", 3, 3) == []
+    (f,) = count_findings("documents", 4, 3)
+    assert "documents" in f.summary and f.evidence == {"api_count": 4, "db_count": 3}
+
+
+def test_orphan_judge():
+    assert orphan_findings("graph_edges→graph_nodes", []) == []
+    (f,) = orphan_findings("graph_edges→graph_nodes", ["e-9"])
+    assert "graph_edges" in f.summary and f.evidence["sample_ids"] == ["e-9"]

--- a/backend/tests/test_e2e_oracles_logscan.py
+++ b/backend/tests/test_e2e_oracles_logscan.py
@@ -36,6 +36,22 @@ RAG_TRACEBACK = [
     "    raise RuntimeError(\"embed failed\")",
     "RuntimeError: embed failed",
 ]
+BARE_EXCEPTION_TRACEBACK_1 = [
+    "Traceback (most recent call last):",
+    '  File "/app/routes/quiz.py", line 12, in start',
+    "Exception: boom",
+]
+BARE_EXCEPTION_TRACEBACK_2 = [
+    "Traceback (most recent call last):",
+    '  File "/app/routes/other.py", line 20, in other',
+    "Exception: totally different",
+]
+RUNTIME_ERROR_TRACEBACK = [
+    "Traceback (most recent call last):",
+    '  File "/app/routes/other.py", line 5, in handler',
+    "    raise RuntimeError(\"nope\")",
+    "RuntimeError: nope",
+]
 
 
 def _scan(lines):
@@ -101,6 +117,39 @@ def test_4xx_and_startup_noise_are_not_findings():
         ]
     )
     assert findings == []
+
+
+def test_bare_exception_terminal_lines_are_distinct_findings():
+    # Finding 1 (logscan.py:37): KEY_RE requires a class-name prefix before
+    # Error/Exception/Interrupt/Exit, so bare "Exception: ..." terminal lines
+    # never match and _block_key falls back to block_lines[0] — the generic
+    # "Traceback (most recent call last):" line — aggregating two unrelated
+    # tracebacks into one finding.
+    findings, _ = _scan(BARE_EXCEPTION_TRACEBACK_1 + [ACCESS_200] + BARE_EXCEPTION_TRACEBACK_2)
+    assert len(findings) == 2
+    summaries = {f.summary for f in findings}
+    assert len(summaries) == 2
+    assert not any(s == "Traceback: Traceback (most recent call last): (1×)" for s in summaries)
+    assert any("boom" in s for s in summaries)
+    assert any("totally different" in s for s in summaries)
+
+
+def test_ansi_pre_request_line_closes_traceback_block():
+    # Finding 2 (logscan.py:33): NEW_LOG_LINE_RE doesn't recognize the
+    # post-ANSI-strip "HH:MM:SS.mmm " pre-request line shape, so it gets
+    # swallowed into an open traceback block instead of closing it.
+    findings, _ = _scan(PLAIN_TRACEBACK + [ANSI_LINE, ACCESS_200])
+    assert len(findings) == 1
+    excerpt = "\n".join(findings[0].evidence["excerpt"])
+    assert "GET /api/health" not in excerpt
+
+
+def test_ansi_pre_request_line_between_two_tracebacks_yields_two_findings():
+    findings, _ = _scan(PLAIN_TRACEBACK + [ANSI_LINE] + RUNTIME_ERROR_TRACEBACK)
+    assert len(findings) == 2
+    summaries = {f.summary for f in findings}
+    assert any("ValueError: boom" in s for s in summaries)
+    assert any("RuntimeError: nope" in s for s in summaries)
 
 
 def test_render_text_and_json_roundtrip():

--- a/backend/tests/test_e2e_oracles_logscan.py
+++ b/backend/tests/test_e2e_oracles_logscan.py
@@ -1,0 +1,114 @@
+"""Hermetic tests for the #400 backend-log scanner. No stack, no DB."""
+
+from e2e_oracles.findings import Finding, render_json, render_text  # noqa: F401 — Finding is part of the public interface under test
+from e2e_oracles.logscan import scan_lines
+
+ACCESS_500 = (
+    'INFO:     127.0.0.1:53354 - "POST /api/graph/rich-user-active/'
+    'concept-description HTTP/1.1" 500 Internal Server Error'
+)
+ACCESS_200 = 'INFO:     127.0.0.1:45290 - "GET /api/health HTTP/1.1" 200 OK'
+REQLOG_500 = (
+    "2026-07-27 22:17:25,882 [ERROR] sapling.request: "
+    "[55bf1ed0-a791-4beb-ab1a-5e3c06cb78ef] GET /api/quiz/start -> 500 (23.0ms)"
+)
+ANSI_LINE = "\x1b[32m22:17:08.488\x1b[0m GET /api/health"
+
+PLAIN_TRACEBACK = [
+    "Traceback (most recent call last):",
+    '  File "/app/routes/quiz.py", line 12, in start',
+    "    raise ValueError(\"boom\")",
+    "ValueError: boom",
+]
+GROUP_TRACEBACK = [
+    "2026-07-27 22:17:47,900 [ERROR] main: Unhandled exception",
+    "  + Exception Group Traceback (most recent call last):",
+    '  |   File "/app/main.py", line 1, in x',
+    "    | Traceback (most recent call last):",
+    '    |   File "/app/services/y.py", line 2, in y',
+    "    | KeyError: 'z'",
+]
+RAG_TRACEBACK = [
+    "2026-07-27 22:17:51,318 [ERROR] routes.documents: [RAG] "
+    "_index_document_chunks failed for doc 0b65",
+    "Traceback (most recent call last):",
+    '  File "/app/routes/documents.py", line 9, in _index_document_chunks',
+    "    raise RuntimeError(\"embed failed\")",
+    "RuntimeError: embed failed",
+]
+
+
+def _scan(lines):
+    return scan_lines(iter(lines))
+
+
+def test_clean_log_yields_no_findings():
+    findings, suppressed = _scan([ACCESS_200, ANSI_LINE, "INFO:     Application startup complete."])
+    assert findings == []
+    assert suppressed == 0
+
+
+def test_access_log_5xx_is_a_finding_aggregated_by_route():
+    findings, _ = _scan([ACCESS_500, ACCESS_200, ACCESS_500])
+    assert len(findings) == 1
+    (f,) = findings
+    assert f.oracle == "logscan"
+    assert "500" in f.summary and "/api/graph/rich-user-active/concept-description" in f.summary
+    assert f.evidence["count"] == 2
+
+
+def test_request_logger_5xx_is_a_finding():
+    findings, _ = _scan([REQLOG_500])
+    assert len(findings) == 1
+    assert "/api/quiz/start" in findings[0].summary
+
+
+def test_ansi_wrapped_5xx_still_detected():
+    findings, _ = _scan(["\x1b[31m" + ACCESS_500 + "\x1b[0m"])
+    assert len(findings) == 1
+
+
+def test_plain_traceback_is_a_finding_keyed_by_exception_line():
+    findings, _ = _scan(PLAIN_TRACEBACK)
+    assert len(findings) == 1
+    assert "ValueError: boom" in findings[0].summary
+
+
+def test_exception_group_traceback_is_a_finding():
+    findings, _ = _scan(GROUP_TRACEBACK)
+    assert len(findings) == 1
+    assert "KeyError" in findings[0].summary
+
+
+def test_repeated_identical_tracebacks_aggregate():
+    findings, _ = _scan(PLAIN_TRACEBACK + [ACCESS_200] + PLAIN_TRACEBACK)
+    assert len(findings) == 1
+    assert findings[0].evidence["count"] == 2
+
+
+def test_rag_index_traceback_is_suppressed_not_reported():
+    findings, suppressed = _scan(RAG_TRACEBACK)
+    assert findings == []
+    assert suppressed == 1
+
+
+def test_4xx_and_startup_noise_are_not_findings():
+    findings, _ = _scan(
+        [
+            'INFO:     127.0.0.1:1 - "GET /api/nope HTTP/1.1" 404 Not Found',
+            "2026-07-27 22:17:08,060 [INFO] httpx: HTTP Request: POST "
+            'http://127.0.0.1:54321/storage/v1/bucket "HTTP/1.1 400 Bad Request"',
+        ]
+    )
+    assert findings == []
+
+
+def test_render_text_and_json_roundtrip():
+    findings, suppressed = _scan([ACCESS_500])
+    text = render_text(findings, suppressed)
+    assert "1 finding" in text
+    import json
+
+    payload = json.loads(render_json(findings, suppressed))
+    assert payload["count"] == 1
+    assert payload["findings"][0]["oracle"] == "logscan"


### PR DESCRIPTION
Chapter 2 of the E2E program (epic #403), PR 1 of 3. Closes #400.

Adds `backend/e2e_oracles/` — deterministic checks the exploratory-testing harness (#399, next PR) invokes mid-session and post-session. The LLM explores; these oracles decide what counts as a finding.

## What's here

- `findings.py` — shared `Finding` record + text/JSON rendering.
- `logscan.py` — streaming scan of `.e2e/backend.log`: 5xx from both the uvicorn access log and the `sapling.request` correlation lines (aggregated per route), traceback blocks in all three observed shapes (bare, ASGI, ExceptionGroup `+`/`|` gutters), ANSI-stripped, with the #439 RAG-indexing noise allowlisted (suppressed + counted, never findings).
- `judges.py` — pure functions: graph payload integrity vs DB (the #355 oracle — duplicate node/edge ids, expected counts = db nodes + distinct enrolled courses / drawable edges + spokes, per-course subject-root multiplicity), ciphertext-at-rest (decrypt-must-succeed-and-differ; injected decrypt_fn), API-vs-DB count integrity, orphaned rows.
- `gather.py` + `__main__.py` — the CLI: `venv/bin/python -m e2e_oracles [--json] [--check graph|counts|ciphertext|logscan|orphans] [--user] [--base-url] [--log]`. Exit 0 clean / 1 findings / 2 infra error. Raw SQL (psycopg, SELECT-only) is sanctioned here as test tooling, mirroring `tests/integration/conftest.py`: same exact-hostname loopback guards (raise, never skip) on both `SUPABASE_DB_URL` and `--base-url`; session minted via `services.session_tokens`.
- 20 hermetic tests (no stack, no DB — the `CHECKS` registry is monkeypatched).
- One drive-by: corrected the stale "not encrypted yet" rollout note in `services/encryption.py` — `messages.content` / `room_messages.text` / `sessions.summary_json` are encrypted (seeder + Chapter 1 journeys prove it at rest).

## Live verification (evidence in the SDD report)

Against the seeded stack (function mode, dummy key): full run exits 1 catching the #355 signature — duplicate `subject_root__rich-course-cs101`, node/edge count mismatches with formula parity to `graph.spec.ts`'s `graphExpectations()` (absolute numbers reconciled against 2 legitimate non-seed rows in the long-lived local volume); `--check ciphertext`, `orphans`, `logscan` all exit 0 with the logscan result spot-checked against the raw log; `--json` parses.

Hermetic suite: 1151 passed / 26 skipped (+ the pre-existing #354 `test_ocr_pipeline` loop-affinity error, unrelated). `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line diagnostic tool for validating end-to-end graph, count, encryption, orphan-record, and backend log health.
  * Added human-readable and JSON reporting with findings, evidence, and suppressed-item counts.
  * Added detection for server errors, tracebacks, data mismatches, missing relationships, and unencrypted values.
  * Restricted diagnostics to local service targets for safer execution.

* **Tests**
  * Added comprehensive coverage for CLI behavior, validation checks, log scanning, reporting, and exit codes.

* **Documentation**
  * Updated encryption documentation to accurately describe encrypted database fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->