### PR TITLE
fix(frontend): UserContext falls back to /api/auth/me on cookie-only sessions (#430)

### DIFF
--- a/frontend/e2e/auth-session.spec.ts
+++ b/frontend/e2e/auth-session.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Journey #430 — cookie-only session hydrates the dashboard.
+ *
+ * Bug: a browser holding a valid `sapling_session` cookie but no
+ * `sapling_user` localStorage entry (cleared site data, another profile, a
+ * stale-cookie flow) loads /dashboard, middleware admits the request on the
+ * cookie alone, but `UserContext` bootstrapped identity ONLY from
+ * localStorage — `userId` never got set, so Dashboard's
+ * `if (userReady && userId) load()` effect never fired and the loading
+ * skeleton (`loading` starts `true`) spun forever.
+ *
+ * Fix (frontend/src/context/UserContext.tsx): when bootstrap finds no
+ * `sapling_user` in localStorage, fall back to cookie-authenticated
+ * GET /api/auth/me — on 200 it hydrates the context and write-throughs
+ * `setActiveUser` (so the *next* load takes the fast synchronous path); on
+ * 401 it settles into the existing signed-out state instead of hanging.
+ *
+ * This journey mints a deliberately cookie-ONLY storageState via
+ * `support/session.ts::mintStorageState(..., { omitLocalStorage: true })` —
+ * every other journey keeps minting cookie + localStorage together (the
+ * pre-#430 workaround, still the default) — then proves /dashboard hydrates
+ * instead of spinning: the same seeded-course assertion `dashboard.spec.ts`
+ * (#386) uses, which only renders once `userId` resolved and the course
+ * fetch completed. A regression back to the old bootstrap-only-from-
+ * localStorage behavior would leave `dashboard-courses-key-toggle` unmounted
+ * forever and this test would time out on the click below.
+ */
+import { expect, test } from "./support/fixtures";
+import { mintStorageState } from "./support/session";
+import { USER_ACTIVE } from "./support/stack";
+
+test("cookie-only session hydrates the dashboard via the /api/auth/me fallback", async ({
+  browser,
+}) => {
+  const context = await browser.newContext({
+    storageState: await mintStorageState(USER_ACTIVE, "Rich Active", {
+      omitLocalStorage: true,
+    }),
+  });
+  try {
+    const page = await context.newPage();
+    await page.goto("/dashboard");
+
+    // Middleware admits the request on the cookie alone — not bounced to
+    // sign-in or /pending.
+    await expect(page).toHaveURL(/\/dashboard$/);
+
+    // The "My courses" key toggle only mounts once enrollments have loaded
+    // (dashboard.spec.ts's same gate) — auto-waiting on the click doubles as
+    // the "dashboard data arrived, skeleton resolved" assertion. Before the
+    // #430 fix this timed out: userId never resolved, so `load()` never ran
+    // and the skeleton never left.
+    await page.getByTestId("dashboard-courses-key-toggle").click();
+
+    // Seeded, user-specific data rendering proves identity actually
+    // resolved to rich-user-active (not just that the shell mounted):
+    // rich-course-math210 ("MATH210") is this user's seeded enrollment.
+    await expect(
+      page.getByTestId("dashboard-course-code").filter({ hasText: "MATH210" }),
+    ).toBeVisible();
+  } finally {
+    await context.close();
+  }
+});

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -65,13 +65,17 @@ export default async function globalSetup(): Promise<void> {
         sameSite: "Lax" as const,
       },
     ],
-    // The cookie alone is not a signed-in browser: the client identity lives
-    // in localStorage (`UserContext` reads `sapling_user`; only the sign-in
-    // flows write it via setActiveUser). Without it every authed screen
-    // renders its shell but never fetches user data — the #386 journey found
-    // /dashboard stuck on its skeleton forever. Mirror exactly what
-    // setActiveUser persists for the primary seeded user (name per
-    // db/seed_local_rich.py).
+    // The cookie alone WAS not a signed-in browser before #430: the client
+    // identity lived only in localStorage (`UserContext` reads
+    // `sapling_user`; only the sign-in flows write it via setActiveUser).
+    // Without it every authed screen rendered its shell but never fetched
+    // user data — the #386 journey found /dashboard stuck on its skeleton
+    // forever. #430 taught UserContext to fall back to cookie-authenticated
+    // GET /api/auth/me when this entry is missing, but every spec here still
+    // mints cookie + localStorage together (this is the DEFAULT, fast path —
+    // e2e/auth-session.spec.ts covers the cookie-only fallback separately).
+    // Mirror exactly what setActiveUser persists for the primary seeded user
+    // (name per db/seed_local_rich.py).
     origins: [
       {
         origin: FRONTEND_URL,

--- a/frontend/e2e/support/session.ts
+++ b/frontend/e2e/support/session.ts
@@ -11,11 +11,18 @@
  *   - mint through the frontend origin (proves the same-origin /api proxy);
  *   - cookie flags mirror the real `sapling_session` (HttpOnly/Lax, and
  *     secure:true — Chromium accepts Secure cookies on http://localhost);
- *   - the cookie alone is NOT a signed-in browser: client identity lives in
- *     localStorage (`UserContext` reads `sapling_user`, written only by the
- *     sign-in flows' setActiveUser) — without it authed screens render their
- *     shell but never fetch user data (found by the #386 journey), so the
- *     storageState carries the same origins entry global-setup writes;
+ *   - the cookie alone WAS not a signed-in browser before #430: client
+ *     identity lived only in localStorage (`UserContext` reads
+ *     `sapling_user`, written only by the sign-in flows' setActiveUser) —
+ *     without it authed screens rendered their shell but never fetched user
+ *     data (found by the #386 journey), so the storageState carries the same
+ *     origins entry global-setup writes by DEFAULT;
+ *   - #430 taught UserContext to fall back to cookie-authenticated
+ *     GET /api/auth/me when localStorage has no `sapling_user` entry, so
+ *     `omitLocalStorage` (below) now mints a deliberately cookie-ONLY
+ *     storageState to exercise that fallback (frontend/e2e/auth-session.spec.ts)
+ *     — every other caller keeps the default (cookie + localStorage) exactly
+ *     as before;
  *   - the token is stateless HMAC, so the per-test TRUNCATE + re-seed can
  *     never invalidate it — the re-seed restores the same rich-* user row.
  */
@@ -40,10 +47,16 @@ type StorageState = {
 
 /** Mint a session for a seeded rich-* user and return it as storageState.
  * `displayName` mirrors what setActiveUser would persist after a real
- * sign-in (the user's profile name per db/seed_local_rich.py). */
+ * sign-in (the user's profile name per db/seed_local_rich.py).
+ *
+ * `opts.omitLocalStorage` deliberately leaves out the `sapling_user`
+ * localStorage entry, minting a cookie-ONLY storageState — the shape a real
+ * browser has when a valid `sapling_session` cookie outlives cleared site
+ * data (#430). Defaults to false so every existing caller is unaffected. */
 export async function mintStorageState(
   userId: string,
   displayName: string,
+  opts?: { omitLocalStorage?: boolean },
 ): Promise<StorageState> {
   const res = await fetch(`${FRONTEND_URL}/api/auth/test-login`, {
     method: "POST",
@@ -80,20 +93,22 @@ export async function mintStorageState(
         sameSite: "Lax",
       },
     ],
-    origins: [
-      {
-        origin: FRONTEND_URL,
-        localStorage: [
+    origins: opts?.omitLocalStorage
+      ? []
+      : [
           {
-            name: "sapling_user",
-            value: JSON.stringify({
-              id: userId,
-              name: displayName,
-              avatar: "",
-            }),
+            origin: FRONTEND_URL,
+            localStorage: [
+              {
+                name: "sapling_user",
+                value: JSON.stringify({
+                  id: userId,
+                  name: displayName,
+                  avatar: "",
+                }),
+              },
+            ],
           },
         ],
-      },
-    ],
   };
 }

--- a/frontend/src/context/UserContext.tsx
+++ b/frontend/src/context/UserContext.tsx
@@ -2,7 +2,7 @@
 
 import React, { createContext, useContext, useState, useEffect, useMemo, useCallback } from 'react';
 import type { UserRole, EquippedCosmetics, Role } from '@/lib/types';
-import { API_URL } from '@/lib/api';
+import { API_URL, getMe } from '@/lib/api';
 
 interface UserOption {
   id: string;
@@ -78,8 +78,41 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
         if (avatar) setAvatarUrl(avatar);
         setIsAuthenticated(true);
       } catch {}
+      setUserReady(true);
+      return;
     }
-    setUserReady(true);
+
+    // No `sapling_user` in localStorage — but the HttpOnly `sapling_session`
+    // cookie can outlive it (cleared site data, a different browser profile,
+    // a stale-cookie flow): middleware already admits the request on the
+    // cookie alone, and this context has no client-readable way to see it,
+    // so without a fallback userId never gets set and every screen gated on
+    // `userReady && userId` (e.g. Dashboard's load effect) waits forever on
+    // its loading skeleton (#430). Fall back to the cookie-authenticated
+    // GET /api/auth/me — the same call the OAuth callback already makes the
+    // same way (same-origin `fetchJSON`, `credentials: 'include'`).
+    let cancelled = false;
+    (async () => {
+      try {
+        const me = await getMe();
+        if (cancelled) return;
+        // Write-through setActiveUser: hydrates state AND persists
+        // localStorage, so the next bootstrap takes the fast synchronous
+        // path above instead of hitting the network again.
+        setActiveUser(me.user_id, me.name || '', me.avatar_url || '');
+        if (me.is_approved) setIsApproved(true);
+      } catch {
+        // 401 (no/expired session) or a network failure — no identity
+        // source is left. Settle into the existing signed-out state
+        // (isAuthenticated stays false); every consumer already gates on
+        // `userReady`, so nothing new to redirect here.
+      } finally {
+        if (!cancelled) setUserReady(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {

--- a/frontend/src/context/UserContext.tsx
+++ b/frontend/src/context/UserContext.tsx
@@ -88,9 +88,26 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     // cookie alone, and this context has no client-readable way to see it,
     // so without a fallback userId never gets set and every screen gated on
     // `userReady && userId` (e.g. Dashboard's load effect) waits forever on
-    // its loading skeleton (#430). Fall back to the cookie-authenticated
-    // GET /api/auth/me — the same call the OAuth callback already makes the
-    // same way (same-origin `fetchJSON`, `credentials: 'include'`).
+    // its loading skeleton (#430). Fall back to the cookie-identified
+    // GET /api/auth/me — the same endpoint the OAuth callback
+    // (src/app/auth/callback/page.tsx) already reads off the same cookie,
+    // though the callback calls it via a bare `fetch`, not this `fetchJSON`
+    // wrapper.
+    //
+    // Skip this fallback entirely on the auth-flow routes (`/auth/*`, e.g.
+    // the callback page): the callback POSTs /api/auth/session to mint the
+    // cookie and only THEN calls GET /api/auth/me itself before its own
+    // setActiveUser. Racing our own getMe() here would be a near-guaranteed
+    // 401 before that POST resolves, and — on a shared browser where a
+    // DIFFERENT user's still-valid `sapling_session` cookie is present —
+    // could momentarily hydrate the wrong identity before the callback's
+    // setActiveUser overwrites it moments later. Let the callback own its
+    // own bootstrap.
+    if (typeof window !== 'undefined' && window.location.pathname.startsWith('/auth')) {
+      setUserReady(true);
+      return;
+    }
+
     let cancelled = false;
     (async () => {
       try {
@@ -102,10 +119,20 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
         setActiveUser(me.user_id, me.name || '', me.avatar_url || '');
         if (me.is_approved) setIsApproved(true);
       } catch {
-        // 401 (no/expired session) or a network failure — no identity
-        // source is left. Settle into the existing signed-out state
+        // No identity source is left, for any reason: a 401 (no/expired
+        // session), a 404 (the cookie names a user row that no longer
+        // exists — the #285-family stale-session scenario), or a plain
+        // network failure. Settle into the existing signed-out state
         // (isAuthenticated stays false); every consumer already gates on
         // `userReady`, so nothing new to redirect here.
+        //
+        // This also means every anonymous visit to a public page pays for
+        // one 401-destined getMe() call here (UserProvider wraps the whole
+        // app, public routes included) — the HttpOnly cookie can't be
+        // probed client-side without a network round trip, and there's no
+        // existing non-HttpOnly signed-in hint to gate on instead. One
+        // cheap failed request per anonymous mount is the accepted cost of
+        // fixing #430.
       } finally {
         if (!cancelled) setUserReady(true);
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -45,6 +45,27 @@ async function fetchJSON<T>(path: string, options?: RequestInit): Promise<T> {
 export const getUsers = () =>
   fetchJSON<{ users: { id: string; name: string; room_id: string | null }[] }>('/api/users');
 
+// Auth
+export interface MeResponse {
+  user_id: string;
+  is_approved: boolean;
+  onboarding_completed: boolean;
+  username: string | null;
+  name: string;
+  avatar_url: string;
+  roles: { role: Role; granted_at: string }[];
+  equipped_cosmetics: Record<string, unknown>;
+  is_admin: boolean;
+}
+
+// Cookie-authenticated identity lookup (backend/routes/auth.py::get_me reads
+// the user id off the `sapling_session` cookie alone via get_session_user_id
+// — no user_id param needed). UserContext's bootstrap falls back to this
+// when localStorage has no `sapling_user` entry but the HttpOnly session
+// cookie is still valid (#430); the OAuth callback already calls the same
+// endpoint the same way.
+export const getMe = () => fetchJSON<MeResponse>('/api/auth/me');
+
 // Graph
 export const getGraph = (userId: string) =>
   fetchJSON<{ nodes: any[]; edges: any[]; stats: any }>(`/api/graph/${userId}`);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -58,12 +58,14 @@ export interface MeResponse {
   is_admin: boolean;
 }
 
-// Cookie-authenticated identity lookup (backend/routes/auth.py::get_me reads
-// the user id off the `sapling_session` cookie alone via get_session_user_id
-// — no user_id param needed). UserContext's bootstrap falls back to this
-// when localStorage has no `sapling_user` entry but the HttpOnly session
-// cookie is still valid (#430); the OAuth callback already calls the same
-// endpoint the same way.
+// Cookie-authenticated identity lookup (backend/routes/auth.py::get_me
+// resolves the user via get_session_user_id, which reads the `sapling_session`
+// cookie or an `auth_token` query param — no `user_id` param needed either
+// way). UserContext's bootstrap falls back to this when localStorage has no
+// `sapling_user` entry but the HttpOnly session cookie is still valid
+// (#430); the OAuth callback (src/app/auth/callback/page.tsx) already reads
+// this same endpoint off the same cookie, though via a bare `fetch` rather
+// than this `fetchJSON` wrapper.
 export const getMe = () => fetchJSON<MeResponse>('/api/auth/me');
 
 // Graph


### PR DESCRIPTION
Fixes #430.

## Root cause

`UserContext` bootstraps client identity only from the `sapling_user` localStorage entry (written solely by sign-in flows). A browser holding a valid HttpOnly `sapling_session` cookie but no localStorage entry — cleared site data, another profile, stale-cookie flows (#285 family) — gets admitted by middleware but renders the dashboard loading skeleton forever.

## Fix

- `frontend/src/context/UserContext.tsx`: when bootstrap finds no localStorage identity, fall back to cookie-based `GET /api/auth/me` (via the same-origin `fetchJSON` convention — new typed `getMe()` in `lib/api.ts`); on 200 hydrate and write-through `setActiveUser` (the existing identity write path — no new source), on 401/failure settle into the normal signed-out state. Effect is guarded against post-unmount setState.

## Promotion (Chapter 2 → Chapter 1, promotion 3 of 3)

- `frontend/e2e/support/session.ts`: `mintStorageState` gains an opt-in `omitLocalStorage` — default output byte-identical to before (existing journeys unaffected; sole existing caller verified).
- `frontend/e2e/auth-session.spec.ts`: new journey minting cookie-ONLY storage state, loading `/dashboard`, and proving hydration (courses key toggle + seeded `MATH210` course code — assertions that require the data load to complete, not mere skeleton absence).

## Verification

- `tsc --noEmit` clean; eslint 0 errors (36 pre-existing warnings, none in touched files); frontend unit suite 204/204.
- Playwright lane (incl. the new journey) + oracles run against the live local stack before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling so users can remain signed in when browser storage is unavailable or cleared.
  * Dashboard user information and personalized course data now load through the active session automatically.
* **Tests**
  * Added end-to-end coverage for cookie-only authentication and dashboard access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->