### PR TITLE
fix(rag): gate below-seam embedding calls on SAPLING_MODEL_MODE (#439)

### DIFF
--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -135,6 +135,20 @@ def _model_mode() -> str:
     return (os.getenv("SAPLING_MODEL_MODE") or "real").strip().lower()
 
 
+def model_mode() -> str:
+    """Public read of the active SAPLING_MODEL_MODE, for call sites outside
+    `agents/` that need to gate on the same seam but don't want a `Model`.
+
+    `_model_mode` stays private to this module for `model_for`'s internal
+    dispatch. This is the one sanctioned way a non-agent module reaches the
+    seam: `services/rag_service.py` and `routes/documents.py`'s RAG indexing
+    build raw `google.genai.Client`s directly (predating #391), so they gate
+    on `model_mode() == "real"` rather than importing the private name across
+    a package boundary (#439).
+    """
+    return _model_mode()
+
+
 def register_function_handler(task: AgentTask, handler: FunctionModelHandler) -> None:
     """Register the FunctionModel handler for a task (function mode only).
 

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -42,6 +42,7 @@ from services.achievement_service import check_achievements
 from services.agent_events import SaplingEvent, sapling_event_to_sse
 from services.request_context import current_request_id
 from agents import WORKER_LIMITS
+from agents._providers import model_mode
 from agents.classifier import classifier_agent
 from agents.summary import summary_agent
 from agents.concept_extraction import concept_extraction_agent
@@ -1084,18 +1085,35 @@ def _index_document_chunks(
         except Exception:
             logger.warning("[RAG] could not store extracted_text for doc %s", doc_id)
 
-        # Relevance gate: skip docs that are off-topic for the course
-        from google import genai as _genai
-        from google.genai import types as genai_types
-        import os
-        _gclient = _genai.Client(api_key=os.getenv("GEMINI_API_KEY", ""))
-
+        # Relevance gate: skip docs that are off-topic for the course. The
+        # embedding-based check below is a `google.genai` call site that
+        # predates the #391 SAPLING_MODEL_MODE seam; catalog_rows itself is a
+        # plain Supabase read (not gated) so the gate is only ever skipped
+        # when there's actually a catalog embedding to compare against.
         catalog_rows = table("course_chunks").select(
             "embedding",
             filters={"course_id": f"eq.{bu_course_id}", "category": "eq.catalog"},
             limit=1,
         )
         if catalog_rows and catalog_rows[0].get("embedding"):
+            if model_mode() != "real":
+                # #439: no google.genai.Client in non-real mode. Raising here
+                # (instead of silently skipping the gate) reproduces the exact
+                # behavior a real embed-call failure already produced: the
+                # outer `except` below aborts indexing and logs
+                # "_index_document_chunks failed for doc %s" — the line
+                # e2e_oracles/logscan.py's ALLOWLIST already expects. Function
+                # mode is now that same no-op, by design, not by accident of a
+                # swallowed exception.
+                raise RuntimeError(
+                    "RAG relevance-gate embedding skipped: "
+                    "SAPLING_MODEL_MODE != 'real' (#439)"
+                )
+
+            from google import genai as _genai
+            from google.genai import types as genai_types
+
+            _gclient = _genai.Client(api_key=os.getenv("GEMINI_API_KEY", ""))
             catalog_vec = catalog_rows[0]["embedding"]
             sample_text = doc_summary or chunks[0]
             resp = _gclient.models.embed_content(

--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -11,27 +11,61 @@ import os
 from google import genai
 from google.genai import types as genai_types
 
+from agents._providers import model_mode
 from db.connection import rpc, table
 
 # Bound embedding requests so a stalled Gemini call can't hang quiz/tutor
 # grounding indefinitely — retrieve_chunks() runs inline on the request path.
 _HTTP_TIMEOUT_MS = 60_000
-
-# `genai.Client(api_key="")` raises ValueError at construction, so a missing
-# GEMINI_API_KEY would break `import main` (routes/quiz.py and routes/learn.py
-# both pull this module in). Fall back to a dummy key the same way
-# services/gemini_service.py and agents/_providers.py do: imports stay clean and
-# the failure surfaces at call time, where it's actionable.
-_client = genai.Client(
-    api_key=os.getenv("GEMINI_API_KEY", "") or "dummy-key-for-import",
-    http_options=genai_types.HttpOptions(timeout=_HTTP_TIMEOUT_MS),
-)
 _EMBED_MODEL = "gemini-embedding-001"
 _OUTPUT_DIM = 768
 
+# `genai.Client(api_key="")` raises ValueError at construction, so a missing
+# GEMINI_API_KEY would break `import main` (routes/quiz.py and routes/learn.py
+# both pull this module in) if built eagerly. #439 goes further: the client is
+# now built lazily, on first REAL-mode use. `_get_client()` is only ever
+# reached from inside an `_embed_*` function AFTER its `model_mode() != "real"`
+# gate below, so a non-real run (SAPLING_MODEL_MODE=function — the hermetic
+# E2E default, ADR 0019) never constructs a genai.Client and never touches the
+# network, instead of constructing one that then degrades by an accidental
+# swallowed exception.
+_client: genai.Client | None = None
+
+
+def _get_client() -> genai.Client:
+    global _client
+    if _client is None:
+        _client = genai.Client(
+            api_key=os.getenv("GEMINI_API_KEY", "") or "dummy-key-for-import",
+            http_options=genai_types.HttpOptions(timeout=_HTTP_TIMEOUT_MS),
+        )
+    return _client
+
+
+class _EmbeddingDisabled(RuntimeError):
+    """Raised by the `_embed_*` helpers when `SAPLING_MODEL_MODE != 'real'`.
+
+    Every caller (`retrieve_chunks`, `index_document_chunks`) already wraps
+    its embed call in a broad try/except — originally there to swallow a real
+    Gemini failure so retrieval/upload degrade gracefully instead of 500ing.
+    Raising here reuses that exact same degrade path, so function-mode
+    behavior is byte-for-byte identical to what an unlucky real-mode failure
+    already produced — except now it happens by design on every run, not by
+    accident of a swallowed exception (#439).
+    """
+
+
+def _require_real_mode() -> None:
+    if model_mode() != "real":
+        raise _EmbeddingDisabled(
+            "embedding skipped: SAPLING_MODEL_MODE != 'real' (below-seam RAG "
+            "embed path, #439)"
+        )
+
 
 def _embed_query(text: str) -> list[float]:
-    resp = _client.models.embed_content(
+    _require_real_mode()
+    resp = _get_client().models.embed_content(
         model=_EMBED_MODEL,
         contents=[text],
         config=genai_types.EmbedContentConfig(
@@ -43,7 +77,8 @@ def _embed_query(text: str) -> list[float]:
 
 
 def _embed_document(text: str) -> list[float]:
-    resp = _client.models.embed_content(
+    _require_real_mode()
+    resp = _get_client().models.embed_content(
         model=_EMBED_MODEL,
         contents=[text],
         config=genai_types.EmbedContentConfig(
@@ -55,7 +90,8 @@ def _embed_document(text: str) -> list[float]:
 
 
 def _embed_documents_batch(texts: list[str]) -> list[list[float]]:
-    resp = _client.models.embed_content(
+    _require_real_mode()
+    resp = _get_client().models.embed_content(
         model=_EMBED_MODEL,
         contents=texts,
         config=genai_types.EmbedContentConfig(

--- a/backend/tests/test_document_indexing.py
+++ b/backend/tests/test_document_indexing.py
@@ -14,7 +14,8 @@ definition sites (`services.chunker.chunk_document`,
 `services.rag_service.index_document_chunks`) rather than on
 `routes.documents`.
 """
-from unittest.mock import patch
+import logging
+from unittest.mock import MagicMock, patch
 
 from routes.documents import _index_document_chunks
 
@@ -94,3 +95,44 @@ class TestIndexDocumentChunks:
             )
 
         mock_index.assert_not_called()
+
+    def test_relevance_gate_skips_client_construction_outside_real_mode(self, monkeypatch, caplog):
+        """#439: the catalog-relevance embed call (a `google.genai.Client`
+        construction site predating the SAPLING_MODEL_MODE seam) only fires
+        when a catalog embedding actually exists for the course. When one
+        does and mode != 'real', no client may be constructed — the whole
+        indexing call aborts exactly like an unlucky real embed-call failure
+        already did (the outer `except` logs "_index_document_chunks failed
+        for doc %s", the line e2e_oracles/logscan.py's ALLOWLIST already
+        expects), so services.rag_service.index_document_chunks is never
+        reached either.
+        """
+        monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+        ctor = MagicMock(side_effect=AssertionError(
+            "genai.Client must not be constructed outside real mode"
+        ))
+        monkeypatch.setattr("google.genai.Client", ctor)
+
+        with (
+            patch(
+                "routes.documents.table",
+                side_effect=_mock_table_for(
+                    courses_rows=[{"course_code": "BIO-101"}],
+                    course_chunks_rows=[{"embedding": [0.1] * 768}],  # catalog row present
+                ),
+            ),
+            patch("services.chunker.chunk_document", return_value=["chunk one"]),
+            patch("services.rag_service.index_document_chunks") as mock_index,
+            caplog.at_level(logging.ERROR, logger="routes.documents"),
+        ):
+            _index_document_chunks(
+                doc_id="doc-gate",
+                course_id="course-uuid-1",
+                user_id="user-1",
+                extracted_text="some extracted text",
+                category="lecture_notes",
+            )
+
+        ctor.assert_not_called()
+        mock_index.assert_not_called()
+        assert "_index_document_chunks failed for doc doc-gate" in caplog.text

--- a/backend/tests/test_rag_service.py
+++ b/backend/tests/test_rag_service.py
@@ -3,15 +3,20 @@ import subprocess
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def test_import_succeeds_without_gemini_api_key():
-    """#378: rag_service builds a module-level `genai.Client` at import time and
-    `genai.Client(api_key="")` raises ValueError, so a missing GEMINI_API_KEY
-    broke `import main` (via routes/quiz.py -> services/rag_service.py) outright.
+    """#378: rag_service originally built a module-level `genai.Client` at
+    import time, and `genai.Client(api_key="")` raises ValueError, so a
+    missing GEMINI_API_KEY broke `import main` (via routes/quiz.py ->
+    services/rag_service.py) outright.
 
-    Its siblings already fall back to a dummy key — services/gemini_service.py
-    and agents/_providers.py — so imports stay clean and the failure surfaces at
-    call time instead. This pins that behaviour for the whole import graph.
+    #439 went further: client construction is now fully lazy (`_get_client()`,
+    reached only from inside a `model_mode() == 'real'` `_embed_*` call), so
+    import no longer touches `google.genai.Client` at all regardless of the
+    key — `rag._client` starts (and, absent a real-mode embed call, stays) as
+    `None`. This pins that behaviour for the whole import graph.
 
     Run in a subprocess: the modules are already imported in-process, so this is
     the only way to observe import-time behaviour. `load_dotenv` is stubbed out
@@ -32,7 +37,7 @@ def test_import_succeeds_without_gemini_api_key():
         "import os; os.environ.pop('GEMINI_API_KEY', None)\n"
         "import main\n"
         "import services.rag_service as rag\n"
-        "assert rag._client is not None\n"
+        "assert rag._client is None\n"
     )
     proc = subprocess.run(
         [sys.executable, "-c", program],
@@ -148,3 +153,99 @@ def test_index_document_chunks_handles_embedding_failure(mock_embed):
         # All records have embedding=None since embedding failed
         assert all(rec["embedding"] is None for rec in upsert_records)
         assert len(upsert_records) == 3
+
+
+# ── #439: below-seam RAG embed calls must gate on SAPLING_MODEL_MODE ───────
+#
+# These call sites (`_embed_query`, `_embed_document`, `_embed_documents_batch`)
+# predate the #391 seam and construct a raw `google.genai.Client` directly, so
+# they need their own mode check rather than going through `model_for`. In
+# non-real mode no client may be constructed and no network call attempted;
+# the existing callers' broad try/except (exercised above) then produces the
+# exact same deterministic empty/no-op result as an unlucky real-mode
+# failure — by design now, not by accident.
+
+
+def test_embed_query_does_not_construct_client_outside_real_mode(monkeypatch):
+    """Force a clean slate (module-level `_client` back to `None`) so this
+    exercises the lazy-construction path fresh, rather than reusing whatever
+    an earlier real-mode test already cached in the module singleton."""
+    import services.rag_service as rag
+
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setattr(rag, "_client", None)
+    ctor = MagicMock(side_effect=AssertionError(
+        "genai.Client must not be constructed outside real mode"
+    ))
+    monkeypatch.setattr(rag.genai, "Client", ctor)
+
+    with pytest.raises(RuntimeError, match="SAPLING_MODEL_MODE"):
+        rag._embed_query("dynamic programming")
+
+    ctor.assert_not_called()
+    assert rag._client is None
+
+
+def test_embed_documents_batch_does_not_construct_client_outside_real_mode(monkeypatch):
+    import services.rag_service as rag
+
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setattr(rag, "_client", None)
+    ctor = MagicMock(side_effect=AssertionError(
+        "genai.Client must not be constructed outside real mode"
+    ))
+    monkeypatch.setattr(rag.genai, "Client", ctor)
+
+    with pytest.raises(RuntimeError, match="SAPLING_MODEL_MODE"):
+        rag._embed_documents_batch(["chunk one", "chunk two"])
+
+    ctor.assert_not_called()
+    assert rag._client is None
+
+
+def test_retrieve_chunks_never_reaches_transport_in_function_mode(monkeypatch, capsys):
+    """Pre-#439, retrieve_chunks ignored SAPLING_MODEL_MODE entirely and always
+    called through to the real cached client — only the suite's autouse
+    `_hermetic_llm_transport` guard (#379) accidentally caught the resulting
+    network attempt, producing an 'unstubbed LLM egress' failure message that
+    retrieve_chunks' own except then swallowed into `[]`. Post-fix the mode
+    gate raises before ever reaching google-genai's transport, so that
+    message must never appear — the swallowed message names
+    SAPLING_MODEL_MODE instead.
+    """
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    from services.rag_service import retrieve_chunks
+
+    with patch("services.rag_service.rpc") as mock_rpc:
+        result = retrieve_chunks("dynamic programming", course_id="CAS CS 330")
+
+    assert result == []
+    mock_rpc.assert_not_called()
+    captured = capsys.readouterr()
+    assert "unstubbed LLM egress" not in captured.out
+    assert "SAPLING_MODEL_MODE" in captured.out
+
+
+def test_index_document_chunks_never_reaches_transport_in_function_mode(monkeypatch, capsys):
+    """Same proof as above for the batch/document embed path used by document
+    upload indexing — the deterministic no-op is count-with-embedding=None,
+    same shape as test_index_document_chunks_handles_embedding_failure, but
+    now reached by the mode gate rather than a real API error."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    from services.rag_service import index_document_chunks
+
+    with patch("services.rag_service.table") as mock_table:
+        mock_table.return_value.upsert.return_value = []
+        count = index_document_chunks(
+            course_code="CAS CS 330",
+            doc_id="doc-func-mode",
+            uploader_id="user-1",
+            chunks=["chunk one", "chunk two"],
+        )
+
+    assert count == 2
+    upsert_records = mock_table.return_value.upsert.call_args[0][0]
+    assert all(rec["embedding"] is None for rec in upsert_records)
+    captured = capsys.readouterr()
+    assert "unstubbed LLM egress" not in captured.out
+    assert "SAPLING_MODEL_MODE" in captured.out


### PR DESCRIPTION
Fixes #439.

## Root cause

`services/rag_service.py` (`_embed_query`/`_embed_document`/`_embed_documents_batch`) and `routes/documents.py::_index_document_chunks` (incl. the catalog-relevance gate) construct raw `google.genai.Client`s — they predate the #391 seam and never consult `SAPLING_MODEL_MODE`. In function mode that meant one live `gemini-embedding-001` call per upload, per quiz generate, and per tutor turn with a `course_code`: the "hermetic" E2E lane silently billed whenever a real key was present (failures swallowed → deterministic empties by accident).

## Fix

- `agents/_providers.py`: small public `model_mode()` accessor beside `model_name_for`.
- `services/rag_service.py`: all three `_embed_*` helpers converge on one `_require_real_mode()` gate at the single point that can reach `genai.Client` — non-`real` modes get the same deterministic empty results as before, now by design; the client is also now lazy (first real call) instead of import-time.
- `routes/documents.py::_index_document_chunks`: mode gate before any client construction; the abort flows to the same outer `except`/log line the swallowed path always produced — byte-identical function-mode behavior, and the client is no longer built when no catalog row could use it.
- Interim mitigations untouched by design: dummy-key forcing in `scripts/explore.sh`/`e2e.yml` and the e2e_oracles logscan allowlist stay as defense in depth.
- Out of scope (pre-existing, not E2E-lane-reachable): `services/gemini_service.py` (deprecated seam) and `scripts/ingest_catalog.py` still build real clients.

## Tests

6 new/updated tests, RED pre-fix: constructor-monkeypatch asserts (no `genai.Client` construction in function mode) for the rag helpers + relevance gate, plus transport-level never-reaches-egress proofs through the hermetic guard. Focused: 15/15 rag+indexing, 40/40 seam/guard. Full suite: 1160 passed, 26 skipped, 1 error = pre-existing #436 flake (fix riding separately in #453). ruff clean.

Playwright lane + oracles run against the live stack before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)