### PR TITLE
ci(db): pin local/CI Postgres to 15, matching staging/prod (#441)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,9 +7,10 @@ name: e2e (browser lane)
 #
 # Trigger is main-only per epic #402 open decision 3 (promote to a PR gate
 # once the #388 stability bar has held for a while). Postgres version comes
-# from supabase/config.toml (PG17) — this deliberately goes AGAINST epic
-# decision 2's recorded PG15 leaning, choosing consistency with the proven
-# local + integration.yml stack instead; the prod skew is tracked in #441.
+# from supabase/config.toml (PG15, #441) — matching staging/prod, so this
+# deterministic lane tests what production actually runs; local dev and CI
+# still stay consistent with each other (and with integration.yml) since both
+# follow the same config.toml pin.
 
 on:
   workflow_dispatch:

--- a/backend/tests/integration/test_postgres_version.py
+++ b/backend/tests/integration/test_postgres_version.py
@@ -1,0 +1,48 @@
+"""Postgres major-version drift guard (#441).
+
+Local/CI Postgres is pinned to PG15 via `db.major_version` in
+`supabase/config.toml`, matching staging/prod — the whole point of the
+deterministic local/CI lane is that it tests what production actually runs.
+PR #440 had bumped local/CI to PG17 for local-dev/CI stack consistency
+(consistency is preserved here too: local and CI both still follow the same
+config.toml pin, just at 15 instead of 17); #441 tracked the resulting skew
+against staging/prod, which this pin closes.
+
+This test runs against the REAL server (via the `db_conn` psycopg fixture,
+never a mock), so a future edit to config.toml — or a local stack that
+predates this pin and was never reset (see the "Postgres version"
+troubleshooting entry in docs/local-supabase.md) — fails LOUDLY here instead
+of silently reintroducing the skew.
+
+Placement: this file lives in the opt-in integration suite
+(`backend/tests/integration/`, RUN_INTEGRATION=1) rather than the browser-lane
+E2E spec, because `.github/workflows/integration.yml` boots the local Supabase
+stack from empty and runs `RUN_INTEGRATION=1 pytest -m integration` on every
+push to main — i.e. this actually executes in CI, against the same
+`supabase start` (config.toml-pinned) Postgres the browser lane
+(`.github/workflows/e2e.yml`) also boots.
+"""
+import pytest
+
+pytestmark = pytest.mark.integration
+
+EXPECTED_MAJOR_VERSION = 15
+
+
+def test_server_major_version_matches_config_toml_pin(db_conn):
+    row = db_conn.execute("SHOW server_version_num").fetchone()
+    version_num = int(row["server_version_num"])
+    # server_version_num is e.g. 150008 for 15.8, 170004 for 17.4 — major
+    # version is the leading two digits for every currently supported PG
+    # release (10 through 18).
+    major = version_num // 10000
+    assert major == EXPECTED_MAJOR_VERSION, (
+        f"Postgres server_version_num={version_num} (major {major}) but "
+        f"supabase/config.toml pins db.major_version = {EXPECTED_MAJOR_VERSION} "
+        "to match staging/prod (#441). Either config.toml drifted from this "
+        "running server, or this is a stale local stack provisioned before "
+        "the pin — its Postgres container doesn't get swapped just because "
+        "config.toml changed. Reset it: scripts/local-db-reset.sh, or a full "
+        "`supabase stop` + `supabase start` if that isn't enough (see "
+        "docs/local-supabase.md's 'Postgres version' troubleshooting entry)."
+    )

--- a/backend/tests/integration/test_postgres_version.py
+++ b/backend/tests/integration/test_postgres_version.py
@@ -3,10 +3,14 @@
 Local/CI Postgres is pinned to PG15 via `db.major_version` in
 `supabase/config.toml`, matching staging/prod — the whole point of the
 deterministic local/CI lane is that it tests what production actually runs.
-PR #440 had bumped local/CI to PG17 for local-dev/CI stack consistency
-(consistency is preserved here too: local and CI both still follow the same
-config.toml pin, just at 15 instead of 17); #441 tracked the resulting skew
-against staging/prod, which this pin closes.
+The PG17 pin originated with the local stack's introduction (`config.toml`
+was born with `major_version = 17` — there was never a staging-matching PG15
+pin to regress from). PR #440 (the browser-lane e2e job) didn't change that
+pin; it added the e2e.yml header comment rationalizing the already-existing
+PG17, explicitly noting it went against epic #402 decision 2's recorded PG15
+leaning and that the resulting skew was tracked in #441. This pin closes that
+skew per decision 2; local/CI consistency is preserved since both still
+follow the same config.toml pin, just at 15 instead of 17.
 
 This test runs against the REAL server (via the `db_conn` psycopg fixture,
 never a mock), so a future edit to config.toml — or a local stack that
@@ -41,8 +45,9 @@ def test_server_major_version_matches_config_toml_pin(db_conn):
         f"supabase/config.toml pins db.major_version = {EXPECTED_MAJOR_VERSION} "
         "to match staging/prod (#441). Either config.toml drifted from this "
         "running server, or this is a stale local stack provisioned before "
-        "the pin — its Postgres container doesn't get swapped just because "
-        "config.toml changed. Reset it: scripts/local-db-reset.sh, or a full "
-        "`supabase stop` + `supabase start` if that isn't enough (see "
-        "docs/local-supabase.md's 'Postgres version' troubleshooting entry)."
+        "the pin — `supabase db reset` does not reliably swap a running "
+        "container's Postgres major version. Tear it down and rebuild: "
+        "`supabase stop --no-backup` then `supabase start`, then re-migrate + "
+        "seed (scripts/local-db-reset.sh or `make e2e-up`) — see "
+        "docs/local-supabase.md's 'Postgres version' troubleshooting entry."
     )

--- a/docs/local-supabase.md
+++ b/docs/local-supabase.md
@@ -273,7 +273,19 @@ e2e oracles) is documented in [e2e-exploration.md](e2e-exploration.md).
 - **404 "Could not find the table … in the schema cache"** — PostgREST cache is
   stale after a migration. `podman exec supabase_db_sapling psql -U postgres -d postgres
   -c "NOTIFY pgrst, 'reload schema';"` (the reset script does this for you).
-- **Postgres version** — local is PG17, staging/prod is PG15. The migrations are
-  version-agnostic and verified to replay on 17; keep new migrations portable.
+- **Postgres version** — local, CI, and staging/prod all pin PG15
+  (`supabase/config.toml`'s `major_version`, #441 — local/CI used to run PG17;
+  that skew is now closed). The migrations are version-agnostic and verified
+  to replay on 15; keep new migrations portable. `backend/tests/integration/`
+  asserts the server major version so future drift is loud, not silent.
+  **If you have an existing local stack from before this pin**, its Postgres
+  container is still the old major version on disk — the CLI does not swap a
+  running container's image just because `config.toml` changed. Reset it:
+  `scripts/local-db-reset.sh` (`supabase db reset` under the hood, which
+  recreates the Postgres container against the pinned version, then
+  migrates + seeds). If `supabase start` still reports the old
+  `server_version` afterwards, fully tear down first — `supabase stop` (add
+  `--no-backup` to also drop the old data volume), then `supabase start` — to
+  force the CLI to provision a fresh PG15 container.
 - **Ports 54321–54327 already in use** — another project's `supabase start` is
   running; `supabase stop` in that project (or `podman ps` to find it).

--- a/docs/local-supabase.md
+++ b/docs/local-supabase.md
@@ -279,13 +279,24 @@ e2e oracles) is documented in [e2e-exploration.md](e2e-exploration.md).
   to replay on 15; keep new migrations portable. `backend/tests/integration/`
   asserts the server major version so future drift is loud, not silent.
   **If you have an existing local stack from before this pin**, its Postgres
-  container is still the old major version on disk — the CLI does not swap a
-  running container's image just because `config.toml` changed. Reset it:
-  `scripts/local-db-reset.sh` (`supabase db reset` under the hood, which
-  recreates the Postgres container against the pinned version, then
-  migrates + seeds). If `supabase start` still reports the old
-  `server_version` afterwards, fully tear down first — `supabase stop` (add
-  `--no-backup` to also drop the old data volume), then `supabase start` — to
-  force the CLI to provision a fresh PG15 container.
+  container is still running the old major version. `supabase db reset` (what
+  `scripts/local-db-reset.sh` calls) does **not** reliably pick up a changed
+  `major_version` — it resets data inside the *existing* container, it never
+  stops/starts the stack, so it cannot swap that container's Postgres image
+  (confirmed against `supabase/cli` issues #5555 and #4522, which report the
+  same gap). The reliable fix for a major-version change is a full teardown:
+  `supabase stop --no-backup` (drops the old data volume so nothing stale is
+  left to reattach to), then `supabase start` — that provisions a fresh,
+  empty container on the now-pinned PG15 (no app schema yet — `supabase
+  start` itself never touches `backend/db/migrations/`, same as any
+  first-time bring-up). From there, `scripts/local-db-reset.sh` is for what
+  it's actually for: applying the app's migrations and reseeding data
+  (migrate → reload PostgREST → seed) on a stack that's *already* the correct
+  Postgres version — run it (or just `make e2e-up`, which calls `supabase
+  start` itself before migrating + seeding) after the teardown to get the
+  schema and seed data back.
+  `backend/tests/integration/test_postgres_version.py` is the drift alarm: it
+  asserts the real server's major version, so a stack still on the wrong
+  version fails loud there instead of silently passing everything else.
 - **Ports 54321–54327 already in use** — another project's `supabase start` is
   running; `supabase stop` in that project (or `podman ps` to find it).

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -39,7 +39,10 @@ shadow_port = 54320
 health_timeout = "2m"
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
-major_version = 17
+# Pinned to 15 to match staging/prod (#441) — the deterministic local/CI lane
+# should test what production actually runs. 15 is also the Supabase CLI's own
+# documented default for this key.
+major_version = 15
 
 [db.pooler]
 enabled = false


### PR DESCRIPTION
Fixes #441.

## Decision

Close the PG17(local/CI) vs PG15(staging/prod) skew by pinning local/CI DOWN to 15: the deterministic lane should test what production runs, and epic #402's recorded leaning (open decision 2) was PG15. History, for the record: the PG17 pin originated with the local Supabase stack's introduction (`supabase/config.toml` was born with `major_version = 17` in 9f54739); PR #440 later added the `e2e.yml` header comment rationalizing that already-existing pin. Local ≡ CI consistency is preserved — both follow `config.toml`. Hosted staging/prod are untouched.

## Changes

- `supabase/config.toml`: `major_version = 17` → `15` (15 is the Supabase CLI's own documented default; no other config keys are Postgres-major-sensitive).
- `backend/tests/integration/test_postgres_version.py`: drift-is-loud assert on `SHOW server_version_num` (major == 15) with an actionable failure message. Placed in the integration suite because `integration.yml` verifiably boots the CLI stack and runs `RUN_INTEGRATION=1 pytest -m integration` on every push to main — the assert actually executes in CI.
- `.github/workflows/e2e.yml`: header comment rewritten (was "deliberately against PG15").
- `docs/local-supabase.md`: version note + reset instructions for pre-existing local stacks. The reliable path for a major-version swap is the primary one: `supabase stop --no-backup` then `supabase start` (a running container's image is never swapped by `db reset` — supabase/cli #5555/#4522); `scripts/local-db-reset.sh` is scoped to what it actually does (migrate + reseed an already-correct-version stack).

## Migration audit

Static sweep of `backend/db/migrations/*.sql` for PG16+-only constructs: none. The one candidate — `UNIQUE NULLS NOT DISTINCT` in `0023_graph_integrity.sql` — is a PostgreSQL 15 feature.

## Verification

- Hermetic suite: 1155 passed + the pre-existing #436 flake (fix riding separately in #453).
- From-empty PG15 boot (full teardown → fresh volumes → migration replay → rich seed → full Playwright lane + oracles) runs against this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)