### PR TITLE
fix(agents): register concept_describe function-mode handler (#446)

### DIFF
--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -129,6 +129,19 @@ FunctionModelHandler = Callable[
 _FUNCTION_HANDLERS: dict[str, FunctionModelHandler] = {}
 
 
+class UnregisteredHandlerError(LookupError):
+    """Raised by the function-mode dispatch when a task has no registered
+    handler (see `_function_model_for`). A dedicated subclass — rather than a
+    bare `LookupError` — lets callers that need to distinguish "seam is
+    misconfigured for this task" from any other `LookupError`-family bug
+    (a stray `KeyError`/`IndexError` deep in agent/response handling) catch
+    precisely this one instead of the whole builtin hierarchy (#446 PR
+    review: routes/graph.py used to catch bare `LookupError`, which silently
+    downgraded unrelated KeyError/IndexError bugs to a 502 instead of letting
+    them surface as the generic 500). Keeping `LookupError` as the base class
+    preserves any existing code that already catches the builtin type."""
+
+
 def _model_mode() -> str:
     """The active model mode. Unset/blank → 'real'. Normalized for stray
     case/whitespace so a CI or shell-exported value isn't brittle."""
@@ -202,7 +215,7 @@ def _function_model_for(task: AgentTask) -> "Model":
             _load_env_handlers_module()
             handler = _FUNCTION_HANDLERS.get(task)
         if handler is None:
-            raise LookupError(
+            raise UnregisteredHandlerError(
                 f"SAPLING_MODEL_MODE=function but no handler is registered for "
                 f"task {task!r}. Call agents._providers.register_function_handler("
                 f"{task!r}, ...) before running the agent (or point "

--- a/backend/agents/function_handlers_e2e.py
+++ b/backend/agents/function_handlers_e2e.py
@@ -183,3 +183,25 @@ register_function_handler(
         ),
     }),
 )
+
+
+# ── Concept description (#446) ──────────────────────────────────────────────
+#
+# `POST /api/graph/{user}/concept-description` (routes/graph.py) runs
+# concept_describe_agent, a tool-less agent with a structured
+# `ConceptDescription` output (a single `description` field — see
+# agents/concept_describe.py). Request-path, not a post-response
+# BackgroundTask, so registering it is safe (unlike `quiz_context`, which
+# stays deliberately unregistered — see the quiz section above).
+
+# Asserted verbatim by frontend/e2e/tutor.spec.ts (rendered concept-blurb
+# text). Keep the two literals in sync.
+E2E_CONCEPT_DESCRIPTION = (
+    "[e2e-function-model] Deterministic concept blurb: recursion is when a "
+    "function calls itself on a smaller version of the same problem."
+)
+
+register_function_handler(
+    "concept_describe",
+    _structured_output({"description": E2E_CONCEPT_DESCRIPTION}),
+)

--- a/backend/routes/graph.py
+++ b/backend/routes/graph.py
@@ -14,6 +14,7 @@ from services.graph_service import (
 )
 from services.request_context import current_request_id
 from agents import WORKER_LIMITS
+from agents._providers import UnregisteredHandlerError
 from agents._run import run_agent_sync
 from agents.deps import SaplingDeps
 from agents.concept_describe import concept_describe_agent, build_message
@@ -136,13 +137,18 @@ def describe_concept(user_id: str, body: ConceptDescriptionBody, request: Reques
                 usage_limits=WORKER_LIMITS,
             )
         )
-    except (AgentRunError, httpx.HTTPError, ValidationError, LookupError) as e:
+    except (AgentRunError, httpx.HTTPError, ValidationError, UnregisteredHandlerError) as e:
         # Model / transport / output-validation failures are upstream problems —
-        # surface them as 502. LookupError covers the SAPLING_MODEL_MODE=function
-        # seam (agents/_providers.py::_dispatch) raising when no handler is
-        # registered for 'concept_describe' (#446): a misconfigured seam
-        # shouldn't 500 the route, it should degrade the same way an upstream
-        # model failure does. Anything else propagates to the generic handler.
+        # surface them as 502. UnregisteredHandlerError covers the
+        # SAPLING_MODEL_MODE=function seam (agents/_providers.py::_dispatch)
+        # raising when no handler is registered for 'concept_describe' (#446):
+        # a misconfigured seam shouldn't 500 the route, it should degrade the
+        # same way an upstream model failure does. Deliberately NOT the bare
+        # `LookupError` builtin here (#446 PR review): that base class also
+        # covers KeyError/IndexError, and a bare `LookupError` catch would
+        # silently downgrade an unrelated KeyError/IndexError bug elsewhere in
+        # the agent-run path to this 502 instead of the generic 500. Anything
+        # else propagates to the generic handler.
         raise HTTPException(
             status_code=502, detail=f"concept-description agent failed: {e}"
         ) from e

--- a/backend/routes/graph.py
+++ b/backend/routes/graph.py
@@ -136,9 +136,13 @@ def describe_concept(user_id: str, body: ConceptDescriptionBody, request: Reques
                 usage_limits=WORKER_LIMITS,
             )
         )
-    except (AgentRunError, httpx.HTTPError, ValidationError) as e:
+    except (AgentRunError, httpx.HTTPError, ValidationError, LookupError) as e:
         # Model / transport / output-validation failures are upstream problems —
-        # surface them as 502. Anything else propagates to the generic handler.
+        # surface them as 502. LookupError covers the SAPLING_MODEL_MODE=function
+        # seam (agents/_providers.py::_dispatch) raising when no handler is
+        # registered for 'concept_describe' (#446): a misconfigured seam
+        # shouldn't 500 the route, it should degrade the same way an upstream
+        # model failure does. Anything else propagates to the generic handler.
         raise HTTPException(
             status_code=502, detail=f"concept-description agent failed: {e}"
         ) from e

--- a/backend/tests/test_e2e_function_handlers.py
+++ b/backend/tests/test_e2e_function_handlers.py
@@ -23,6 +23,7 @@ import agents._providers as providers
 from agents._providers import clear_function_handlers, model_for
 from agents.chat_tutor import socratic_agent
 from agents.classifier import classifier_agent
+from agents.concept_describe import build_message, concept_describe_agent
 from agents.deps import SaplingDeps
 from agents.quiz import quiz_agent
 from agents.summary import summary_agent
@@ -273,3 +274,54 @@ def test_env_module_summary_handler_passes_real_output_schema(monkeypatch):
     assert result.output.headline == E2E_DOC_HEADLINE
     assert result.output.abstract == E2E_DOC_ABSTRACT
     assert 3 <= len(result.output.key_points) <= 8
+
+
+# ── Concept description (#446) ────────────────────────────────────────────
+#
+# routes/graph.py's POST /api/graph/{user}/concept-description runs
+# concept_describe_agent (tool-less, structured `ConceptDescription` output).
+# Before #446 this module registered six tasks but not `concept_describe`, so
+# function mode's dispatch raised LookupError and the route 500'd. This is
+# the constants-sync contract test: frontend/e2e/tutor.spec.ts asserts
+# E2E_CONCEPT_DESCRIPTION verbatim.
+
+
+def test_env_module_registers_concept_describe_handler_on_dispatch(monkeypatch):
+    """Full E2E-boot contract for concept_describe: function mode + the
+    env-named module give a real concept_describe_agent run the module's
+    fixed description — through the REAL structured output tool, with no
+    handler registered by the test itself."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv(
+        "SAPLING_FUNCTION_HANDLERS", "agents.function_handlers_e2e"
+    )
+
+    with concept_describe_agent.override(model=model_for("concept_describe")):
+        result = concept_describe_agent.run_sync(
+            build_message("Recursion", "CS 101"), deps=_deps()
+        )
+
+    from agents.function_handlers_e2e import E2E_CONCEPT_DESCRIPTION
+
+    assert result.output.description == E2E_CONCEPT_DESCRIPTION
+    assert "concept_describe" in providers._FUNCTION_HANDLERS
+
+
+def test_concept_describe_handler_passes_real_output_schema(monkeypatch):
+    """The scripted description must satisfy ConceptDescription's real schema
+    (max_length=400) — drift between the module constant and the schema fails
+    here, in the hermetic lane, not mid-browser-run."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv(
+        "SAPLING_FUNCTION_HANDLERS", "agents.function_handlers_e2e"
+    )
+
+    with concept_describe_agent.override(model=model_for("concept_describe")):
+        result = concept_describe_agent.run_sync(
+            build_message("Recursion", None), deps=_deps()
+        )
+
+    from agents.function_handlers_e2e import E2E_CONCEPT_DESCRIPTION
+
+    assert result.output.description == E2E_CONCEPT_DESCRIPTION
+    assert len(E2E_CONCEPT_DESCRIPTION) <= 400

--- a/backend/tests/test_graph_concept_description.py
+++ b/backend/tests/test_graph_concept_description.py
@@ -4,6 +4,8 @@ Backs the knowledge-map rail's on-demand concept blurb. Covers:
   - happy path returns the agent's description
   - oversized concept / course_label are truncated before the agent sees them
   - model / transport / validation failures translate to HTTP 502
+  - a LookupError (function-mode seam with no registered handler, #446)
+    degrades the same way rather than a bare 500
   - empty concept is rejected with 400
   - unexpected exceptions still fall through to the generic 500 handler
 """
@@ -64,6 +66,25 @@ def test_oversized_inputs_truncated_before_agent():
 def test_agent_failure_translates_to_502():
     with _agent_run_stub(), \
          patch("routes.graph.run_agent_sync", side_effect=UnexpectedModelBehavior("model exploded")):
+        resp = client.post(URL, json={"concept": "Recursion"})
+    assert resp.status_code == 502
+    assert "concept-description agent failed" in resp.json()["detail"]
+
+
+def test_lookup_error_translates_to_502():
+    # #446: SAPLING_MODEL_MODE=function with no handler registered for
+    # 'concept_describe' raises LookupError out of the dispatch seam
+    # (agents/_providers.py::_dispatch). A misconfigured seam is an upstream
+    # problem, not a route bug — it must degrade the same way AgentRunError
+    # does, not 500.
+    with _agent_run_stub(), \
+         patch(
+             "routes.graph.run_agent_sync",
+             side_effect=LookupError(
+                 "SAPLING_MODEL_MODE=function but no handler is registered "
+                 "for task 'concept_describe'"
+             ),
+         ):
         resp = client.post(URL, json={"concept": "Recursion"})
     assert resp.status_code == 502
     assert "concept-description agent failed" in resp.json()["detail"]

--- a/backend/tests/test_graph_concept_description.py
+++ b/backend/tests/test_graph_concept_description.py
@@ -4,10 +4,13 @@ Backs the knowledge-map rail's on-demand concept blurb. Covers:
   - happy path returns the agent's description
   - oversized concept / course_label are truncated before the agent sees them
   - model / transport / validation failures translate to HTTP 502
-  - a LookupError (function-mode seam with no registered handler, #446)
-    degrades the same way rather than a bare 500
+  - an UnregisteredHandlerError (function-mode seam with no registered
+    handler, #446) degrades the same way rather than a bare 500
   - empty concept is rejected with 400
-  - unexpected exceptions still fall through to the generic 500 handler
+  - unexpected exceptions — including a bare KeyError/IndexError, the
+    LookupError builtin's other subclasses (#446 PR review) — still fall
+    through to the generic 500 handler rather than being caught by the
+    route's over-broad-if-it-were-`except LookupError` clause
 """
 from __future__ import annotations
 
@@ -16,6 +19,7 @@ from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 from pydantic_ai.exceptions import UnexpectedModelBehavior
 
+from agents._providers import UnregisteredHandlerError
 from main import app
 from routes.graph import _MAX_CONCEPT_LEN, _MAX_COURSE_LABEL_LEN
 
@@ -71,16 +75,16 @@ def test_agent_failure_translates_to_502():
     assert "concept-description agent failed" in resp.json()["detail"]
 
 
-def test_lookup_error_translates_to_502():
+def test_unregistered_handler_error_translates_to_502():
     # #446: SAPLING_MODEL_MODE=function with no handler registered for
-    # 'concept_describe' raises LookupError out of the dispatch seam
-    # (agents/_providers.py::_dispatch). A misconfigured seam is an upstream
-    # problem, not a route bug — it must degrade the same way AgentRunError
-    # does, not 500.
+    # 'concept_describe' raises UnregisteredHandlerError out of the dispatch
+    # seam (agents/_providers.py::_dispatch). A misconfigured seam is an
+    # upstream problem, not a route bug — it must degrade the same way
+    # AgentRunError does, not 500.
     with _agent_run_stub(), \
          patch(
              "routes.graph.run_agent_sync",
-             side_effect=LookupError(
+             side_effect=UnregisteredHandlerError(
                  "SAPLING_MODEL_MODE=function but no handler is registered "
                  "for task 'concept_describe'"
              ),
@@ -100,6 +104,23 @@ def test_unexpected_exception_falls_through_to_500():
     safe_client = TestClient(app, raise_server_exceptions=False)
     with _agent_run_stub(), \
          patch("routes.graph.run_agent_sync", side_effect=ValueError("bug")):
+        resp = safe_client.post(URL, json={"concept": "Recursion"})
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Internal server error."
+
+
+def test_unrelated_key_error_falls_through_to_500():
+    # #446 PR review (empirical repro): LookupError is the builtin base class
+    # of KeyError/IndexError. A prior version of the route caught bare
+    # `LookupError`, which silently converted an unrelated KeyError bug deep
+    # in the agent-run path (e.g. pydantic-ai response handling) into this
+    # endpoint's 502 "concept-description agent failed" instead of letting it
+    # surface as the generic 500 like any other unexpected bug. The route now
+    # catches the specific `UnregisteredHandlerError` subclass only, so a bare
+    # KeyError must still fall through here.
+    safe_client = TestClient(app, raise_server_exceptions=False)
+    with _agent_run_stub(), \
+         patch("routes.graph.run_agent_sync", side_effect=KeyError("some_unrelated_bug")):
         resp = safe_client.post(URL, json={"concept": "Recursion"})
     assert resp.status_code == 500
     assert resp.json()["detail"] == "Internal server error."

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -138,6 +138,7 @@ route:
 | `tutor-action-confused` | "I'm confused" |
 | `tutor-action-skip` | "Skip" |
 | `tutor-session-resume-{sessionId}` | a "Recent sessions" row's resume button (`screens/Learn.tsx`), suffixed with the session's own id per the stable-domain-id rule |
+| `tutor-focus-concept-description` | the knowledge-map rail's "Focused concept" card description text (`screens/Learn.tsx`) — stored `description` if the node has one, else the AI-fetched blurb (`POST /api/graph/{user}/concept-description`, #446), else the connected-concepts fallback sentence |
 
 ### `quiz`
 

--- a/frontend/e2e/tutor.spec.ts
+++ b/frontend/e2e/tutor.spec.ts
@@ -39,6 +39,11 @@ const TUTOR_REPLY =
   "[e2e-function-model] Deterministic tutor reply: every recursive function " +
   "needs a base case so it can stop calling itself.";
 
+/** Must match backend/agents/function_handlers_e2e.py::E2E_CONCEPT_DESCRIPTION. */
+const CONCEPT_DESCRIPTION =
+  "[e2e-function-model] Deterministic concept blurb: recursion is when a " +
+  "function calls itself on a smaller version of the same problem.";
+
 test("tutor turn renders a reply and persists encrypted to messages", async ({
   page,
 }) => {
@@ -97,4 +102,38 @@ test("tutor turn renders a reply and persists encrypted to messages", async ({
   ]);
   expect(userPlain).toBe(STUDENT_MESSAGE);
   expect(assistantPlain).toBe(TUTOR_REPLY);
+});
+
+/**
+ * Journey (#446): resuming a session surfaces the knowledge-map rail's
+ * "Focused concept" card for that session's topic node. The seeded
+ * `rich-node-cs-recursion` node (concept "Recursion", db/seed_local_rich.py)
+ * carries no stored `description`, so the card falls through to an
+ * on-demand `POST /api/graph/{user}/concept-description` call
+ * (Learn.tsx's focus-description effect) — exactly the function-mode path
+ * that used to 500 (`agents/_providers.py::_dispatch` raised LookupError
+ * because `function_handlers_e2e.py` had no `concept_describe` handler
+ * registered). No click on the rail is needed: resuming sets `topic` to the
+ * session's topic ("Recursion") synchronously, which the rail's `highlightId`
+ * memo matches against the already-loaded graph nodes and auto-focuses.
+ */
+test("resuming a session surfaces the deterministic concept description in the rail", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("sapling_disclaimer_ack", "true");
+  });
+
+  await page.goto("/learn");
+  await page.getByTestId(`tutor-session-resume-${SESSION_ID}`).click();
+
+  // Proves resume actually loaded before asserting on the rail (same signal
+  // the tutor-reply journey above uses).
+  await expect(page.getByTestId("tutor-messages")).toContainText(
+    "Can you explain recursion?",
+  );
+
+  await expect(
+    page.getByTestId("tutor-focus-concept-description"),
+  ).toHaveText(CONCEPT_DESCRIPTION);
 });

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -888,7 +888,10 @@ function LearnInner() {
                   <div style={{ fontFamily: "var(--font-display)", fontSize: 19, fontWeight: 500, color: "var(--text)", marginTop: 7, lineHeight: 1.2 }}>
                     {focusConcept ? focusConcept.name : (cardCourse?.course_name ?? topic)}
                   </div>
-                  <div style={{ fontSize: 12.5, color: "var(--text-muted)", marginTop: 6, lineHeight: 1.5 }}>
+                  <div
+                    data-testid="tutor-focus-concept-description"
+                    style={{ fontSize: 12.5, color: "var(--text-muted)", marginTop: 6, lineHeight: 1.5 }}
+                  >
                     {focusConcept
                       ? (focusConcept.description
                           ?? descCache[focusConcept.id]


### PR DESCRIPTION
Fixes #446.

## Root cause

`agents/function_handlers_e2e.py` registers handlers for six tasks but not `concept_describe`, so in function mode (`SAPLING_MODEL_MODE=function`) resuming a tutor session drives `POST /api/graph/{user}/concept-description` into `_providers._dispatch`'s `LookupError`, which `routes/graph.py` didn't catch → 500. Found by the Chapter 2 exploration harness (epic #403); the e2e_oracles logscan caught the traceback independently.

## Fix

- `backend/agents/function_handlers_e2e.py`: register a fixed `concept_describe` handler via the existing `_structured_output` pattern, exporting `E2E_CONCEPT_DESCRIPTION` (matches `concept_describe.py`'s `ConceptDescription` schema, under the 400-char cap). Request-path handler — the `quiz_context` stay-unregistered precedent (post-response BackgroundTasks) is untouched.
- `backend/routes/graph.py`: `LookupError` joins the caught exceptions with the same 502 degradation the route already applies to `AgentRunError` — a misconfigured seam degrades instead of 500ing. Covered red-first by `test_lookup_error_translates_to_502`.
- `backend/tests/test_e2e_function_handlers.py`: two new tests dispatch through the real env-module seam (constants sync contract).

## Promotion (Chapter 2 → Chapter 1, promotion 2 of 3)

- `frontend/e2e/tutor.spec.ts`: new journey — resuming the seeded "Understanding Recursion" session surfaces the deterministic concept description in the concept rail; the spec asserts the exported constant byte-for-byte.
- `docs/frontend-testids.md`: inventory row for the concept-description surface.

## Verification

- Hermetic suite: 1157 passed, 26 skipped, 1 error = pre-existing #436 flake (untouched).
- `ruff` clean; `tsc --noEmit` clean; eslint clean.
- Playwright tutor lane + oracles run against the live function-mode stack before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)