### PR TITLE
feat(evals): complete extraction-accuracy harness + baselines (#148)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,9 +7,10 @@ name: e2e (browser lane)
 #
 # Trigger is main-only per epic #402 open decision 3 (promote to a PR gate
 # once the #388 stability bar has held for a while). Postgres version comes
-# from supabase/config.toml (PG17) — this deliberately goes AGAINST epic
-# decision 2's recorded PG15 leaning, choosing consistency with the proven
-# local + integration.yml stack instead; the prod skew is tracked in #441.
+# from supabase/config.toml (PG15, #441) — matching staging/prod, so this
+# deterministic lane tests what production actually runs; local dev and CI
+# still stay consistent with each other (and with integration.yml) since both
+# follow the same config.toml pin.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,19 +1,20 @@
 name: Evals
-# Triggered manually only until cassette coverage is complete.
-#
-# Today only 4 of 70 cassettes are recorded, so a pull_request trigger
-# would mark every PR red on missing cassettes. Once the remaining 66
-# are recorded (one-time SAPLING_EVAL_MODE=record pass against live
-# Gemini, then commit cassettes/), re-enable the pull_request trigger
-# below to gate prompt changes on eval pass/fail.
+# Gates agent/prompt changes on the offline extraction-accuracy harness
+# (backend/tests/evals). Runs in replay mode against committed cassettes, so it
+# needs no Gemini key and is fully deterministic: a task only goes red when its
+# aggregate score drops below the committed baseline in baselines.json (someone
+# weakened an evaluator/expectation or swapped a cassette) or a cassette is
+# missing. Refresh cassettes + baselines with a local
+# `SAPLING_EVAL_MODE=record` pass and a `SAPLING_EVAL_UPDATE_BASELINES=1` pass,
+# then commit the changes (see backend/tests/evals/README or the ADR).
 on:
   workflow_dispatch:
-  # pull_request:
-  #   paths:
-  #     - 'backend/agents/**'
-  #     - 'backend/tests/evals/**'
-  #     - 'backend/services/agent_events.py'
-  #     - 'backend/routes/documents.py'
+  pull_request:
+    paths:
+      - 'backend/agents/**'
+      - 'backend/tests/evals/**'
+      - 'backend/services/agent_events.py'
+      - 'backend/routes/documents.py'
 
 jobs:
   evals:
@@ -38,7 +39,4 @@ jobs:
           ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
         run: |
           cd backend
-          python tests/evals/document_classification.py
-          python tests/evals/document_summary.py
-          python tests/evals/concept_extraction.py
-          python tests/evals/syllabus_extraction.py
+          python tests/evals/run_all.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,16 @@ ruff check .                    # lint, gated in CI against the ruff.toml baseli
 ruff format .                   # formatter — available, not yet CI-gated (see ruff.toml)
 ```
 
+E2E (repo root; full guide `docs/e2e-exploration.md`, stack guide `docs/local-supabase.md`):
+
+```
+make e2e-up                        # deterministic local stack: Supabase PG15 from config.toml + backend + frontend, function-mode LLM seam, rich seed
+cd frontend && npx playwright test # Chapter 1 journeys (frontend/e2e/*.spec.ts) — needs the stack up
+cd backend && venv/bin/python -m e2e_oracles   # deterministic judges (graph|counts|ciphertext|logscan|orphans); exit 0 clean / 1 findings / 2 infra
+make e2e-down                      # ALWAYS tear down, even after failures
+make explore                       # Chapter 2: bounded AI exploration of the running app (interactive: /explore); local-only, never CI
+```
+
 ## Conventions
 
 - All Supabase access goes through `db/connection.py::table()`. Do not instantiate `httpx` clients or import `supabase` directly elsewhere. The one sanctioned exception is `db/migrate.py`, which connects with psycopg to run DDL.
@@ -79,6 +89,9 @@ ruff format .                   # formatter — available, not yet CI-gated (see
 - `functools.lru_cache` is reserved for **deterministic, per-process reads** (#98) — either immutable mappings that never need invalidation (e.g. `academics.offering_course_id`) or reads with a matching `clear_*_cache()` hook that every mutator calls (e.g. `course_context_service.get_course_context` is cleared by `update_course_context`). Cache only hashable-arg functions; return a deep copy if the cached value is mutable; never cache without a clear invalidation story. The autouse `_clear_lru_caches` fixture in `tests/conftest.py` resets these between tests.
 - Backend tests live in `backend/tests/` and run via `pytest`; shared fixtures (mock Supabase, mock Gemini) are in `tests/conftest.py`.
 - Routers are mounted in `main.py` with `/api/<name>` prefixes; new routes follow that pattern.
+- **Verify substantive changes against the E2E lanes before merge**: hermetic suite + the Chapter 1 Playwright lane + the oracles (all three where applicable — `e2e.yml` re-runs the lane on every push to main, but pre-merge is the gate that can still say no). A bug fix in E2E-covered territory pairs with a promoted regression journey in `frontend/e2e/` (triage/promotion recipe: `docs/e2e-exploration.md` §7–§8; journey style: fixtures-based `test` from `support/fixtures.ts`, DB asserts via `support/db.ts`, testids per `docs/frontend-testids.md` "Adding a surface").
+- **The local E2E stack is a machine singleton.** Serialize ALL stack use (yours and every subagent's) via `flock` on `/tmp/claude-<uid>/sapling-e2e-stack.lock`, wrapping each whole up→test→down cycle in ONE flock invocation — never separate flock calls for up and down (detached servers inherit the lock fd; a separately-flocked teardown deadlocks). `make explore` manages its own lock.
+- **Function-mode seam**: the E2E lanes run `SAPLING_MODEL_MODE=function` with fixed handler constants from `agents/function_handlers_e2e.py` — every upload "summarizing" gradient descent is the seam working as designed, not a data bug (the tell: byte-match to an `E2E_*` constant). New request-path agent tasks need a handler registered there (unregistered tasks raise `UnregisteredHandlerError`); post-response BackgroundTask handlers stay deliberately unregistered. Keep handler constants ↔ spec assertions ↔ `tests/test_e2e_function_handlers.py` in sync. Code below the `agents/_providers.py` seam must never construct a raw `google.genai.Client` without a `model_mode()` gate (#439).
 
 ## Pointers
 
@@ -86,6 +99,7 @@ ruff format .                   # formatter — available, not yet CI-gated (see
 - For things that didn't work, see `docs/attempts/`.
 - For the current architecture overview, see `docs/architecture.md`.
 - For agent-building patterns, run `/sync-context` at session start.
+- For E2E testing (Chapter 1 scripted journeys + Chapter 2 AI exploration, oracles, triage, promotion), see `docs/e2e-exploration.md`.
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -272,17 +272,14 @@ npm test            # vitest run
 npm run test:watch  # vitest watch
 ```
 
-**Evals** (live Gemini, on demand) — 95 cases across 6 agents: the 4 worker agents (`document_classification`, `document_summary`, `concept_extraction`, `syllabus_extraction`) plus the chat tutor (`chat_tutor`) and quiz generator (`quiz_generation`). Three modes via `SAPLING_EVAL_MODE`:
+**Evals** — extraction-accuracy harness for the migrated agents. Five offline datasets (`document_classification`, `document_summary`, `concept_extraction`, `syllabus_extraction`, `quiz_generation`) run in replay mode against committed cassettes — no network, fully deterministic. Each task reports a per-evaluator accuracy score; a task fails only when it regresses below the committed baseline in `tests/evals/baselines.json` or a cassette is missing. One command runs them all:
 ```bash
 cd backend
-# Replay (default; no network, requires recorded cassettes):
-SAPLING_EVAL_MODE=replay python tests/evals/document_classification.py
-# Record (hits live Gemini, writes cassettes to tests/evals/cassettes/):
-SAPLING_EVAL_MODE=record python tests/evals/document_classification.py
-# Live (hits live Gemini, no recording):
-SAPLING_EVAL_MODE=live   python tests/evals/document_classification.py
+python tests/evals/run_all.py                                  # replay (default), gate on baselines
+SAPLING_EVAL_MODE=record python tests/evals/run_all.py         # refresh cassettes (live Gemini)
+SAPLING_EVAL_UPDATE_BASELINES=1 python tests/evals/run_all.py  # refresh baselines from current scores
 ```
-The `.github/workflows/evals.yml` workflow runs replay-mode in CI; it's currently `workflow_dispatch`-only until cassette coverage is complete (4 / 95 recorded today).
+`.github/workflows/evals.yml` runs `run_all.py` in replay mode on every PR that touches `backend/agents/**` or the harness. The `chat_tutor` dataset is excluded from the offline harness because its retrieval tool reads a live Supabase (tracked under #149). See `backend/tests/evals/README.md` for the record/refresh workflow.
 
 ## Architecture & Dev Context
 

--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -371,9 +371,11 @@ def _function_model_for(task: AgentTask) -> "Model":
     """Build a FunctionModel that dispatches to the task's registered handler at
     run time. The lookup is deferred to the call (not capture time) so a handler
     registered after the agent was imported still takes effect."""
-    from pydantic_ai.models.function import FunctionModel
+    import json
 
-    def _dispatch(messages, info):
+    from pydantic_ai.models.function import DeltaToolCall, FunctionModel
+
+    def _resolve_handler() -> FunctionModelHandler:
         handler = _FUNCTION_HANDLERS.get(task)
         if handler is None:
             # Out-of-process runs (E2E uvicorn) register via the env-named
@@ -387,9 +389,38 @@ def _function_model_for(task: AgentTask) -> "Model":
                 f"{task!r}, ...) before running the agent (or point "
                 f"SAPLING_FUNCTION_HANDLERS at a module that does)."
             )
-        return handler(messages, info)
+        return handler
 
-    return FunctionModel(_dispatch, model_name=f"function:{task}")
+    def _dispatch(messages, info):
+        return _resolve_handler()(messages, info)
+
+    async def _stream_dispatch(messages, info):
+        # Streamed runs (`agent.run_stream_events`, the SSE tutor routes) reuse
+        # the SAME registered handler rather than a parallel stream registry:
+        # the handler's ModelResponse is replayed as a stream — each text part
+        # as one delta, each tool call as a DeltaToolCall — so a task's handler
+        # constants stay byte-identical between the JSON and streamed lanes
+        # (spec assertions compare against the same E2E_* constants either way).
+        response = _resolve_handler()(messages, info)
+        for index, part in enumerate(response.parts):
+            kind = getattr(part, "part_kind", "")
+            if kind == "text":
+                if part.content:
+                    yield part.content
+            elif kind == "tool-call":
+                args = part.args
+                json_args = args if isinstance(args, str) else json.dumps(args or {})
+                yield {
+                    index: DeltaToolCall(
+                        name=part.tool_name,
+                        json_args=json_args,
+                        tool_call_id=part.tool_call_id,
+                    )
+                }
+
+    return FunctionModel(
+        _dispatch, stream_function=_stream_dispatch, model_name=f"function:{task}"
+    )
 
 
 def model_name_for(task: AgentTask) -> str:

--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -148,6 +148,20 @@ def _model_mode() -> str:
     return (os.getenv("SAPLING_MODEL_MODE") or "real").strip().lower()
 
 
+def model_mode() -> str:
+    """Public read of the active SAPLING_MODEL_MODE, for call sites outside
+    `agents/` that need to gate on the same seam but don't want a `Model`.
+
+    `_model_mode` stays private to this module for `model_for`'s internal
+    dispatch. This is the one sanctioned way a non-agent module reaches the
+    seam: `services/rag_service.py` and `routes/documents.py`'s RAG indexing
+    build raw `google.genai.Client`s directly (predating #391), so they gate
+    on `model_mode() == "real"` rather than importing the private name across
+    a package boundary (#439).
+    """
+    return _model_mode()
+
+
 def register_function_handler(task: AgentTask, handler: FunctionModelHandler) -> None:
     """Register the FunctionModel handler for a task (function mode only).
 

--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -18,9 +18,12 @@ the Pro tier for the conversational tutor where reasoning depth matters.
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import os
-from typing import TYPE_CHECKING, Callable, Literal
+import threading
+import weakref
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from pydantic_ai.models.google import GoogleModel
 from pydantic_ai.providers.google import GoogleProvider
@@ -92,10 +95,153 @@ _DEFAULTS: dict[AgentTask, str] = {
 }
 
 
-# Pydantic AI's GoogleProvider expects an API key at construction. CI and
-# import-time tools don't have GEMINI_API_KEY set; the dummy keeps imports
-# clean and only fails at .run() time when the agent actually needs Gemini.
-_provider = GoogleProvider(api_key=GEMINI_API_KEY or "dummy-key-for-import")
+def _new_provider() -> GoogleProvider:
+    """A fresh `GoogleProvider` (fresh `google.genai` client + httpx connection
+    pool). CI and import-time tools don't have GEMINI_API_KEY set; the dummy
+    keeps imports clean and only fails at .run() time when the agent actually
+    needs Gemini."""
+    return GoogleProvider(api_key=GEMINI_API_KEY or "dummy-key-for-import")
+
+
+# ── #354 root-cause fix: loop-scoped provider, resolved at READ time ───────
+#
+# Every agent is built ONCE, at import time, from `Agent(model=model_for(task),
+# ...)` — so whatever `Model` instance `model_for`/`google_model` hand back is
+# shared across every later `.run()` call for that agent's whole process
+# lifetime, across every concurrent request. Until this fix, that model
+# wrapped ONE module-level `GoogleProvider` singleton, and `GoogleProvider.
+# __init__` eagerly builds an `httpx.AsyncClient` whose connection pool binds
+# internal asyncio primitives (locks, etc.) to whichever event loop is running
+# the first time a request actually goes out over it.
+#
+# `run_agent_sync` (`agents/_run.py`, `asyncio.run`) drives agents on a BRAND
+# NEW throwaway loop per call, closed on return — and, identically, so does any
+# test that calls `asyncio.run()` more than once against the same shared agent
+# in one process (e.g. `tests/test_ocr_pipeline.py::test_agent_parse` then
+# the `parsed_assignments` fixture feeding `test_save_to_db`, #436). Reusing
+# the singleton's client after its original loop closes trips
+# `RuntimeError: Event loop is closed` on the very next call through it —
+# every SECOND real call, alternating forever.
+#
+# A prior attempt (#358, never merged) fixed this by sweeping every
+# `run_agent_sync` call SITE to pass a `model=` override built on a fresh
+# provider. That requires every current AND future caller to remember the
+# override — `agents/ocr_vision.py` already needed its own ad hoc copy of the
+# same idea for the one path #358 didn't wait for (OCR page transcription),
+# and `test_save_to_db`'s failure shows a caller (`calendar_service`'s
+# syllabus-extraction agent) that wasn't even on #358's sweep list. The issue
+# itself flagged this as "the tactical sweep", with "make the shared provider
+# loop-safe" as the strategic fix.
+#
+# FIX-ROUND-1 CORRECTION (PR review finding, concurrency bug): the first
+# version of `_LoopSafeGoogleModel` resolved the right provider under a lock
+# in `_bind_to_current_loop()`, but then handed it off through a single
+# shared MUTABLE `self._provider` attribute — and `self` is itself a
+# module-level singleton shared by every concurrent call to the agent it
+# backs. `GoogleModel._generate_content` reads `self.client` (→
+# `self._provider.client`) only AFTER an `await` (`self._build_content_and_
+# config(...)`); in that window, a DIFFERENT thread running a DIFFERENT event
+# loop — exactly what happens under concurrent requests, since every
+# sync-`def` route drives `run_agent_sync` on a fresh thread + throwaway
+# loop, and `gemini_vision_backend._run_from_anywhere` does the same for OCR
+# — could call its OWN `_bind_to_current_loop()` and overwrite that same
+# shared attribute. The first call would then resume and read a provider
+# bound to someone ELSE's — possibly already-closed — loop: a deterministic
+# every-second-call flake turned into a probabilistic, load-dependent one,
+# not fixed. Confirmed empirically: 6 threads × 20 sequential `asyncio.run`
+# calls against one shared instance, with an `asyncio.sleep` standing in for
+# the real await gap, produced 95/120 mismatches between the provider bound
+# for a call and the one actually read back.
+#
+# The fix below removes the hand-off entirely — there is no longer any
+# instance attribute that one thread resolves and a later expression, on
+# a possibly-different thread, trusts is still current. `self._provider` (the
+# base `GoogleModel`/`Model` attribute) is now a FIXED TEMPLATE: constructed
+# once, in `__init__`, and never reassigned afterward. It backs only the
+# handful of reads that are genuinely loop-INDEPENDENT — `system`/`base_url`,
+# and the bare `.name`/`.base_url` pydantic-ai's own inherited `count_tokens`/
+# usage-metadata code reads directly off `self._provider` — which are
+# identical no matter which provider instance answers them, because every
+# provider this module ever constructs (`_new_provider()`) is built with the
+# exact same arguments (deterministic given the API key). This module does
+# NOT override `system`/`base_url`; they stay on the inherited GoogleModel
+# implementation, reading the fixed template, by this explicit design choice.
+#
+# The ONE read that IS loop-affine — `.client`, the actual `google.genai.
+# Client` that makes real HTTP requests — is overridden below as a PROPERTY
+# that resolves `asyncio.get_running_loop()` → the loop-keyed cache FRESH, AT
+# THE MOMENT OF EVERY ACCESS, and returns immediately: no `await`, no
+# instance-attribute write, nothing for a concurrent thread to race against
+# in between "resolve" and "use". Every inherited method (`request`,
+# `count_tokens`, `request_stream`, `_generate_content`, ...) reads
+# `self.client` through ordinary Python attribute lookup, so this one
+# override covers every one of them automatically — none of `request`/
+# `count_tokens`/`request_stream` need to be (and are no longer) overridden
+# themselves. Because there is no shared pointer left to go stale, correctness
+# no longer depends on timing: whichever thread/loop happens to be running
+# when `.client` is evaluated gets exactly (and only) the provider that
+# belongs to it, cached per-loop in a `WeakKeyDictionary` keyed by the loop
+# object itself so entries vanish on their own once a throwaway loop is
+# garbage-collected (no unbounded growth over a long process's lifetime of
+# `run_agent_sync` calls). The one persistent loop that matters most —
+# FastAPI's per-process async loop, shared by every `async def` route handler
+# for the app's whole lifetime — still gets the same connection-pooling
+# benefit the old singleton gave it, since its cache entry is looked up (not
+# rebuilt) on every subsequent call. No call site — present or future — has
+# to know event loops (or threads) exist.
+class _LoopSafeGoogleModel(GoogleModel):
+    """A `GoogleModel` whose `.client` resolves the provider bound to the
+    CURRENTLY RUNNING event loop at every access, instead of caching one on
+    `self`. See the module-level comment above for why (#354/#436, and the
+    fix-round-1 correction to this class's first version, which cached a
+    shared `self._provider` pointer and raced under concurrent requests)."""
+
+    def __init__(self, model_name: str) -> None:
+        # `provider=` here becomes a fixed TEMPLATE (see module comment) —
+        # constructed once, never reassigned, read only for loop-independent
+        # metadata. It must NEVER be read for `.client` — that's what the
+        # property override below is for.
+        super().__init__(model_name, provider=_new_provider())
+        self._loop_providers: "weakref.WeakKeyDictionary[Any, GoogleProvider]" = (
+            weakref.WeakKeyDictionary()
+        )
+        self._loop_providers_lock = threading.Lock()
+
+    def _provider_for_current_loop(self) -> GoogleProvider:
+        """The provider bound to whichever event loop is running RIGHT NOW,
+        creating one on first use. Deliberately never cached anywhere on
+        `self` — every caller (`client`, `__aenter__`, `__aexit__`) calls
+        this at the exact point of use, so the result can never go stale by
+        the time it's read. Caching it into an instance attribute between
+        "resolve" and "use" is exactly the fix-round-1 bug this replaces."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop — a plain sync caller inspecting `.client`
+            # outside any asyncio context (e.g. a test). Nothing can race
+            # this: with no loop, there is no concurrent request in flight
+            # to collide with. The fixed template is a safe, deterministic
+            # fallback.
+            return self._provider
+        with self._loop_providers_lock:
+            provider = self._loop_providers.get(loop)
+            if provider is None:
+                provider = _new_provider()
+                self._loop_providers[loop] = provider
+            return provider
+
+    @property
+    def client(self):
+        return self._provider_for_current_loop().client
+
+    async def __aenter__(self):
+        provider = self._provider_for_current_loop()
+        await provider.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        provider = self._provider_for_current_loop()
+        await provider.__aexit__(exc_type, exc_val, exc_tb)
 
 
 # ── Test seam: SAPLING_MODEL_MODE (#391) ───────────────────────────────────
@@ -261,12 +407,14 @@ def model_for(task: AgentTask) -> "Model":
 
     Dispatches on SAPLING_MODEL_MODE (default 'real'). In real mode, reads the
     per-task SAPLING_MODEL_<TASK_UPPER> override first (ADR 0008), else the
-    per-task default, and returns a GoogleModel sharing the project provider.
-    In function mode, returns a FunctionModel (see the seam notes above).
+    per-task default, and returns a `_LoopSafeGoogleModel` (#354/#436 — see the
+    comment above that class) so the caller never has to think about which
+    event loop it ends up running on. In function mode, returns a FunctionModel
+    (see the seam notes above).
     """
     mode = _model_mode()
     if mode == "real":
-        return GoogleModel(model_name_for(task), provider=_provider)
+        return _LoopSafeGoogleModel(model_name_for(task))
     if mode == "function":
         return _function_model_for(task)
     if mode == "cassette":
@@ -284,5 +432,7 @@ def model_for(task: AgentTask) -> "Model":
 
 # Back-compat shim for any caller still using google_model(name).
 def google_model(name: str) -> GoogleModel:
-    """Return a configured GoogleModel sharing the project-wide provider."""
-    return GoogleModel(name, provider=_provider)
+    """Return a configured GoogleModel for a bare model name (bypassing the
+    per-task `_DEFAULTS`/env-override resolution `model_for` does), on the
+    same loop-safe basis as `model_for` (#354/#436)."""
+    return _LoopSafeGoogleModel(name)

--- a/backend/agents/_providers.py
+++ b/backend/agents/_providers.py
@@ -95,6 +95,12 @@ _DEFAULTS: dict[AgentTask, str] = {
 }
 
 
+# The admin `/api/gemini-test` connectivity probe has no `_DEFAULTS` task of
+# its own; it just needs the cheapest round-trip. Pinned here so probe sites
+# (agents/health.py) can't drift from each other.
+HEALTH_PROBE_MODEL = "gemini-2.5-flash-lite"
+
+
 def _new_provider() -> GoogleProvider:
     """A fresh `GoogleProvider` (fresh `google.genai` client + httpx connection
     pool). CI and import-time tools don't have GEMINI_API_KEY set; the dummy

--- a/backend/agents/_run.py
+++ b/backend/agents/_run.py
@@ -21,7 +21,30 @@ T = TypeVar("T")
 def run_agent_sync(coro: Coroutine[Any, Any, T]) -> T:
     """Run an agent coroutine to completion from synchronous code.
 
-    Must be called from a thread with no running event loop (the case for
-    FastAPI sync handlers and direct unit-test calls under TestClient).
+    Intended for FastAPI sync ``def`` handlers, which FastAPI runs in a worker
+    thread with no event loop — there ``asyncio.run`` drives the agent.
+
+    Some sync helpers are ALSO reached from *async* handlers via a sync call
+    chain (e.g. ``_legacy_chat`` -> ``apply_graph_update`` ->
+    ``update_course_context`` -> ``_generate_summary_with_gemini`` -> here,
+    and the same shape from the async upload pipeline). A loop is already running on
+    that thread, so ``asyncio.run`` can't be used and — critically — we must not
+    block the event loop on an LLM round-trip. The old code let ``asyncio.run``
+    raise and leaked a "coroutine 'run' was never awaited" warning. Instead,
+    close ``coro`` (no warning) and raise a clear error so the (already
+    ``try/except``-guarded) caller degrades gracefully; the async path should
+    ``await`` the agent directly rather than route through this seam.
     """
-    return asyncio.run(coro)
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No loop on this thread: the sanctioned synchronous seam.
+        return asyncio.run(coro)
+    # A loop is already running: we can't drive the coroutine here without
+    # blocking it. Close it to avoid a "never awaited" warning, then signal
+    # the misuse clearly for the caller to handle.
+    coro.close()
+    raise RuntimeError(
+        "run_agent_sync() was called from a running event loop; async callers "
+        "must await the agent directly."
+    )

--- a/backend/agents/health.py
+++ b/backend/agents/health.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 from pydantic_ai import Agent
 
-from agents._providers import google_model
+from agents._providers import HEALTH_PROBE_MODEL, google_model
 
 
 # Cheapest model on the shared provider; the probe only needs a round-trip.
 health_probe_agent = Agent[None, str](
-    model=google_model("gemini-2.5-flash-lite"),
+    model=google_model(HEALTH_PROBE_MODEL),
     output_type=str,
     system_prompt="You are a connectivity probe. Reply with exactly the text the user asks for.",
     metadata={"agent": "health_probe"},

--- a/backend/agents/ocr_vision.py
+++ b/backend/agents/ocr_vision.py
@@ -26,7 +26,7 @@ import hashlib
 from pydantic_ai import Agent
 from pydantic_ai.models.google import GoogleModelSettings
 
-from agents._providers import _model_mode, model_for, model_name_for
+from agents._providers import model_for
 
 
 # The model is asked to return this verbatim for an empty page. Public because
@@ -72,38 +72,12 @@ ocr_vision_agent = Agent[None, str](
     metadata={"prompt_version": _PROMPT_HASH, "agent": "ocr_vision"},
 )
 
-
-def fresh_ocr_vision_model():
-    """A model bound to no prior event loop, for one `run_agent_sync` call.
-
-    `_providers._provider` is a module-level GoogleProvider, so its async httpx
-    client binds to the first loop `asyncio.run` creates and dies with it:
-    call 1 succeeds, call 2 raises `RuntimeError: Event loop is closed`,
-    call 3 succeeds. Measured exactly that way against the live API.
-
-    Every `run_agent_sync` caller shares this (#354; the sweep is open in PR
-    #358), but transcription is the only one that runs in a LOOP — a 10-page
-    scan alternates success/failure page by page, and
-    `_apply_gemini_vision_fallback`'s per-page `except Exception: continue`
-    keeps Docling's text without a word, so half a document silently degrades.
-    That is the difference between a latent bug and an unusable feature, which
-    is why this path does not wait for #358.
-
-    Scoped deliberately: a fresh provider for THIS agent's runs only, passed as
-    a per-run `model=` override. It leaves the shared `_provider` untouched, so
-    it cannot conflict with whatever #358 lands.
-
-    Returns None when SAPLING_MODEL_MODE is not 'real' — the FunctionModel seam
-    builds no client, has no loop affinity, and must not be overridden.
-    """
-    if _model_mode() != "real":
-        return None
-    from pydantic_ai.models.google import GoogleModel
-    from pydantic_ai.providers.google import GoogleProvider
-
-    from config import GEMINI_API_KEY
-
-    return GoogleModel(
-        model_name_for("ocr_vision"),
-        provider=GoogleProvider(api_key=GEMINI_API_KEY or "dummy-key-for-import"),
-    )
+# A 10-page scan calls this agent in a per-page LOOP from
+# `services/extraction_backends/gemini_vision_backend.py`; that used to be the
+# one path that couldn't wait for #354's fresh-provider fix to land (a stale
+# `_providers._provider` singleton alternated success/failure page by page,
+# and `_apply_gemini_vision_fallback`'s per-page `except Exception: continue`
+# silently kept Docling's empty text instead). `model_for("ocr_vision")` above
+# is now loop-safe on its own (`agents._providers._LoopSafeGoogleModel`), so
+# this call site needs no per-run `model=` override anymore — it used to build
+# one here (`fresh_ocr_vision_model`), which is now redundant and removed.

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -377,11 +377,31 @@ def list_documents(user_id: str, request: Request):
         filters={"user_id": f"eq.{user_id}", "deleted_at": "is.null"},
         order="created_at.desc",
     ) or []
+    # The row keys on the OFFERING (0025); the HTTP boundary keeps the
+    # abstract course_id (#435 — Library.tsx filters/labels on d.course_id).
+    # Resolve each unique offering_id once (mirrors routes/learn.py's
+    # list_sessions offering_to_course pattern), not once per row.
+    offering_to_course: dict[str, str | None] = {}
     for d in docs:
         d["summary"] = decrypt_if_present(d.get("summary"))
         notes_raw = d.get("concept_notes")
         if isinstance(notes_raw, str):
-            d["concept_notes"] = decrypt_json(notes_raw)
+            try:
+                d["concept_notes"] = decrypt_json(notes_raw)
+            except Exception:
+                # decrypt_json re-raises when both decrypt AND plaintext
+                # parse fail (a genuinely corrupted row) — degrade that one
+                # row instead of 500ing the whole list (matches
+                # _existing_doc_by_request_id and scan_document_concepts).
+                logger.warning(
+                    "concept_notes decrypt failed for document %s; degrading to []",
+                    d.get("id"),
+                )
+                d["concept_notes"] = []
+        off_id = d.get("offering_id")
+        if off_id and off_id not in offering_to_course:
+            offering_to_course[off_id] = offering_course_id(off_id)
+        d["course_id"] = offering_to_course.get(off_id)
     return {"documents": docs}
 
 

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -42,6 +42,7 @@ from services.achievement_service import check_achievements
 from services.agent_events import SaplingEvent, sapling_event_to_sse
 from services.request_context import current_request_id
 from agents import WORKER_LIMITS
+from agents._providers import model_mode
 from agents.classifier import classifier_agent
 from agents.summary import summary_agent
 from agents.concept_extraction import concept_extraction_agent
@@ -1084,18 +1085,35 @@ def _index_document_chunks(
         except Exception:
             logger.warning("[RAG] could not store extracted_text for doc %s", doc_id)
 
-        # Relevance gate: skip docs that are off-topic for the course
-        from google import genai as _genai
-        from google.genai import types as genai_types
-        import os
-        _gclient = _genai.Client(api_key=os.getenv("GEMINI_API_KEY", ""))
-
+        # Relevance gate: skip docs that are off-topic for the course. The
+        # embedding-based check below is a `google.genai` call site that
+        # predates the #391 SAPLING_MODEL_MODE seam; catalog_rows itself is a
+        # plain Supabase read (not gated) so the gate is only ever skipped
+        # when there's actually a catalog embedding to compare against.
         catalog_rows = table("course_chunks").select(
             "embedding",
             filters={"course_id": f"eq.{bu_course_id}", "category": "eq.catalog"},
             limit=1,
         )
         if catalog_rows and catalog_rows[0].get("embedding"):
+            if model_mode() != "real":
+                # #439: no google.genai.Client in non-real mode. Raising here
+                # (instead of silently skipping the gate) reproduces the exact
+                # behavior a real embed-call failure already produced: the
+                # outer `except` below aborts indexing and logs
+                # "_index_document_chunks failed for doc %s" — the line
+                # e2e_oracles/logscan.py's ALLOWLIST already expects. Function
+                # mode is now that same no-op, by design, not by accident of a
+                # swallowed exception.
+                raise RuntimeError(
+                    "RAG relevance-gate embedding skipped: "
+                    "SAPLING_MODEL_MODE != 'real' (#439)"
+                )
+
+            from google import genai as _genai
+            from google.genai import types as genai_types
+
+            _gclient = _genai.Client(api_key=os.getenv("GEMINI_API_KEY", ""))
             catalog_vec = catalog_rows[0]["embedding"]
             sample_text = doc_summary or chunks[0]
             resp = _gclient.models.embed_content(

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -7,6 +7,7 @@ import os
 from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Query, Request
+from sse_starlette.sse import EventSourceResponse
 
 from pydantic_ai.exceptions import UsageLimitExceeded, UnexpectedModelBehavior
 from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
@@ -17,7 +18,9 @@ from agents.deps import SaplingDeps
 from db.connection import table
 from services.academics import offering_course_id, resolve_offering
 from models import StartSessionBody, ChatBody, EndSessionBody, ActionBody, ModeSwitchBody, RenameSessionBody
+from services.agent_events import sapling_event_to_sse
 from services.auth_guard import require_self, get_session_user_id
+from services.chat_stream import merge_graph_updates, stream_agent_turn
 from services.encryption import encrypt_if_present, encrypt_json, decrypt_if_present, decrypt_json
 from services.profiles import get_display_name
 from services.gemini_service import (
@@ -450,17 +453,32 @@ def _ensure_session_ready(session_id: str, user_id: str) -> None:
     _consume_pending(session_id, user_id)
 
 
-@router.post("/start-session")
-def start_session(body: StartSessionBody, request: Request):
-    # TODO(refactor-3 follow-up): migrate `start_session` to chat_tutor_agent
-    # using the same try-agent-then-legacy pattern as `chat`. Current PR scopes
-    # the agent-path migration to the main `chat` route only.
-    require_self(body.user_id, request)
-    session_id = str(uuid.uuid4())
+def _start_session_legacy(body: StartSessionBody, session_id: str | None = None) -> dict:
+    """Core start-session pipeline: call_gemini_multiturn -> extract_graph_update
+    -> apply_graph_update -> stash PENDING_SESSIONS.
+
+    Extracted so the JSON route and the streaming route's Rung-1
+    `legacy_fallback` (agent failed before any token) share this verbatim —
+    the JSON route's external behavior stays byte-identical (ADR 0001/0015),
+    it just reshapes this dict into its historical response below.
+
+    `session_id`: the streaming route already minted one up front (it needs
+    it for SaplingDeps before it knows whether the agent or this fallback
+    will serve the turn); passing it through here means a turn only ever
+    has ONE session_id and PENDING_SESSIONS is stashed exactly once,
+    regardless of which path serves it. `None` (the JSON route's case)
+    mints a fresh one, matching the original inline behavior.
+
+    Returns {"session_id", "reply", "graph_update", "mastery_changes",
+    "graph_state"} — a superset of what the JSON route needs, and exactly
+    the shape the streaming `done` event / frontend `ChatResult` expects.
+    """
+    if session_id is None:
+        session_id = str(uuid.uuid4())
 
     student_name = get_user_name(body.user_id)
     graph_data = get_graph(body.user_id)
-    
+
     # Use abstract course_id from body, or resolve it from the topic. The graph
     # + shared context key on this abstract id; documents + the session row key
     # on the offering it resolves to (current term).
@@ -486,7 +504,7 @@ def start_session(body: StartSessionBody, request: Request):
         raise HTTPException(status_code=502, detail=f"Gemini error: {e}")
 
     reply, graph_update = extract_graph_update(raw)
-    apply_graph_update(body.user_id, graph_update, course_id=course_id)
+    mastery_changes = apply_graph_update(body.user_id, graph_update, course_id=course_id)
 
     PENDING_SESSIONS[session_id] = {
         "user_id": body.user_id,
@@ -501,12 +519,30 @@ def start_session(body: StartSessionBody, request: Request):
 
     return {
         "session_id": session_id,
-        "initial_message": reply,
+        "reply": reply,
+        "graph_update": graph_update,
+        "mastery_changes": mastery_changes,
         "graph_state": get_graph(body.user_id),
     }
 
 
-async def _chat_via_agent(
+@router.post("/start-session")
+def start_session(body: StartSessionBody, request: Request):
+    # TODO(refactor-3 follow-up): migrate `start_session` to chat_tutor_agent
+    # using the same try-agent-then-legacy pattern as `chat`. Current PR scopes
+    # the agent-path migration to the main `chat` route only. (The streamed
+    # counterpart, /start-session/stream, already does this — see below;
+    # this JSON route stays the untouched rollback target per ADR 0001/0015.)
+    require_self(body.user_id, request)
+    result = _start_session_legacy(body)
+    return {
+        "session_id": result["session_id"],
+        "initial_message": result["reply"],
+        "graph_state": result["graph_state"],
+    }
+
+
+def _prepare_chat_run(
     *,
     user_id: str,
     session_id: str,
@@ -517,23 +553,12 @@ async def _chat_via_agent(
     use_shared_context: bool,
     request_id: str,
     model_pref: str | None = None,
-) -> dict:
-    """Run chat_tutor_agent and return the legacy response shape.
+) -> tuple:
+    """Build (agent, assembled_message, run_kwargs, deps) for a chat turn.
 
-    Returns ``{"reply": str, "graph_update": dict, "mastery_changes": list}``.
-    Graph changes are persisted in-band during the agent run by
-    `apply_graph_update_tool` / `update_mastery_tool` (registered on
-    chat_tutor); the tools also accumulate their payloads on `deps` so the
-    route can echo `graph_update` (for graph_update_json / concepts_covered)
-    and the real `mastery_changes` deltas back to the client, matching the
-    legacy path. Both are empty when nothing changed this turn.
-
-    `use_shared_context=False` flips the model into "no class-aggregate"
-    mode by appending a constraint instruction to the user message —
-    the chat tutor's class-aggregate tools (read_user_progress, etc.)
-    aggregate per-user data, but a future shared-context tool would
-    need this guard rail. Keeping the constraint in-band rather than
-    branching the agent surface keeps the agent definition stable.
+    Shared verbatim by the JSON path (`_chat_via_agent`) and the streaming
+    route so prompt assembly never forks. Extracted from `_chat_via_agent`;
+    behavior is unchanged.
     """
     agent = agent_for_mode(mode)
 
@@ -588,16 +613,57 @@ async def _chat_via_agent(
     if model_pref != "fast":
         run_kwargs["model_settings"] = _build_pro_model_settings()
 
+    return agent, user_message, run_kwargs, deps
+
+
+async def _chat_via_agent(
+    *,
+    user_id: str,
+    session_id: str,
+    course_id: str,
+    mode: str,
+    user_message: str,
+    message_history: list,
+    use_shared_context: bool,
+    request_id: str,
+    model_pref: str | None = None,
+) -> dict:
+    """Run chat_tutor_agent and return the legacy response shape.
+
+    Returns ``{"reply": str, "graph_update": dict, "mastery_changes": list}``.
+    Graph changes are persisted in-band during the agent run by
+    `apply_graph_update_tool` / `update_mastery_tool` (registered on
+    chat_tutor); the tools also accumulate their payloads on `deps` so the
+    route can echo `graph_update` (for graph_update_json / concepts_covered)
+    and the real `mastery_changes` deltas back to the client, matching the
+    legacy path. Both are empty when nothing changed this turn.
+
+    `use_shared_context=False` flips the model into "no class-aggregate"
+    mode by appending a constraint instruction to the user message —
+    the chat tutor's class-aggregate tools (read_user_progress, etc.)
+    aggregate per-user data, but a future shared-context tool would
+    need this guard rail. Keeping the constraint in-band rather than
+    branching the agent surface keeps the agent definition stable.
+    """
+    agent, user_message, run_kwargs, deps = _prepare_chat_run(
+        user_id=user_id,
+        session_id=session_id,
+        course_id=course_id,
+        mode=mode,
+        user_message=user_message,
+        message_history=message_history,
+        use_shared_context=use_shared_context,
+        request_id=request_id,
+        model_pref=model_pref,
+    )
+
     result = await agent.run(user_message, **run_kwargs)
     reply = result.output  # str — chat_tutor agents return plain Markdown.
 
     # Merge all graph update payloads accumulated by tools during this run
     # into a single dict so the route can persist graph_update_json and
     # end_session can derive concepts_covered correctly.
-    merged_graph_update: dict = {}
-    for gu in deps.graph_updates:
-        for key, items in gu.items():
-            merged_graph_update.setdefault(key, []).extend(items)
+    merged_graph_update = merge_graph_updates(deps.graph_updates)
 
     return {
         "reply": reply,
@@ -720,6 +786,175 @@ async def chat(body: ChatBody, request: Request):
     save_message(body.session_id, "assistant", response["reply"], graph_update)
 
     return response
+
+
+@router.post("/chat/stream")
+async def chat_stream(body: ChatBody, request: Request):
+    """SSE token-streaming chat turn (#70) with live graph deltas (#74).
+
+    The JSON /chat route stays the non-streaming fallback (ADR 0001). No DBOS
+    wrap here — stream routes are deliberately outside durable execution
+    (ADR 0011); retries are client-driven and idempotent via X-Request-ID.
+    """
+    require_self(body.user_id, request)
+    _consume_pending(body.session_id, body.user_id)
+
+    request_id = (
+        getattr(request.state, "request_id", None)
+        or current_request_id()
+        or str(uuid.uuid4())
+    )
+
+    offering_id = _get_session_offering_id(body.session_id)
+    course_id = offering_course_id(offering_id) if offering_id else ""
+    # Load prior turns BEFORE the new user row is written, so history is
+    # conversation state up to (not including) this turn.
+    message_history = _load_message_history(body.session_id)
+
+    agent, assembled, run_kwargs, deps = _prepare_chat_run(
+        user_id=body.user_id,
+        session_id=body.session_id,
+        course_id=course_id,
+        mode=body.mode,
+        user_message=body.message,
+        message_history=message_history,
+        use_shared_context=body.use_shared_context,
+        request_id=request_id,
+        model_pref=body.model_pref,
+    )
+    # No extra model override here: _prepare_chat_run already applied the
+    # seam-aware fast/smart preference (_resolve_model_pref), and the agent's
+    # own model is _LoopSafeGoogleModel in real mode / FunctionModel under
+    # SAPLING_MODEL_MODE=function — forcing a GoogleModel here would bypass
+    # the e2e seam and re-create the cross-loop client problem #453 solved.
+
+    def _persist(reply: str, graph_update: dict, mastery_changes: list) -> dict:
+        # Mirrors chat()'s ordering: user row, then assistant row. Runs only
+        # after the agent run completes, so a disconnect mid-generation
+        # persists nothing. Encryption happens inside save_message.
+        save_message(body.session_id, "user", body.message)
+        save_message(body.session_id, "assistant", reply, graph_update or None)
+        return {}
+
+    async def _legacy() -> dict:
+        # Rung 1 only (agent failed before any token). _legacy_chat persists
+        # its own user + assistant rows, so _persist must not also run —
+        # stream_agent_turn enforces that exclusivity.
+        return await _legacy_chat(body, request)
+
+    async def event_stream():
+        async for ev in stream_agent_turn(
+            agent=agent,
+            user_message=assembled,
+            run_kwargs=run_kwargs,
+            deps=deps,
+            on_complete=_persist,
+            legacy_fallback=_legacy,
+            request_id=request_id,
+        ):
+            yield sapling_event_to_sse(ev)
+
+    return EventSourceResponse(
+        event_stream(), headers={"X-Request-ID": request_id}
+    )
+
+
+@router.post("/start-session/stream")
+async def start_session_stream(body: StartSessionBody, request: Request):
+    """Streamed session opener — closes ADR-0015's start_session TODO by
+    running chat_tutor_agent instead of call_gemini_multiturn, and removes a
+    legacy call site on the primary path (#152/#151).
+
+    The JSON /start-session route is unchanged and remains the fallback.
+    PENDING_SESSIONS lazy materialization is preserved exactly: the row is
+    still written on first chat, by _consume_pending.
+
+    Rung 1 (agent fails before any token) falls back to
+    `_start_session_legacy` — the JSON route's own pipeline, per the spec's
+    fallback ladder. `stream_agent_turn` guarantees AT MOST one of
+    `on_complete` (`_stash`, below) / `legacy_fallback` (`_legacy`, below)
+    runs per turn — never both — so PENDING_SESSIONS is stashed at most
+    once: `_stash` on the agent-success path, `_start_session_legacy`
+    internally on the Rung-1 fallback path. A Rung-2 error (failure after
+    the greeting started streaming) stashes NOTHING for this session_id —
+    the client never received it in a `done` event, so a retry simply mints
+    a fresh session.
+    """
+    require_self(body.user_id, request)
+    request_id = (
+        getattr(request.state, "request_id", None)
+        or current_request_id()
+        or str(uuid.uuid4())
+    )
+    session_id = str(uuid.uuid4())
+
+    course_id = body.course_id or _get_course_id_for_topic(body.topic, body.user_id)
+    offering_id = resolve_offering(course_id, create=True) if course_id else ""
+
+    user_message = (
+        f"Student wants to learn about: {body.topic}\n\n"
+        "Begin the session with a warm greeting and your first question or explanation."
+    )
+
+    agent, assembled, run_kwargs, deps = _prepare_chat_run(
+        user_id=body.user_id,
+        session_id=session_id,
+        course_id=course_id,
+        mode=body.mode,
+        user_message=user_message,
+        message_history=[],
+        use_shared_context=body.use_shared_context,
+        request_id=request_id,
+        model_pref=body.model_pref,
+    )
+    # No extra model override here: _prepare_chat_run already applied the
+    # seam-aware fast/smart preference (_resolve_model_pref), and the agent's
+    # own model is _LoopSafeGoogleModel in real mode / FunctionModel under
+    # SAPLING_MODEL_MODE=function — forcing a GoogleModel here would bypass
+    # the e2e seam and re-create the cross-loop client problem #453 solved.
+
+    def _stash(reply: str, graph_update: dict, mastery_changes: list) -> dict:
+        # Agent path succeeded. Same lazy contract as the JSON route:
+        # nothing hits `sessions` until the first chat turn calls
+        # _consume_pending. Mutually exclusive with `_legacy` below — see
+        # the docstring above.
+        PENDING_SESSIONS[session_id] = {
+            "user_id": body.user_id,
+            "mode": body.mode,
+            "topic": body.topic,
+            "course_id": course_id,
+            "offering_id": offering_id,
+            "use_shared_context": body.use_shared_context,
+            "assistant_reply": reply,
+            "graph_update": graph_update,
+        }
+        return {"session_id": session_id, "graph_state": get_graph(body.user_id)}
+
+    async def _legacy() -> dict:
+        # Rung 1 only (agent failed before any token). Reuses the SAME
+        # session_id already minted above — via `session_id=` — so this
+        # turn only ever has one session_id, whichever path serves it.
+        # `_start_session_legacy` stashes PENDING_SESSIONS itself; `_stash`
+        # above must NOT also run, and stream_agent_turn enforces that
+        # exclusivity (exactly one of on_complete/legacy_fallback executes
+        # per turn — see stream_agent_turn's docstring).
+        return _start_session_legacy(body, session_id)
+
+    async def event_stream():
+        async for ev in stream_agent_turn(
+            agent=agent,
+            user_message=assembled,
+            run_kwargs=run_kwargs,
+            deps=deps,
+            on_complete=_stash,
+            legacy_fallback=_legacy,
+            request_id=request_id,
+        ):
+            yield sapling_event_to_sse(ev)
+
+    return EventSourceResponse(
+        event_stream(), headers={"X-Request-ID": request_id}
+    )
 
 
 @router.post("/end-session")

--- a/backend/services/agent_events.py
+++ b/backend/services/agent_events.py
@@ -12,7 +12,11 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 
-SaplingEventType = Literal["status", "progress", "result", "error"]
+# "status"/"progress"/"result" are the document-pipeline vocabulary (ADR 0006).
+# "token"/"graph_update"/"done" extend it for chat streams; "error" is shared.
+SaplingEventType = Literal[
+    "status", "progress", "result", "error", "token", "graph_update", "done"
+]
 
 
 class SaplingEvent(BaseModel):

--- a/backend/services/chat_stream.py
+++ b/backend/services/chat_stream.py
@@ -1,0 +1,261 @@
+# backend/services/chat_stream.py
+"""Translate a Pydantic AI chat run into Sapling SSE events.
+
+The single seam for streaming chat turns (ADR 0006 vocabulary). Iterates
+`agent.run_stream_events()` — the only API that yields BOTH text deltas and
+mid-run tool events in one pass — and emits:
+
+    status:start -> token* -> (progress:<tool> -> graph_update)* -> done
+
+Graph deltas are READ from `deps.graph_updates` / `deps.mastery_changes`,
+which the graph tools populate as they write through
+`graph_service.apply_graph_update` (ADR 0004). This module never writes the
+graph and never persists a message: persistence is the route's, via
+`on_complete`.
+
+At most one of `on_complete` / `legacy_fallback` runs per turn — never both,
+and the error rungs run neither. See `stream_agent_turn` for the rungs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, AsyncIterator, Awaitable, Callable
+
+from services.agent_events import SaplingEvent
+
+logger = logging.getLogger(__name__)
+
+
+def merge_graph_updates(updates: list[dict]) -> dict:
+    """Merge tool-emitted payloads into one {key: [items]} dict.
+
+    Mirrors the merge in `routes.learn._chat_via_agent` verbatim: keys
+    concatenate (setdefault + extend), never clobber.
+    """
+    merged: dict = {}
+    for gu in updates:
+        for key, items in gu.items():
+            merged.setdefault(key, []).extend(items)
+    return merged
+
+
+def _text_from(event: Any) -> str | None:
+    """Extract a NEW text chunk from a stream event, or None.
+
+    Dispatches on class name, which matters more than it looks (all three
+    shapes below were observed live against gemini-2.5-pro on 2026-07-16):
+
+      PartStartEvent  -> part.content        the reply's FIRST chunk
+      PartDeltaEvent  -> delta.content_delta each subsequent chunk
+      PartEndEvent    -> part.content        the FULL assembled text — SKIP
+
+    Reading `part.content` generically would emit the whole reply a second
+    time when PartEndEvent lands ("hello world" -> "hello worldhello
+    world"). Reading only deltas would drop the opening chunk. Both are
+    regression-tested.
+
+    Class-name dispatch alone is NOT enough, though: `PartStartEvent` and
+    `PartDeltaEvent` wrap ANY part kind, not just text — a `ThinkingPart` /
+    `ThinkingPartDelta` (pydantic-ai 1.89.1, `pydantic_ai.messages`) rides
+    the exact same event classes with the exact same attribute names
+    (`.part.content` / `.delta.content_delta`). Gate on the part's own
+    discriminator so reasoning content can never masquerade as reply text:
+    `TextPart.part_kind == "text"`, `TextPartDelta.part_delta_kind ==
+    "text"` (verified by inspecting the installed library — `ThinkingPart`/
+    `ThinkingPartDelta` carry `"thinking"` in the same fields). Today
+    `_build_pro_model_settings` never sets `include_thoughts`, so this is
+    latent — but the moment thought summaries are enabled, an ungated
+    reader would stream raw chain-of-thought into a student's chat bubble.
+    """
+    cls_name = type(event).__name__
+
+    if cls_name == "PartDeltaEvent":
+        delta = getattr(event, "delta", None)
+        if getattr(delta, "part_delta_kind", None) != "text":
+            return None
+        content_delta = getattr(delta, "content_delta", None)
+        return content_delta if isinstance(content_delta, str) and content_delta else None
+
+    if cls_name == "PartStartEvent":
+        part = getattr(event, "part", None)
+        if getattr(part, "part_kind", None) != "text":
+            return None
+        content = getattr(part, "content", None)
+        return content if isinstance(content, str) and content else None
+
+    # PartEndEvent / FinalResultEvent / tool + result events carry no NEW text.
+    return None
+
+
+def _tool_name_from(event: Any) -> str | None:
+    for path in ("part.tool_name", "tool_name", "result.tool_name"):
+        obj: Any = event
+        try:
+            for attr in path.split("."):
+                obj = getattr(obj, attr)
+            if isinstance(obj, str):
+                return obj
+        except AttributeError:
+            continue
+    return None
+
+
+async def stream_agent_turn(
+    *,
+    agent: Any,
+    user_message: str,
+    run_kwargs: dict,
+    deps: Any,
+    on_complete: Callable[[str, dict, list], dict | None],
+    legacy_fallback: Callable[[], Awaitable[dict]] | None = None,
+    request_id: str = "",
+) -> AsyncIterator[SaplingEvent]:
+    """Stream one agent turn as SaplingEvents.
+
+    on_complete(reply, merged_graph_update, mastery_changes) -> extra `done`
+    data. It persists; on the success path it is called once, after the run
+    completes and BEFORE `done` is yielded, so a mid-generation disconnect
+    (which cancels this generator at its current yield) persists nothing.
+
+    legacy_fallback() -> awaitable returning the route's pre-agent result,
+    used ONLY when the agent fails before emitting any text (Rung 1). It is
+    async because the routes' legacy paths are (`_legacy_chat`). It owns its
+    own persistence, so on_complete is NOT called on that branch — calling
+    both double-writes.
+
+    Invariant: AT MOST one of on_complete / legacy_fallback runs per turn —
+    never both. The error rungs run NEITHER: Rung 2 (failure after tokens
+    streamed), Rung 1 with no fallback, and a Rung-1 fallback that itself
+    raises all yield an `error` event and persist nothing (regression-tested
+    in test_chat_stream.py).
+    """
+    yield SaplingEvent(type="status", step="start", message="Starting.")
+
+    chunks: list[str] = []
+    final_output: str | None = None
+    # High-water marks: how much of deps.* we have already emitted.
+    graph_hw = 0
+    mastery_hw = 0
+
+    try:
+        async for event in agent.run_stream_events(user_message, **run_kwargs):
+            text = _text_from(event)
+            if text:
+                chunks.append(text)
+                yield SaplingEvent(
+                    type="token", step="reply", message="", data={"delta": text}
+                )
+                continue
+
+            cls_name = type(event).__name__
+
+            if cls_name == "FunctionToolCallEvent":
+                tool = _tool_name_from(event) or "tool"
+                yield SaplingEvent(
+                    type="progress", step=tool, message=f"Calling {tool}."
+                )
+                continue
+
+            if cls_name == "FunctionToolResultEvent":
+                # A graph tool may have just written. Emit only what is new.
+                new_nodes = merge_graph_updates(deps.graph_updates[graph_hw:])
+                new_mastery = deps.mastery_changes[mastery_hw:]
+                graph_hw = len(deps.graph_updates)
+                mastery_hw = len(deps.mastery_changes)
+                if new_nodes or new_mastery:
+                    yield SaplingEvent(
+                        type="graph_update",
+                        step="graph",
+                        message="Knowledge graph updated.",
+                        data={"nodes": new_nodes, "mastery_changes": new_mastery},
+                    )
+                continue
+
+            if cls_name == "AgentRunResultEvent":
+                output = getattr(getattr(event, "result", None), "output", None)
+                if isinstance(output, str):
+                    final_output = output
+
+    # Catches UsageLimitExceeded / UnexpectedModelBehavior (both Exception
+    # subclasses) and anything else the model or a tool raises. Deliberately
+    # NOT BaseException: asyncio.CancelledError must propagate so a client
+    # disconnect stays a cancellation — never a "fallback to legacy".
+    except Exception as exc:
+        if chunks:
+            # Rung 2: text already shown. Never silently re-run — the user
+            # would see the reply restart. Terminal error; persist nothing.
+            logger.warning("Chat stream failed mid-generation", exc_info=exc)
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor was interrupted. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+
+        # Rung 1: nothing shown yet — degrade to the route's legacy path.
+        logger.warning("Chat agent failed before first token; using legacy", exc_info=exc)
+        if legacy_fallback is None:
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor is unavailable. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+        try:
+            legacy = await legacy_fallback()
+        except Exception:
+            logger.exception("Legacy fallback also failed")
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor is unavailable. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+        # legacy_fallback persisted its own rows; do NOT call on_complete.
+        yield SaplingEvent(
+            type="token", step="reply", message="",
+            data={"delta": legacy.get("reply", "")},
+        )
+        yield SaplingEvent(
+            type="done", step="reply", message="Complete.", data=legacy
+        )
+        return
+
+    reply = final_output if final_output is not None else "".join(chunks)
+    merged = merge_graph_updates(deps.graph_updates)
+    mastery = list(deps.mastery_changes)
+
+    try:
+        extra = on_complete(reply, merged, mastery) or {}
+    except Exception as exc:
+        # Persistence failed AFTER the reply fully streamed. Letting this
+        # propagate would abort the ASGI response mid-stream with no closing
+        # event (sse_starlette has already flushed headers), leaving the
+        # client an unstructured network error. Emit the structured error
+        # instead so the ADR-0020 interrupted-turn treatment (keep partial
+        # text, offer Retry) applies; the turn persisted at most a partial
+        # write, and Retry re-sends it.
+        logger.warning("on_complete persistence failed after streamed reply", exc_info=exc)
+        yield SaplingEvent(
+            type="error",
+            step="reply",
+            message="The tutor was interrupted. Please retry.",
+            data={"request_id": request_id},
+        )
+        return
+
+    yield SaplingEvent(
+        type="done",
+        step="reply",
+        message="Complete.",
+        data={
+            "reply": reply,
+            "graph_update": merged,
+            "mastery_changes": mastery,
+            **extra,
+        },
+    )

--- a/backend/services/extraction_backends/gemini_vision_backend.py
+++ b/backend/services/extraction_backends/gemini_vision_backend.py
@@ -40,7 +40,6 @@ from agents._run import run_agent_sync
 from agents.ocr_vision import (
     BLANK_PAGE_SENTINEL,
     TRANSCRIBE_PROMPT,
-    fresh_ocr_vision_model,
     ocr_vision_agent,
 )
 
@@ -122,12 +121,11 @@ def extract_page_with_gemini_vision(image_bytes: bytes) -> str:
                     BinaryContent(data=image_bytes, media_type="image/png"),
                     TRANSCRIBE_PROMPT,
                 ],
-                # Per-run model with its own provider: the shared one binds to
-                # the first asyncio.run loop and every second call in the
-                # per-page loop dies with "Event loop is closed" (#354).
-                # None in the FunctionModel test mode, where the agent's own
-                # model is already loop-free.
-                model=fresh_ocr_vision_model(),
+                # No per-run `model=` override needed: `ocr_vision_agent`'s own
+                # default model (`model_for("ocr_vision")`) is loop-safe on its
+                # own now (#354/#436 — see agents/_providers.py), so it
+                # survives this per-page loop's alternating asyncio.run()
+                # loops without help from this call site.
                 usage_limits=WORKER_LIMITS,
             )
         )

--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -11,27 +11,61 @@ import os
 from google import genai
 from google.genai import types as genai_types
 
+from agents._providers import model_mode
 from db.connection import rpc, table
 
 # Bound embedding requests so a stalled Gemini call can't hang quiz/tutor
 # grounding indefinitely — retrieve_chunks() runs inline on the request path.
 _HTTP_TIMEOUT_MS = 60_000
-
-# `genai.Client(api_key="")` raises ValueError at construction, so a missing
-# GEMINI_API_KEY would break `import main` (routes/quiz.py and routes/learn.py
-# both pull this module in). Fall back to a dummy key the same way
-# services/gemini_service.py and agents/_providers.py do: imports stay clean and
-# the failure surfaces at call time, where it's actionable.
-_client = genai.Client(
-    api_key=os.getenv("GEMINI_API_KEY", "") or "dummy-key-for-import",
-    http_options=genai_types.HttpOptions(timeout=_HTTP_TIMEOUT_MS),
-)
 _EMBED_MODEL = "gemini-embedding-001"
 _OUTPUT_DIM = 768
 
+# `genai.Client(api_key="")` raises ValueError at construction, so a missing
+# GEMINI_API_KEY would break `import main` (routes/quiz.py and routes/learn.py
+# both pull this module in) if built eagerly. #439 goes further: the client is
+# now built lazily, on first REAL-mode use. `_get_client()` is only ever
+# reached from inside an `_embed_*` function AFTER its `model_mode() != "real"`
+# gate below, so a non-real run (SAPLING_MODEL_MODE=function — the hermetic
+# E2E default, ADR 0019) never constructs a genai.Client and never touches the
+# network, instead of constructing one that then degrades by an accidental
+# swallowed exception.
+_client: genai.Client | None = None
+
+
+def _get_client() -> genai.Client:
+    global _client
+    if _client is None:
+        _client = genai.Client(
+            api_key=os.getenv("GEMINI_API_KEY", "") or "dummy-key-for-import",
+            http_options=genai_types.HttpOptions(timeout=_HTTP_TIMEOUT_MS),
+        )
+    return _client
+
+
+class _EmbeddingDisabled(RuntimeError):
+    """Raised by the `_embed_*` helpers when `SAPLING_MODEL_MODE != 'real'`.
+
+    Every caller (`retrieve_chunks`, `index_document_chunks`) already wraps
+    its embed call in a broad try/except — originally there to swallow a real
+    Gemini failure so retrieval/upload degrade gracefully instead of 500ing.
+    Raising here reuses that exact same degrade path, so function-mode
+    behavior is byte-for-byte identical to what an unlucky real-mode failure
+    already produced — except now it happens by design on every run, not by
+    accident of a swallowed exception (#439).
+    """
+
+
+def _require_real_mode() -> None:
+    if model_mode() != "real":
+        raise _EmbeddingDisabled(
+            "embedding skipped: SAPLING_MODEL_MODE != 'real' (below-seam RAG "
+            "embed path, #439)"
+        )
+
 
 def _embed_query(text: str) -> list[float]:
-    resp = _client.models.embed_content(
+    _require_real_mode()
+    resp = _get_client().models.embed_content(
         model=_EMBED_MODEL,
         contents=[text],
         config=genai_types.EmbedContentConfig(
@@ -43,7 +77,8 @@ def _embed_query(text: str) -> list[float]:
 
 
 def _embed_document(text: str) -> list[float]:
-    resp = _client.models.embed_content(
+    _require_real_mode()
+    resp = _get_client().models.embed_content(
         model=_EMBED_MODEL,
         contents=[text],
         config=genai_types.EmbedContentConfig(
@@ -55,7 +90,8 @@ def _embed_document(text: str) -> list[float]:
 
 
 def _embed_documents_batch(texts: list[str]) -> list[list[float]]:
-    resp = _client.models.embed_content(
+    _require_real_mode()
+    resp = _get_client().models.embed_content(
         model=_EMBED_MODEL,
         contents=texts,
         config=genai_types.EmbedContentConfig(

--- a/backend/tests/evals/README.md
+++ b/backend/tests/evals/README.md
@@ -1,0 +1,64 @@
+# Agent evals (extraction-accuracy harness)
+
+Offline accuracy harness for the migrated Pydantic AI agents (epic #152, issue
+#148). It answers "did this prompt/model change make extraction worse?" without
+hitting the network on every run.
+
+## What it does
+
+Each dataset is a set of `pydantic_evals.Case`s plus deterministic evaluators
+(field accuracy, count-in-range, ISO-date shape, no-invented-dates, etc.). A
+dataset runs an agent over its cases and scores the output.
+
+Modes are selected by `SAPLING_EVAL_MODE`:
+
+| Mode | Network | Use |
+|------|---------|-----|
+| `replay` (default) | none | CI + local checks. Loads frozen model outputs from `cassettes/`; a missing cassette fails loudly. |
+| `record` | live Gemini | Capture/refresh cassettes. Writes `cassettes/<dataset>/<case>.json`. |
+| `live` | live Gemini | One-off experimentation, no recording. |
+
+Because replay is deterministic (the model output is frozen in the cassette), a
+task's aggregate score only moves when an **evaluator**, an **expected output**,
+or a **cassette** changes. CI gates on *regression below a committed baseline*
+(`baselines.json`), not on "< 1.0" — the harness measures accuracy, it does not
+assume perfection.
+
+## Running
+
+```bash
+cd backend
+python tests/evals/run_all.py            # all offline datasets, gate on baselines
+python tests/evals/document_summary.py   # one dataset, with the full per-case table
+```
+
+Exit code is non-zero on a regression or a missing cassette.
+
+## Refreshing after a prompt/model change
+
+Recording hits live Gemini, so it needs `GEMINI_API_KEY` set (in `.env`).
+Transient 503s are retried automatically.
+
+```bash
+cd backend
+# 1. Re-record cassettes from the new prompt/model:
+SAPLING_EVAL_MODE=record python tests/evals/run_all.py
+# 2. Eyeball the score deltas the run prints. If the new numbers are the
+#    intended new baseline, commit them:
+SAPLING_EVAL_UPDATE_BASELINES=1 python tests/evals/run_all.py
+# 3. Commit cassettes/ and baselines.json together:
+git add tests/evals/cassettes tests/evals/baselines.json
+git commit -m "evals: refresh cassettes + baselines for <change>"
+```
+
+Never hand-edit an existing case to make it pass; add a new case when
+production surfaces a miss (see each dataset's module docstring).
+
+## Coverage
+
+Offline (in `run_all.py` + CI): `document_classification`, `document_summary`,
+`concept_extraction`, `syllabus_extraction`, `quiz_generation` — 80 cassettes.
+
+Excluded: `chat_tutor`. Its retrieval tool reads a live Supabase, so it can't
+run offline against cassettes; it belongs with the graph-grounded tutor work
+(#149).

--- a/backend/tests/evals/_replay.py
+++ b/backend/tests/evals/_replay.py
@@ -110,10 +110,12 @@ def ensure_utf8_output() -> None:
 def evaluate_dataset(make_dataset, run_fn, *, update: bool, print_report: bool = True) -> bool:
     """Evaluate one dataset, print an accuracy summary, and return ``ok``.
 
-    ``ok`` is False when a case raised (e.g. a missing cassette in replay mode)
-    or a task's aggregate evaluator score regressed below its committed baseline
-    in ``baselines.json``. Sub-1.0 scores alone are NOT failures — the harness
-    measures accuracy, it doesn't assume perfection. With ``update=True`` the
+    ``ok`` is False when a case raised (e.g. a missing cassette in replay mode),
+    a task's aggregate evaluator score regressed below its committed baseline
+    in ``baselines.json``, or the dataset/an evaluator has NO committed baseline
+    (fail closed — an ungated dataset must not read as PASS in CI). Sub-1.0
+    scores alone are NOT failures — the harness measures accuracy, it doesn't
+    assume perfection. With ``update=True`` the
     current scores are written back as the new baseline (unless the run had
     failures). This function never calls ``sys.exit`` so callers can aggregate
     across datasets.
@@ -159,11 +161,16 @@ def evaluate_dataset(make_dataset, run_fn, *, update: bool, print_report: bool =
 
     baseline = all_baselines.get(name)
     if baseline is None:
+        # Fail closed: this function is CI's regression gate (evals.yml). A
+        # dataset with no committed baseline has ZERO protection — reporting
+        # PASS here would read as "covered" while gating nothing (a rename in
+        # `Dataset(name=...)` not mirrored in baselines.json hits this too).
         print(
             f"\nNo committed baseline for {name}; run with "
             "SAPLING_EVAL_UPDATE_BASELINES=1 to record one.",
             file=sys.stderr,
         )
+        ok = False
     else:
         regressions: list[str] = []
         for ev_name, base in baseline.items():
@@ -172,9 +179,17 @@ def evaluate_dataset(make_dataset, run_fn, *, update: bool, print_report: bool =
                 regressions.append(f"{ev_name}: missing (baseline {base:.3f})")
             elif got < base - BASELINE_TOLERANCE:
                 regressions.append(f"{ev_name}: {got:.3f} < baseline {base:.3f}")
+        # Same fail-closed logic per evaluator: one added to a dataset but not
+        # committed to the baseline would otherwise never be gated at all.
+        unbaselined = sorted(set(scores) - set(baseline))
+        for ev_name in unbaselined:
+            regressions.append(
+                f"{ev_name}: no committed baseline (scored {scores[ev_name]:.3f}) — "
+                "refresh baselines.json with SAPLING_EVAL_UPDATE_BASELINES=1"
+            )
         if regressions:
             print(
-                f"\n{len(regressions)} accuracy regression(s) in {name} vs baseline:",
+                f"\n{len(regressions)} baseline gap(s)/regression(s) in {name}:",
                 file=sys.stderr,
             )
             for line in regressions:

--- a/backend/tests/evals/_replay.py
+++ b/backend/tests/evals/_replay.py
@@ -58,46 +58,140 @@ def make_deps() -> SaplingDeps:
     )
 
 
-def cli_main(make_dataset, run_fn) -> None:
-    """Shared `__main__` entrypoint for eval scripts.
+BASELINES_PATH = Path(__file__).parent / "baselines.json"
 
-    Runs the dataset, prints a report, and exits non-zero when any case
-    raised (e.g. missing cassette in replay mode) or any evaluator score
-    is below 1.0. Without this, pydantic-evals catches per-case errors
-    and the script exits 0, which would let CI silently rubber-stamp a
-    completely-broken run.
+# Accuracy is measured, not assumed perfect: replay is deterministic (the model
+# output is frozen in the cassette), so a task's aggregate score only moves when
+# evaluators, expected outputs, or cassettes change. We gate on *regression*
+# below a committed baseline rather than on "< 1.0" — the whole point of the
+# harness is to track sub-100% accuracy over time. A small tolerance absorbs
+# float noise.
+BASELINE_TOLERANCE = 1e-6
+
+
+def _aggregate_scores(report) -> dict[str, float]:
+    """Mean of each evaluator's score across all (non-errored) cases."""
+    sums: dict[str, float] = {}
+    counts: dict[str, int] = {}
+    for case in report.cases:
+        for ev_name, result in case.scores.items():
+            sums[ev_name] = sums.get(ev_name, 0.0) + float(result.value)
+            counts[ev_name] = counts.get(ev_name, 0) + 1
+    return {ev: sums[ev] / counts[ev] for ev in sums if counts[ev]}
+
+
+def _load_baselines() -> dict[str, dict[str, float]]:
+    if not BASELINES_PATH.exists():
+        return {}
+    return json.loads(BASELINES_PATH.read_text())
+
+
+def _write_baselines(all_baselines: dict[str, dict[str, float]]) -> None:
+    BASELINES_PATH.write_text(json.dumps(all_baselines, indent=2, sort_keys=True) + "\n")
+
+
+def ensure_utf8_output() -> None:
+    """Force UTF-8 on stdout/stderr.
+
+    Cases carry non-ASCII content (e.g. Mandarin syllabi). rich renders the
+    report through the console's native encoding, which is cp1252 on Windows
+    when stdout is redirected/piped, and crashes on CJK. Forcing UTF-8 makes the
+    harness run identically on every platform.
+    """
+    import sys
+
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError):
+            pass
+
+
+def evaluate_dataset(make_dataset, run_fn, *, update: bool, print_report: bool = True) -> bool:
+    """Evaluate one dataset, print an accuracy summary, and return ``ok``.
+
+    ``ok`` is False when a case raised (e.g. a missing cassette in replay mode)
+    or a task's aggregate evaluator score regressed below its committed baseline
+    in ``baselines.json``. Sub-1.0 scores alone are NOT failures — the harness
+    measures accuracy, it doesn't assume perfection. With ``update=True`` the
+    current scores are written back as the new baseline (unless the run had
+    failures). This function never calls ``sys.exit`` so callers can aggregate
+    across datasets.
     """
     import asyncio
     import sys
 
     dataset = make_dataset()
     report = asyncio.run(dataset.evaluate(run_fn))
-    report.print(include_input=False, include_output=True)
+    if print_report:
+        report.print(include_input=False, include_output=True)
 
-    failed = False
+    name = getattr(dataset, "name", None) or "unknown"
+    scores = _aggregate_scores(report)
+
+    print(f"\nAccuracy ({name}):")
+    for ev_name in sorted(scores):
+        print(f"  {ev_name}: {scores[ev_name]:.3f}")
+
+    ok = True
     if report.failures:
         print(
             f"\n{len(report.failures)} case(s) raised during evaluation.",
             file=sys.stderr,
         )
-        failed = True
+        ok = False
 
-    # Surface any evaluator score < 1.0 as a CI failure.
-    bad_scores: list[str] = []
-    for case in report.cases:
-        for ev_name, result in case.scores.items():
-            if result.value < 1.0:
-                bad_scores.append(f"{case.name}:{ev_name}={result.value}")
-    if bad_scores:
+    all_baselines = _load_baselines()
+
+    if update:
+        # Never persist baselines from a partially-broken run — that would bake
+        # a crash's degraded scores in as the new "expected".
+        if not ok:
+            print(
+                f"\nRefusing to update {name} baselines: run had case failures.",
+                file=sys.stderr,
+            )
+            return False
+        all_baselines[name] = {ev: round(scores[ev], 6) for ev in scores}
+        _write_baselines(all_baselines)
+        print(f"\nUpdated baselines for {name} in {BASELINES_PATH.name}.")
+        return True
+
+    baseline = all_baselines.get(name)
+    if baseline is None:
         print(
-            f"\n{len(bad_scores)} evaluator score(s) below 1.0:",
+            f"\nNo committed baseline for {name}; run with "
+            "SAPLING_EVAL_UPDATE_BASELINES=1 to record one.",
             file=sys.stderr,
         )
-        for line in bad_scores:
-            print(f"  - {line}", file=sys.stderr)
-        failed = True
+    else:
+        regressions: list[str] = []
+        for ev_name, base in baseline.items():
+            got = scores.get(ev_name)
+            if got is None:
+                regressions.append(f"{ev_name}: missing (baseline {base:.3f})")
+            elif got < base - BASELINE_TOLERANCE:
+                regressions.append(f"{ev_name}: {got:.3f} < baseline {base:.3f}")
+        if regressions:
+            print(
+                f"\n{len(regressions)} accuracy regression(s) in {name} vs baseline:",
+                file=sys.stderr,
+            )
+            for line in regressions:
+                print(f"  - {line}", file=sys.stderr)
+            ok = False
 
-    if failed:
+    return ok
+
+
+def cli_main(make_dataset, run_fn) -> None:
+    """Shared `__main__` entrypoint for a single eval script."""
+    import sys
+
+    ensure_utf8_output()
+    update = os.getenv("SAPLING_EVAL_UPDATE_BASELINES") == "1"
+    ok = evaluate_dataset(make_dataset, run_fn, update=update)
+    if not ok:
         sys.exit(1)
 
 
@@ -125,10 +219,42 @@ async def run_with_cassette(
         return output_model.model_validate(body)
 
     deps = make_deps()
-    result = await agent.run(case_input, deps=deps)
+    result = await _run_with_retry(agent, case_input, deps)
     output = result.output
 
     if MODE == "record":
         save_cassette(dataset, case_name, output)
 
     return output
+
+
+# Gemini returns 503/UNAVAILABLE under load; a whole record run shouldn't lose a
+# case (and leave a permanent cassette gap) to a transient blip. Retry only the
+# transient provider errors, with linear backoff. Passed timestamps aren't
+# available here and we're offline-recording, so a fixed short sleep is fine.
+_TRANSIENT_RECORD_RETRIES = 4
+_TRANSIENT_BACKOFF_SECONDS = 3.0
+
+
+async def _run_with_retry(agent, case_input: str, deps):
+    import asyncio
+
+    last_exc: Exception | None = None
+    for attempt in range(_TRANSIENT_RECORD_RETRIES + 1):
+        try:
+            return await agent.run(case_input, deps=deps)
+        except Exception as exc:  # noqa: BLE001 - re-raised below if non-transient
+            if not _is_transient(exc) or attempt == _TRANSIENT_RECORD_RETRIES:
+                raise
+            last_exc = exc
+            await asyncio.sleep(_TRANSIENT_BACKOFF_SECONDS * (attempt + 1))
+    # Unreachable: the loop either returns or raises. Kept for type-checkers.
+    raise last_exc  # type: ignore[misc]
+
+
+def _is_transient(exc: Exception) -> bool:
+    status = getattr(exc, "status_code", None)
+    if status in (429, 503):
+        return True
+    text = str(exc).upper()
+    return "UNAVAILABLE" in text or "503" in text or "RESOURCE_EXHAUSTED" in text

--- a/backend/tests/evals/baselines.json
+++ b/backend/tests/evals/baselines.json
@@ -1,0 +1,36 @@
+{
+  "concept_extraction": {
+    "AllNamesTitleCaseEvaluator": 1.0,
+    "ConceptCountInRangeEvaluator": 1.0,
+    "NoAdministrativeNamesEvaluator": 1.0,
+    "OrderedByImportanceEvaluator": 1.0
+  },
+  "document_classification": {
+    "CategoryEvaluator": 0.8,
+    "SyllabusFlagEvaluator": 0.88
+  },
+  "document_summary": {
+    "AbstractLengthEvaluator": 0.933333,
+    "HeadlineLengthEvaluator": 1.0,
+    "KeyPointsCountEvaluator": 1.0,
+    "NoMarkdownLeakEvaluator": 1.0
+  },
+  "quiz_generation": {
+    "AdaptiveDifficultyEvaluator": 1.0,
+    "ConceptCoverageEvaluator": 1.0,
+    "DifficultyMixEvaluator": 1.0,
+    "MultipleChoiceShapeEvaluator": 1.0,
+    "QuestionCountEvaluator": 1.0,
+    "SpacedRepetitionConceptEvaluator": 1.0,
+    "TypeMixEvaluator": 1.0
+  },
+  "syllabus_extraction": {
+    "AssignmentCountEvaluator": 1.0,
+    "AssignmentTypeNonNullEvaluator": 1.0,
+    "DueDateIsoStringEvaluator": 1.0,
+    "GradingCategoriesPresenceEvaluator": 1.0,
+    "NoInventedDatesEvaluator": 0.933333,
+    "WeightsAreNumericEvaluator": 1.0,
+    "WireFormatRequiredKeysEvaluator": 1.0
+  }
+}

--- a/backend/tests/evals/cassettes/concept_extraction/adversarial_problem_n_headers.json
+++ b/backend/tests/evals/cassettes/concept_extraction/adversarial_problem_n_headers.json
@@ -1,0 +1,29 @@
+{
+  "concepts": [
+    {
+      "description": "This concept involves proving the Law of Cosines, a fundamental geometric theorem relating the lengths of the sides of a triangle to the cosine of one of its angles, by utilizing the properties of the dot product of vectors.",
+      "importance": 0.95,
+      "name": "Law of Cosines"
+    },
+    {
+      "description": "This concept focuses on deriving the angle-addition formula for the sine function, sin(a+b), which expresses the sine of a sum of two angles in terms of the sines and cosines of the individual angles.",
+      "importance": 0.95,
+      "name": "Angle-Addition Identity for Sine"
+    },
+    {
+      "description": "This concept explores the property of orthogonal matrices, demonstrating how they preserve the Euclidean inner product, meaning the dot product of two vectors remains unchanged after transformation by an orthogonal matrix.",
+      "importance": 0.95,
+      "name": "Orthogonal Matrices and Inner Product Preservation"
+    },
+    {
+      "description": "This concept involves proving the anti-commutative property of the cross product, which states that changing the order of the vectors in a cross product reverses the direction of the resulting vector.",
+      "importance": 0.95,
+      "name": "Anti-Commutativity of the Cross Product"
+    },
+    {
+      "description": "This concept demonstrates how the Cauchy-Schwarz inequality, a fundamental inequality in linear algebra, can be used to prove the triangle inequality, which states that the sum of the lengths of any two sides of a triangle must be greater than or equal to the length of the third side.",
+      "importance": 0.95,
+      "name": "Triangle Inequality and Cauchy-Schwarz"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/adversarial_week_n_slides.json
+++ b/backend/tests/evals/cassettes/concept_extraction/adversarial_week_n_slides.json
@@ -1,0 +1,39 @@
+{
+  "concepts": [
+    {
+      "description": "This concept covers the foundational principles of statistics, defining its scope, purpose, and basic terminology.",
+      "importance": 1.0,
+      "name": "Introduction to Statistics"
+    },
+    {
+      "description": "This concept focuses on methods for summarizing and organizing data, including measures of central tendency, variability, and data visualization.",
+      "importance": 0.95,
+      "name": "Descriptive Statistics"
+    },
+    {
+      "description": "This concept introduces various probability distributions, explaining how to model the likelihood of different outcomes for random variables.",
+      "importance": 0.9,
+      "name": "Probability Distributions"
+    },
+    {
+      "description": "This concept explores different sampling techniques and the fundamental Central Limit Theorem, which is crucial for making inferences about populations from samples.",
+      "importance": 0.88,
+      "name": "Sampling and the Central Limit Theorem"
+    },
+    {
+      "description": "This concept covers the methodology for testing claims or hypotheses about population parameters using sample data.",
+      "importance": 0.85,
+      "name": "Hypothesis Testing"
+    },
+    {
+      "description": "This concept explains how to construct and interpret confidence intervals, providing a range of plausible values for an unknown population parameter.",
+      "importance": 0.82,
+      "name": "Confidence Intervals"
+    },
+    {
+      "description": "This concept introduces the basics of linear regression, a statistical method used to model the linear relationship between a dependent variable and one or more independent variables.",
+      "importance": 0.8,
+      "name": "Linear Regression"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/bio_cellular_respiration.json
+++ b/backend/tests/evals/cassettes/concept_extraction/bio_cellular_respiration.json
@@ -1,0 +1,59 @@
+{
+  "concepts": [
+    {
+      "description": "The metabolic process that breaks down glucose to produce ATP, involving glycolysis, the citric acid cycle, and oxidative phosphorylation.",
+      "importance": 1.0,
+      "name": "Cellular Respiration"
+    },
+    {
+      "description": "A series of protein complexes on the inner mitochondrial membrane that uses electron carriers to drive oxidative phosphorylation, producing the bulk of ATP.",
+      "importance": 0.95,
+      "name": "Electron Transport Chain"
+    },
+    {
+      "description": "The process of ATP synthesis driven by the electron transport chain and chemiosmosis, producing the majority of ATP during cellular respiration.",
+      "importance": 0.9,
+      "name": "Oxidative Phosphorylation"
+    },
+    {
+      "description": "The initial stage of cellular respiration where glucose is broken down into pyruvate, ATP, and NADH in the cytoplasm.",
+      "importance": 0.9,
+      "name": "Glycolysis"
+    },
+    {
+      "description": "The process by which a proton gradient across the inner mitochondrial membrane drives the synthesis of ATP through ATP synthase during oxidative phosphorylation.",
+      "importance": 0.85,
+      "name": "Chemiosmosis"
+    },
+    {
+      "description": "A series of reactions within the mitochondrion that further oxidizes acetyl-CoA, producing additional NADH and FADH2.",
+      "importance": 0.85,
+      "name": "Citric Acid Cycle"
+    },
+    {
+      "description": "A three-carbon molecule produced during glycolysis, which enters the mitochondrion to be oxidized to acetyl-CoA.",
+      "importance": 0.8,
+      "name": "Pyruvate"
+    },
+    {
+      "description": "An electron carrier molecule produced during glycolysis and the citric acid cycle, essential for providing electrons to the electron transport chain.",
+      "importance": 0.8,
+      "name": "NADH"
+    },
+    {
+      "description": "An organelle in eukaryotic cells where pyruvate is oxidized, and the citric acid cycle, electron transport chain, and oxidative phosphorylation occur.",
+      "importance": 0.75,
+      "name": "Mitochondrion"
+    },
+    {
+      "description": "A two-carbon molecule formed from the oxidation of pyruvate within the mitochondrion, which then enters the citric acid cycle.",
+      "importance": 0.7,
+      "name": "Acetyl-CoA"
+    },
+    {
+      "description": "An electron carrier molecule produced during the citric acid cycle, which donates electrons to the electron transport chain.",
+      "importance": 0.7,
+      "name": "FADH2"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/chemistry_thermodynamics.json
+++ b/backend/tests/evals/cassettes/concept_extraction/chemistry_thermodynamics.json
@@ -1,0 +1,34 @@
+{
+  "concepts": [
+    {
+      "description": "A branch of chemistry that deals with the relationships between heat and other forms of energy in chemical reactions and physical changes.",
+      "importance": 1.0,
+      "name": "Chemical Thermodynamics"
+    },
+    {
+      "description": "A thermodynamic potential that combines enthalpy and entropy, used to predict the spontaneity of a chemical reaction at constant temperature and pressure.",
+      "importance": 0.95,
+      "name": "Gibbs Free Energy"
+    },
+    {
+      "description": "States that energy is conserved and is applied through enthalpy to understand energy changes in chemical reactions.",
+      "importance": 0.9,
+      "name": "First Law of Thermodynamics"
+    },
+    {
+      "description": "Introduces the concept of entropy, defining it as a measure of disorder within a system.",
+      "importance": 0.9,
+      "name": "Second Law of Thermodynamics"
+    },
+    {
+      "description": "A thermodynamic property used to quantify the heat exchanged in chemical reactions, particularly when applying the First Law of Thermodynamics.",
+      "importance": 0.85,
+      "name": "Enthalpy"
+    },
+    {
+      "description": "A thermodynamic property that quantifies the degree of disorder or randomness within a system, central to the Second Law of Thermodynamics.",
+      "importance": 0.85,
+      "name": "Entropy"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/code_heavy_algorithms.json
+++ b/backend/tests/evals/cassettes/concept_extraction/code_heavy_algorithms.json
@@ -1,0 +1,64 @@
+{
+  "concepts": [
+    {
+      "description": "An algorithmic paradigm that solves complex problems by breaking them into simpler overlapping subproblems and storing the results to avoid redundant computations, often implemented bottom-up or with memoization.",
+      "importance": 0.95,
+      "name": "Dynamic Programming"
+    },
+    {
+      "description": "An algorithmic design paradigm that recursively breaks down a problem into two or more subproblems of the same or related type, until these become simple enough to be solved directly, and then combines their solutions to get a solution to the original problem.",
+      "importance": 0.9,
+      "name": "Divide-and-Conquer"
+    },
+    {
+      "description": "An algorithmic paradigm that makes locally optimal choices at each stage with the hope of finding a global optimum, often suitable for optimization problems where a globally optimal solution can be found by making a sequence of locally optimal choices.",
+      "importance": 0.85,
+      "name": "Greedy Algorithms"
+    },
+    {
+      "description": "A formula used to analyze the running time of recursive algorithms that follow a divide-and-conquer pattern, providing a solution for recurrence relations of the form T(n) = aT(n/b) + f(n).",
+      "importance": 0.8,
+      "name": "Master Theorem"
+    },
+    {
+      "description": "A programming technique where a function calls itself directly or indirectly to solve a problem, often used in algorithms that naturally break down into smaller instances of the same problem.",
+      "importance": 0.75,
+      "name": "Recursion"
+    },
+    {
+      "description": "An optimization technique used primarily with recursive algorithms, where the results of expensive function calls are stored and returned when the same inputs occur again, avoiding redundant computations.",
+      "importance": 0.7,
+      "name": "Memoization"
+    },
+    {
+      "description": "A theoretical structure used to prove the correctness and optimality of certain greedy algorithms, providing a formal basis for understanding when a greedy approach will yield the best possible solution.",
+      "importance": 0.65,
+      "name": "Matroid Framework"
+    },
+    {
+      "description": "A stable sorting algorithm that exemplifies the divide-and-conquer paradigm by dividing an unsorted list into n sublists, each containing one element, and then repeatedly merging sublists to produce new sorted sublists until there is only one sorted list remaining.",
+      "importance": 0.6,
+      "name": "Merge Sort"
+    },
+    {
+      "description": "An efficient, in-place sorting algorithm that uses a divide-and-conquer strategy, selecting a 'pivot' element from the array and partitioning the other elements into two sub-arrays according to whether they are less than or greater than the pivot.",
+      "importance": 0.55,
+      "name": "Quicksort"
+    },
+    {
+      "description": "A classic problem in dynamic programming that involves finding the longest subsequence common to two sequences, often used to illustrate the core principles of dynamic programming table construction.",
+      "importance": 0.5,
+      "name": "Longest Common Subsequence"
+    },
+    {
+      "description": "A classic optimization problem in dynamic programming where a set of items, each with a weight and a value, must be packed into a knapsack of limited capacity, aiming to maximize the total value of packed items.",
+      "importance": 0.45,
+      "name": "Knapsack Problem"
+    },
+    {
+      "description": "A classic dynamic programming problem that calculates the minimum number of single-character edits (insertions, deletions, or substitutions) required to change one word into the other, also known as Levenshtein distance.",
+      "importance": 0.4,
+      "name": "Edit Distance"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/cs_networking_tcp.json
+++ b/backend/tests/evals/cassettes/concept_extraction/cs_networking_tcp.json
@@ -1,0 +1,49 @@
+{
+  "concepts": [
+    {
+      "description": "TCP (Transmission Control Protocol) is a core internet protocol that provides reliable, ordered, and byte-stream oriented communication between applications. It forms the basis for many network services.",
+      "importance": 1.0,
+      "name": "TCP Fundamentals"
+    },
+    {
+      "description": "The three-way handshake is the mechanism TCP uses to establish a connection between two hosts, ensuring both sides are ready to send and receive data. It involves the exchange of SYN and ACK segments.",
+      "importance": 0.9,
+      "name": "Three-Way Handshake"
+    },
+    {
+      "description": "TCP's congestion control mechanism aims to prevent network overload by dynamically adjusting the data transmission rate, employing strategies like slow start, congestion avoidance, and fast recovery.",
+      "importance": 0.9,
+      "name": "Congestion Control"
+    },
+    {
+      "description": "TCP segments are the basic unit of data transfer in TCP, characterized by their reliability, ordered delivery, and byte-stream orientation, ensuring data integrity and correct sequencing.",
+      "importance": 0.8,
+      "name": "TCP Segments"
+    },
+    {
+      "description": "TCP's flow control mechanism prevents a sender from overwhelming a receiver with data by using the receiver's advertised window to limit the amount of unacknowledged data outstanding.",
+      "importance": 0.8,
+      "name": "Flow Control"
+    },
+    {
+      "description": "Slow start is an algorithm used in TCP congestion control to gradually increase the amount of data sent into the network after a connection is established or after congestion is detected.",
+      "importance": 0.7,
+      "name": "Slow Start"
+    },
+    {
+      "description": "Congestion avoidance is a phase in TCP congestion control that follows slow start, where the transmission window is increased more conservatively to probe for available bandwidth and avoid network congestion.",
+      "importance": 0.7,
+      "name": "Congestion Avoidance"
+    },
+    {
+      "description": "Fast recovery is a TCP congestion control algorithm that attempts to quickly recover from packet loss indicated by duplicate ACKs without entering a slow start phase, thus maintaining high throughput.",
+      "importance": 0.7,
+      "name": "Fast Recovery"
+    },
+    {
+      "description": "The receiver's advertised window is a value sent by the receiving host to the sending host, indicating the amount of buffer space currently available for incoming data, thereby regulating the sender's data rate.",
+      "importance": 0.6,
+      "name": "Receiver's Advertised Window"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/econ_supply_demand.json
+++ b/backend/tests/evals/cassettes/concept_extraction/econ_supply_demand.json
@@ -1,0 +1,44 @@
+{
+  "concepts": [
+    {
+      "description": "These fundamental forces interact to set the market price and quantity in a competitive market.",
+      "importance": 1.0,
+      "name": "Supply and Demand"
+    },
+    {
+      "description": "The specific price and quantity at which the amount producers are willing to supply equals the amount consumers are willing to buy, determined by the interaction of supply and demand.",
+      "importance": 0.95,
+      "name": "Equilibrium Price and Quantity"
+    },
+    {
+      "description": "The reduction in total surplus (consumer and producer surplus) that results from a market distortion, such as a government intervention that prevents the market from reaching its efficient equilibrium.",
+      "importance": 0.95,
+      "name": "Deadweight Loss"
+    },
+    {
+      "description": "A measure indicating how much the quantity demanded of a good responds to a change in its price.",
+      "importance": 0.9,
+      "name": "Price Elasticity of Demand"
+    },
+    {
+      "description": "Policies such as price floors, price ceilings, and taxes implemented by governments that can affect market outcomes.",
+      "importance": 0.9,
+      "name": "Government Interventions"
+    },
+    {
+      "description": "The difference between the maximum price consumers are willing to pay for a good and the actual market price they pay, representing a measure of consumer welfare.",
+      "importance": 0.85,
+      "name": "Consumer Surplus"
+    },
+    {
+      "description": "The difference between the price producers receive for a good and the minimum price they would have been willing to accept, representing a measure of producer welfare.",
+      "importance": 0.85,
+      "name": "Producer Surplus"
+    },
+    {
+      "description": "A market structure where numerous buyers and sellers interact, and no single participant can influence the market price, allowing supply and demand to freely determine equilibrium.",
+      "importance": 0.8,
+      "name": "Competitive Market"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/exploratory_empty_input.json
+++ b/backend/tests/evals/cassettes/concept_extraction/exploratory_empty_input.json
@@ -1,0 +1,9 @@
+{
+  "concepts": [
+    {
+      "description": "The provided document is empty, so no concepts can be extracted.",
+      "importance": 1.0,
+      "name": "Empty Document"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/history_reading_industrial_rev.json
+++ b/backend/tests/evals/cassettes/concept_extraction/history_reading_industrial_rev.json
@@ -1,0 +1,34 @@
+{
+  "concepts": [
+    {
+      "description": "The Industrial Revolution was a period in 18th-century Britain characterized by significant economic and social changes, driven by factors like cheap coal, expensive labor, and steam power.",
+      "importance": 1.0,
+      "name": "Industrial Revolution"
+    },
+    {
+      "description": "Key conditions in 18th-century Britain, including cheap coal, expensive labor, an open patent regime, and a navigable transport network, facilitated the onset of the Industrial Revolution.",
+      "importance": 0.9,
+      "name": "Factors Enabling the Industrial Revolution"
+    },
+    {
+      "description": "Steam power was a transformative technology during the Industrial Revolution that dramatically changed manufacturing processes.",
+      "importance": 0.85,
+      "name": "Steam Power"
+    },
+    {
+      "description": "Urbanization during the Industrial Revolution led to the concentration of workers in factory towns, altering population distribution and social structures.",
+      "importance": 0.75,
+      "name": "Urbanization"
+    },
+    {
+      "description": "During the Industrial Revolution, working conditions in factories became a significant public concern due to their harshness.",
+      "importance": 0.7,
+      "name": "Working Conditions"
+    },
+    {
+      "description": "The Factory Acts were legislative measures introduced in response to public concerns about poor working conditions during the Industrial Revolution.",
+      "importance": 0.65,
+      "name": "Factory Acts"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/long_lecture_neural_networks.json
+++ b/backend/tests/evals/cassettes/concept_extraction/long_lecture_neural_networks.json
@@ -1,49 +1,79 @@
 {
   "concepts": [
     {
-      "description": "Backpropagation is the algorithm used to efficiently compute the gradients of the loss function with respect to the weights of the network, applying the chain rule layer by layer.",
+      "description": "An introductory lecture covering fundamental concepts and techniques essential for understanding and building neural networks.",
       "importance": 1.0,
+      "name": "Neural Networks Foundations"
+    },
+    {
+      "description": "An algorithm that efficiently computes the gradients of the loss function with respect to the weights of the network, essential for training neural networks via gradient descent. It applies the chain rule layerwise.",
+      "importance": 0.95,
       "name": "Backpropagation"
     },
     {
-      "description": "These are the foundational architecture in neural networks, where information flows in one direction from input to output layers without cycles.",
-      "importance": 1.0,
+      "description": "A type of artificial neural network where connections between nodes do not form a cycle, moving information only in one direction from input to output layers.",
+      "importance": 0.9,
       "name": "Feedforward Networks"
     },
     {
-      "description": "This is an optimization algorithm used to train neural networks, where model parameters are updated using gradients computed from small random subsets of the training data called mini-batches.",
-      "importance": 0.95,
+      "description": "An optimization algorithm used to train neural networks by updating model parameters using the gradient of the loss function calculated on small random subsets of the training data.",
+      "importance": 0.9,
       "name": "Stochastic Gradient Descent with Mini-batches"
     },
     {
-      "description": "Batch normalization is a technique that normalizes the inputs of each layer, helping to stabilize and speed up the training of deep neural networks by mitigating vanishing/exploding gradients and allowing higher learning rates.",
+      "description": "A technique that normalizes the inputs to layers in a neural network by re-centering and re-scaling them, which helps stabilize and speed up the training process and mitigate vanishing/exploding gradients.",
       "importance": 0.9,
       "name": "Batch Normalization"
     },
     {
-      "description": "Functions like ReLU, sigmoid, and tanh are applied to the output of each neuron to introduce non-linearity, enabling neural networks to learn complex patterns.",
-      "importance": 0.9,
+      "description": "Non-linear functions applied to the output of neurons in a neural network, enabling the model to learn complex patterns and introduce non-linearity.",
+      "importance": 0.85,
       "name": "Activation Functions"
     },
     {
-      "description": "The softmax function is used in the output layer of a neural network for multi-class classification, converting raw scores into probabilities that sum to one.",
-      "importance": 0.85,
-      "name": "Softmax Output"
-    },
-    {
-      "description": "Cross-entropy loss is a common loss function used in classification tasks, measuring the performance of a classification model whose output is a probability value between 0 and 1.",
+      "description": "A widely used loss function for classification tasks that measures the performance of a classification model whose output is a probability value between 0 and 1.",
       "importance": 0.85,
       "name": "Cross-Entropy Loss"
     },
     {
-      "description": "Methods such as L2 weight decay and dropout are employed to prevent neural networks from overfitting the training data, improving their generalization ability to unseen examples.",
+      "description": "Problems encountered during training deep neural networks where gradients either become extremely small, halting learning, or extremely large, causing unstable updates.",
+      "importance": 0.85,
+      "name": "Vanishing and Exploding Gradients"
+    },
+    {
+      "description": "An activation function used in the output layer of a neural network for multi-class classification, converting a vector of arbitrary real values into a probability distribution.",
+      "importance": 0.8,
+      "name": "Softmax Output"
+    },
+    {
+      "description": "Methods used to prevent overfitting in neural networks by adding a penalty to the loss function, thereby improving the model's generalization performance on unseen data.",
       "importance": 0.8,
       "name": "Regularization Techniques"
     },
     {
-      "description": "These are issues encountered during training deep neural networks where gradients become either extremely small (vanishing) or extremely large (exploding), hindering effective learning.",
+      "description": "A popular activation function that outputs the input directly if it is positive, otherwise it outputs zero, effectively introducing non-linearity.",
       "importance": 0.75,
-      "name": "Vanishing and Exploding Gradients"
+      "name": "ReLU (Rectified Linear Unit)"
+    },
+    {
+      "description": "A regularization technique that adds a penalty proportional to the square of the magnitude of weights to the loss function, encouraging smaller weights and preventing overfitting.",
+      "importance": 0.75,
+      "name": "L2 Weight Decay"
+    },
+    {
+      "description": "A regularization technique that randomly deactivates a fraction of neurons during training, preventing complex co-adaptations on the training data and improving generalization.",
+      "importance": 0.75,
+      "name": "Dropout"
+    },
+    {
+      "description": "An activation function that squashes input values to a range between 0 and 1, often used in the output layer for binary classification.",
+      "importance": 0.7,
+      "name": "Sigmoid Function"
+    },
+    {
+      "description": "An activation function similar to sigmoid but squashes input values to a range between -1 and 1, often leading to faster convergence than sigmoid.",
+      "importance": 0.7,
+      "name": "Tanh (Hyperbolic Tangent) Function"
     }
   ]
 }

--- a/backend/tests/evals/cassettes/concept_extraction/math_text_regression_complexity.json
+++ b/backend/tests/evals/cassettes/concept_extraction/math_text_regression_complexity.json
@@ -1,0 +1,44 @@
+{
+  "concepts": [
+    {
+      "description": "A fundamental statistical method used to model the linear relationship between a dependent variable and one or more independent variables by fitting a linear equation to observed data.",
+      "importance": 0.95,
+      "name": "Linear Regression"
+    },
+    {
+      "description": "A framework that analyzes a model's prediction error into components related to bias (error from incorrect assumptions), variance (error from sensitivity to training data fluctuations), and irreducible error.",
+      "importance": 0.9,
+      "name": "Bias-Variance Decomposition"
+    },
+    {
+      "description": "The mathematical formulation central to linear regression, where the goal is to minimize the sum of the squares of the differences between observed and predicted values.",
+      "importance": 0.85,
+      "name": "Least-Squares Problem"
+    },
+    {
+      "description": "The process of choosing the most appropriate model from a set of candidates, often informed by understanding the bias-variance trade-off to optimize generalization performance.",
+      "importance": 0.8,
+      "name": "Model Selection"
+    },
+    {
+      "description": "A direct analytical solution for finding the coefficients that minimize the least-squares objective function in linear regression.",
+      "importance": 0.75,
+      "name": "Normal Equations"
+    },
+    {
+      "description": "A matrix factorization technique used to solve the least-squares problem, often preferred for its numerical stability compared to the normal equations.",
+      "importance": 0.75,
+      "name": "QR Decomposition"
+    },
+    {
+      "description": "A technique used in linear regression to prevent overfitting by adding a penalty term to the least-squares cost function, shrinking coefficients towards zero.",
+      "importance": 0.7,
+      "name": "Ridge Regularization"
+    },
+    {
+      "description": "A mathematical notation used to describe the asymptotic upper bound of the runtime or space complexity of algorithms, applied here to assess the efficiency of matrix solves.",
+      "importance": 0.6,
+      "name": "Big-O Analysis"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/narrow_assignment_proofs.json
+++ b/backend/tests/evals/cassettes/concept_extraction/narrow_assignment_proofs.json
@@ -1,0 +1,19 @@
+{
+  "concepts": [
+    {
+      "description": "A fundamental proof in number theory demonstrating that the square root of two cannot be expressed as a simple fraction, often proven by contradiction.",
+      "importance": 0.9,
+      "name": "Irrationality of the Square Root of Two"
+    },
+    {
+      "description": "Euclid's theorem stating that there are infinitely many prime numbers, a classic proof often using contradiction or construction.",
+      "importance": 0.9,
+      "name": "Infinitude of Primes"
+    },
+    {
+      "description": "A basic proof in number theory demonstrating that the result of adding any two odd integers will always be an even integer.",
+      "importance": 0.9,
+      "name": "Sum of Two Odd Integers"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/physics_classical_mechanics.json
+++ b/backend/tests/evals/cassettes/concept_extraction/physics_classical_mechanics.json
@@ -1,0 +1,39 @@
+{
+  "concepts": [
+    {
+      "description": "These fundamental laws describe the relationship between an object and the forces acting upon it, forming the basis of classical mechanics.",
+      "importance": 1.0,
+      "name": "Newton's Laws of Motion"
+    },
+    {
+      "description": "In conservative force fields, the total mechanical energy (sum of kinetic and potential energy) of a system remains constant, a powerful tool for analyzing motion.",
+      "importance": 0.95,
+      "name": "Conservation of Energy"
+    },
+    {
+      "description": "For an isolated system, the total linear momentum remains constant, especially useful for analyzing collisions and explosions.",
+      "importance": 0.9,
+      "name": "Conservation of Linear Momentum"
+    },
+    {
+      "description": "In the absence of external torques, the total angular momentum of a system remains constant, essential for understanding rotational motion.",
+      "importance": 0.85,
+      "name": "Conservation of Angular Momentum"
+    },
+    {
+      "description": "This formulation uses the Lagrangian (kinetic minus potential energy) and the principle of least action to derive equations of motion, offering an alternative and often more general approach than Newtonian mechanics.",
+      "importance": 0.8,
+      "name": "Lagrangian Mechanics"
+    },
+    {
+      "description": "An advanced formulation of classical mechanics using the Hamiltonian (total energy) in terms of generalized coordinates and momenta, providing a bridge to quantum mechanics.",
+      "importance": 0.75,
+      "name": "Hamiltonian Mechanics"
+    },
+    {
+      "description": "A type of periodic motion where the restoring force is directly proportional to the displacement and acts in the direction opposite to the displacement, common in oscillating systems.",
+      "importance": 0.7,
+      "name": "Simple Harmonic Motion"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/psychology_study_guide.json
+++ b/backend/tests/evals/cassettes/concept_extraction/psychology_study_guide.json
@@ -1,0 +1,64 @@
+{
+  "concepts": [
+    {
+      "description": "A cognitive system responsible for temporarily holding and manipulating information, crucial for tasks like reasoning and comprehension.",
+      "importance": 0.95,
+      "name": "Working Memory"
+    },
+    {
+      "description": "The system responsible for storing information over extended periods, ranging from minutes to a lifetime.",
+      "importance": 0.95,
+      "name": "Long-Term Memory"
+    },
+    {
+      "description": "A conceptual model that describes the three fundamental processes involved in memory formation and access: getting information in, keeping it there, and getting it back out.",
+      "importance": 0.93,
+      "name": "Encoding-Storage-Retrieval Framework"
+    },
+    {
+      "description": "A prominent model proposing that working memory consists of several components, including the central executive, phonological loop, and visuospatial sketchpad.",
+      "importance": 0.92,
+      "name": "Baddeley's Model of Working Memory"
+    },
+    {
+      "description": "A type of learning where an organism learns to associate a neutral stimulus with a meaningful stimulus, leading to a learned response.",
+      "importance": 0.9,
+      "name": "Classical Conditioning"
+    },
+    {
+      "description": "A type of learning in which behaviors are strengthened or weakened by the consequences that follow them, often involving reinforcement or punishment.",
+      "importance": 0.9,
+      "name": "Operant Conditioning"
+    },
+    {
+      "description": "A dual-process theory proposing two distinct modes of thinking: System 1 is fast, intuitive, and emotional, while System 2 is slower, more deliberate, and logical.",
+      "importance": 0.88,
+      "name": "Kahneman's System 1 and System 2"
+    },
+    {
+      "description": "A perceptual process where existing knowledge, expectations, and context influence how sensory information is interpreted.",
+      "importance": 0.87,
+      "name": "Top-Down Perception"
+    },
+    {
+      "description": "A perceptual process driven by sensory input from the environment, where raw data is processed and built up into a complete perception.",
+      "importance": 0.87,
+      "name": "Bottom-Up Perception"
+    },
+    {
+      "description": "Cognitive models that explain how individuals selectively focus on certain stimuli while ignoring others, influencing perception and information processing.",
+      "importance": 0.85,
+      "name": "Theories of Attention"
+    },
+    {
+      "description": "A metaphor suggesting that attention works like a spotlight, highlighting a specific area of interest and processing information within that focused region more thoroughly.",
+      "importance": 0.8,
+      "name": "Spotlight Model of Attention"
+    },
+    {
+      "description": "A model proposing that attention can be flexibly adjusted, either narrowing to intensely focus on a small area or widening to encompass a broader region with less detail.",
+      "importance": 0.8,
+      "name": "Zoom Lens Model of Attention"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/concept_extraction/whole_course_syllabus_calc1.json
+++ b/backend/tests/evals/cassettes/concept_extraction/whole_course_syllabus_calc1.json
@@ -1,0 +1,74 @@
+{
+  "concepts": [
+    {
+      "description": "Explores the behavior of functions as input approaches a certain value, forming the foundational understanding of continuity and the basis for calculus.",
+      "importance": 1.0,
+      "name": "Limits and Continuity"
+    },
+    {
+      "description": "Introduces the concept of instantaneous rate of change and slope of a tangent line, along with systematic rules for computing derivatives of various functions.",
+      "importance": 0.98,
+      "name": "Derivatives and Rules of Differentiation"
+    },
+    {
+      "description": "Establishes the crucial connection between differentiation and integration, providing a method for evaluating definite integrals using antiderivatives.",
+      "importance": 0.97,
+      "name": "The Fundamental Theorem of Calculus"
+    },
+    {
+      "description": "Covers various methods for finding antiderivatives and evaluating integrals, including substitution, integration by parts, trigonometric substitution, and partial fractions.",
+      "importance": 0.95,
+      "name": "Techniques of Integration"
+    },
+    {
+      "description": "Utilizes definite integrals to calculate areas between curves and volumes of solids of revolution using methods like disk, washer, and shell.",
+      "importance": 0.93,
+      "name": "Applications of Integration to Area and Volume"
+    },
+    {
+      "description": "Applies derivatives to analyze the properties of functions, such as intervals of increase/decrease, concavity, and local extrema, to accurately sketch their graphs.",
+      "importance": 0.92,
+      "name": "Curve Sketching"
+    },
+    {
+      "description": "Uses calculus to find the maximum or minimum values of a function, often applied to solve real-world problems involving quantities like area, volume, or cost.",
+      "importance": 0.91,
+      "name": "Optimization"
+    },
+    {
+      "description": "Involves finding the rate at which one quantity is changing based on the known rates of other related quantities, often in dynamic physical scenarios.",
+      "importance": 0.9,
+      "name": "Related Rates"
+    },
+    {
+      "description": "A technique for differentiating functions that are not explicitly defined in terms of one variable, often used for equations involving mixed variables.",
+      "importance": 0.89,
+      "name": "Implicit Differentiation"
+    },
+    {
+      "description": "States that for a continuous and differentiable function on a closed interval, there is at least one point where the instantaneous rate of change equals the average rate of change.",
+      "importance": 0.88,
+      "name": "Mean Value Theorem"
+    },
+    {
+      "description": "A method used to evaluate indeterminate forms of limits by taking the derivatives of the numerator and denominator.",
+      "importance": 0.87,
+      "name": "L'Hopital's Rule"
+    },
+    {
+      "description": "Approximates the area under a curve by dividing it into a series of rectangles, leading to the formal definition of the definite integral.",
+      "importance": 0.85,
+      "name": "Riemann Sums"
+    },
+    {
+      "description": "Introduces simple differential equations and methods for solving them, providing a foundation for understanding models of change.",
+      "importance": 0.83,
+      "name": "Differential Equations Basics"
+    },
+    {
+      "description": "Explores ordered lists of numbers and the sums of these lists, including concepts like convergence and divergence, which are typically covered at the end of Calculus I or in Calculus II.",
+      "importance": 0.8,
+      "name": "Sequences and Series"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/document_classification/assignment.json
+++ b/backend/tests/evals/cassettes/document_classification/assignment.json
@@ -1,0 +1,6 @@
+{
+  "category": "assignment",
+  "confidence": 1.0,
+  "is_syllabus": false,
+  "rationale": "The document contains numbered problems typical of a problem set or homework assignment, with a clear due date mentioned."
+}

--- a/backend/tests/evals/cassettes/document_classification/assignment_list_with_weights.json
+++ b/backend/tests/evals/cassettes/document_classification/assignment_list_with_weights.json
@@ -1,0 +1,6 @@
+{
+  "category": "assignment",
+  "confidence": 0.8,
+  "is_syllabus": true,
+  "rationale": "The document lists graded items for a course with point values and mentions submission deadlines, indicating a syllabus or grading policy."
+}

--- a/backend/tests/evals/cassettes/document_classification/course_handbook_with_schedule.json
+++ b/backend/tests/evals/cassettes/document_classification/course_handbook_with_schedule.json
@@ -1,0 +1,6 @@
+{
+  "category": "syllabus",
+  "confidence": 1.0,
+  "is_syllabus": true,
+  "rationale": "The document explicitly states it is a \"handbook\" containing \"policies and the term schedule\" and includes a week-by-week breakdown of topics."
+}

--- a/backend/tests/evals/cassettes/document_classification/course_welcome_letter_no_schedule.json
+++ b/backend/tests/evals/cassettes/document_classification/course_welcome_letter_no_schedule.json
@@ -1,0 +1,6 @@
+{
+  "category": "syllabus",
+  "confidence": 0.9,
+  "is_syllabus": true,
+  "rationale": "The document mentions office hours, academic integrity, and that the schedule and grading will be discussed, all of which are typical components of a syllabus."
+}

--- a/backend/tests/evals/cassettes/document_classification/cs_programming_project.json
+++ b/backend/tests/evals/cassettes/document_classification/cs_programming_project.json
@@ -1,0 +1,6 @@
+{
+  "category": "assignment",
+  "confidence": 0.9,
+  "is_syllabus": false,
+  "rationale": "The document lists project deliverables, a due date, and grading criteria, which are characteristic of an assignment."
+}

--- a/backend/tests/evals/cassettes/document_classification/exam.json
+++ b/backend/tests/evals/cassettes/document_classification/exam.json
@@ -1,0 +1,6 @@
+{
+  "category": "study_guide",
+  "confidence": 0.8,
+  "is_syllabus": false,
+  "rationale": "The document is formatted like an exam and includes point values for questions, indicating it is study material for an exam."
+}

--- a/backend/tests/evals/cassettes/document_classification/french_assignment.json
+++ b/backend/tests/evals/cassettes/document_classification/french_assignment.json
@@ -1,0 +1,6 @@
+{
+  "category": "assignment",
+  "confidence": 1.0,
+  "is_syllabus": false,
+  "rationale": "The document is labeled \"Devoir\" (assignment) and contains numbered problems and instructions for a homework assignment."
+}

--- a/backend/tests/evals/cassettes/document_classification/grading_rubric.json
+++ b/backend/tests/evals/cassettes/document_classification/grading_rubric.json
@@ -1,0 +1,6 @@
+{
+  "category": "assignment",
+  "confidence": 0.9,
+  "is_syllabus": false,
+  "rationale": "The document includes point distributions for different aspects of an essay, indicating it is likely part of an assignment or grading criteria for one."
+}

--- a/backend/tests/evals/cassettes/document_classification/lab_handout_chemistry.json
+++ b/backend/tests/evals/cassettes/document_classification/lab_handout_chemistry.json
@@ -1,0 +1,6 @@
+{
+  "category": "assignment",
+  "confidence": 0.9,
+  "is_syllabus": false,
+  "rationale": "The document describes a lab experiment with a clear objective, procedure, and a deliverable (lab report)."
+}

--- a/backend/tests/evals/cassettes/document_classification/latex_source_problem_set.json
+++ b/backend/tests/evals/cassettes/document_classification/latex_source_problem_set.json
@@ -1,0 +1,6 @@
+{
+  "category": "assignment",
+  "confidence": 1.0,
+  "is_syllabus": false,
+  "rationale": "The document contains numbered problems typical of a problem set or homework assignment."
+}

--- a/backend/tests/evals/cassettes/document_classification/lecture_notes.json
+++ b/backend/tests/evals/cassettes/document_classification/lecture_notes.json
@@ -1,0 +1,6 @@
+{
+  "category": "lecture_notes",
+  "confidence": 0.8,
+  "is_syllabus": false,
+  "rationale": "The document discusses lecture content on backpropagation and recalls previous concepts, typical of lecture notes."
+}

--- a/backend/tests/evals/cassettes/document_classification/math_heavy_lecture_notes.json
+++ b/backend/tests/evals/cassettes/document_classification/math_heavy_lecture_notes.json
@@ -1,0 +1,6 @@
+{
+  "category": "lecture_notes",
+  "confidence": 0.9,
+  "is_syllabus": false,
+  "rationale": "The document discusses Fourier series, coefficients, Parseval's identity, and the Dirichlet kernel, which are typical topics covered in a lecture."
+}

--- a/backend/tests/evals/cassettes/document_classification/math_problem_set.json
+++ b/backend/tests/evals/cassettes/document_classification/math_problem_set.json
@@ -1,0 +1,6 @@
+{
+  "category": "assignment",
+  "confidence": 1.0,
+  "is_syllabus": false,
+  "rationale": "The document lists specific problems to solve, refers to a due date, and mentions a late policy, which are all hallmarks of an assignment."
+}

--- a/backend/tests/evals/cassettes/document_classification/minimal_syllabus.json
+++ b/backend/tests/evals/cassettes/document_classification/minimal_syllabus.json
@@ -1,0 +1,6 @@
+{
+  "category": "syllabus",
+  "confidence": 1.0,
+  "is_syllabus": true,
+  "rationale": "The document explicitly labels itself as a course outline and includes a week-by-week schedule leading up to a final exam."
+}

--- a/backend/tests/evals/cassettes/document_classification/near_empty_doc.json
+++ b/backend/tests/evals/cassettes/document_classification/near_empty_doc.json
@@ -1,0 +1,6 @@
+{
+  "category": "lecture_notes",
+  "confidence": 1.0,
+  "is_syllabus": false,
+  "rationale": "The document is explicitly titled \"Lecture 1 notes.\""
+}

--- a/backend/tests/evals/cassettes/document_classification/past_history_exam.json
+++ b/backend/tests/evals/cassettes/document_classification/past_history_exam.json
@@ -1,0 +1,6 @@
+{
+  "category": "study_guide",
+  "confidence": 0.9,
+  "is_syllabus": false,
+  "rationale": "The document lists specific topics and questions for an exam, characteristic of a study guide or exam review."
+}

--- a/backend/tests/evals/cassettes/document_classification/reading_list_pdf.json
+++ b/backend/tests/evals/cassettes/document_classification/reading_list_pdf.json
@@ -1,0 +1,6 @@
+{
+  "category": "reading",
+  "confidence": 0.8,
+  "is_syllabus": false,
+  "rationale": "The document lists suggested and optional readings for a course, typical of a reading list which falls under the \"reading\" category."
+}

--- a/backend/tests/evals/cassettes/document_classification/required_readings_with_weeks.json
+++ b/backend/tests/evals/cassettes/document_classification/required_readings_with_weeks.json
@@ -1,0 +1,6 @@
+{
+  "category": "reading",
+  "confidence": 0.9,
+  "is_syllabus": true,
+  "rationale": "The document lists required readings by week and mentions reading responses, indicating course structure and requirements."
+}

--- a/backend/tests/evals/cassettes/document_classification/research_paper.json
+++ b/backend/tests/evals/cassettes/document_classification/research_paper.json
@@ -1,0 +1,6 @@
+{
+  "category": "reading",
+  "confidence": 1.0,
+  "is_syllabus": false,
+  "rationale": "The document is a research paper with an abstract and introduction, typical of academic readings."
+}

--- a/backend/tests/evals/cassettes/document_classification/slides_sparse_bullets.json
+++ b/backend/tests/evals/cassettes/document_classification/slides_sparse_bullets.json
@@ -1,0 +1,6 @@
+{
+  "category": "slides",
+  "confidence": 0.9,
+  "is_syllabus": false,
+  "rationale": "The document is structured as presentation slides with bullet points summarizing lecture topics."
+}

--- a/backend/tests/evals/cassettes/document_classification/spanish_syllabus.json
+++ b/backend/tests/evals/cassettes/document_classification/spanish_syllabus.json
@@ -1,0 +1,6 @@
+{
+  "category": "syllabus",
+  "confidence": 1.0,
+  "is_syllabus": true,
+  "rationale": "The document explicitly states it is a \"Programa del curso\" (Course Program) and includes a grading policy with percentages and a class schedule indicating 16 weeks."
+}

--- a/backend/tests/evals/cassettes/document_classification/study_guide_overlapping_syllabus.json
+++ b/backend/tests/evals/cassettes/document_classification/study_guide_overlapping_syllabus.json
@@ -1,0 +1,6 @@
+{
+  "category": "study_guide",
+  "confidence": 0.9,
+  "is_syllabus": true,
+  "rationale": "The document is explicitly labeled as a \"STUDY GUIDE\" and covers specific topics with practice questions and an answer key, indicating preparation for an exam. It also references the \"syllabus\" and covers material from specific \"weeks\", thus it is also a syllabus."
+}

--- a/backend/tests/evals/cassettes/document_classification/syllabus_embedded_in_handbook.json
+++ b/backend/tests/evals/cassettes/document_classification/syllabus_embedded_in_handbook.json
@@ -1,0 +1,6 @@
+{
+  "category": "syllabus",
+  "confidence": 0.9,
+  "is_syllabus": true,
+  "rationale": "The document explicitly mentions \"Course Information\" and provides a \"Schedule of topics\" organized by week, along with a list of \"Assessments\" and required readings."
+}

--- a/backend/tests/evals/cassettes/document_classification/textbook_chapter.json
+++ b/backend/tests/evals/cassettes/document_classification/textbook_chapter.json
@@ -1,0 +1,6 @@
+{
+  "category": "reading",
+  "confidence": 0.9,
+  "is_syllabus": false,
+  "rationale": "The document discusses a specific topic (Recurrence Relations) and provides a definition and example, which is characteristic of a reading material."
+}

--- a/backend/tests/evals/cassettes/document_classification/typical_university_syllabus.json
+++ b/backend/tests/evals/cassettes/document_classification/typical_university_syllabus.json
@@ -2,5 +2,5 @@
   "category": "syllabus",
   "confidence": 1.0,
   "is_syllabus": true,
-  "rationale": "The document includes a course schedule, grading policy, and late policy, clearly indicating it is a syllabus."
+  "rationale": "The document explicitly states the course schedule, grading policy, and late policy, which are key components of a syllabus."
 }

--- a/backend/tests/evals/cassettes/document_summary/bullet_only_presentation.json
+++ b/backend/tests/evals/cassettes/document_summary/bullet_only_presentation.json
@@ -1,0 +1,12 @@
+{
+  "abstract": "This document provides a concise overview of photosynthesis, detailing the key stages of the light-dependent reactions, including Photosystems II and I, water splitting, and electron transport. It further explains the Calvin cycle, covering carbon fixation, reduction, and the regeneration of RuBP. The net products of photosynthesis, such as ATP, NADPH, and glucose, are identified, along with the primary limiting factors: light intensity, carbon dioxide concentration, and temperature.",
+  "headline": "Photosynthesis: An Overview of Light Reactions, Calvin Cycle, and Limiting Factors",
+  "key_points": [
+    "Photosynthesis involves light-dependent reactions and the Calvin cycle.",
+    "The light reactions utilize water and light energy to produce ATP and NADPH.",
+    "The Calvin cycle uses ATP, NADPH, and CO2 to synthesize glucose.",
+    "Water splitting in the light reactions releases oxygen.",
+    "Key factors limiting photosynthesis include light, CO2, and temperature.",
+    "The process culminates in the production of glucose, ATP, and NADPH."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/course_handbook_policies.json
+++ b/backend/tests/evals/cassettes/document_summary/course_handbook_policies.json
@@ -1,0 +1,10 @@
+{
+  "abstract": "This document outlines the key policies for BIO 130, including academic integrity, late work, and accommodations. It details consequences for academic dishonesty such as plagiarism and unauthorized AI use, stipulating a zero on the assignment and a referral. The handbook also specifies a penalty of 10% per day, up to three days, for late submissions. Students requiring accommodations must notify the instructor and the Office of Disability Services within the first week of the course.",
+  "headline": "BIO 130 Course Handbook: Policies on Academic Integrity, Late Work, and Accommodations",
+  "key_points": [
+    "Plagiarism, unauthorized collaboration, or undisclosed AI use will result in a zero and a referral.",
+    "Late submissions incur a 10% penalty per day, capped at three days.",
+    "Students needing accommodations must inform the instructor and the Office of Disability Services during the first week.",
+    "The course handbook covers academic integrity, late work penalties, and accommodation procedures."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/empty_document.json
+++ b/backend/tests/evals/cassettes/document_summary/empty_document.json
@@ -1,0 +1,9 @@
+{
+  "abstract": "The document provided was intentionally left blank and contains no content to summarize.",
+  "headline": "Document is Blank",
+  "key_points": [
+    "The document is blank.",
+    "There is no information to extract.",
+    "No summary can be created."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/glossary_style_reading.json
+++ b/backend/tests/evals/cassettes/document_summary/glossary_style_reading.json
@@ -1,0 +1,12 @@
+{
+  "abstract": "This document provides a glossary of fundamental statistics terms. It defines key concepts including mean, median, mode, variance, standard deviation, and p-value. Each definition is concise and explains the core meaning of the statistical term.",
+  "headline": "Glossary of basic statistics terms and definitions.",
+  "key_points": [
+    "Mean is the arithmetic average of a dataset.",
+    "Median represents the middle value in an ordered dataset.",
+    "Mode identifies the most frequently occurring value in a dataset.",
+    "Variance measures the spread of data points around the mean.",
+    "Standard deviation is the square root of variance, indicating data dispersion.",
+    "A p-value quantifies the probability of observing extreme results under a null hypothesis."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/lab_procedure.json
+++ b/backend/tests/evals/cassettes/document_summary/lab_procedure.json
@@ -1,0 +1,12 @@
+{
+  "abstract": "This document outlines the procedure for an acid-base titration to determine the concentration of an unknown hydrochloric acid (HCl) solution. The process involves calibrating a burette, pipetting a precise volume of HCl into an Erlenmeyer flask, and adding phenolphthalein indicator. The HCl is then titrated with a standardized sodium hydroxide (NaOH) solution until a persistent pink color indicates the equivalence point. The volume of NaOH used is recorded, and the experiment is repeated for accuracy. ",
+  "headline": "Acid-Base Titration Procedure for Determining Unknown HCl Concentration",
+  "key_points": [
+    "Calibrate the burette before starting the titration.",
+    "Pipette 25.0 mL of the unknown HCl solution into an Erlenmeyer flask.",
+    "Add three drops of phenolphthalein indicator to the HCl solution.",
+    "Titrate with standardized NaOH until the first persistent pink color appears.",
+    "Record the volume of NaOH dispensed from the burette.",
+    "Repeat the titration for a total of three trials and average the results to ensure accuracy."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/lecture_backpropagation.json
+++ b/backend/tests/evals/cassettes/document_summary/lecture_backpropagation.json
@@ -1,0 +1,11 @@
+{
+  "abstract": "This lecture covers the backpropagation algorithm, a fundamental method for training neural networks. The process begins with a forward pass to calculate the loss based on inputs and weights. Backpropagation then utilizes the chain rule to compute the partial derivatives of this loss with respect to each model parameter. Gradients are computed layer by layer, with each layer's gradient depending on the previous layer's activations and the gradient from the subsequent layer. Finally, these gradients are used in a gradient-descent step to update the model's weights.",
+  "headline": "Backpropagation: Calculating Gradients for Model Training",
+  "key_points": [
+    "Backpropagation uses the chain rule to compute gradients of the loss function with respect to model parameters.",
+    "The forward pass calculates the loss from inputs and weights.",
+    "Gradients are computed layer by layer, using activations from the previous layer and gradients from the next.",
+    "Gradient descent is applied to update weights using the computed gradients.",
+    "Backpropagation is essential for training neural network models."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/linear_algebra_problem_set.json
+++ b/backend/tests/evals/cassettes/document_summary/linear_algebra_problem_set.json
@@ -1,0 +1,10 @@
+{
+  "abstract": "This document contains Problem Set 6 for a Linear Algebra course. It includes three problems: the first requires diagonalizing a 2x2 matrix and computing its 10th power, the second asks for a proof that every real symmetric matrix has an orthonormal eigenbasis, and the third involves finding the rank, nullity, and column space basis for a 4x5 matrix. All problems require showing detailed work.",
+  "headline": "Problem Set 6: Linear Algebra Problems on Diagonalization, Symmetric Matrices, and Matrix Properties",
+  "key_points": [
+    "Problem 1: Diagonalize a 2x2 matrix and compute its 10th power.",
+    "Problem 2: Prove that real symmetric matrices possess an orthonormal eigenbasis.",
+    "Problem 3: Determine the rank, nullity, and column space basis for a 4x5 matrix.",
+    "The problem set covers key concepts in linear algebra including matrix diagonalization, properties of symmetric matrices, and fundamental subspaces."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/literature_review.json
+++ b/backend/tests/evals/cassettes/document_summary/literature_review.json
@@ -1,0 +1,12 @@
+{
+  "abstract": "This review examines 30 years of research on the bilingual advantage in executive function. While early studies showed a consistent advantage in inhibition, more recent replications indicate smaller, context-dependent, and often null effects in adults. The current understanding suggests that bilingualism selectively influences attention, particularly in task switching, and most notably in children and older adults. The review proposes a unified model and identifies three key areas for future research.",
+  "headline": "Review of Bilingual Advantage in Executive Function",
+  "key_points": [
+    "Bilingual advantage in executive function is not consistently found across all tasks and age groups.",
+    "Early research suggested a strong advantage in inhibition, but recent studies show smaller or null effects in adults.",
+    "Bilingualism appears to selectively impact attention, especially in task switching.",
+    "The effects of bilingualism on executive function are more pronounced in children and older adults.",
+    "A unified model is proposed to explain the varied findings.",
+    "Three open questions remain regarding the bilingual advantage in executive function."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/math_heavy_notes_with_dollar_signs.json
+++ b/backend/tests/evals/cassettes/document_summary/math_heavy_notes_with_dollar_signs.json
@@ -1,0 +1,9 @@
+{
+  "abstract": "This document provides a brief overview of Fourier analysis, covering the calculation of Fourier coefficients using integrals of the function multiplied by cosine and sine terms. It also introduces Parseval's identity, which connects the integral of the squared function to the sum of the squares of its Fourier coefficients. Finally, it mentions the Dirichlet kernel as the key element governing the convergence of Fourier series.",
+  "headline": "Notes on Fourier analysis and its core components",
+  "key_points": [
+    "Fourier coefficients (a_n, b_n) are calculated via integration involving cosine and sine terms.",
+    "Parseval's identity relates the integral of a function squared to the sum of the squares of its Fourier coefficients.",
+    "The Dirichlet kernel determines the convergence properties of Fourier series."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/multi_topic_study_guide.json
+++ b/backend/tests/evals/cassettes/document_summary/multi_topic_study_guide.json
@@ -1,0 +1,10 @@
+{
+  "abstract": "This document serves as a study guide for Midterm 1, covering four main topics. It details experimental methods, including independent and dependent variables and confounding factors. The guide also explains the biological basis of behavior through neurons, action potentials, and synaptic transmission. Furthermore, it delves into sensation and perception, discussing absolute and difference thresholds, and finally, it outlines the principles of classical and operant conditioning.",
+  "headline": "Midterm 1 Study Guide: Methods, Neurons, Sensation, and Conditioning",
+  "key_points": [
+    "Experimental methods involve understanding independent/dependent variables and confounding factors.",
+    "Neural communication is explained through action potentials and synaptic transmission.",
+    "Sensation and perception are covered, with a focus on absolute and difference thresholds.",
+    "The study guide includes key concepts of both classical and operant conditioning."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/short_syllabus_excerpt.json
+++ b/backend/tests/evals/cassettes/document_summary/short_syllabus_excerpt.json
@@ -1,10 +1,10 @@
 {
-  "abstract": "This document outlines the basic information for PSY 240 Cognitive Psychology during Fall 2026. It details the course grading breakdown, with weekly quizzes accounting for 20%, the midterm for 30%, and a final paper for 50% of the overall grade. The class meetings are scheduled on Mondays, Wednesdays, and Fridays from 9:00 am to 9:50 am in Room 214.",
-  "headline": "PSY 240 Cognitive Psychology Fall 2026 Course Information",
+  "abstract": "This document outlines the basic information for PSY 240 Cognitive Psychology during the Fall 2026 semester. It details the course meeting times as Monday, Wednesday, and Friday from 9:00 to 9:50 AM in Room 214. The grading distribution is provided, with weekly quizzes accounting for 20% of the final grade, the midterm for 30%, and a final paper for 50%.",
+  "headline": "PSY 240 Cognitive Psychology Course Information for Fall 2026",
   "key_points": [
-    "Course: PSY 240 Cognitive Psychology, Fall 2026",
-    "Grading: 20% quizzes, 30% midterm, 50% final paper",
-    "Meeting times: MWF 9-9:50am",
-    "Location: Room 214"
+    "Course Name: PSY 240 Cognitive Psychology",
+    "Meeting Time: MWF 9-9:50am",
+    "Location: Room 214",
+    "Grading Breakdown: 20% quizzes, 30% midterm, 50% final paper"
   ]
 }

--- a/backend/tests/evals/cassettes/document_summary/spanish_syllabus.json
+++ b/backend/tests/evals/cassettes/document_summary/spanish_syllabus.json
@@ -1,0 +1,9 @@
+{
+  "abstract": "Este es el programa del curso de C\u00e1lculo I impartido por el Profesor Garc\u00eda. El curso tiene una duraci\u00f3n de 16 semanas y cubre temas fundamentales como l\u00edmites, derivadas, integrales y series. La evaluaci\u00f3n del curso se compone de un parcial (30%), tareas semanales (20%) y un examen final (50%). Se enfatiza la importancia de la asistencia regular para el \u00e9xito en la materia.",
+  "headline": "Programa del curso: C\u00e1lculo I",
+  "key_points": [
+    "El curso de C\u00e1lculo I, impartido por el Profesor Garc\u00eda, abarca l\u00edmites, derivadas, integrales y series en 16 semanas.",
+    "La calificaci\u00f3n final se determinar\u00e1 mediante un parcial (30%), tareas semanales (20%) y un examen final (50%).",
+    "La asistencia regular es un requisito del curso."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/statement_of_work.json
+++ b/backend/tests/evals/cassettes/document_summary/statement_of_work.json
@@ -1,0 +1,11 @@
+{
+  "abstract": "This document outlines a project to redesign the Sapling onboarding flow, specifically the signup-to-first-document process. The primary goal is to decrease the median time for users to complete their first upload to under 90 seconds. The redesign will cover the handoff from marketing, the signup form, and the upload screen. Features such as chat, library, and settings are excluded from this project's scope. The design team is responsible for this 4-week project.",
+  "headline": "Redesign of Sapling onboarding to reduce time-to-first-upload.",
+  "key_points": [
+    "Redesign the Sapling onboarding flow from signup to first document upload.",
+    "Reduce the median time-to-first-upload to under 90 seconds.",
+    "The project scope includes marketing-to-app handoff, signup form, and upload screen.",
+    "Chat, library, and settings are out of scope for this project.",
+    "The design team owns this 4-week project."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/textbook_chapter_thesis.json
+++ b/backend/tests/evals/cassettes/document_summary/textbook_chapter_thesis.json
@@ -1,0 +1,10 @@
+{
+  "abstract": "This chapter argues that the Industrial Revolution in 18th-century Britain was not solely the product of invention. Instead, it was driven by a convergence of factors: abundant cheap coal, the high cost of labor, and a permissive patent system. These conditions allowed engineering innovations to flourish and become commercially viable.",
+  "headline": "Chapter 3: The Industrial Revolution",
+  "key_points": [
+    "Mechanization in 18th-century Britain resulted from a combination of cheap coal, expensive labor, and an open patent system.",
+    "Engineering ideas during the Industrial Revolution might have remained mere curiosities without these enabling factors.",
+    "The chapter analyzes each of these key factors in detail.",
+    "The availability of coal, the cost of labor, and patent laws were crucial for the widespread adoption of new technologies."
+  ]
+}

--- a/backend/tests/evals/cassettes/document_summary/verbose_redundant_topic.json
+++ b/backend/tests/evals/cassettes/document_summary/verbose_redundant_topic.json
@@ -1,0 +1,11 @@
+{
+  "abstract": "This document details binary search trees (BSTs), defining them as binary trees where each node's key is greater than all keys in its left subtree and less than all keys in its right subtree. It explains insertion and lookup operations by traversing the tree based on key comparisons. Deletion, particularly for nodes with two children, is addressed by replacing the node with its in-order successor. The notes also highlight the BST's worst-case O(n) performance due to potential imbalance and introduce self-balancing variants like AVL and red-black trees as solutions.",
+  "headline": "Binary Search Trees: Properties, Operations, and Balancing",
+  "key_points": [
+    "A Binary Search Tree (BST) organizes nodes such that each node's key is greater than all keys in its left subtree and less than all keys in its right subtree.",
+    "Insertion and lookup in a BST involve traversing the tree from the root, comparing keys to determine the correct path.",
+    "Deleting a node with two children typically involves replacing it with its in-order successor to maintain BST properties.",
+    "The performance of a BST can degrade to O(n) in the worst case if the tree becomes unbalanced.",
+    "Self-balancing BST variants, such as AVL trees and red-black trees, are used to prevent imbalance and ensure efficient operations."
+  ]
+}

--- a/backend/tests/evals/cassettes/quiz_generation/adaptive_downshift_struggling_student.json
+++ b/backend/tests/evals/cassettes/quiz_generation/adaptive_downshift_struggling_student.json
@@ -1,0 +1,46 @@
+{
+  "questions": [
+    {
+      "concept": "Recursion",
+      "correct_answer": "If n is 0 or 1, return n.",
+      "difficulty": "medium",
+      "explanation": "The base cases for the Fibonacci sequence are F(0) = 0 and F(1) = 1. The function should return these values directly to stop the recursion.",
+      "options": [
+        "If n is 0 or 1, return n.",
+        "If n is less than 2, return n.",
+        "If n is 0, return 0. If n is 1, return 1.",
+        "If n is 0, return 1. If n is 1, return 0."
+      ],
+      "question": "What is the base case in a recursive function for calculating the nth Fibonacci number?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Dynamic Programming",
+      "correct_answer": "It avoids recomputing solutions to overlapping subproblems.",
+      "difficulty": "medium",
+      "explanation": "Memoization is a technique used in dynamic programming to store the results of expensive function calls and return the cached result when the same inputs occur again, thus avoiding redundant computations.",
+      "options": [
+        "It allows for parallel processing of subproblems.",
+        "It avoids recomputing solutions to overlapping subproblems.",
+        "It reduces the space complexity of the solution.",
+        "It guarantees a unique solution to the problem."
+      ],
+      "question": "In dynamic programming, what is the primary advantage of using memoization?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Graph Traversal",
+      "correct_answer": "Queue",
+      "difficulty": "medium",
+      "explanation": "Breadth-First Search (BFS) uses a queue to keep track of the nodes to visit. Nodes are added to the queue as they are discovered, and processed in a first-in, first-out (FIFO) manner.",
+      "options": [
+        "Stack",
+        "Queue",
+        "Heap",
+        "Hash Map"
+      ],
+      "question": "Which of the following data structures is most commonly used to implement Breadth-First Search (BFS) for graph traversal?",
+      "type": "multiple_choice"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/quiz_generation/easy_mcq_basic_biology.json
+++ b/backend/tests/evals/cassettes/quiz_generation/easy_mcq_basic_biology.json
@@ -1,0 +1,60 @@
+{
+  "questions": [
+    {
+      "concept": "Cell Membrane",
+      "correct_answer": "Regulating passage of substances",
+      "difficulty": "easy",
+      "explanation": "The cell membrane acts as a selective barrier, controlling which molecules enter and leave the cell.",
+      "options": [
+        "Protein synthesis",
+        "Energy production",
+        "Regulating passage of substances",
+        "Waste disposal"
+      ],
+      "question": "Which of the following is the primary function of the cell membrane?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Photosynthesis",
+      "correct_answer": "Oxygen and glucose",
+      "difficulty": "easy",
+      "explanation": "Photosynthesis uses light energy, water, and carbon dioxide to produce glucose (sugar) for energy and oxygen as a byproduct.",
+      "options": [
+        "Carbon dioxide and water",
+        "Oxygen and glucose",
+        "ATP and heat",
+        "Nitrogen and minerals"
+      ],
+      "question": "What are the main products of photosynthesis?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Mitosis",
+      "correct_answer": "Metaphase",
+      "difficulty": "easy",
+      "explanation": "In metaphase, the chromosomes line up along the metaphase plate, an imaginary plane equidistant from the two poles of the cell.",
+      "options": [
+        "Prophase",
+        "Metaphase",
+        "Anaphase",
+        "Telophase"
+      ],
+      "question": "During which phase of mitosis do chromosomes align at the center of the cell?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Diffusion",
+      "correct_answer": "High, low",
+      "difficulty": "easy",
+      "explanation": "Diffusion is a passive process driven by the random motion of molecules, causing them to spread from regions where they are more concentrated to regions where they are less concentrated.",
+      "options": [
+        "Low, high",
+        "High, low",
+        "Equal, equal",
+        "Zero, infinite"
+      ],
+      "question": "Diffusion is the movement of molecules from an area of ________ concentration to an area of ________ concentration.",
+      "type": "multiple_choice"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/quiz_generation/easy_mcq_intro_calculus.json
+++ b/backend/tests/evals/cassettes/quiz_generation/easy_mcq_intro_calculus.json
@@ -1,0 +1,46 @@
+{
+  "questions": [
+    {
+      "concept": "Limits",
+      "correct_answer": "The value a function approaches as the input approaches some value.",
+      "difficulty": "easy",
+      "explanation": "The limit of a function describes the behavior of the function near a particular point, not necessarily at the point itself.",
+      "options": [
+        "The value a function approaches as the input approaches some value.",
+        "The instantaneous rate of change of a function.",
+        "The area under the curve of a function.",
+        "A point where a function is undefined."
+      ],
+      "question": "What is the definition of a limit in calculus?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Derivatives",
+      "correct_answer": "The instantaneous rate of change of the function.",
+      "difficulty": "easy",
+      "explanation": "The derivative of a function at a point gives the slope of the tangent line to the function at that point, which represents its instantaneous rate of change.",
+      "options": [
+        "The instantaneous rate of change of the function.",
+        "The average rate of change of the function over an interval.",
+        "The total change in the function.",
+        "The point where the function crosses the x-axis."
+      ],
+      "question": "What does the derivative of a function represent?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Continuity",
+      "correct_answer": "The limit as x approaches c exists, the function value at c exists, and these two values are equal.",
+      "difficulty": "easy",
+      "explanation": "Continuity at a point requires that the function is defined at that point, the limit exists at that point, and the limit equals the function value.",
+      "options": [
+        "The limit as x approaches c exists, the function value at c exists, and these two values are equal.",
+        "The function must be differentiable at c.",
+        "The function must be defined for all real numbers.",
+        "The graph of the function must be a straight line."
+      ],
+      "question": "For a function to be continuous at a point 'c', what must be true?",
+      "type": "multiple_choice"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/quiz_generation/easy_mcq_physics_definitions.json
+++ b/backend/tests/evals/cassettes/quiz_generation/easy_mcq_physics_definitions.json
@@ -1,0 +1,46 @@
+{
+  "questions": [
+    {
+      "concept": "Newton's First Law",
+      "correct_answer": "An object in motion stays in motion with the same speed and in the same direction unless acted upon by an unbalanced force.",
+      "difficulty": "easy",
+      "explanation": "Newton's First Law states that an object will remain at rest or in uniform motion in a straight line unless acted upon by an external force. This is also known as the law of inertia.",
+      "options": [
+        "An object in motion stays in motion with the same speed and in the same direction unless acted upon by an unbalanced force.",
+        "For every action, there is an equal and opposite reaction.",
+        "The acceleration of an object is directly proportional to the net force acting on it and inversely proportional to its mass.",
+        "The total momentum of an isolated system remains constant."
+      ],
+      "question": "What is Newton's First Law of Motion, also known as the Law of Inertia?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Kinetic Energy",
+      "correct_answer": "The energy an object possesses due to its motion.",
+      "difficulty": "easy",
+      "explanation": "Kinetic energy is the energy an object has because it is moving. It depends on the object's mass and velocity.",
+      "options": [
+        "The energy an object possesses due to its position or height.",
+        "The energy an object possesses due to its motion.",
+        "The energy stored in chemical bonds.",
+        "The energy associated with temperature."
+      ],
+      "question": "Which of the following best defines kinetic energy?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Momentum",
+      "correct_answer": "The product of an object's mass and its velocity.",
+      "difficulty": "easy",
+      "explanation": "Momentum is a measure of an object's motion and is calculated as the product of its mass and velocity. It is a vector quantity.",
+      "options": [
+        "The force applied to an object over a period of time.",
+        "The product of an object's mass and its velocity.",
+        "The rate of change of an object's velocity.",
+        "The total energy of an object."
+      ],
+      "question": "What is the definition of momentum?",
+      "type": "multiple_choice"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/quiz_generation/hard_mcq_real_analysis.json
+++ b/backend/tests/evals/cassettes/quiz_generation/hard_mcq_real_analysis.json
@@ -1,0 +1,32 @@
+{
+  "questions": [
+    {
+      "concept": "Cauchy Sequences",
+      "correct_answer": "A sequence is Cauchy if and only if it converges in a complete metric space.",
+      "difficulty": "hard",
+      "explanation": "In a complete metric space, the definition of Cauchy sequences and convergent sequences are equivalent. This means every Cauchy sequence converges to a limit within the space, and every convergent sequence is a Cauchy sequence. The completeness of the space is crucial for this equivalence.",
+      "options": [
+        "A Cauchy sequence is convergent if and only if it is bounded.",
+        "A sequence is Cauchy if and only if it converges in a complete metric space.",
+        "A convergent sequence is always Cauchy, but the converse is only true in complete metric spaces.",
+        "A sequence converges if and only if it is a Cauchy sequence in any metric space."
+      ],
+      "question": "Which of the following statements best characterizes the relationship between Cauchy sequences and convergent sequences in a complete metric space?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Uniform Convergence",
+      "correct_answer": "f(x) must be continuous on E.",
+      "difficulty": "hard",
+      "explanation": "A fundamental theorem in real analysis states that the uniform limit of a sequence of continuous functions is continuous. Therefore, if {f_n(x)} converges uniformly to f(x) and each f_n is continuous, then f(x) must also be continuous on E.",
+      "options": [
+        "f(x) must be continuous on E.",
+        "f(x) is not necessarily continuous on E.",
+        "f(x) is continuous on E if E is a compact set.",
+        "f(x) is continuous on E if the convergence is pointwise."
+      ],
+      "question": "Consider a sequence of functions {f_n(x)} converging uniformly to f(x) on a set E. If each f_n is continuous on E, and f is also continuous on E, what can be said about the limit function f(x)?",
+      "type": "multiple_choice"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/quiz_generation/hard_mcq_theory_of_computation.json
+++ b/backend/tests/evals/cassettes/quiz_generation/hard_mcq_theory_of_computation.json
@@ -1,0 +1,32 @@
+{
+  "questions": [
+    {
+      "concept": "Pumping Lemma",
+      "correct_answer": "If a language is regular, then it can be pumped.",
+      "difficulty": "hard",
+      "explanation": "The Pumping Lemma states that if a language is regular, then any string in the language of sufficient length can be divided into three parts that can be 'pumped' to create new strings that are also in the language. The converse is not true; a language that can be pumped is not necessarily regular.",
+      "options": [
+        "If a language is infinite, then it can be pumped.",
+        "If a language is regular, then it can be pumped.",
+        "If a language can be pumped, then it is regular.",
+        "If a language is not regular, then it cannot be pumped."
+      ],
+      "question": "Which of the following is a consequence of the Pumping Lemma for regular languages?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Decidability",
+      "correct_answer": "L is decidable by a Turing machine.",
+      "difficulty": "hard",
+      "explanation": "While L is not a regular language, it is a context-free language and is decidable by a Turing machine. A simple algorithm can verify if a string is in L by counting the number of 'a's and 'b's.",
+      "options": [
+        "L is decidable because it is context-free.",
+        "L is undecidable because it is not regular.",
+        "L is decidable by a Turing machine.",
+        "L is undecidable because no algorithm can determine if a string is in L."
+      ],
+      "question": "Consider the language L = {a^n b^n | n >= 0}. Which of the following statements is true regarding the decidability of L?",
+      "type": "multiple_choice"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/quiz_generation/medium_mcq_data_structures.json
+++ b/backend/tests/evals/cassettes/quiz_generation/medium_mcq_data_structures.json
@@ -1,0 +1,46 @@
+{
+  "questions": [
+    {
+      "concept": "Hash Tables",
+      "correct_answer": "Average O(1) time complexity for insertions, deletions, and searches.",
+      "difficulty": "medium",
+      "explanation": "Hash tables provide an average time complexity of O(1) for insertions, deletions, and searches by using a hash function to map keys to indices in an array. While worst-case scenarios can be O(n), the average performance is excellent.",
+      "options": [
+        "Guaranteed O(1) average time complexity for all operations.",
+        "Efficient handling of ordered data for range queries.",
+        "Average O(1) time complexity for insertions, deletions, and searches.",
+        "Simple implementation with minimal memory overhead."
+      ],
+      "question": "What is the primary advantage of using a hash table for data storage and retrieval?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Binary Search Trees",
+      "correct_answer": "The value of a node is greater than all values in its left subtree and less than all values in its right subtree.",
+      "difficulty": "medium",
+      "explanation": "The defining property of a BST is that for any given node, all values in its left subtree are less than the node's value, and all values in its right subtree are greater than the node's value. This property allows for efficient searching.",
+      "options": [
+        "The left child's value is greater than or equal to the parent's value, and the right child's value is less than or equal to the parent's value.",
+        "All leaf nodes must have a depth of at most 2.",
+        "The value of a node is greater than all values in its left subtree and less than all values in its right subtree.",
+        "The tree must be balanced, with heights of left and right subtrees differing by at most 1."
+      ],
+      "question": "In a Binary Search Tree (BST), which property must hold true for all nodes?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Big-O Analysis",
+      "correct_answer": "The upper bound of an algorithm's time or space complexity as input size grows.",
+      "difficulty": "medium",
+      "explanation": "Big-O notation provides a way to classify algorithms based on how their run time or space requirements grow as the input size increases. It focuses on the worst-case scenario or the upper bound of the growth rate.",
+      "options": [
+        "The exact execution time of an algorithm on a specific machine.",
+        "The best-case performance of an algorithm.",
+        "The amount of memory an algorithm uses.",
+        "The upper bound of an algorithm's time or space complexity as input size grows."
+      ],
+      "question": "When analyzing algorithms, what does Big-O notation primarily describe?",
+      "type": "multiple_choice"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/quiz_generation/medium_mcq_econ.json
+++ b/backend/tests/evals/cassettes/quiz_generation/medium_mcq_econ.json
@@ -1,0 +1,46 @@
+{
+  "questions": [
+    {
+      "concept": "Marginal Cost",
+      "correct_answer": "Marginal cost is the cost of producing one more unit of a good.",
+      "difficulty": "medium",
+      "explanation": "Marginal cost specifically refers to the change in total cost resulting from producing one additional unit of output.",
+      "options": [
+        "Marginal cost is the total cost of all units produced.",
+        "Marginal cost is the cost of producing one more unit of a good.",
+        "Marginal cost is the average cost per unit.",
+        "Marginal cost is the fixed cost that does not change with output."
+      ],
+      "question": "What is the relationship between marginal cost and the production of one additional unit of a good?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Price Elasticity of Demand",
+      "correct_answer": "2.0",
+      "difficulty": "medium",
+      "explanation": "Price elasticity of demand is calculated as the percentage change in quantity demanded divided by the percentage change in price. In this case, 20% / -10% = -2. The absolute value is 2.0, indicating elastic demand.",
+      "options": [
+        "0.5",
+        "2.0",
+        "10%",
+        "20%"
+      ],
+      "question": "If a 10% decrease in price leads to a 20% increase in the quantity demanded, what is the price elasticity of demand?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Comparative Advantage",
+      "correct_answer": "Opportunity cost than another country.",
+      "difficulty": "medium",
+      "explanation": "Comparative advantage is determined by opportunity cost, meaning the value of the next best alternative forgone. A country has a comparative advantage if it can produce a good with a lower opportunity cost than other countries.",
+      "options": [
+        "Absolute cost than another country.",
+        "Opportunity cost than another country.",
+        "Price than another country.",
+        "Total production cost than another country."
+      ],
+      "question": "A country has a comparative advantage in producing a good if it can produce that good at a lower:",
+      "type": "multiple_choice"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/quiz_generation/medium_mcq_organic_chem.json
+++ b/backend/tests/evals/cassettes/quiz_generation/medium_mcq_organic_chem.json
@@ -1,0 +1,46 @@
+{
+  "questions": [
+    {
+      "concept": "Resonance Structures",
+      "correct_answer": "They represent different distributions of electrons within the same molecule.",
+      "difficulty": "medium",
+      "explanation": "Resonance structures are different Lewis structures that can be drawn for a molecule or ion, where the actual structure is an average of all the resonance forms. They differ only in the placement of electrons, not in the arrangement of atoms.",
+      "options": [
+        "They are constitutional isomers with the same molecular formula.",
+        "They are enantiomers that are non-superimposable mirror images.",
+        "They are different compounds with different chemical properties.",
+        "They represent different distributions of electrons within the same molecule."
+      ],
+      "question": "Which of the following best describes the relationship between two structures that are resonance forms of the same molecule?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "SN1 vs SN2",
+      "correct_answer": "SN1 reactions involve a carbocation intermediate, while SN2 reactions involve a concerted mechanism.",
+      "difficulty": "medium",
+      "explanation": "SN1 reactions are a two-step process involving the formation of a carbocation intermediate, while SN2 reactions are a one-step (concerted) process where bond breaking and bond formation occur simultaneously.",
+      "options": [
+        "SN1 reactions occur in one step, while SN2 reactions occur in two steps.",
+        "SN1 reactions involve a carbocation intermediate, while SN2 reactions involve a concerted mechanism.",
+        "SN1 reactions are favored by primary alkyl halides, while SN2 reactions are favored by tertiary alkyl halides.",
+        "SN1 reactions proceed with inversion of configuration, while SN2 reactions proceed with racemization."
+      ],
+      "question": "What is the key difference between an SN1 and an SN2 reaction?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Stereochemistry",
+      "correct_answer": "A carbon atom bonded to four different groups.",
+      "difficulty": "medium",
+      "explanation": "A chiral center, typically a carbon atom, is a stereogenic center that is bonded to four different atoms or groups, leading to the existence of stereoisomers (enantiomers).",
+      "options": [
+        "A carbon atom bonded to four different groups.",
+        "A carbon atom bonded to two identical groups.",
+        "A carbon atom participating in a double bond.",
+        "A carbon atom with no lone pairs of electrons."
+      ],
+      "question": "Which of the following best defines a chiral center in stereochemistry?",
+      "type": "multiple_choice"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/quiz_generation/spaced_repetition_revives_stale_concept.json
+++ b/backend/tests/evals/cassettes/quiz_generation/spaced_repetition_revives_stale_concept.json
@@ -1,0 +1,46 @@
+{
+  "questions": [
+    {
+      "concept": "Cell Membrane",
+      "correct_answer": "To regulate the passage of substances into and out of the cell",
+      "difficulty": "medium",
+      "explanation": "The cell membrane acts as a selective barrier, controlling which molecules can enter or leave the cell, thus maintaining the cell's internal environment.",
+      "options": [
+        "To provide structural support to the cell",
+        "To regulate the passage of substances into and out of the cell",
+        "To synthesize proteins",
+        "To store genetic information"
+      ],
+      "question": "What is the primary function of the cell membrane?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Cell Membrane",
+      "correct_answer": "A double layer of phospholipids with embedded proteins",
+      "difficulty": "medium",
+      "explanation": "The cell membrane is composed of a phospholipid bilayer, where hydrophilic heads face outwards and hydrophobic tails face inwards, with various proteins interspersed throughout.",
+      "options": [
+        "A rigid cell wall made of cellulose",
+        "A single layer of phospholipids",
+        "A double layer of phospholipids with embedded proteins",
+        "A network of microtubules"
+      ],
+      "question": "Which of the following best describes the structure of the cell membrane?",
+      "type": "multiple_choice"
+    },
+    {
+      "concept": "Cell Membrane",
+      "correct_answer": "Phagocytosis",
+      "difficulty": "medium",
+      "explanation": "Phagocytosis is a type of endocytosis where the cell membrane surrounds and engulfs large particles or other cells.",
+      "options": [
+        "Exocytosis",
+        "Active transport",
+        "Phagocytosis",
+        "Diffusion"
+      ],
+      "question": "The process by which cells absorb large molecules from the outside by engulfing them with the cell membrane is called:",
+      "type": "multiple_choice"
+    }
+  ]
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/course_handbook_disguised.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/course_handbook_disguised.json
@@ -1,0 +1,6 @@
+{
+  "assignments": [],
+  "course_title": "BIO 130 Course Handbook",
+  "grading_categories": [],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/exam_only_schedule.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/exam_only_schedule.json
@@ -1,0 +1,28 @@
+{
+  "assignments": [
+    {
+      "description": null,
+      "due_date": "2026-10-15",
+      "title": "Midterm",
+      "weight_pct": 40.0
+    },
+    {
+      "description": null,
+      "due_date": "2026-12-12",
+      "title": "Final",
+      "weight_pct": 60.0
+    }
+  ],
+  "course_title": "HIST 110",
+  "grading_categories": [
+    {
+      "name": "Midterm",
+      "weight": 40.0
+    },
+    {
+      "name": "Final",
+      "weight": 60.0
+    }
+  ],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/grading_tbd.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/grading_tbd.json
@@ -1,0 +1,25 @@
+{
+  "assignments": [
+    {
+      "description": null,
+      "due_date": "2026-02-07",
+      "title": "Lab 1",
+      "weight_pct": null
+    },
+    {
+      "description": null,
+      "due_date": "2026-02-21",
+      "title": "Lab 2",
+      "weight_pct": null
+    },
+    {
+      "description": null,
+      "due_date": "2026-05-04",
+      "title": "Final exam",
+      "weight_pct": null
+    }
+  ],
+  "course_title": "PHYS 101",
+  "grading_categories": [],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/mandarin_syllabus_excerpt.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/mandarin_syllabus_excerpt.json
@@ -1,0 +1,19 @@
+{
+  "assignments": [
+    {
+      "description": "\u6bcf\u5468\u4e00\u6b21\u7684\u4f5c\u4e1a\u3002",
+      "due_date": null,
+      "title": "\u4f5c\u4e1a",
+      "weight_pct": null
+    },
+    {
+      "description": "\u5b66\u671f\u672b\u8fdb\u884c\u7684\u8003\u8bd5\u3002",
+      "due_date": null,
+      "title": "\u671f\u672b\u8003\u8bd5",
+      "weight_pct": null
+    }
+  ],
+  "course_title": "\u9ad8\u7b49\u6570\u5b66 I",
+  "grading_categories": [],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/minimal_topics_only.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/minimal_topics_only.json
@@ -1,0 +1,6 @@
+{
+  "assignments": [],
+  "course_title": "Intro to Linguistics",
+  "grading_categories": [],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/mixed_concrete_and_relative_dates.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/mixed_concrete_and_relative_dates.json
@@ -1,0 +1,44 @@
+{
+  "assignments": [
+    {
+      "description": null,
+      "due_date": "2026-09-12",
+      "title": "Lab Report 1",
+      "weight_pct": null
+    },
+    {
+      "description": null,
+      "due_date": null,
+      "title": "Lab Report 2",
+      "weight_pct": null
+    },
+    {
+      "description": null,
+      "due_date": "2026-10-17",
+      "title": "Midterm",
+      "weight_pct": 30.0
+    },
+    {
+      "description": null,
+      "due_date": null,
+      "title": "Final",
+      "weight_pct": 40.0
+    }
+  ],
+  "course_title": "BIO 201",
+  "grading_categories": [
+    {
+      "name": "Labs",
+      "weight": 30.0
+    },
+    {
+      "name": "Midterm",
+      "weight": 30.0
+    },
+    {
+      "name": "Final",
+      "weight": 40.0
+    }
+  ],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/no_grading_breakdown.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/no_grading_breakdown.json
@@ -1,0 +1,13 @@
+{
+  "assignments": [
+    {
+      "description": "A portfolio showcasing term work.",
+      "due_date": null,
+      "title": "Final portfolio",
+      "weight_pct": null
+    }
+  ],
+  "course_title": "ART 110",
+  "grading_categories": [],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/overlapping_deadlines.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/overlapping_deadlines.json
@@ -1,0 +1,38 @@
+{
+  "assignments": [
+    {
+      "description": null,
+      "due_date": "2026-03-05",
+      "title": "Reading response 1",
+      "weight_pct": null
+    },
+    {
+      "description": null,
+      "due_date": "2026-03-05",
+      "title": "Peer review",
+      "weight_pct": null
+    },
+    {
+      "description": null,
+      "due_date": "2026-04-02",
+      "title": "Essay 1",
+      "weight_pct": null
+    }
+  ],
+  "course_title": "ENG 305",
+  "grading_categories": [
+    {
+      "name": "Responses",
+      "weight": 20.0
+    },
+    {
+      "name": "Peer review",
+      "weight": 10.0
+    },
+    {
+      "name": "Essays",
+      "weight": 70.0
+    }
+  ],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/points_based_rubric.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/points_based_rubric.json
@@ -1,0 +1,38 @@
+{
+  "assignments": [
+    {
+      "description": null,
+      "due_date": null,
+      "title": "Reading responses",
+      "weight_pct": null
+    },
+    {
+      "description": null,
+      "due_date": null,
+      "title": "Midterm essay",
+      "weight_pct": null
+    },
+    {
+      "description": null,
+      "due_date": null,
+      "title": "Final essay",
+      "weight_pct": null
+    }
+  ],
+  "course_title": "PHIL 101",
+  "grading_categories": [
+    {
+      "name": "Reading responses",
+      "weight": 40.0
+    },
+    {
+      "name": "Midterm essay",
+      "weight": 60.0
+    },
+    {
+      "name": "Final essay",
+      "weight": 100.0
+    }
+  ],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/policies_only_no_graded_items.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/policies_only_no_graded_items.json
@@ -1,0 +1,6 @@
+{
+  "assignments": [],
+  "course_title": "MATH 102",
+  "grading_categories": [],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/relative_dates_only.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/relative_dates_only.json
@@ -1,0 +1,44 @@
+{
+  "assignments": [
+    {
+      "description": null,
+      "due_date": null,
+      "title": "Quiz 1",
+      "weight_pct": 10.0
+    },
+    {
+      "description": null,
+      "due_date": null,
+      "title": "Quiz 2",
+      "weight_pct": 10.0
+    },
+    {
+      "description": null,
+      "due_date": null,
+      "title": "Midterm",
+      "weight_pct": 30.0
+    },
+    {
+      "description": null,
+      "due_date": null,
+      "title": "Final",
+      "weight_pct": 50.0
+    }
+  ],
+  "course_title": "MATH 220",
+  "grading_categories": [
+    {
+      "name": "Quizzes",
+      "weight": 20.0
+    },
+    {
+      "name": "Midterm",
+      "weight": 30.0
+    },
+    {
+      "name": "Final",
+      "weight": 50.0
+    }
+  ],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/spanish_syllabus_concrete_dates.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/spanish_syllabus_concrete_dates.json
@@ -1,0 +1,38 @@
+{
+  "assignments": [
+    {
+      "description": null,
+      "due_date": "2026-02-10",
+      "title": "Tarea 1",
+      "weight_pct": null
+    },
+    {
+      "description": null,
+      "due_date": "2026-03-15",
+      "title": "Parcial",
+      "weight_pct": null
+    },
+    {
+      "description": null,
+      "due_date": "2026-05-05",
+      "title": "Examen final",
+      "weight_pct": null
+    }
+  ],
+  "course_title": "C\u00e1lculo I \u2014 Semestre primavera 2026",
+  "grading_categories": [
+    {
+      "name": "Tareas",
+      "weight": 20.0
+    },
+    {
+      "name": "Parcial",
+      "weight": 30.0
+    },
+    {
+      "name": "Final",
+      "weight": 50.0
+    }
+  ],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/typical_syllabus_with_dates.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/typical_syllabus_with_dates.json
@@ -25,7 +25,7 @@
       "weight_pct": 35.0
     }
   ],
-  "course_title": "CS 188 \u2014 Spring 2026",
+  "course_title": "CS 188",
   "grading_categories": [
     {
       "name": "Problem sets",

--- a/backend/tests/evals/cassettes/syllabus_extraction/weekly_topics_no_deliverables.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/weekly_topics_no_deliverables.json
@@ -1,0 +1,6 @@
+{
+  "assignments": [],
+  "course_title": "PSY 240",
+  "grading_categories": [],
+  "instructor": null
+}

--- a/backend/tests/evals/cassettes/syllabus_extraction/weights_stated_twice.json
+++ b/backend/tests/evals/cassettes/syllabus_extraction/weights_stated_twice.json
@@ -1,0 +1,38 @@
+{
+  "assignments": [
+    {
+      "description": null,
+      "due_date": "2026-02-01",
+      "title": "Quiz 1",
+      "weight_pct": null
+    },
+    {
+      "description": null,
+      "due_date": "2026-03-14",
+      "title": "Midterm",
+      "weight_pct": 30.0
+    },
+    {
+      "description": null,
+      "due_date": "2026-05-07",
+      "title": "Final",
+      "weight_pct": 50.0
+    }
+  ],
+  "course_title": "ECON 101",
+  "grading_categories": [
+    {
+      "name": "Quizzes",
+      "weight": 20.0
+    },
+    {
+      "name": "Midterm",
+      "weight": 30.0
+    },
+    {
+      "name": "Final",
+      "weight": 50.0
+    }
+  ],
+  "instructor": null
+}

--- a/backend/tests/evals/run_all.py
+++ b/backend/tests/evals/run_all.py
@@ -1,0 +1,64 @@
+"""Run every offline eval dataset in one process and report a combined result.
+
+    cd backend
+    python tests/evals/run_all.py                     # replay (default), gate on baselines
+    SAPLING_EVAL_MODE=record python tests/evals/run_all.py            # refresh cassettes
+    SAPLING_EVAL_UPDATE_BASELINES=1 python tests/evals/run_all.py     # refresh baselines
+
+Exits non-zero if any dataset regressed below its committed baseline or had a
+case failure (e.g. a missing cassette). This is the single command CI runs and
+the one to run locally before changing an agent's prompt or model.
+
+``chat_tutor`` is intentionally excluded: its retrieval tool reads a live
+Supabase and cannot run offline against cassettes. Bringing it into the harness
+is tracked with the graph-grounded tutor work (#149).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+# `python tests/evals/run_all.py` from backend/: add backend/ (for `agents.*`)
+# and tests/evals/ (so the datasets' top-level `from _replay import ...` and the
+# `import <dataset>` below both resolve).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _replay import ensure_utf8_output, evaluate_dataset  # noqa: E402
+
+# Offline datasets only. Keep in sync with the datasets that have cassettes.
+DATASETS = [
+    "document_classification",
+    "document_summary",
+    "concept_extraction",
+    "syllabus_extraction",
+    "quiz_generation",
+]
+
+
+def main() -> None:
+    ensure_utf8_output()
+    update = os.getenv("SAPLING_EVAL_UPDATE_BASELINES") == "1"
+
+    results: list[tuple[str, bool]] = []
+    for name in DATASETS:
+        mod = importlib.import_module(name)
+        print(f"\n{'=' * 78}\n{name}\n{'=' * 78}")
+        # Suppress the giant per-case rich table here; the per-task accuracy
+        # summary and any regression lines still print.
+        ok = evaluate_dataset(mod.make_dataset, mod._run, update=update, print_report=False)
+        results.append((name, ok))
+
+    print(f"\n{'=' * 78}\nSummary\n{'=' * 78}")
+    for name, ok in results:
+        print(f"  {'PASS' if ok else 'FAIL'}  {name}")
+
+    if not all(ok for _, ok in results):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/integration/test_postgres_version.py
+++ b/backend/tests/integration/test_postgres_version.py
@@ -1,0 +1,53 @@
+"""Postgres major-version drift guard (#441).
+
+Local/CI Postgres is pinned to PG15 via `db.major_version` in
+`supabase/config.toml`, matching staging/prod — the whole point of the
+deterministic local/CI lane is that it tests what production actually runs.
+The PG17 pin originated with the local stack's introduction (`config.toml`
+was born with `major_version = 17` — there was never a staging-matching PG15
+pin to regress from). PR #440 (the browser-lane e2e job) didn't change that
+pin; it added the e2e.yml header comment rationalizing the already-existing
+PG17, explicitly noting it went against epic #402 decision 2's recorded PG15
+leaning and that the resulting skew was tracked in #441. This pin closes that
+skew per decision 2; local/CI consistency is preserved since both still
+follow the same config.toml pin, just at 15 instead of 17.
+
+This test runs against the REAL server (via the `db_conn` psycopg fixture,
+never a mock), so a future edit to config.toml — or a local stack that
+predates this pin and was never reset (see the "Postgres version"
+troubleshooting entry in docs/local-supabase.md) — fails LOUDLY here instead
+of silently reintroducing the skew.
+
+Placement: this file lives in the opt-in integration suite
+(`backend/tests/integration/`, RUN_INTEGRATION=1) rather than the browser-lane
+E2E spec, because `.github/workflows/integration.yml` boots the local Supabase
+stack from empty and runs `RUN_INTEGRATION=1 pytest -m integration` on every
+push to main — i.e. this actually executes in CI, against the same
+`supabase start` (config.toml-pinned) Postgres the browser lane
+(`.github/workflows/e2e.yml`) also boots.
+"""
+import pytest
+
+pytestmark = pytest.mark.integration
+
+EXPECTED_MAJOR_VERSION = 15
+
+
+def test_server_major_version_matches_config_toml_pin(db_conn):
+    row = db_conn.execute("SHOW server_version_num").fetchone()
+    version_num = int(row["server_version_num"])
+    # server_version_num is e.g. 150008 for 15.8, 170004 for 17.4 — major
+    # version is the leading two digits for every currently supported PG
+    # release (10 through 18).
+    major = version_num // 10000
+    assert major == EXPECTED_MAJOR_VERSION, (
+        f"Postgres server_version_num={version_num} (major {major}) but "
+        f"supabase/config.toml pins db.major_version = {EXPECTED_MAJOR_VERSION} "
+        "to match staging/prod (#441). Either config.toml drifted from this "
+        "running server, or this is a stale local stack provisioned before "
+        "the pin — `supabase db reset` does not reliably swap a running "
+        "container's Postgres major version. Tear it down and rebuild: "
+        "`supabase stop --no-backup` then `supabase start`, then re-migrate + "
+        "seed (scripts/local-db-reset.sh or `make e2e-up`) — see "
+        "docs/local-supabase.md's 'Postgres version' troubleshooting entry."
+    )

--- a/backend/tests/test_agent_events.py
+++ b/backend/tests/test_agent_events.py
@@ -1,0 +1,15 @@
+import json
+
+from services.agent_events import SaplingEvent, sapling_event_to_sse
+
+
+def test_token_event_serializes_to_sse():
+    ev = SaplingEvent(type="token", step="reply", message="", data={"delta": "Hi"})
+    wire = sapling_event_to_sse(ev)
+    assert wire["event"] == "token"
+    assert json.loads(wire["data"])["data"]["delta"] == "Hi"
+
+
+def test_graph_update_and_done_types_accepted():
+    for t in ("graph_update", "done"):
+        assert SaplingEvent(type=t, step="reply", message="").type == t

--- a/backend/tests/test_chat_stream.py
+++ b/backend/tests/test_chat_stream.py
@@ -1,0 +1,342 @@
+"""Unit tests for services/chat_stream.py against a fake event stream.
+
+No live LLM: FakeAgent yields stand-ins whose CLASS NAMES and attribute
+shapes match Pydantic AI 1.89.1 (verified by inspection), which is all
+stream_agent_turn dispatches on.
+"""
+import asyncio
+
+from agents.deps import SaplingDeps
+from services.chat_stream import merge_graph_updates, stream_agent_turn
+
+
+# ── Fakes mirroring pydantic_ai event shapes ──────────────────────────────
+
+class TextPartDelta:
+    def __init__(self, content_delta):
+        self.content_delta = content_delta
+        self.part_delta_kind = "text"
+
+
+class ThinkingPartDelta:
+    """Mirrors pydantic_ai.messages.ThinkingPartDelta: same attribute name
+    (`content_delta`) as TextPartDelta, discriminated only by
+    `part_delta_kind`. Must never surface as a `token` event."""
+    def __init__(self, content_delta):
+        self.content_delta = content_delta
+        self.part_delta_kind = "thinking"
+
+
+class PartDeltaEvent:
+    def __init__(self, content_delta, part_delta_kind="text"):
+        self.delta = (
+            ThinkingPartDelta(content_delta)
+            if part_delta_kind == "thinking"
+            else TextPartDelta(content_delta)
+        )
+
+
+class _TextPart:
+    def __init__(self, content):
+        self.content = content
+        self.part_kind = "text"
+
+
+class _ThinkingPart:
+    """Mirrors pydantic_ai.messages.ThinkingPart: same attribute name
+    (`content`) as TextPart, discriminated only by `part_kind`. Must never
+    surface as a `token` event."""
+    def __init__(self, content):
+        self.content = content
+        self.part_kind = "thinking"
+
+
+class PartStartEvent:
+    """First text chunk arrives here — NOT as a delta."""
+    def __init__(self, content, part_kind="text"):
+        self.part = _ThinkingPart(content) if part_kind == "thinking" else _TextPart(content)
+
+
+class PartEndEvent:
+    """Carries the FULL assembled text on the same `.part.content`
+    attribute PartStartEvent uses. Must NOT produce a token."""
+    def __init__(self, content):
+        self.part = _TextPart(content)
+
+
+class _ToolPart:
+    def __init__(self, tool_name):
+        self.tool_name = tool_name
+
+
+class FunctionToolCallEvent:
+    def __init__(self, tool_name):
+        self.part = _ToolPart(tool_name)
+
+
+class FunctionToolResultEvent:
+    def __init__(self, on_fire=None):
+        # Simulates the tool having written to deps during its execution.
+        if on_fire:
+            on_fire()
+
+
+class _Result:
+    def __init__(self, output):
+        self.output = output
+
+
+class AgentRunResultEvent:
+    def __init__(self, output):
+        self.result = _Result(output)
+
+
+class FakeAgent:
+    def __init__(self, events, raise_after=None):
+        self._events = events
+        self._raise_after = raise_after
+
+    async def run_stream_events(self, user_message, **kwargs):
+        for i, ev in enumerate(self._events):
+            if self._raise_after is not None and i == self._raise_after:
+                raise RuntimeError("model blew up")
+            yield ev
+
+
+def make_deps():
+    return SaplingDeps(
+        user_id="u1", course_id="c1", supabase=None,
+        request_id="r1", session_id="s1",
+    )
+
+
+async def collect(agent, deps, on_complete, legacy_fallback=None):
+    events = []
+    async for ev in stream_agent_turn(
+        agent=agent, user_message="hi", run_kwargs={}, deps=deps,
+        on_complete=on_complete, legacy_fallback=legacy_fallback,
+        request_id="r1",
+    ):
+        events.append(ev)
+    return events
+
+
+# ── merge ─────────────────────────────────────────────────────────────────
+
+def test_merge_concatenates_and_never_clobbers():
+    merged = merge_graph_updates(
+        [{"new_nodes": [{"n": 1}]}, {"new_nodes": [{"n": 2}]}, {"updated_nodes": [{"n": 3}]}]
+    )
+    assert merged == {"new_nodes": [{"n": 1}, {"n": 2}], "updated_nodes": [{"n": 3}]}
+
+
+# ── happy path ────────────────────────────────────────────────────────────
+
+def test_first_chunk_from_part_start_is_not_dropped():
+    """PartStartEvent carries the reply's FIRST chunk. Regression: handling
+    only PartDeltaEvent silently truncates the opening."""
+    async def run():
+        agent = FakeAgent([
+            PartStartEvent("Hello "),
+            PartDeltaEvent("world"),
+            AgentRunResultEvent("Hello world"),
+        ])
+        saved = {}
+        events = await collect(agent, make_deps(), lambda r, g, m: saved.update(reply=r) or {})
+        tokens = [e.data["delta"] for e in events if e.type == "token"]
+        assert tokens == ["Hello ", "world"]
+        assert saved["reply"] == "Hello world"
+
+    asyncio.run(run())
+
+
+def test_part_end_event_does_not_duplicate_the_reply():
+    """PartEndEvent carries the FULL assembled text on .part.content — the
+    same attribute PartStartEvent uses for the FIRST chunk. Emitting a token
+    for it duplicates the whole reply in the user's bubble.
+
+    Regression: a duck-typed `getattr(event.part, 'content')` reader turns
+    "hello world" into "hello worldhello world". Observed live in Task 1's
+    spike."""
+    async def run():
+        agent = FakeAgent([
+            PartStartEvent("hello "),
+            PartDeltaEvent("world"),
+            PartEndEvent("hello world"),      # full text — must be ignored
+            AgentRunResultEvent("hello world"),
+        ])
+        events = await collect(agent, make_deps(), lambda r, g, m: {})
+        tokens = [e.data["delta"] for e in events if e.type == "token"]
+        assert tokens == ["hello ", "world"], "PartEndEvent must not re-emit the reply"
+        assert "".join(tokens) == "hello world"
+
+    asyncio.run(run())
+
+
+def test_thinking_part_never_produces_a_token():
+    """`_text_from` dispatches on event CLASS, but PartStartEvent/
+    PartDeltaEvent wrap ANY part kind — a ThinkingPart/ThinkingPartDelta
+    rides the identical `.part.content` / `.delta.content_delta`
+    attributes a TextPart/TextPartDelta uses. Without gating on
+    part_kind/part_delta_kind, reasoning content would stream into the
+    student's chat bubble the moment thought summaries are enabled
+    (latent today only because _build_pro_model_settings doesn't set
+    include_thoughts). Text-shaped parts in the same run must still
+    produce tokens normally."""
+    async def run():
+        agent = FakeAgent([
+            PartStartEvent("Let me reason about this privately...", part_kind="thinking"),
+            PartDeltaEvent(" and some more private reasoning.", part_delta_kind="thinking"),
+            PartStartEvent("The answer is "),
+            PartDeltaEvent("42."),
+            AgentRunResultEvent("The answer is 42."),
+        ])
+        events = await collect(agent, make_deps(), lambda r, g, m: {})
+        tokens = [e.data["delta"] for e in events if e.type == "token"]
+        assert tokens == ["The answer is ", "42."], (
+            "thinking-shaped parts must never be emitted as tokens, "
+            "and text-shaped parts in the same run must still stream"
+        )
+
+    asyncio.run(run())
+
+
+def test_event_order_and_single_persistence():
+    async def run():
+        agent = FakeAgent([
+            PartStartEvent("Hi"),
+            AgentRunResultEvent("Hi"),
+        ])
+        calls = []
+        events = await collect(agent, make_deps(), lambda r, g, m: calls.append(r) or {"extra": 1})
+        assert [e.type for e in events] == ["status", "token", "done"]
+        assert calls == ["Hi"], "on_complete must fire exactly once"
+        done = events[-1]
+        assert done.data["reply"] == "Hi"
+        assert done.data["extra"] == 1, "on_complete's return merges into done"
+
+    asyncio.run(run())
+
+
+def test_graph_update_emitted_once_per_new_write():
+    """High-water mark: an already-emitted delta must not re-emit on the
+    next tool result."""
+    async def run():
+        deps = make_deps()
+
+        def first_write():
+            deps.graph_updates.append({"new_nodes": [{"name": "Eigenvalues"}]})
+            deps.mastery_changes.append({"concept": "Eigenvalues", "before": 0.1, "after": 0.6})
+
+        agent = FakeAgent([
+            FunctionToolCallEvent("update_mastery_tool"),
+            FunctionToolResultEvent(on_fire=first_write),
+            PartStartEvent("Done."),
+            FunctionToolCallEvent("search_course_materials_tool"),
+            FunctionToolResultEvent(),          # writes nothing new
+            AgentRunResultEvent("Done."),
+        ])
+        events = await collect(agent, deps, lambda r, g, m: {})
+        graph_events = [e for e in events if e.type == "graph_update"]
+        assert len(graph_events) == 1, "second tool result added nothing — must not re-emit"
+        assert graph_events[0].data["nodes"] == {"new_nodes": [{"name": "Eigenvalues"}]}
+        assert graph_events[0].data["mastery_changes"][0]["after"] == 0.6
+        assert [e.type for e in events].index("graph_update") < [e.type for e in events].index("done")
+
+    asyncio.run(run())
+
+
+# ── failure rungs ─────────────────────────────────────────────────────────
+
+def test_rung1_failure_before_any_token_uses_legacy_and_skips_on_complete():
+    async def run():
+        agent = FakeAgent([PartStartEvent("x")], raise_after=0)
+        on_complete_calls = []
+
+        async def fake_legacy():
+            # async because the real routes' legacy paths are (_legacy_chat)
+            return {"reply": "legacy reply", "graph_update": {}, "mastery_changes": []}
+
+        events = await collect(
+            agent, make_deps(),
+            on_complete=lambda r, g, m: on_complete_calls.append(r),
+            legacy_fallback=fake_legacy,
+        )
+        assert [e.type for e in events] == ["status", "token", "done"]
+        assert events[1].data["delta"] == "legacy reply"
+        assert events[-1].data["reply"] == "legacy reply"
+        assert on_complete_calls == [], "legacy owns persistence — on_complete must NOT run"
+
+    asyncio.run(run())
+
+
+def test_rung2_failure_after_tokens_errors_and_persists_nothing():
+    async def run():
+        agent = FakeAgent([PartStartEvent("Half a th"), PartDeltaEvent("ought")], raise_after=1)
+        on_complete_calls = []
+        legacy_calls = []
+
+        async def fake_legacy():
+            legacy_calls.append(1)
+            return {"reply": "nope"}
+
+        events = await collect(
+            agent, make_deps(),
+            on_complete=lambda r, g, m: on_complete_calls.append(r),
+            legacy_fallback=fake_legacy,
+        )
+        assert events[-1].type == "error"
+        assert events[-1].data["request_id"] == "r1"
+        assert on_complete_calls == [], "nothing may persist after a mid-stream failure"
+        assert legacy_calls == [], "never silently re-run once text was shown"
+
+    asyncio.run(run())
+
+
+def test_cancel_mid_stream_persists_nothing():
+    """Client disconnect cancels the generator at its current yield."""
+    async def run():
+        agent = FakeAgent([PartStartEvent("a"), PartDeltaEvent("b"), AgentRunResultEvent("ab")])
+        on_complete_calls = []
+        gen = stream_agent_turn(
+            agent=agent, user_message="hi", run_kwargs={}, deps=make_deps(),
+            on_complete=lambda r, g, m: on_complete_calls.append(r), request_id="r1",
+        )
+        await gen.__anext__()   # status
+        await gen.__anext__()   # first token
+        await gen.aclose()      # disconnect
+        assert on_complete_calls == [], "a partial reply must never persist"
+
+    asyncio.run(run())
+
+
+def test_on_complete_raising_yields_error_not_unhandled_exception():
+    """Persistence failing AFTER the reply fully streamed must surface as a
+    structured `error` event (ADR-0020 interrupted-turn treatment), never an
+    unhandled exception — sse_starlette has already flushed headers by then,
+    so a propagated exception aborts the response with no closing event at
+    all and the client sees an unstructured network failure."""
+    async def run():
+        agent = FakeAgent(
+            [PartStartEvent("hi"), AgentRunResultEvent("hi")]
+        )
+        legacy_calls = []
+
+        def failing_persist(reply, graph_update, mastery_changes):
+            raise RuntimeError("db write failed")
+
+        async def fake_legacy():
+            legacy_calls.append(1)
+            return {"reply": "nope"}
+
+        events = await collect(
+            agent, make_deps(),
+            on_complete=failing_persist,
+            legacy_fallback=fake_legacy,
+        )
+        assert events[-1].type == "error"
+        assert events[-1].data["request_id"] == "r1"
+        assert all(e.type != "done" for e in events), "no done after failed persistence"
+        assert legacy_calls == [], "reply already streamed — never re-run legacy"
+
+    asyncio.run(run())

--- a/backend/tests/test_document_indexing.py
+++ b/backend/tests/test_document_indexing.py
@@ -14,7 +14,8 @@ definition sites (`services.chunker.chunk_document`,
 `services.rag_service.index_document_chunks`) rather than on
 `routes.documents`.
 """
-from unittest.mock import patch
+import logging
+from unittest.mock import MagicMock, patch
 
 from routes.documents import _index_document_chunks
 
@@ -94,3 +95,44 @@ class TestIndexDocumentChunks:
             )
 
         mock_index.assert_not_called()
+
+    def test_relevance_gate_skips_client_construction_outside_real_mode(self, monkeypatch, caplog):
+        """#439: the catalog-relevance embed call (a `google.genai.Client`
+        construction site predating the SAPLING_MODEL_MODE seam) only fires
+        when a catalog embedding actually exists for the course. When one
+        does and mode != 'real', no client may be constructed — the whole
+        indexing call aborts exactly like an unlucky real embed-call failure
+        already did (the outer `except` logs "_index_document_chunks failed
+        for doc %s", the line e2e_oracles/logscan.py's ALLOWLIST already
+        expects), so services.rag_service.index_document_chunks is never
+        reached either.
+        """
+        monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+        ctor = MagicMock(side_effect=AssertionError(
+            "genai.Client must not be constructed outside real mode"
+        ))
+        monkeypatch.setattr("google.genai.Client", ctor)
+
+        with (
+            patch(
+                "routes.documents.table",
+                side_effect=_mock_table_for(
+                    courses_rows=[{"course_code": "BIO-101"}],
+                    course_chunks_rows=[{"embedding": [0.1] * 768}],  # catalog row present
+                ),
+            ),
+            patch("services.chunker.chunk_document", return_value=["chunk one"]),
+            patch("services.rag_service.index_document_chunks") as mock_index,
+            caplog.at_level(logging.ERROR, logger="routes.documents"),
+        ):
+            _index_document_chunks(
+                doc_id="doc-gate",
+                course_id="course-uuid-1",
+                user_id="user-1",
+                extracted_text="some extracted text",
+                category="lecture_notes",
+            )
+
+        ctor.assert_not_called()
+        mock_index.assert_not_called()
+        assert "_index_document_chunks failed for doc doc-gate" in caplog.text

--- a/backend/tests/test_documents_routes.py
+++ b/backend/tests/test_documents_routes.py
@@ -60,6 +60,119 @@ class TestListDocuments:
             # filters should contain the user_id
             assert "user_andres" in str(call_kwargs)
 
+    def test_documents_carry_course_id_resolved_from_offering(self):
+        """#435: Library filters/labels on d.course_id, but this route only
+        ever returned offering_id — uploads never matched a course filter
+        and always fell into "Uncategorized". Each row must now carry the
+        abstract course_id, resolved via services.academics.offering_course_id."""
+        docs = [
+            {"id": "d1", "user_id": "u1", "offering_id": "off-1", "file_name": "notes.pdf", "category": "lecture_notes"},
+            {"id": "d2", "user_id": "u1", "offering_id": "off-2", "file_name": "syllabus.pdf", "category": "syllabus"},
+        ]
+        with (
+            _mock_validate_user(),
+            patch("routes.documents.table") as t,
+            patch("routes.documents.offering_course_id") as mock_ocid,
+        ):
+            t.return_value.select.return_value = docs
+            mock_ocid.side_effect = {"off-1": "course-A", "off-2": "course-B"}.get
+            r = client.get("/api/documents/user/u1")
+
+        assert r.status_code == 200
+        body = r.json()["documents"]
+        assert body[0]["course_id"] == "course-A"
+        assert body[1]["course_id"] == "course-B"
+
+    def test_course_id_resolved_once_per_unique_offering(self):
+        """Batch resolution: repeated offering_ids across rows must only hit
+        offering_course_id once each, not once per row (mirrors the
+        offering_to_course pattern in routes/learn.py::list_sessions)."""
+        docs = [
+            {"id": "d1", "user_id": "u1", "offering_id": "off-1", "file_name": "a.pdf", "category": "other"},
+            {"id": "d2", "user_id": "u1", "offering_id": "off-1", "file_name": "b.pdf", "category": "other"},
+            {"id": "d3", "user_id": "u1", "offering_id": "off-1", "file_name": "c.pdf", "category": "other"},
+        ]
+        with (
+            _mock_validate_user(),
+            patch("routes.documents.table") as t,
+            patch("routes.documents.offering_course_id", return_value="course-A") as mock_ocid,
+        ):
+            t.return_value.select.return_value = docs
+            r = client.get("/api/documents/user/u1")
+
+        assert r.status_code == 200
+        assert all(d["course_id"] == "course-A" for d in r.json()["documents"])
+        mock_ocid.assert_called_once_with("off-1")
+
+    def test_missing_offering_id_yields_null_course_id(self):
+        """Defensive-code coverage: documents.offering_id is NOT NULL (0025),
+        so a real persisted row can never surface offering_id=None here — but
+        the route's `if off_id and ...` guard must not raise on a None/falsy
+        offering_id (e.g. a partially-mocked row in another test, or future
+        schema drift). Confirms it degrades to course_id: null instead of
+        KeyError/TypeError."""
+        docs = [
+            {"id": "d1", "user_id": "u1", "offering_id": None, "file_name": "a.pdf", "category": "other"},
+        ]
+        with _mock_validate_user(), patch("routes.documents.table") as t:
+            t.return_value.select.return_value = docs
+            r = client.get("/api/documents/user/u1")
+
+        assert r.status_code == 200
+        assert r.json()["documents"][0]["course_id"] is None
+
+    def test_unresolvable_offering_id_yields_null_course_id(self):
+        """The actually-reachable null case: offering_id IS present (schema
+        requires it) but offering_course_id fails to resolve it to a course
+        — e.g. the course_offerings row backing it was deleted/data drift.
+        Must surface course_id: null, not raise, so the rest of the list
+        still renders (Library.tsx buckets this doc as "Uncategorized")."""
+        docs = [
+            {"id": "d1", "user_id": "u1", "offering_id": "off-orphaned", "file_name": "a.pdf", "category": "other"},
+        ]
+        with (
+            _mock_validate_user(),
+            patch("routes.documents.table") as t,
+            patch("routes.documents.offering_course_id", return_value=None),
+        ):
+            t.return_value.select.return_value = docs
+            r = client.get("/api/documents/user/u1")
+
+        assert r.status_code == 200
+        assert r.json()["documents"][0]["course_id"] is None
+
+    def test_corrupted_concept_notes_degrades_row_others_still_return(self):
+        """PR review follow-up: decrypt_json re-raises when both the decrypt
+        AND the plaintext-JSON fallback fail (a genuinely corrupted row).
+        The loop this fix touches must degrade THAT row's concept_notes to
+        [] instead of letting the exception 500 the whole list — sibling
+        rows must still come back intact. Mirrors the established
+        try/except pattern at _existing_doc_by_request_id and
+        scan_document_concepts."""
+        docs = [
+            {"id": "d-good", "user_id": "u1", "offering_id": "off-1", "file_name": "a.pdf",
+             "category": "other", "concept_notes": "GOOD_CIPHERTEXT"},
+            {"id": "d-bad", "user_id": "u1", "offering_id": "off-1", "file_name": "b.pdf",
+             "category": "other", "concept_notes": "CORRUPTED_CIPHERTEXT"},
+        ]
+
+        def fake_decrypt_json(value):
+            if value == "CORRUPTED_CIPHERTEXT":
+                raise ValueError("decrypt and plaintext parse both failed")
+            return [{"name": "Concept A", "description": "d"}]
+
+        with (
+            _mock_validate_user(),
+            patch("routes.documents.table") as t,
+            patch("routes.documents.decrypt_json", side_effect=fake_decrypt_json),
+        ):
+            t.return_value.select.return_value = docs
+            r = client.get("/api/documents/user/u1")
+
+        assert r.status_code == 200
+        body = {d["id"]: d for d in r.json()["documents"]}
+        assert body["d-good"]["concept_notes"] == [{"name": "Concept A", "description": "d"}]
+        assert body["d-bad"]["concept_notes"] == []
 
 # ── DELETE /api/documents/doc/{document_id} ──────────────────────────────────
 

--- a/backend/tests/test_hermetic_llm_guard.py
+++ b/backend/tests/test_hermetic_llm_guard.py
@@ -91,11 +91,16 @@ class TestPydanticAISharesTheSameSeam:
     provider client blocked as well."""
 
     def test_agent_provider_client_transport_is_guarded(self):
+        """#354/#436: there is no module-level provider singleton anymore
+        (`agents._providers._LoopSafeGoogleModel` builds a fresh one per
+        event loop) — but the guard patches the transport CLASS, not any one
+        instance, so every provider any agent builds is covered regardless.
+        Prove that on a model built the same way agents build theirs."""
         from google.genai._api_client import BaseApiClient
 
-        from agents._providers import _provider
+        from agents._providers import model_for
 
-        api_client = _provider.client._api_client
+        api_client = model_for("classifier").client._api_client
         assert isinstance(api_client, BaseApiClient)
         assert getattr(type(api_client).request, "_sapling_llm_guard", False), (
             "pydantic-ai's provider client is not covered by the LLM guard"

--- a/backend/tests/test_learn_stream_routes.py
+++ b/backend/tests/test_learn_stream_routes.py
@@ -1,0 +1,198 @@
+# backend/tests/test_learn_stream_routes.py
+"""Route-level tests for the SSE chat streams."""
+import inspect
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def _sse_events(text: str) -> list[str]:
+    """Event names from a raw SSE body."""
+    return [
+        line.split("event:", 1)[1].strip()
+        for line in text.splitlines()
+        if line.startswith("event:")
+    ]
+
+
+class TestChatStream:
+    def test_streams_tokens_then_done(self):
+        # Distinctive sentinel (not []) so an accidental `message_history=[]`
+        # in the route is caught by the assertion below, instead of silently
+        # matching whatever the mock happens to default to.
+        history_sentinel = [{"sentinel": "prior-turns"}]
+
+        stream_kwargs = {}
+
+        async def fake_stream(**kwargs):
+            # Capture exactly what the route hands to stream_agent_turn,
+            # so we can assert on legacy_fallback wiring after the request.
+            stream_kwargs.update(kwargs)
+            from services.agent_events import SaplingEvent
+            yield SaplingEvent(type="status", step="start", message="Starting.")
+            yield SaplingEvent(type="token", step="reply", message="", data={"delta": "Hi"})
+            kwargs["on_complete"]("Hi", {}, [])
+            yield SaplingEvent(type="done", step="reply", message="Complete.",
+                               data={"reply": "Hi", "graph_update": {}, "mastery_changes": []})
+
+        saved = []
+        with patch("routes.learn.stream_agent_turn", fake_stream), \
+             patch("routes.learn._prepare_chat_run",
+                   return_value=(MagicMock(), "msg", {}, MagicMock())) as prep, \
+             patch("routes.learn._consume_pending"), \
+             patch("routes.learn._get_session_offering_id", return_value="off-1"), \
+             patch("routes.learn.offering_course_id", return_value="c1"), \
+             patch("routes.learn._load_message_history", return_value=history_sentinel), \
+             patch("routes.learn.save_message", side_effect=lambda *a, **k: saved.append(a)):
+            r = client.post("/api/learn/chat/stream", json={
+                "session_id": "s1", "user_id": "u1", "message": "hello", "mode": "socratic",
+                "model_pref": "smart",
+            })
+
+        assert r.status_code == 200
+        assert "text/event-stream" in r.headers["content-type"]
+        assert _sse_events(r.text) == ["status", "token", "done"]
+        assert [a[1] for a in saved] == ["user", "assistant"], "user row persists before assistant"
+
+        # Wiring into _prepare_chat_run: prior turns loaded before the new
+        # user row is written (message_history), correct course scoping,
+        # the actual user message, and the model override — all as the
+        # route actually passes them, not whatever the mock defaults to.
+        prep_kwargs = prep.call_args.kwargs
+        assert prep_kwargs["message_history"] is history_sentinel, (
+            "message_history must be exactly what _load_message_history returned "
+            "(loaded BEFORE the new user row is written), not [] or something else"
+        )
+        assert prep_kwargs["course_id"] == "c1"
+        assert prep_kwargs["user_message"] == "hello"
+        assert prep_kwargs["model_pref"] == "smart"
+
+        # Rung-1 legacy fallback must be wired into stream_agent_turn so an
+        # agent failure before any token degrades to _legacy_chat instead of
+        # erroring outright.
+        assert stream_kwargs.get("legacy_fallback") is not None, (
+            "legacy_fallback must be passed to stream_agent_turn (Rung-1 fallback)"
+        )
+        assert inspect.iscoroutinefunction(stream_kwargs["legacy_fallback"])
+
+    def test_requires_self(self):
+        """The guard must run BEFORE any streaming work starts.
+
+        Note the strict assertions: an earlier draft wrapped this in
+        try/except Exception: pass, which swallowed the AssertionError and
+        made the test pass even when auth was bypassed entirely.
+        """
+        from fastapi import HTTPException
+
+        with patch("routes.learn.require_self",
+                   side_effect=HTTPException(status_code=403, detail="forbidden")) as guard, \
+             patch("routes.learn._consume_pending"), \
+             patch("routes.learn._prepare_chat_run") as prep:
+            r = client.post("/api/learn/chat/stream", json={
+                "session_id": "s1", "user_id": "someone-else",
+                "message": "hi", "mode": "socratic",
+            })
+
+        assert r.status_code == 403
+        guard.assert_called_once()
+        assert not prep.called, "auth must gate before any agent setup"
+
+
+class TestStartSessionStream:
+    def test_stashes_pending_session_and_does_not_write_db(self):
+        async def fake_stream(**kwargs):
+            from services.agent_events import SaplingEvent
+            extra = kwargs["on_complete"]("Welcome!", {}, [])
+            yield SaplingEvent(type="done", step="reply", message="Complete.",
+                               data={"reply": "Welcome!", **extra})
+
+        from routes.learn import PENDING_SESSIONS
+        PENDING_SESSIONS.clear()
+
+        with patch("routes.learn.stream_agent_turn", fake_stream), \
+             patch("routes.learn._prepare_chat_run",
+                   return_value=(MagicMock(), "msg", {}, MagicMock())) as prep, \
+             patch("routes.learn._get_course_id_for_topic", return_value="c1"), \
+             patch("routes.learn.resolve_offering", return_value="off-1"), \
+             patch("routes.learn.get_graph", return_value={"nodes": []}), \
+             patch("routes.learn.table") as tbl:
+            r = client.post("/api/learn/start-session/stream", json={
+                "user_id": "u1", "topic": "Eigenvalues", "mode": "socratic",
+            })
+
+        assert r.status_code == 200
+        assert len(PENDING_SESSIONS) == 1, "session must be stashed, not written"
+        stashed = next(iter(PENDING_SESSIONS.values()))
+        assert stashed["assistant_reply"] == "Welcome!"
+        assert stashed["topic"] == "Eigenvalues"
+        tbl.assert_not_called()
+
+        # A brand-new session genuinely has no prior turns; pin that literal
+        # (not a mock artifact) so a regression that starts loading history
+        # here — or drops it — is caught.
+        assert prep.call_args.kwargs["message_history"] == [], (
+            "a new session must start with no prior message history"
+        )
+
+    def test_legacy_fallback_wired_and_stashes_exactly_once(self):
+        """Finding 1 regression: start_session_stream used to pass
+        legacy_fallback=None, diverging from the spec's Rung 1 ("falls back
+        to the existing start_session body"). Mirrors TestChatStream's
+        wiring assertion, then goes further: simulates stream_agent_turn's
+        REAL mutual-exclusion contract (Rung 1 invokes ONLY
+        legacy_fallback, never on_complete) and proves the fallback stashes
+        PENDING_SESSIONS exactly once via the shared _start_session_legacy
+        helper — no double-stash, no double-persist.
+        """
+        stream_kwargs = {}
+
+        async def fake_stream(**kwargs):
+            stream_kwargs.update(kwargs)
+            from services.agent_events import SaplingEvent
+            # Rung 1: agent failed before any token. Real stream_agent_turn
+            # calls ONLY legacy_fallback here, never on_complete — that
+            # exclusivity is exactly what this test is pinning.
+            legacy_result = await kwargs["legacy_fallback"]()
+            yield SaplingEvent(type="token", step="reply", message="",
+                                data={"delta": legacy_result["reply"]})
+            yield SaplingEvent(type="done", step="reply", message="Complete.",
+                                data=legacy_result)
+
+        from routes.learn import PENDING_SESSIONS
+        PENDING_SESSIONS.clear()
+
+        with patch("routes.learn.stream_agent_turn", fake_stream), \
+             patch("routes.learn._prepare_chat_run",
+                   return_value=(MagicMock(), "msg", {}, MagicMock())), \
+             patch("routes.learn._get_course_id_for_topic", return_value="c1"), \
+             patch("routes.learn.resolve_offering", return_value="off-1"), \
+             patch("routes.learn.get_graph", return_value={"nodes": []}), \
+             patch("routes.learn.get_user_name", return_value="Student"), \
+             patch("routes.learn._get_course_documents", return_value=[]), \
+             patch("routes.learn.build_system_prompt", return_value="prompt"), \
+             patch("routes.learn.call_gemini_multiturn", return_value="raw"), \
+             patch("routes.learn.extract_graph_update",
+                   return_value=("Legacy greeting", {"new_nodes": []})), \
+             patch("routes.learn.apply_graph_update", return_value=[]):
+            r = client.post("/api/learn/start-session/stream", json={
+                "user_id": "u1", "topic": "Eigenvalues", "mode": "socratic",
+            })
+
+        assert r.status_code == 200
+        assert stream_kwargs.get("legacy_fallback") is not None, (
+            "legacy_fallback must be passed to stream_agent_turn (Rung-1 fallback)"
+        )
+        assert inspect.iscoroutinefunction(stream_kwargs["legacy_fallback"])
+
+        assert len(PENDING_SESSIONS) == 1, (
+            "legacy_fallback must stash PENDING_SESSIONS exactly once "
+            "(via _start_session_legacy) — never zero, never twice"
+        )
+        stashed = next(iter(PENDING_SESSIONS.values()))
+        assert stashed["assistant_reply"] == "Legacy greeting"
+        assert stashed["topic"] == "Eigenvalues"
+        assert "Legacy greeting" in r.text, "the legacy reply must reach the client as a token/done"

--- a/backend/tests/test_loop_safe_google_model.py
+++ b/backend/tests/test_loop_safe_google_model.py
@@ -1,0 +1,252 @@
+"""#354/#436: `agents._providers._LoopSafeGoogleModel` must never let a
+`GoogleModel`'s provider (and hence its `google.genai`/httpx client) survive
+across two different asyncio event loops — that is exactly the bug that
+produced `RuntimeError: Event loop is closed` on every SECOND real call
+through `run_agent_sync`, and identically on any test/agent that ends up
+calling `asyncio.run()` more than once against the same shared agent in one
+process (`test_ocr_pipeline.py::test_save_to_db`'s failure on main).
+
+Fix-round-1 (PR review finding): the FIRST version of `_LoopSafeGoogleModel`
+resolved the right provider under a lock, then handed it off through a
+single shared mutable `self._provider` attribute — and `self` is a
+module-level singleton shared by every concurrent call to the agent it
+backs. A different thread's own resolve-and-hand-off, running concurrently
+(exactly what happens under concurrent requests: every sync-`def` route
+drives `run_agent_sync` on a fresh thread + throwaway loop), could stomp
+that shared attribute during another thread's await gap, so the first
+thread would resume and read a provider bound to someone ELSE's — possibly
+already-closed — loop. Confirmed empirically: 6 threads x 20 sequential
+`asyncio.run` calls against one shared instance, with an `asyncio.sleep`
+standing in for the real await gap, produced 95/120 mismatches.
+
+The fix removes the hand-off: `.client` is now a PROPERTY that resolves
+`asyncio.get_running_loop()` -> the loop-keyed cache fresh, at the moment of
+every access, with no instance-attribute write in between "resolve" and
+"use". `TestConcurrentAccessIsRaceFree` below is the regression test for
+that: it reproduces the reviewer's repro shape (N threads, each doing
+sequential `asyncio.run` calls, with a deliberate await gap between
+"provider ensured" and "client read") first against a minimal stand-in of
+the ORIGINAL (buggy) hand-off design — proving the test shape itself would
+have caught it — and then against the real, fixed `_LoopSafeGoogleModel`.
+
+All tests here are hermetic: no actual `.request()`/network call, so no
+dependence on GEMINI_API_KEY being a real key and nothing for the autouse
+hermetic-LLM-guard fixture to intercept.
+"""
+from __future__ import annotations
+
+import asyncio
+import gc
+import threading
+
+from agents._providers import _LoopSafeGoogleModel, google_model, model_for
+
+
+def test_model_for_real_mode_returns_loop_safe_model(monkeypatch):
+    monkeypatch.delenv("SAPLING_MODEL_MODE", raising=False)
+    m = model_for("classifier")
+    assert isinstance(m, _LoopSafeGoogleModel)
+
+
+def test_google_model_shim_returns_loop_safe_model():
+    m = google_model("gemini-2.5-flash-lite")
+    assert isinstance(m, _LoopSafeGoogleModel)
+
+
+def test_fresh_provider_per_new_event_loop():
+    """The core #354 regression: three SEPARATE, SEQUENTIAL asyncio.run()
+    loops (exactly what `run_agent_sync` does per call, and what two
+    independent test functions calling `asyncio.run()` do in the same
+    process) must never share a provider — that sharing is what ties a
+    client to a loop that is about to close."""
+    m = _LoopSafeGoogleModel("gemini-2.5-flash-lite")
+
+    seen = []
+
+    async def _touch():
+        seen.append(m._provider_for_current_loop())
+
+    asyncio.run(_touch())
+    asyncio.run(_touch())
+    asyncio.run(_touch())
+
+    assert len(seen) == 3
+    assert seen[0] is not seen[1]
+    assert seen[1] is not seen[2]
+    assert seen[0] is not seen[2]
+
+
+def test_same_provider_reused_within_one_loop():
+    """Within a single loop's lifetime (e.g. FastAPI's persistent per-process
+    loop across many `await agent.run(...)` calls, or a multi-step agent run
+    that calls the model more than once), the provider — and its connection
+    pool — should be reused rather than rebuilt on every call."""
+    m = _LoopSafeGoogleModel("gemini-2.5-flash-lite")
+    seen = []
+
+    async def _touch_twice():
+        seen.append(m._provider_for_current_loop())
+        seen.append(m._provider_for_current_loop())
+
+    asyncio.run(_touch_twice())
+
+    assert seen[0] is seen[1]
+
+
+def test_client_property_resolves_per_loop_too():
+    """The public `.client` property — what every inherited GoogleModel
+    method (`request`, `count_tokens`, `request_stream`, `_generate_content`)
+    actually reads — must show the same per-loop behavior as the private
+    resolver: fresh across loops, stable within one."""
+    m = _LoopSafeGoogleModel("gemini-2.5-flash-lite")
+    clients_by_run = []
+
+    async def _touch():
+        clients_by_run.append((m.client, m.client))
+
+    asyncio.run(_touch())
+    asyncio.run(_touch())
+
+    (a1, a2), (b1, b2) = clients_by_run
+    assert a1 is a2, "same loop: .client should be stable across two reads"
+    assert b1 is b2, "same loop: .client should be stable across two reads"
+    assert a1 is not b1, "different (sequential) loops must not share a client"
+
+
+def test_loop_cache_self_cleans_after_loop_is_collected():
+    """The per-loop cache is a WeakKeyDictionary keyed by the loop object
+    itself, so a disposable `run_agent_sync`/`asyncio.run()` loop's entry
+    must not linger forever — a long process making many such calls over its
+    lifetime must not accumulate one provider per call."""
+    m = _LoopSafeGoogleModel("gemini-2.5-flash-lite")
+
+    async def _touch():
+        m._provider_for_current_loop()
+
+    asyncio.run(_touch())
+    gc.collect()
+    assert len(m._loop_providers) == 0
+
+
+def test_no_running_loop_is_a_safe_fallback_to_the_template():
+    """Calling this outside any running loop (e.g. a test that inspects
+    `.client` synchronously, like `test_hermetic_llm_guard.py`) must not
+    raise — it falls back to the fixed template provider set at
+    construction, since with no loop there is nothing to race."""
+    m = _LoopSafeGoogleModel("gemini-2.5-flash-lite")
+    assert m._provider_for_current_loop() is m._provider
+    assert m.client is m._provider.client
+
+
+class _PointerHandoffStandin:
+    """Minimal reproduction of the ORIGINAL (buggy) `_LoopSafeGoogleModel`
+    design that fix-round-1 replaced: `_bind_to_current_loop()` resolves the
+    right provider under a lock, keyed correctly per loop — but then hands
+    it off through ONE shared mutable `self._provider` attribute. A
+    concurrent thread's own `_bind_to_current_loop()` call, running on a
+    DIFFERENT loop, can rebind that same attribute during this thread's
+    await gap, so a later read sees someone else's provider instead of the
+    one that was just resolved for THIS loop.
+
+    The real fix (`_LoopSafeGoogleModel.client`, tested below) never does
+    this hand-off: it resolves straight from the loop-keyed dict at the
+    exact point of read, with no shared instance attribute in between.
+    """
+
+    def __init__(self):
+        self._loop_providers = {}
+        self._lock = threading.Lock()
+        self._provider = None
+
+    def _bind_to_current_loop(self):
+        loop = asyncio.get_running_loop()
+        with self._lock:
+            provider = self._loop_providers.get(loop)
+            if provider is None:
+                provider = object()
+                self._loop_providers[loop] = provider
+            self._provider = provider  # <-- the buggy shared hand-off
+        return provider
+
+    @property
+    def client(self):
+        return self._provider
+
+
+def _hammer_for_mismatches(one_call, *, n_threads=6, n_calls=20):
+    """Run `n_threads` threads, each doing `n_calls` sequential
+    `asyncio.run(one_call())` calls. Mirrors the reviewer's repro shape
+    (6 threads x 20 sequential asyncio.run calls against one shared model).
+    """
+    def _worker():
+        for _ in range(n_calls):
+            asyncio.run(one_call())
+
+    threads = [threading.Thread(target=_worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+
+class TestConcurrentAccessIsRaceFree:
+    """Fix-round-1 regression coverage: N threads, each running sequential
+    `asyncio.run` calls against ONE shared model, with a deliberate await
+    gap (mirroring the real `await self._build_content_and_config(...)` gap
+    in pydantic-ai's `GoogleModel._generate_content`) between "the provider
+    for this loop has been ensured/resolved" and "read the client actually
+    used to make the request". Deterministic, hermetic, no network.
+    """
+
+    def test_pointer_handoff_standin_reproduces_the_original_race(self):
+        """Sanity-checks the test shape itself against the ORIGINAL (buggy)
+        design fix-round-1 replaced: it MUST mismatch under concurrent
+        threads. If this ever stopped failing, the test shape below would no
+        longer be trusted to catch a regression back to a shared pointer."""
+        standin = _PointerHandoffStandin()
+        mismatches = []
+        mismatches_lock = threading.Lock()
+
+        async def _one_call():
+            expected = standin._bind_to_current_loop()
+            await asyncio.sleep(0.001)  # the gap a concurrent thread exploits
+            actual = standin.client
+            if actual is not expected:
+                with mismatches_lock:
+                    mismatches.append((expected, actual))
+
+        _hammer_for_mismatches(_one_call)
+
+        assert mismatches, (
+            "expected the buggy pointer-handoff stand-in to mismatch under "
+            "concurrent threads — if it didn't, this test's shape no longer "
+            "reproduces the original race and can't be trusted to catch a "
+            "regression back to it"
+        )
+
+    def test_loop_safe_google_model_never_cross_wires_providers(self):
+        """The actual fix-round-1 regression test: same shape as above, but
+        reading through the REAL `.client` property. Must be zero
+        mismatches — `.client` resolves from `asyncio.get_running_loop()` at
+        read time, so it can't be affected by what any other thread does to
+        its OWN loop's cache entry."""
+        model = _LoopSafeGoogleModel("gemini-2.5-flash-lite")
+        mismatches = []
+        mismatches_lock = threading.Lock()
+
+        async def _one_call():
+            loop = asyncio.get_running_loop()
+            # "Provider ensured" — a real request path's equivalent of the
+            # first touch that would create this loop's cache entry.
+            expected_provider = model._provider_for_current_loop()
+            await asyncio.sleep(0.001)  # the same gap that broke the hand-off
+            # "Client read" — the real path every inherited GoogleModel
+            # method (request/count_tokens/request_stream) actually uses.
+            actual_client = model.client
+            if actual_client is not expected_provider.client:
+                with mismatches_lock:
+                    mismatches.append((loop, expected_provider, actual_client))
+
+        _hammer_for_mismatches(_one_call)
+
+        assert mismatches == []

--- a/backend/tests/test_model_mode_seam.py
+++ b/backend/tests/test_model_mode_seam.py
@@ -301,3 +301,104 @@ def test_default_real_mode_agent_run_still_trips_the_guard():
     class identities differ)."""
     with pytest.raises(RuntimeError, match="unstubbed LLM egress"):
         classifier_agent.run_sync("anything", deps=_deps())
+
+
+# ── Streamed runs (#349): the seam serves run_stream_events too ───────────
+
+
+def test_function_mode_streams_text_from_the_same_handler(monkeypatch):
+    """The SSE tutor routes drive agents via `run_stream_events`. A streamed
+    run in function mode must be served by the SAME registered handler as a
+    JSON run — its text replayed as stream deltas — so spec assertions can
+    compare both lanes against one E2E_* constant. Before #349 the seam's
+    FunctionModel had no `stream_function`, so every streamed turn errored
+    into the legacy fallback and the streamed path was untestable."""
+    import asyncio
+
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    register_function_handler(
+        "note_chat",
+        lambda m, i: ModelResponse(parts=[TextPart(content="streamed seam reply")]),
+    )
+
+    async def collect() -> tuple[list[str], str | None]:
+        deltas: list[str] = []
+        final: str | None = None
+        with note_chat_agent.override(model=model_for("note_chat")):
+            async for event in note_chat_agent.run_stream_events(
+                "hello", deps=_deps()
+            ):
+                cls_name = type(event).__name__
+                if cls_name == "PartStartEvent":
+                    part = getattr(event, "part", None)
+                    if getattr(part, "part_kind", None) == "text" and part.content:
+                        deltas.append(part.content)
+                elif cls_name == "PartDeltaEvent":
+                    delta = getattr(event, "delta", None)
+                    if getattr(delta, "part_delta_kind", None) == "text":
+                        deltas.append(delta.content_delta)
+                elif cls_name == "AgentRunResultEvent":
+                    final = event.result.output
+        return deltas, final
+
+    deltas, final = asyncio.run(collect())
+    assert "".join(deltas) == "streamed seam reply"
+    assert final == "streamed seam reply"
+
+
+def test_function_mode_streams_scripted_tool_calls(monkeypatch):
+    """A streamed function-mode run must also replay scripted TOOL CALLS (as
+    DeltaToolCall chunks) through the real tool-registration/validation loop —
+    the streamed twin of the JSON-lane acceptance test above."""
+    import asyncio
+
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+
+    received: dict = {}
+
+    async def _spy_search(course_id, query, limit=5, *, user_id):
+        received.update(query=query, limit=limit)
+        return []
+
+    monkeypatch.setattr(
+        "agents.tools.chat_context.search_course_materials", _spy_search
+    )
+
+    calls = {"n": 0}
+
+    def handler(messages, info) -> ModelResponse:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        tool_name="search_course_materials_tool",
+                        args={"query": "eigenvalues", "limit": 2},
+                    )
+                ]
+            )
+        return ModelResponse(parts=[TextPart(content="used the tool")])
+
+    register_function_handler("note_chat", handler)
+
+    async def run() -> tuple[str | None, list[str]]:
+        final: str | None = None
+        tool_events: list[str] = []
+        with note_chat_agent.override(model=model_for("note_chat")):
+            async for event in note_chat_agent.run_stream_events(
+                "find eigenvalues", deps=_deps()
+            ):
+                cls_name = type(event).__name__
+                if cls_name == "FunctionToolCallEvent":
+                    tool_events.append(cls_name)
+                elif cls_name == "AgentRunResultEvent":
+                    final = event.result.output
+        return final, tool_events
+
+    final, tool_events = asyncio.run(run())
+    # The scripted call streamed as a real mid-run tool event, was
+    # schema-validated, and dispatched to the real (spied) tool body.
+    assert tool_events == ["FunctionToolCallEvent"]
+    assert received == {"query": "eigenvalues", "limit": 2}
+    assert final == "used the tool"
+    assert calls["n"] == 2

--- a/backend/tests/test_rag_service.py
+++ b/backend/tests/test_rag_service.py
@@ -3,15 +3,20 @@ import subprocess
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def test_import_succeeds_without_gemini_api_key():
-    """#378: rag_service builds a module-level `genai.Client` at import time and
-    `genai.Client(api_key="")` raises ValueError, so a missing GEMINI_API_KEY
-    broke `import main` (via routes/quiz.py -> services/rag_service.py) outright.
+    """#378: rag_service originally built a module-level `genai.Client` at
+    import time, and `genai.Client(api_key="")` raises ValueError, so a
+    missing GEMINI_API_KEY broke `import main` (via routes/quiz.py ->
+    services/rag_service.py) outright.
 
-    Its siblings already fall back to a dummy key — services/gemini_service.py
-    and agents/_providers.py — so imports stay clean and the failure surfaces at
-    call time instead. This pins that behaviour for the whole import graph.
+    #439 went further: client construction is now fully lazy (`_get_client()`,
+    reached only from inside a `model_mode() == 'real'` `_embed_*` call), so
+    import no longer touches `google.genai.Client` at all regardless of the
+    key — `rag._client` starts (and, absent a real-mode embed call, stays) as
+    `None`. This pins that behaviour for the whole import graph.
 
     Run in a subprocess: the modules are already imported in-process, so this is
     the only way to observe import-time behaviour. `load_dotenv` is stubbed out
@@ -32,7 +37,7 @@ def test_import_succeeds_without_gemini_api_key():
         "import os; os.environ.pop('GEMINI_API_KEY', None)\n"
         "import main\n"
         "import services.rag_service as rag\n"
-        "assert rag._client is not None\n"
+        "assert rag._client is None\n"
     )
     proc = subprocess.run(
         [sys.executable, "-c", program],
@@ -148,3 +153,99 @@ def test_index_document_chunks_handles_embedding_failure(mock_embed):
         # All records have embedding=None since embedding failed
         assert all(rec["embedding"] is None for rec in upsert_records)
         assert len(upsert_records) == 3
+
+
+# ── #439: below-seam RAG embed calls must gate on SAPLING_MODEL_MODE ───────
+#
+# These call sites (`_embed_query`, `_embed_document`, `_embed_documents_batch`)
+# predate the #391 seam and construct a raw `google.genai.Client` directly, so
+# they need their own mode check rather than going through `model_for`. In
+# non-real mode no client may be constructed and no network call attempted;
+# the existing callers' broad try/except (exercised above) then produces the
+# exact same deterministic empty/no-op result as an unlucky real-mode
+# failure — by design now, not by accident.
+
+
+def test_embed_query_does_not_construct_client_outside_real_mode(monkeypatch):
+    """Force a clean slate (module-level `_client` back to `None`) so this
+    exercises the lazy-construction path fresh, rather than reusing whatever
+    an earlier real-mode test already cached in the module singleton."""
+    import services.rag_service as rag
+
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setattr(rag, "_client", None)
+    ctor = MagicMock(side_effect=AssertionError(
+        "genai.Client must not be constructed outside real mode"
+    ))
+    monkeypatch.setattr(rag.genai, "Client", ctor)
+
+    with pytest.raises(RuntimeError, match="SAPLING_MODEL_MODE"):
+        rag._embed_query("dynamic programming")
+
+    ctor.assert_not_called()
+    assert rag._client is None
+
+
+def test_embed_documents_batch_does_not_construct_client_outside_real_mode(monkeypatch):
+    import services.rag_service as rag
+
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setattr(rag, "_client", None)
+    ctor = MagicMock(side_effect=AssertionError(
+        "genai.Client must not be constructed outside real mode"
+    ))
+    monkeypatch.setattr(rag.genai, "Client", ctor)
+
+    with pytest.raises(RuntimeError, match="SAPLING_MODEL_MODE"):
+        rag._embed_documents_batch(["chunk one", "chunk two"])
+
+    ctor.assert_not_called()
+    assert rag._client is None
+
+
+def test_retrieve_chunks_never_reaches_transport_in_function_mode(monkeypatch, capsys):
+    """Pre-#439, retrieve_chunks ignored SAPLING_MODEL_MODE entirely and always
+    called through to the real cached client — only the suite's autouse
+    `_hermetic_llm_transport` guard (#379) accidentally caught the resulting
+    network attempt, producing an 'unstubbed LLM egress' failure message that
+    retrieve_chunks' own except then swallowed into `[]`. Post-fix the mode
+    gate raises before ever reaching google-genai's transport, so that
+    message must never appear — the swallowed message names
+    SAPLING_MODEL_MODE instead.
+    """
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    from services.rag_service import retrieve_chunks
+
+    with patch("services.rag_service.rpc") as mock_rpc:
+        result = retrieve_chunks("dynamic programming", course_id="CAS CS 330")
+
+    assert result == []
+    mock_rpc.assert_not_called()
+    captured = capsys.readouterr()
+    assert "unstubbed LLM egress" not in captured.out
+    assert "SAPLING_MODEL_MODE" in captured.out
+
+
+def test_index_document_chunks_never_reaches_transport_in_function_mode(monkeypatch, capsys):
+    """Same proof as above for the batch/document embed path used by document
+    upload indexing — the deterministic no-op is count-with-embedding=None,
+    same shape as test_index_document_chunks_handles_embedding_failure, but
+    now reached by the mode gate rather than a real API error."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    from services.rag_service import index_document_chunks
+
+    with patch("services.rag_service.table") as mock_table:
+        mock_table.return_value.upsert.return_value = []
+        count = index_document_chunks(
+            course_code="CAS CS 330",
+            doc_id="doc-func-mode",
+            uploader_id="user-1",
+            chunks=["chunk one", "chunk two"],
+        )
+
+    assert count == 2
+    upsert_records = mock_table.return_value.upsert.call_args[0][0]
+    assert all(rec["embedding"] is None for rec in upsert_records)
+    captured = capsys.readouterr()
+    assert "unstubbed LLM egress" not in captured.out
+    assert "SAPLING_MODEL_MODE" in captured.out

--- a/backend/tests/test_run_agent_sync_loop.py
+++ b/backend/tests/test_run_agent_sync_loop.py
@@ -1,0 +1,41 @@
+# backend/tests/test_run_agent_sync_loop.py
+"""Regression: run_agent_sync's event-loop handling.
+
+`run_agent_sync` drives agents via ``asyncio.run`` from sync route handlers.
+Called from a thread that already has a running loop (an async handler's sync
+call chain, e.g. _legacy_chat -> apply_graph_update -> update_course_context
+-> _generate_summary_with_gemini), it must never
+(a) blindly ``asyncio.run`` — that raises opaquely — nor (b) leak the
+coroutine it was handed (a "never awaited" warning). Cross-loop client safety
+itself lives in `_LoopSafeGoogleModel` (see test_loop_safe_google_model.py).
+"""
+import asyncio
+import inspect
+
+import pytest
+
+from agents._run import run_agent_sync
+
+
+def test_runs_coroutine_when_no_loop():
+    async def work():
+        return 7
+
+    assert run_agent_sync(work()) == 7
+
+
+def test_from_running_loop_raises_and_closes_coro():
+    """Called from an async context it must not asyncio.run (that would raise
+    opaquely) nor leak the coroutine (a "never awaited" warning); it closes the
+    coroutine and raises a clear error the caller can degrade on."""
+    async def scenario():
+        async def agent_call():
+            return 1
+
+        coro = agent_call()
+        with pytest.raises(RuntimeError, match="running event loop"):
+            run_agent_sync(coro)
+        # Closed, not abandoned — so no "coroutine was never awaited" warning.
+        assert inspect.getcoroutinestate(coro) == inspect.CORO_CLOSED
+
+    asyncio.run(scenario())

--- a/docs/decisions/0020-agent-eval-harness-baselines.md
+++ b/docs/decisions/0020-agent-eval-harness-baselines.md
@@ -1,0 +1,76 @@
+# 0020: Extraction-accuracy eval harness with committed baselines
+
+- Status: accepted
+- Date: 2026-07-28
+- Relates to: #152 (agent migration epic), #148 (this issue); extends 0019 (test seams for agents)
+
+## Context
+
+The feature-surface agent migrations (#143–#147) are complete: `classifier`,
+`summary`, `concepts`, `syllabus`, `quiz` and friends all run through Pydantic
+AI. But they were only smoke-tested — nothing measured whether a prompt or model
+change made *extraction accuracy* worse. #148 asks for an evaluation harness so
+migrations can be validated and compared, and so the final `gemini_service`
+cutover (#151) can lean on evidence rather than vibes.
+
+A record/replay harness scaffold already existed under `backend/tests/evals`
+(`_replay.py` + per-task `pydantic_evals` datasets), but it was non-functional:
+only 4 of ~95 cases had cassettes, `quiz_generation`/`chat_tutor` had none, the
+runner failed on any evaluator score `< 1.0` (wrong for an accuracy harness),
+and the CI workflow was `workflow_dispatch`-only because of the coverage gap.
+
+## Decision
+
+Complete the harness and gate agent changes on it.
+
+1. **Record cassettes for all five offline datasets** (`document_classification`,
+   `document_summary`, `concept_extraction`, `syllabus_extraction`,
+   `quiz_generation`) against live Gemini — 80 cassettes committed. Recording
+   retries transient 503/UNAVAILABLE/429 so a blip can't leave a permanent gap.
+
+2. **Gate on regression below a committed baseline, not on `< 1.0`.** Replay is
+   deterministic (the model output is frozen in the cassette), so a task's
+   aggregate score only moves when an evaluator, an expected output, or a
+   cassette changes. `baselines.json` records the current per-evaluator scores;
+   a run fails when a score drops below its baseline or a case raises (missing
+   cassette). `SAPLING_EVAL_UPDATE_BASELINES=1` rewrites baselines from the
+   current scores (refused if the run had failures).
+
+3. **One command, one CI job.** `tests/evals/run_all.py` runs every offline
+   dataset and prints a per-task accuracy summary. `evals.yml` runs it in replay
+   mode (no Gemini key) on every PR touching `backend/agents/**` or the harness.
+
+4. **`chat_tutor` stays out of the offline harness.** Its retrieval tool reads a
+   live Supabase and cannot run against cassettes; it moves in with the
+   graph-grounded tutor work (#149).
+
+5. **Cross-platform robustness:** the runner forces UTF-8 on stdout/stderr so
+   non-ASCII cases (e.g. a Mandarin syllabus) don't crash `rich` on a Windows
+   cp1252 console.
+
+## Baseline numbers (2026-07-28, current per-task models)
+
+| Dataset | Evaluators | Score |
+|---------|-----------|-------|
+| document_classification | Category / SyllabusFlag | 0.80 / 0.88 |
+| document_summary | AbstractLength | 0.933 (Headline / KeyPointsCount / NoMarkdownLeak: 1.00) |
+| concept_extraction | all four | 1.00 |
+| syllabus_extraction | NoInventedDates | 0.933 (all six others: 1.00) |
+| quiz_generation | all seven | 1.00 |
+
+These are the outputs of the frozen cassettes under the current models; they are
+a floor, not a target. Re-record and re-baseline when a prompt or model changes,
+reviewing the score deltas the run prints.
+
+## Consequences
+
+- (+) Prompt/model regressions on the migrated agents surface as a red PR check
+  instead of a production incident, unblocking the #151 cutover with evidence.
+- (+) Refresh is a two-command, reviewable diff (`record` then update baselines),
+  committed alongside the change that moved the numbers.
+- (−) Cassettes are frozen samples: replay validates evaluators/expectations
+  against a snapshot, it does not re-exercise the live model. Catching a live
+  model *regression* still requires a periodic `record` pass — a deliberate
+  trade for a deterministic, keyless CI gate.
+- (−) `chat_tutor` accuracy remains unmeasured until #149 gives it an offline
+  retrieval seam.

--- a/docs/decisions/0020-streaming-tutor-interrupt-retry.md
+++ b/docs/decisions/0020-streaming-tutor-interrupt-retry.md
@@ -1,0 +1,69 @@
+# 0020 — Interrupted tutor turns keep the partial reply and offer Retry (#356 item 5)
+
+**Status:** decided · **Issue:** #356 (PR #349 e2e-smoke item 5) · **Implements:** the streaming feature in PR #349
+
+## The decision
+
+When a streaming tutor turn is **stopped by the user** or **fails mid-stream**
+(a Rung-2 `error` event, including during a Rung-3 JSON fallback), the client
+**keeps the partial reply text visible, marks the bubble interrupted, and offers
+Retry**. Because nothing is persisted until a turn completes, Retry simply
+re-sends the same turn. This is the behavior the streaming spec already
+specifies — we adopt it rather than amend the spec.
+
+## Context
+
+PR #349 shipped the SSE streaming tutor with a known divergence from spec,
+called out in its "Known gaps":
+
+> **Stop/Rung-2 discards the partial reply and offers no Retry.** As shipped,
+> Stop appends nothing (leaving the user's message with no reply) and Rung 2
+> shows a generic error.
+
+The e2e-smoke item 5 (#356) asked us to confirm this live and decide:
+**(a)** implement per spec — keep the partial, mark it interrupted, offer Retry;
+or **(b)** amend the spec to bless the discard.
+
+The spec (`docs/superpowers/specs/2026-07-16-streaming-design.md`) is explicit:
+
+- Bubble-state table (§ "failed / stopped"): *"mid-stream `error` or user Stop:
+  keep the partial text visually, mark it interrupted, offer Retry (nothing was
+  persisted, so Retry re-sends the turn)."*
+- Failure ladder: *"persist nothing; client marks the bubble interrupted and
+  offers Retry. No silent auto-retry."*
+
+## Why (a), not (b)
+
+- **No dropped turns.** Discarding on Stop leaves the user's own message sitting
+  with no reply and no affordance to recover — the worst outcome of the two,
+  and precisely what a "Stop" (pause, not delete) does not imply.
+- **The partial is real output.** Tokens already rendered are the model's actual
+  answer so far; keeping them visible (dimmed/"interrupted") is more useful than
+  blanking the bubble.
+- **Retry is already safe.** The persistence contract persists exactly once, on
+  completion, before `done` — so a stopped/failed turn wrote nothing, and Retry
+  re-sends without risk of a double-write or a phantom half-message. (`CancelledError`
+  is deliberately not caught; a mid-stream disconnect cancels the generator
+  before persistence — covered by `backend/tests/test_chat_stream.py`.)
+- **Consistency across rungs.** The same interrupted+Retry affordance covers a
+  user Stop, a Rung-2 mid-stream error, and a failure during the Rung-3 JSON
+  fallback, so degraded states never look "frozen."
+
+## Scope / where it lands
+
+The streaming chat UI (`frontend/src/components/ChatPanel.tsx`,
+`frontend/src/components/screens/Learn.tsx`, `frontend/src/lib/api.ts`) lives on
+the **PR #349 branch (`feat/streaming-tutor`)**, not on `main`. This ADR records
+the product decision; the implementation is a follow-up on that branch (or
+immediately after it merges), not part of the `main`-based follow-up branch that
+carries #354/#355. Acceptance for item 5 in #356 is: this decision recorded
+(done here) and implemented on the streaming branch.
+
+## Consequences
+
+- ChatPanel gains an `interrupted` bubble treatment (keep `streamingText`, style
+  as interrupted) and a Retry action; Learn wires Retry to re-dispatch the
+  turn's original `message`/`mode`.
+- No backend change: the persistence contract and fallback ladder already
+  guarantee "nothing persisted on stop/failure," which is what makes Retry a
+  plain re-send. This is a client-rendering decision on top of the existing seam.

--- a/docs/decisions/0021-agent-eval-harness-baselines.md
+++ b/docs/decisions/0021-agent-eval-harness-baselines.md
@@ -1,4 +1,4 @@
-# 0020: Extraction-accuracy eval harness with committed baselines
+# 0021: Extraction-accuracy eval harness with committed baselines
 
 - Status: accepted
 - Date: 2026-07-28

--- a/docs/e2e-exploration.md
+++ b/docs/e2e-exploration.md
@@ -154,9 +154,13 @@ cd backend && venv/bin/python -m e2e_oracles [--json] [--check ciphertext|counts
   results as untrustworthy when this happens, not just the failing check).
 - Needs the stack up (`make e2e-up` or `scripts/explore.sh up`) — it hits the
   local Postgres directly and the backend's `/api/health`-adjacent surface.
-- The `logscan` check allowlists known #439 RAG-indexing log noise — an
-  allowlisted hit still counts toward "N suppressed" in the summary line, but
-  doesn't produce a `Finding`.
+- The `logscan` check allowlists known #439 RAG-indexing log noise. #439
+  itself is fixed (embeddings are now mode-gated), but the allowlist entry
+  stays as defense in depth — the mode-gate abort deliberately routes through
+  the same log line, so a real regression would still need to be
+  distinguishable from the expected abort path. An allowlisted hit still
+  counts toward "N suppressed" in the summary line, but doesn't produce a
+  `Finding`.
 
 ## 7. Triage protocol
 
@@ -172,10 +176,13 @@ For each entry in `findings.md` (explorer-written or oracle-appended):
    (steps/expected/actual), the oracle JSON if there is any, and the
    `.explore/traces/` path attached. Label it as sourced from exploration so
    it's traceable back to a session.
-3. **Already-known** (currently: #355, #430, #435, #436, #439, #441) → don't
-   file a new issue. Add the new evidence as a comment on the existing issue
-   only if it's actually new evidence (a different surface, a clearer repro,
-   fresh oracle output) — otherwise it's just noise on an already-tracked bug.
+3. **Already-known** (currently: #449 — `get_courses` per-enrollment fan-out
+   produces duplicate `course_id` rows; Library's instance was fixed
+   render-side in #451, but Tree/Dashboard/etc. and the
+   `DocumentUploadModal` course picker still show it) → don't file a new
+   issue. Add the new evidence as a comment on the existing issue only if
+   it's actually new evidence (a different surface, a clearer repro, fresh
+   oracle output) — otherwise it's just noise on an already-tracked bug.
 4. **Noise the oracle wrongly flagged** → that's a bug in the oracle itself
    (a missing allowlist entry, or a judge that's too strict/wrong). Fix it as
    a normal PR against `backend/e2e_oracles/` — don't just delete the finding
@@ -194,7 +201,9 @@ genuinely has no handler in `backend/agents/function_handlers_e2e.py`. The
 `logscan` oracle independently caught the same `500` and traceback in the
 backend log, so this has both a UI-observed repro and oracle corroboration.
 It isn't on the known-bugs list — exactly the kind of thing this chapter
-exists to surface, and a strong promotion candidate (§8).
+exists to surface, and a strong promotion candidate (§8). (It was: filed as
+#446, fixed, and promoted into `tutor.spec.ts` — the pipeline working
+end-to-end.)
 
 **Seam artifact — drop it, then improve the harness, not the app (still
 category 1).** A different run's explorer flagged what looked like a
@@ -223,9 +232,11 @@ the pattern explicitly so a future explorer recognizes it before writing the
 stub, rather than filing an issue against the harness's own known-fixed
 output.
 
-By contrast, #355 (the graph's duplicated CS subject-root hub) shows up in
-the graph oracle on essentially every run against the rich seed data —
-that's the known-not-new case category 3 above exists for.
+By contrast, #355 (the graph's duplicated CS subject-root hub) used to show
+up in the graph oracle on essentially every run against the rich seed data —
+that was the known-not-new case category 3 above exists for, back when #355
+was still open (it's since been fixed by #447; see the §8 note on its
+`graph.spec.ts` assertion).
 
 ## 8. Promotion pipeline
 
@@ -249,9 +260,10 @@ written in the existing specs' style —
 
 If the promoted journey documents a bug that's still open and must stay red,
 ride it in on `test.fixme` with the bug number — exactly how
-`frontend/e2e/graph.spec.ts` carries its `#355` assertion today (marked
-`fixme`, not relaxed, with companion tests asserting everything #355 does
-*not* corrupt).
+`frontend/e2e/graph.spec.ts` carried its `#355` assertion (marked `fixme`,
+not relaxed, with companion tests asserting everything #355 did *not*
+corrupt) until the fix landed in #447 and the test was un-`fixme`'d — the
+intended lifecycle.
 
 ## 9. Cadence + cost
 

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -134,6 +134,7 @@ route:
 | `tutor-messages` | conversation log (`role="log"`) |
 | `tutor-input` | message `<textarea>` |
 | `tutor-send` | send button |
+| `tutor-stop` | stop-streaming button (visible only while a streamed reply is in flight, #349) |
 | `tutor-action-hint` | "Hint" |
 | `tutor-action-confused` | "I'm confused" |
 | `tutor-action-skip` | "Skip" |

--- a/docs/local-supabase.md
+++ b/docs/local-supabase.md
@@ -273,7 +273,30 @@ e2e oracles) is documented in [e2e-exploration.md](e2e-exploration.md).
 - **404 "Could not find the table … in the schema cache"** — PostgREST cache is
   stale after a migration. `podman exec supabase_db_sapling psql -U postgres -d postgres
   -c "NOTIFY pgrst, 'reload schema';"` (the reset script does this for you).
-- **Postgres version** — local is PG17, staging/prod is PG15. The migrations are
-  version-agnostic and verified to replay on 17; keep new migrations portable.
+- **Postgres version** — local, CI, and staging/prod all pin PG15
+  (`supabase/config.toml`'s `major_version`, #441 — local/CI used to run PG17;
+  that skew is now closed). The migrations are version-agnostic and verified
+  to replay on 15; keep new migrations portable. `backend/tests/integration/`
+  asserts the server major version so future drift is loud, not silent.
+  **If you have an existing local stack from before this pin**, its Postgres
+  container is still running the old major version. `supabase db reset` (what
+  `scripts/local-db-reset.sh` calls) does **not** reliably pick up a changed
+  `major_version` — it resets data inside the *existing* container, it never
+  stops/starts the stack, so it cannot swap that container's Postgres image
+  (confirmed against `supabase/cli` issues #5555 and #4522, which report the
+  same gap). The reliable fix for a major-version change is a full teardown:
+  `supabase stop --no-backup` (drops the old data volume so nothing stale is
+  left to reattach to), then `supabase start` — that provisions a fresh,
+  empty container on the now-pinned PG15 (no app schema yet — `supabase
+  start` itself never touches `backend/db/migrations/`, same as any
+  first-time bring-up). From there, `scripts/local-db-reset.sh` is for what
+  it's actually for: applying the app's migrations and reseeding data
+  (migrate → reload PostgREST → seed) on a stack that's *already* the correct
+  Postgres version — run it (or just `make e2e-up`, which calls `supabase
+  start` itself before migrating + seeding) after the teardown to get the
+  schema and seed data back.
+  `backend/tests/integration/test_postgres_version.py` is the drift alarm: it
+  asserts the real server's major version, so a stack still on the wrong
+  version fails loud there instead of silently passing everything else.
 - **Ports 54321–54327 already in use** — another project's `supabase start` is
   running; `supabase stop` in that project (or `podman ps` to find it).

--- a/docs/superpowers/plans/2026-07-16-streaming-tutor.md
+++ b/docs/superpowers/plans/2026-07-16-streaming-tutor.md
@@ -1,0 +1,1642 @@
+# Streaming Tutor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stream the Learn tutor's replies token-by-token over SSE with live knowledge-graph deltas on the same stream, and migrate `start_session` onto the chat agent so its greeting streams too.
+
+**Architecture:** One new async generator (`services/chat_stream.py::stream_agent_turn`) wraps `agent.run_stream_events()` and translates Pydantic AI events into the existing `SaplingEvent` SSE envelope, extended with three new types (`token`, `graph_update`, `done`). Two thin new routes (`/api/learn/chat/stream`, `/api/learn/start-session/stream`) hand that generator to `EventSourceResponse`. The existing JSON routes are untouched and remain the fallback. The frontend consumes it through one `streamChat()` built on the existing `streamSSE`.
+
+**Tech Stack:** FastAPI · sse-starlette `EventSourceResponse` · Pydantic AI 1.89.1 (`run_stream_events`) · pytest · Next.js/React · vitest
+
+**Spec:** `docs/superpowers/specs/2026-07-16-streaming-design.md`
+**Issues:** #70 (token streaming), #74 (live graph deltas). Also advances #152/#151 and closes ADR-0015's `start_session` TODO.
+**Branch:** `feat/streaming-tutor` (already exists, spec committed at `ea149f7`)
+
+## Global Constraints
+
+- **Never adopt a second SSE protocol or parser.** New event types extend `SaplingEvent` in `backend/services/agent_events.py`; the frontend consumes via `frontend/src/lib/sse.ts::streamSSE`. (ADR 0006)
+- **All graph mutations flow through `graph_service.apply_graph_update`.** Streamed deltas are *read from* `deps.graph_updates` / `deps.mastery_changes`, which the tools populate. Never write the graph from the stream module. (ADR 0004)
+- **Encryption boundary:** persist only via `routes/learn.py::save_message` (which calls `encrypt_if_present`). Never add a second persistence path. (ADR 0015 + CLAUDE.md)
+- **Legacy fallback survives.** `_legacy_chat` and the JSON `/chat` + `/start-session` routes stay callable and behaviorally unchanged. (ADR 0001/0015)
+- **Never wrap a stream route in a DBOS workflow.** (ADR 0011)
+- **Never use FastAPI `BackgroundTasks` in a streaming route** — it does not fire. Use `asyncio.create_task(asyncio.to_thread(...))` if post-stream work is ever needed. (`docs/attempts/2026-05-03-vault-gap-prompts-13-14.md`)
+- **No hardcoded model names** in new code. Model choice comes from `agents/_providers.py` slots; `learn.py::_resolve_model_pref` resolves the user's `model_pref`. (ADR 0008)
+- **Usage limits:** every agent run passes `usage_limits=ORCHESTRATOR_LIMITS` (from `agents/__init__.py`).
+- **Stamp `X-Request-ID`** on every stream; include `request_id` in every `error` payload. (ADR 0009)
+- Run backend commands from `backend/` using `venv/bin/python`. Frontend commands from `frontend/`.
+- `ruff check .` must pass before every backend commit.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `backend/services/agent_events.py` (modify) | Add `token` / `graph_update` / `done` to `SaplingEventType`. Wire-format helper `sapling_event_to_sse` unchanged. |
+| `backend/services/chat_stream.py` (create) | **New.** `stream_agent_turn()` — the only place that iterates a Pydantic AI event stream for chat, emits SaplingEvents, owns the graph-delta high-water mark, the completion/persistence handoff, and the fallback rungs. |
+| `backend/routes/learn.py` (modify) | Extract `_prepare_chat_run()` from `_chat_via_agent`; add `POST /chat/stream` and `POST /start-session/stream`. Existing routes untouched. |
+| `backend/tests/test_chat_stream.py` (create) | Unit tests for `stream_agent_turn` against a fake event stream. |
+| `backend/tests/test_learn_stream_routes.py` (create) | Route-level tests (auth, SSE wire format, PENDING_SESSIONS). |
+| `frontend/src/lib/sse.ts` (modify) | Add optional `idleTimeoutMs` stall guard. |
+| `frontend/src/lib/api.ts` (modify) | Add `streamChat()` / `startSessionStream()` + `GraphDelta` / `ChatResult` types. |
+| `frontend/src/lib/api.stream.test.ts` (create) | vitest for the consumer. |
+| `frontend/src/components/ChatPanel.tsx` (modify) | Streaming bubble states + Stop. |
+| `frontend/src/components/screens/Learn.tsx` (modify) | Call `streamChat`, reduce graph deltas, fallback to `sendChat`. |
+
+**Task order rationale:** Task 1 is a spike that gates everything (ADR-0012's open question). Tasks 2–5 are backend, bottom-up. Tasks 6–9 are frontend. Each task ends green and committed.
+
+---
+
+### Task 1: Spike — prove the provider streams incrementally
+
+**This gates the whole plan.** ADR 0012 deferred concept streaming partly because nobody verified Gemini emits usable incremental output through our stack. Confirm it before writing production code. Nothing here ships.
+
+**Files:**
+- Create (throwaway, deleted in Step 4): `backend/spike_stream.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a written finding that pins which events carry text and whether tool events interleave. Task 2 depends on the answer.
+
+- [ ] **Step 1: Write the spike script**
+
+```python
+# backend/spike_stream.py  — THROWAWAY. Deleted at the end of this task.
+import asyncio
+
+from agents import ORCHESTRATOR_LIMITS
+from agents.chat_tutor import agent_for_mode
+from agents.deps import SaplingDeps
+
+
+async def main():
+    agent = agent_for_mode("expository")
+    deps = SaplingDeps(
+        user_id="spike-user",
+        course_id=None,
+        supabase=None,
+        request_id="spike",
+        session_id=None,
+    )
+    counts: dict[str, int] = {}
+    first_text_event: str | None = None
+    async for event in agent.run_stream_events(
+        "Explain what an eigenvalue is in two sentences.",
+        deps=deps,
+        usage_limits=ORCHESTRATOR_LIMITS,
+    ):
+        name = type(event).__name__
+        counts[name] = counts.get(name, 0) + 1
+        # Which event class first carries text?
+        if first_text_event is None:
+            delta = getattr(getattr(event, "delta", None), "content_delta", None)
+            part = getattr(getattr(event, "part", None), "content", None)
+            if delta or part:
+                first_text_event = f"{name} -> {(delta or part)!r}"
+    print("EVENT COUNTS:", counts)
+    print("FIRST TEXT FROM:", first_text_event)
+
+
+asyncio.run(main())
+```
+
+- [ ] **Step 2: Run it against a real key**
+
+Run from `backend/`:
+
+```bash
+venv/bin/python spike_stream.py
+```
+
+Expected: a `PartDeltaEvent` count well above 1 (proving incremental text, not one blob), and `FIRST TEXT FROM: PartStartEvent -> '...'`.
+
+- [ ] **Step 3: Record the finding**
+
+**If `PartDeltaEvent` count is > 1:** the gate is closed — proceed. Append the observed counts to the spec's Risks section, replacing the "spike could fail" hypothetical with the measured result.
+
+**If it is 0 or 1** (one blob, no incremental deltas): **stop and report to Andres before continuing.** #70's premise does not hold on this provider/version, and the plan needs rescoping. Write the finding to `docs/attempts/2026-07-16-gemini-incremental-streaming.md` per the `log-attempt` convention.
+
+- [ ] **Step 4: Delete the spike and commit the finding**
+
+```bash
+rm backend/spike_stream.py
+git add docs/superpowers/specs/2026-07-16-streaming-design.md
+git commit -m "docs(spec): record streaming spike results — close ADR-0012 gate"
+```
+
+---
+
+### Task 2: Extend the SaplingEvent vocabulary
+
+**Files:**
+- Modify: `backend/services/agent_events.py:15` (the `SaplingEventType` Literal)
+- Test: `backend/tests/test_agent_events.py` (create if absent)
+
+**Interfaces:**
+- Consumes: existing `SaplingEvent`, `sapling_event_to_sse`.
+- Produces: `SaplingEventType` now accepts `"token" | "graph_update" | "done"`. Task 3 constructs these.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/test_agent_events.py
+import json
+
+from services.agent_events import SaplingEvent, sapling_event_to_sse
+
+
+def test_token_event_serializes_to_sse():
+    ev = SaplingEvent(type="token", step="reply", message="", data={"delta": "Hi"})
+    wire = sapling_event_to_sse(ev)
+    assert wire["event"] == "token"
+    assert json.loads(wire["data"])["data"]["delta"] == "Hi"
+
+
+def test_graph_update_and_done_types_accepted():
+    for t in ("graph_update", "done"):
+        assert SaplingEvent(type=t, step="reply", message="").type == t
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `venv/bin/python -m pytest tests/test_agent_events.py -q`
+Expected: FAIL — pydantic `ValidationError`, `"token"` is not a permitted `SaplingEventType`.
+
+- [ ] **Step 3: Extend the Literal**
+
+In `backend/services/agent_events.py`, replace line 15:
+
+```python
+SaplingEventType = Literal["status", "progress", "result", "error"]
+```
+
+with:
+
+```python
+# "status"/"progress"/"result" are the document-pipeline vocabulary (ADR 0006).
+# "token"/"graph_update"/"done" extend it for chat streams; "error" is shared.
+SaplingEventType = Literal[
+    "status", "progress", "result", "error", "token", "graph_update", "done"
+]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `venv/bin/python -m pytest tests/test_agent_events.py -q && ruff check .`
+Expected: 2 passed, ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/agent_events.py backend/tests/test_agent_events.py
+git commit -m "feat(events): extend SaplingEvent vocabulary with token/graph_update/done (#70)"
+```
+
+---
+
+### Task 3: `services/chat_stream.py` — the generator
+
+The heart of the change. Everything it does is proven by Task 4's tests against a fake stream; no live LLM.
+
+**Files:**
+- Create: `backend/services/chat_stream.py`
+
+**Interfaces:**
+- Consumes: `SaplingEvent` (Task 2); `SaplingDeps` (`agents/deps.py`) — specifically `deps.graph_updates: list` and `deps.mastery_changes: list`, which `agents/tools/graph.py` appends to at `:117` (`{"new_nodes": [...]}`), `:169` (`{"updated_nodes": [...]}`), and `:171` (mastery changes).
+- Produces:
+  - `async def stream_agent_turn(*, agent, user_message, run_kwargs, deps, on_complete, legacy_fallback) -> AsyncIterator[SaplingEvent]`
+  - `def merge_graph_updates(updates: list[dict]) -> dict`
+  Task 5 (routes) calls both.
+
+**Pydantic AI 1.89.1 event shapes** (verified by inspection — do not guess):
+
+| Event class | Fields | Carries | Emit a `token`? |
+|---|---|---|---|
+| `PartStartEvent` | `index, part, previous_part_kind, event_kind` | **the first text chunk**, at `event.part.content` | **yes** |
+| `PartDeltaEvent` | `index, delta, event_kind` | subsequent text at `event.delta.content_delta` | **yes** |
+| `PartEndEvent` | `index, part, next_part_kind, event_kind` | **the FULL assembled text** at `event.part.content` | **NO — would duplicate the reply** |
+| `FinalResultEvent` | `tool_name, tool_call_id, event_kind` | no text | no |
+| `FunctionToolCallEvent` | `part, args_valid, event_kind` | tool name at `event.part.tool_name` | no (emit `progress`) |
+| `FunctionToolResultEvent` | `result, content, event_kind` | tool finished — **check deps here** | no (maybe `graph_update`) |
+| `AgentRunResultEvent` | `result, event_kind` | final output at `event.result.output` | no (feeds `done`) |
+
+> **Two traps, both observed live against `gemini-2.5-pro` on 2026-07-16 (Task 1's spike), both regression-tested in Task 4:**
+> 1. The reply's first chunk arrives on `PartStartEvent`, **not** `PartDeltaEvent`. Handling only deltas drops the opening — for a two-sentence answer the spike saw the entire first sentence arrive this way.
+> 2. `PartEndEvent` carries the **complete assembled reply** on the same `part.content` attribute `PartStartEvent` uses. Reading `part.content` without checking the class emits the whole reply a second time (`"hello world"` → `"hello worldhello world"`).
+>
+> This is why `_text_from` dispatches on class name instead of duck-typing attributes.
+
+- [ ] **Step 1: Write the module**
+
+```python
+# backend/services/chat_stream.py
+"""Translate a Pydantic AI chat run into Sapling SSE events.
+
+The single seam for streaming chat turns (ADR 0006 vocabulary). Iterates
+`agent.run_stream_events()` — the only API that yields BOTH text deltas and
+mid-run tool events in one pass — and emits:
+
+    status:start -> token* -> (progress:<tool> -> graph_update)* -> done
+
+Graph deltas are READ from `deps.graph_updates` / `deps.mastery_changes`,
+which the graph tools populate as they write through
+`graph_service.apply_graph_update` (ADR 0004). This module never writes the
+graph and never persists a message: persistence is the route's, via
+`on_complete`.
+
+Exactly one of `on_complete` / `legacy_fallback` runs per turn — see
+`stream_agent_turn` for the rungs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, AsyncIterator, Awaitable, Callable
+
+from services.agent_events import SaplingEvent
+
+logger = logging.getLogger(__name__)
+
+
+def merge_graph_updates(updates: list[dict]) -> dict:
+    """Merge tool-emitted payloads into one {key: [items]} dict.
+
+    Mirrors the merge in `routes.learn._chat_via_agent` verbatim: keys
+    concatenate (setdefault + extend), never clobber.
+    """
+    merged: dict = {}
+    for gu in updates:
+        for key, items in gu.items():
+            merged.setdefault(key, []).extend(items)
+    return merged
+
+
+def _text_from(event: Any) -> str | None:
+    """Extract a NEW text chunk from a stream event, or None.
+
+    Dispatches on class name, which matters more than it looks (all three
+    shapes below were observed live against gemini-2.5-pro on 2026-07-16):
+
+      PartStartEvent  -> part.content        the reply's FIRST chunk
+      PartDeltaEvent  -> delta.content_delta each subsequent chunk
+      PartEndEvent    -> part.content        the FULL assembled text — SKIP
+
+    Reading `part.content` generically would emit the whole reply a second
+    time when PartEndEvent lands ("hello world" -> "hello worldhello
+    world"). Reading only deltas would drop the opening chunk. Both are
+    regression-tested.
+    """
+    cls_name = type(event).__name__
+
+    if cls_name == "PartDeltaEvent":
+        delta = getattr(getattr(event, "delta", None), "content_delta", None)
+        return delta if isinstance(delta, str) and delta else None
+
+    if cls_name == "PartStartEvent":
+        content = getattr(getattr(event, "part", None), "content", None)
+        return content if isinstance(content, str) and content else None
+
+    # PartEndEvent / FinalResultEvent / tool + result events carry no NEW text.
+    return None
+
+
+def _tool_name_from(event: Any) -> str | None:
+    for path in ("part.tool_name", "tool_name", "result.tool_name"):
+        obj: Any = event
+        try:
+            for attr in path.split("."):
+                obj = getattr(obj, attr)
+            if isinstance(obj, str):
+                return obj
+        except AttributeError:
+            continue
+    return None
+
+
+async def stream_agent_turn(
+    *,
+    agent: Any,
+    user_message: str,
+    run_kwargs: dict,
+    deps: Any,
+    on_complete: Callable[[str, dict, list], dict | None],
+    legacy_fallback: Callable[[], Awaitable[dict]] | None = None,
+    request_id: str = "",
+) -> AsyncIterator[SaplingEvent]:
+    """Stream one agent turn as SaplingEvents.
+
+    on_complete(reply, merged_graph_update, mastery_changes) -> extra `done`
+    data. It persists; it is called exactly once, after the run completes and
+    BEFORE `done` is yielded, so a mid-generation disconnect (which cancels
+    this generator at its current yield) persists nothing.
+
+    legacy_fallback() -> awaitable returning the route's pre-agent result,
+    used ONLY when the agent fails before emitting any text (Rung 1). It is
+    async because the routes' legacy paths are (`_legacy_chat`). It owns its
+    own persistence, so on_complete is NOT called on that branch — calling
+    both double-writes.
+    """
+    yield SaplingEvent(type="status", step="start", message="Starting.")
+
+    chunks: list[str] = []
+    final_output: str | None = None
+    # High-water marks: how much of deps.* we have already emitted.
+    graph_hw = 0
+    mastery_hw = 0
+
+    try:
+        async for event in agent.run_stream_events(user_message, **run_kwargs):
+            text = _text_from(event)
+            if text:
+                chunks.append(text)
+                yield SaplingEvent(
+                    type="token", step="reply", message="", data={"delta": text}
+                )
+                continue
+
+            cls_name = type(event).__name__
+
+            if cls_name == "FunctionToolCallEvent":
+                tool = _tool_name_from(event) or "tool"
+                yield SaplingEvent(
+                    type="progress", step=tool, message=f"Calling {tool}."
+                )
+                continue
+
+            if cls_name == "FunctionToolResultEvent":
+                # A graph tool may have just written. Emit only what is new.
+                new_nodes = merge_graph_updates(deps.graph_updates[graph_hw:])
+                new_mastery = deps.mastery_changes[mastery_hw:]
+                graph_hw = len(deps.graph_updates)
+                mastery_hw = len(deps.mastery_changes)
+                if new_nodes or new_mastery:
+                    yield SaplingEvent(
+                        type="graph_update",
+                        step="graph",
+                        message="Knowledge graph updated.",
+                        data={"nodes": new_nodes, "mastery_changes": new_mastery},
+                    )
+                continue
+
+            if cls_name == "AgentRunResultEvent":
+                output = getattr(getattr(event, "result", None), "output", None)
+                if isinstance(output, str):
+                    final_output = output
+
+    # Catches UsageLimitExceeded / UnexpectedModelBehavior (both Exception
+    # subclasses) and anything else the model or a tool raises. Deliberately
+    # NOT BaseException: asyncio.CancelledError must propagate so a client
+    # disconnect stays a cancellation — never a "fallback to legacy".
+    except Exception as exc:
+        if chunks:
+            # Rung 2: text already shown. Never silently re-run — the user
+            # would see the reply restart. Terminal error; persist nothing.
+            logger.warning("Chat stream failed mid-generation", exc_info=exc)
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor was interrupted. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+
+        # Rung 1: nothing shown yet — degrade to the route's legacy path.
+        logger.warning("Chat agent failed before first token; using legacy", exc_info=exc)
+        if legacy_fallback is None:
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor is unavailable. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+        try:
+            legacy = await legacy_fallback()
+        except Exception:
+            logger.exception("Legacy fallback also failed")
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor is unavailable. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
+        # legacy_fallback persisted its own rows; do NOT call on_complete.
+        yield SaplingEvent(
+            type="token", step="reply", message="",
+            data={"delta": legacy.get("reply", "")},
+        )
+        yield SaplingEvent(
+            type="done", step="reply", message="Complete.", data=legacy
+        )
+        return
+
+    reply = final_output if final_output is not None else "".join(chunks)
+    merged = merge_graph_updates(deps.graph_updates)
+    mastery = list(deps.mastery_changes)
+
+    extra = on_complete(reply, merged, mastery) or {}
+
+    yield SaplingEvent(
+        type="done",
+        step="reply",
+        message="Complete.",
+        data={
+            "reply": reply,
+            "graph_update": merged,
+            "mastery_changes": mastery,
+            **extra,
+        },
+    )
+```
+
+- [ ] **Step 2: Verify it imports and lints**
+
+Run from `backend/`:
+
+```bash
+venv/bin/python -c "from services.chat_stream import stream_agent_turn, merge_graph_updates; print('ok')" && ruff check services/chat_stream.py
+```
+
+Expected: `ok`, ruff clean. (Behavior is proven in Task 4 — this step only catches syntax/import errors.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/services/chat_stream.py
+git commit -m "feat(chat): add stream_agent_turn — Pydantic AI run → SaplingEvents (#70, #74)"
+```
+
+---
+
+### Task 4: Test `stream_agent_turn`
+
+**Files:**
+- Create: `backend/tests/test_chat_stream.py`
+
+**Interfaces:**
+- Consumes: `stream_agent_turn`, `merge_graph_updates` (Task 3).
+- Produces: nothing consumed downstream.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# backend/tests/test_chat_stream.py
+"""Unit tests for services/chat_stream.py against a fake event stream.
+
+No live LLM: FakeAgent yields stand-ins whose CLASS NAMES and attribute
+shapes match Pydantic AI 1.89.1 (verified by inspection), which is all
+stream_agent_turn dispatches on.
+"""
+import pytest
+
+from agents.deps import SaplingDeps
+from services.chat_stream import merge_graph_updates, stream_agent_turn
+
+
+# ── Fakes mirroring pydantic_ai event shapes ──────────────────────────────
+
+class TextPartDelta:
+    def __init__(self, content_delta):
+        self.content_delta = content_delta
+
+
+class PartDeltaEvent:
+    def __init__(self, content_delta):
+        self.delta = TextPartDelta(content_delta)
+
+
+class _TextPart:
+    def __init__(self, content):
+        self.content = content
+
+
+class PartStartEvent:
+    """First text chunk arrives here — NOT as a delta."""
+    def __init__(self, content):
+        self.part = _TextPart(content)
+
+
+class PartEndEvent:
+    """Carries the FULL assembled text on the same `.part.content`
+    attribute PartStartEvent uses. Must NOT produce a token."""
+    def __init__(self, content):
+        self.part = _TextPart(content)
+
+
+class _ToolPart:
+    def __init__(self, tool_name):
+        self.tool_name = tool_name
+
+
+class FunctionToolCallEvent:
+    def __init__(self, tool_name):
+        self.part = _ToolPart(tool_name)
+
+
+class FunctionToolResultEvent:
+    def __init__(self, on_fire=None):
+        # Simulates the tool having written to deps during its execution.
+        if on_fire:
+            on_fire()
+
+
+class _Result:
+    def __init__(self, output):
+        self.output = output
+
+
+class AgentRunResultEvent:
+    def __init__(self, output):
+        self.result = _Result(output)
+
+
+class FakeAgent:
+    def __init__(self, events, raise_after=None):
+        self._events = events
+        self._raise_after = raise_after
+
+    async def run_stream_events(self, user_message, **kwargs):
+        for i, ev in enumerate(self._events):
+            if self._raise_after is not None and i == self._raise_after:
+                raise RuntimeError("model blew up")
+            yield ev
+
+
+def make_deps():
+    return SaplingDeps(
+        user_id="u1", course_id="c1", supabase=None,
+        request_id="r1", session_id="s1",
+    )
+
+
+async def collect(agent, deps, on_complete, legacy_fallback=None):
+    events = []
+    async for ev in stream_agent_turn(
+        agent=agent, user_message="hi", run_kwargs={}, deps=deps,
+        on_complete=on_complete, legacy_fallback=legacy_fallback,
+        request_id="r1",
+    ):
+        events.append(ev)
+    return events
+
+
+# ── merge ─────────────────────────────────────────────────────────────────
+
+def test_merge_concatenates_and_never_clobbers():
+    merged = merge_graph_updates(
+        [{"new_nodes": [{"n": 1}]}, {"new_nodes": [{"n": 2}]}, {"updated_nodes": [{"n": 3}]}]
+    )
+    assert merged == {"new_nodes": [{"n": 1}, {"n": 2}], "updated_nodes": [{"n": 3}]}
+
+
+# ── happy path ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_first_chunk_from_part_start_is_not_dropped():
+    """PartStartEvent carries the reply's FIRST chunk. Regression: handling
+    only PartDeltaEvent silently truncates the opening."""
+    agent = FakeAgent([
+        PartStartEvent("Hello "),
+        PartDeltaEvent("world"),
+        AgentRunResultEvent("Hello world"),
+    ])
+    saved = {}
+    events = await collect(agent, make_deps(), lambda r, g, m: saved.update(reply=r) or {})
+    tokens = [e.data["delta"] for e in events if e.type == "token"]
+    assert tokens == ["Hello ", "world"]
+    assert saved["reply"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_part_end_event_does_not_duplicate_the_reply():
+    """PartEndEvent carries the FULL assembled text on .part.content — the
+    same attribute PartStartEvent uses for the FIRST chunk. Emitting a token
+    for it duplicates the whole reply in the user's bubble.
+
+    Regression: a duck-typed `getattr(event.part, 'content')` reader turns
+    "hello world" into "hello worldhello world". Observed live in Task 1's
+    spike."""
+    agent = FakeAgent([
+        PartStartEvent("hello "),
+        PartDeltaEvent("world"),
+        PartEndEvent("hello world"),      # full text — must be ignored
+        AgentRunResultEvent("hello world"),
+    ])
+    events = await collect(agent, make_deps(), lambda r, g, m: {})
+    tokens = [e.data["delta"] for e in events if e.type == "token"]
+    assert tokens == ["hello ", "world"], "PartEndEvent must not re-emit the reply"
+    assert "".join(tokens) == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_event_order_and_single_persistence():
+    agent = FakeAgent([
+        PartStartEvent("Hi"),
+        AgentRunResultEvent("Hi"),
+    ])
+    calls = []
+    events = await collect(agent, make_deps(), lambda r, g, m: calls.append(r) or {"extra": 1})
+    assert [e.type for e in events] == ["status", "token", "done"]
+    assert calls == ["Hi"], "on_complete must fire exactly once"
+    done = events[-1]
+    assert done.data["reply"] == "Hi"
+    assert done.data["extra"] == 1, "on_complete's return merges into done"
+
+
+@pytest.mark.asyncio
+async def test_graph_update_emitted_once_per_new_write():
+    """High-water mark: an already-emitted delta must not re-emit on the
+    next tool result."""
+    deps = make_deps()
+
+    def first_write():
+        deps.graph_updates.append({"new_nodes": [{"name": "Eigenvalues"}]})
+        deps.mastery_changes.append({"concept": "Eigenvalues", "before": 0.1, "after": 0.6})
+
+    agent = FakeAgent([
+        FunctionToolCallEvent("update_mastery_tool"),
+        FunctionToolResultEvent(on_fire=first_write),
+        PartStartEvent("Done."),
+        FunctionToolCallEvent("search_course_materials_tool"),
+        FunctionToolResultEvent(),          # writes nothing new
+        AgentRunResultEvent("Done."),
+    ])
+    events = await collect(agent, deps, lambda r, g, m: {})
+    graph_events = [e for e in events if e.type == "graph_update"]
+    assert len(graph_events) == 1, "second tool result added nothing — must not re-emit"
+    assert graph_events[0].data["nodes"] == {"new_nodes": [{"name": "Eigenvalues"}]}
+    assert graph_events[0].data["mastery_changes"][0]["after"] == 0.6
+    assert [e.type for e in events].index("graph_update") < [e.type for e in events].index("done")
+
+
+# ── failure rungs ─────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_rung1_failure_before_any_token_uses_legacy_and_skips_on_complete():
+    agent = FakeAgent([PartStartEvent("x")], raise_after=0)
+    on_complete_calls = []
+
+    async def fake_legacy():
+        # async because the real routes' legacy paths are (_legacy_chat)
+        return {"reply": "legacy reply", "graph_update": {}, "mastery_changes": []}
+
+    events = await collect(
+        agent, make_deps(),
+        on_complete=lambda r, g, m: on_complete_calls.append(r),
+        legacy_fallback=fake_legacy,
+    )
+    assert [e.type for e in events] == ["status", "token", "done"]
+    assert events[1].data["delta"] == "legacy reply"
+    assert events[-1].data["reply"] == "legacy reply"
+    assert on_complete_calls == [], "legacy owns persistence — on_complete must NOT run"
+
+
+@pytest.mark.asyncio
+async def test_rung2_failure_after_tokens_errors_and_persists_nothing():
+    agent = FakeAgent([PartStartEvent("Half a th"), PartDeltaEvent("ought")], raise_after=1)
+    on_complete_calls = []
+    legacy_calls = []
+
+    async def fake_legacy():
+        legacy_calls.append(1)
+        return {"reply": "nope"}
+
+    events = await collect(
+        agent, make_deps(),
+        on_complete=lambda r, g, m: on_complete_calls.append(r),
+        legacy_fallback=fake_legacy,
+    )
+    assert events[-1].type == "error"
+    assert events[-1].data["request_id"] == "r1"
+    assert on_complete_calls == [], "nothing may persist after a mid-stream failure"
+    assert legacy_calls == [], "never silently re-run once text was shown"
+
+
+@pytest.mark.asyncio
+async def test_cancel_mid_stream_persists_nothing():
+    """Client disconnect cancels the generator at its current yield."""
+    agent = FakeAgent([PartStartEvent("a"), PartDeltaEvent("b"), AgentRunResultEvent("ab")])
+    on_complete_calls = []
+    gen = stream_agent_turn(
+        agent=agent, user_message="hi", run_kwargs={}, deps=make_deps(),
+        on_complete=lambda r, g, m: on_complete_calls.append(r), request_id="r1",
+    )
+    await gen.__anext__()   # status
+    await gen.__anext__()   # first token
+    await gen.aclose()      # disconnect
+    assert on_complete_calls == [], "a partial reply must never persist"
+```
+
+- [ ] **Step 2: Run to verify they fail meaningfully**
+
+Run: `venv/bin/python -m pytest tests/test_chat_stream.py -q`
+Expected: all pass if Task 3 is correct. **If `test_first_chunk_from_part_start_is_not_dropped` fails**, `_text_from` is not reading `part.content` — fix Task 3's helper, do not weaken the test.
+
+If `pytest-asyncio` errors on the `@pytest.mark.asyncio` marks, check `pytest.ini`/`pyproject` for `asyncio_mode`; if it is `auto`, drop the marks.
+
+- [ ] **Step 3: Run the full suite for regressions**
+
+Run: `venv/bin/python -m pytest tests/ -q 2>&1 | tail -5 && ruff check .`
+Expected: no NEW failures. Known pre-existing on clean main: 2 `storage_service`, 1 OCR event-loop flake.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/test_chat_stream.py
+git commit -m "test(chat): cover stream_agent_turn ordering, deltas, and fallback rungs (#70, #74)"
+```
+
+---
+
+### Task 5: Wire the two stream routes
+
+**Files:**
+- Modify: `backend/routes/learn.py` — extract `_prepare_chat_run()` from `_chat_via_agent` (currently `:501-601`); add two routes after `chat()` (`:658-714`).
+- Test: `backend/tests/test_learn_stream_routes.py` (create)
+
+**Interfaces:**
+- Consumes: `stream_agent_turn`, `merge_graph_updates` (Task 3).
+- Produces: `POST /api/learn/chat/stream`, `POST /api/learn/start-session/stream`.
+
+- [ ] **Step 1: Extract `_prepare_chat_run` and keep `_chat_via_agent` on it**
+
+The context assembly currently inside `_chat_via_agent` (`learn.py:530-581`: deps, catalog chunk, RAG, shared-context constraint, model override, model settings) must be shared verbatim by both paths — not copy-pasted. Add above `_chat_via_agent`:
+
+```python
+def _prepare_chat_run(
+    *,
+    user_id: str,
+    session_id: str,
+    course_id: str,
+    mode: str,
+    user_message: str,
+    message_history: list,
+    use_shared_context: bool,
+    request_id: str,
+    model_pref: str | None = None,
+) -> tuple:
+    """Build (agent, assembled_message, run_kwargs, deps) for a chat turn.
+
+    Shared verbatim by the JSON path (`_chat_via_agent`) and the streaming
+    route so prompt assembly never forks. Extracted from `_chat_via_agent`;
+    behavior is unchanged.
+    """
+    agent = agent_for_mode(mode)
+
+    deps = SaplingDeps(
+        user_id=user_id,
+        course_id=course_id or None,
+        supabase=None,
+        request_id=request_id,
+        session_id=session_id,
+    )
+
+    bu_code = _get_course_info(course_id).get("course_code") if course_id else None
+    context_blocks: list[str] = []
+    if bu_code:
+        catalog_text = _get_catalog_chunk(bu_code)
+        if catalog_text:
+            context_blocks.append("COURSE CATALOG INFO (official BU course data):\n\n" + catalog_text)
+
+        from services.rag_service import retrieve_chunks, format_rag_context
+        rag_chunks = retrieve_chunks(user_message, course_id=bu_code, k=5)
+        rag_block = format_rag_context(rag_chunks)
+        if rag_block:
+            context_blocks.append(rag_block)
+
+    if context_blocks:
+        user_message = "\n\n".join(context_blocks) + "\n\n[STUDENT QUESTION]\n" + user_message
+
+    if not use_shared_context:
+        user_message = (
+            user_message
+            + "\n\n[Constraint: do not call any class-aggregate tool — "
+            "student opted out of shared context.]"
+        )
+
+    model_override = _resolve_model_pref(model_pref)
+    run_kwargs: dict = {
+        "deps": deps,
+        "message_history": message_history,
+        "usage_limits": ORCHESTRATOR_LIMITS,
+    }
+    if model_override is not None:
+        run_kwargs["model"] = model_override
+    if model_pref != "fast":
+        run_kwargs["model_settings"] = _build_pro_model_settings()
+
+    return agent, user_message, run_kwargs, deps
+```
+
+Then replace the body of `_chat_via_agent` from `agent = agent_for_mode(mode)` through the `run_kwargs` construction with:
+
+```python
+    agent, user_message, run_kwargs, deps = _prepare_chat_run(
+        user_id=user_id,
+        session_id=session_id,
+        course_id=course_id,
+        mode=mode,
+        user_message=user_message,
+        message_history=message_history,
+        use_shared_context=use_shared_context,
+        request_id=request_id,
+        model_pref=model_pref,
+    )
+```
+
+Leave the rest of `_chat_via_agent` (the `await agent.run(...)`, merge, and return) exactly as it is.
+
+- [ ] **Step 2: Verify the JSON path still passes**
+
+Run: `venv/bin/python -m pytest tests/test_learn_routes.py tests/test_chat_context_tools.py -q`
+Expected: PASS — a pure extraction must not change behavior.
+
+- [ ] **Step 3: Add the imports and the two routes**
+
+Add to the imports at the top of `learn.py`:
+
+```python
+from sse_starlette.sse import EventSourceResponse
+
+from services.agent_events import sapling_event_to_sse
+from services.chat_stream import stream_agent_turn
+```
+
+Add after `chat()` (i.e. after `learn.py:714`):
+
+```python
+@router.post("/chat/stream")
+async def chat_stream(body: ChatBody, request: Request):
+    """SSE token-streaming chat turn (#70) with live graph deltas (#74).
+
+    The JSON /chat route stays the non-streaming fallback (ADR 0001). No DBOS
+    wrap here — stream routes are deliberately outside durable execution
+    (ADR 0011); retries are client-driven and idempotent via X-Request-ID.
+    """
+    require_self(body.user_id, request)
+    _consume_pending(body.session_id, body.user_id)
+
+    request_id = (
+        getattr(request.state, "request_id", None)
+        or current_request_id()
+        or str(uuid.uuid4())
+    )
+
+    offering_id = _get_session_offering_id(body.session_id)
+    course_id = offering_course_id(offering_id) if offering_id else ""
+    # Load prior turns BEFORE the new user row is written, so history is
+    # conversation state up to (not including) this turn.
+    message_history = _load_message_history(body.session_id)
+
+    agent, assembled, run_kwargs, deps = _prepare_chat_run(
+        user_id=body.user_id,
+        session_id=body.session_id,
+        course_id=course_id,
+        mode=body.mode,
+        user_message=body.message,
+        message_history=message_history,
+        use_shared_context=body.use_shared_context,
+        request_id=request_id,
+        model_pref=body.model_pref,
+    )
+
+    def _persist(reply: str, graph_update: dict, mastery_changes: list) -> dict:
+        # Mirrors chat()'s ordering: user row, then assistant row. Runs only
+        # after the agent run completes, so a disconnect mid-generation
+        # persists nothing. Encryption happens inside save_message.
+        save_message(body.session_id, "user", body.message)
+        save_message(body.session_id, "assistant", reply, graph_update or None)
+        return {}
+
+    async def _legacy() -> dict:
+        # Rung 1 only (agent failed before any token). _legacy_chat persists
+        # its own user + assistant rows, so _persist must not also run —
+        # stream_agent_turn enforces that exclusivity.
+        return await _legacy_chat(body, request)
+
+    async def event_stream():
+        async for ev in stream_agent_turn(
+            agent=agent,
+            user_message=assembled,
+            run_kwargs=run_kwargs,
+            deps=deps,
+            on_complete=_persist,
+            legacy_fallback=_legacy,
+            request_id=request_id,
+        ):
+            yield sapling_event_to_sse(ev)
+
+    return EventSourceResponse(
+        event_stream(), headers={"X-Request-ID": request_id}
+    )
+```
+
+- [ ] **Step 4: Verify the chat stream route end to end at the unit level**
+
+Run: `venv/bin/python -m pytest tests/test_chat_stream.py -q && ruff check routes/learn.py services/chat_stream.py`
+Expected: PASS, ruff clean. (Route tests land in Step 6.)
+
+- [ ] **Step 5: Add the start-session stream route**
+
+```python
+@router.post("/start-session/stream")
+async def start_session_stream(body: StartSessionBody, request: Request):
+    """Streamed session opener — closes ADR-0015's start_session TODO by
+    running chat_tutor_agent instead of call_gemini_multiturn, and removes a
+    legacy call site on the primary path (#152/#151).
+
+    The JSON /start-session route is unchanged and remains the fallback.
+    PENDING_SESSIONS lazy materialization is preserved exactly: the row is
+    still written on first chat, by _consume_pending.
+    """
+    require_self(body.user_id, request)
+    request_id = (
+        getattr(request.state, "request_id", None)
+        or current_request_id()
+        or str(uuid.uuid4())
+    )
+    session_id = str(uuid.uuid4())
+
+    course_id = body.course_id or _get_course_id_for_topic(body.topic, body.user_id)
+    offering_id = resolve_offering(course_id, create=True) if course_id else ""
+
+    user_message = (
+        f"Student wants to learn about: {body.topic}\n\n"
+        "Begin the session with a warm greeting and your first question or explanation."
+    )
+
+    agent, assembled, run_kwargs, deps = _prepare_chat_run(
+        user_id=body.user_id,
+        session_id=session_id,
+        course_id=course_id,
+        mode=body.mode,
+        user_message=user_message,
+        message_history=[],
+        use_shared_context=body.use_shared_context,
+        request_id=request_id,
+        model_pref=body.model_pref,
+    )
+
+    def _stash(reply: str, graph_update: dict, mastery_changes: list) -> dict:
+        # Same lazy contract as the JSON route: nothing hits `sessions` until
+        # the first chat turn calls _consume_pending.
+        PENDING_SESSIONS[session_id] = {
+            "user_id": body.user_id,
+            "mode": body.mode,
+            "topic": body.topic,
+            "course_id": course_id,
+            "offering_id": offering_id,
+            "use_shared_context": body.use_shared_context,
+            "assistant_reply": reply,
+            "graph_update": graph_update,
+        }
+        return {"session_id": session_id, "graph_state": get_graph(body.user_id)}
+
+    async def event_stream():
+        async for ev in stream_agent_turn(
+            agent=agent,
+            user_message=assembled,
+            run_kwargs=run_kwargs,
+            deps=deps,
+            on_complete=_stash,
+            legacy_fallback=None,
+            request_id=request_id,
+        ):
+            yield sapling_event_to_sse(ev)
+
+    return EventSourceResponse(
+        event_stream(), headers={"X-Request-ID": request_id}
+    )
+```
+
+> `legacy_fallback=None` here is deliberate: the JSON `/start-session` remains reachable, and the client's Rung-3 fallback covers this route. A `None` fallback yields a terminal `error`, which the client handles.
+
+- [ ] **Step 6: Write route tests**
+
+```python
+# backend/tests/test_learn_stream_routes.py
+"""Route-level tests for the SSE chat streams."""
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def _sse_events(text: str) -> list[str]:
+    """Event names from a raw SSE body."""
+    return [
+        line.split("event:", 1)[1].strip()
+        for line in text.splitlines()
+        if line.startswith("event:")
+    ]
+
+
+class TestChatStream:
+    def test_streams_tokens_then_done(self):
+        async def fake_stream(**kwargs):
+            from services.agent_events import SaplingEvent
+            yield SaplingEvent(type="status", step="start", message="Starting.")
+            yield SaplingEvent(type="token", step="reply", message="", data={"delta": "Hi"})
+            kwargs["on_complete"]("Hi", {}, [])
+            yield SaplingEvent(type="done", step="reply", message="Complete.",
+                               data={"reply": "Hi", "graph_update": {}, "mastery_changes": []})
+
+        saved = []
+        with patch("routes.learn.stream_agent_turn", fake_stream), \
+             patch("routes.learn._prepare_chat_run",
+                   return_value=(MagicMock(), "msg", {}, MagicMock())), \
+             patch("routes.learn._consume_pending"), \
+             patch("routes.learn._get_session_offering_id", return_value="off-1"), \
+             patch("routes.learn.offering_course_id", return_value="c1"), \
+             patch("routes.learn._load_message_history", return_value=[]), \
+             patch("routes.learn.save_message", side_effect=lambda *a, **k: saved.append(a)):
+            r = client.post("/api/learn/chat/stream", json={
+                "session_id": "s1", "user_id": "u1", "message": "hello", "mode": "socratic",
+            })
+
+        assert r.status_code == 200
+        assert "text/event-stream" in r.headers["content-type"]
+        assert _sse_events(r.text) == ["status", "token", "done"]
+        assert [a[1] for a in saved] == ["user", "assistant"], "user row persists before assistant"
+
+    def test_requires_self(self):
+        """The guard must run BEFORE any streaming work starts.
+
+        Note the strict assertions: an earlier draft wrapped this in
+        try/except Exception: pass, which swallowed the AssertionError and
+        made the test pass even when auth was bypassed entirely.
+        """
+        from fastapi import HTTPException
+
+        with patch("routes.learn.require_self",
+                   side_effect=HTTPException(status_code=403, detail="forbidden")) as guard, \
+             patch("routes.learn._consume_pending"), \
+             patch("routes.learn._prepare_chat_run") as prep:
+            r = client.post("/api/learn/chat/stream", json={
+                "session_id": "s1", "user_id": "someone-else",
+                "message": "hi", "mode": "socratic",
+            })
+
+        assert r.status_code == 403
+        guard.assert_called_once()
+        prep.assert_not_called(), "auth must gate before any agent setup"
+
+
+class TestStartSessionStream:
+    def test_stashes_pending_session_and_does_not_write_db(self):
+        async def fake_stream(**kwargs):
+            from services.agent_events import SaplingEvent
+            extra = kwargs["on_complete"]("Welcome!", {}, [])
+            yield SaplingEvent(type="done", step="reply", message="Complete.",
+                               data={"reply": "Welcome!", **extra})
+
+        from routes.learn import PENDING_SESSIONS
+        PENDING_SESSIONS.clear()
+
+        with patch("routes.learn.stream_agent_turn", fake_stream), \
+             patch("routes.learn._prepare_chat_run",
+                   return_value=(MagicMock(), "msg", {}, MagicMock())), \
+             patch("routes.learn._get_course_id_for_topic", return_value="c1"), \
+             patch("routes.learn.resolve_offering", return_value="off-1"), \
+             patch("routes.learn.get_graph", return_value={"nodes": []}), \
+             patch("routes.learn.table") as tbl:
+            r = client.post("/api/learn/start-session/stream", json={
+                "user_id": "u1", "topic": "Eigenvalues", "mode": "socratic",
+            })
+
+        assert r.status_code == 200
+        assert len(PENDING_SESSIONS) == 1, "session must be stashed, not written"
+        stashed = next(iter(PENDING_SESSIONS.values()))
+        assert stashed["assistant_reply"] == "Welcome!"
+        assert stashed["topic"] == "Eigenvalues"
+        tbl.assert_not_called()
+```
+
+- [ ] **Step 7: Run the tests**
+
+Run: `venv/bin/python -m pytest tests/test_learn_stream_routes.py -q`
+Expected: PASS. If TestClient blocks on the stream, confirm the route returns `EventSourceResponse` (TestClient buffers SSE bodies fine; an infinite generator would hang — these fakes are finite).
+
+- [ ] **Step 8: Full suite + lint, then commit**
+
+```bash
+venv/bin/python -m pytest tests/ -q 2>&1 | tail -5
+ruff check .
+git add backend/routes/learn.py backend/services/chat_stream.py backend/tests/test_learn_stream_routes.py backend/tests/test_chat_stream.py
+git commit -m "feat(learn): SSE streaming routes for chat + start-session (#70, #74)"
+```
+
+---
+
+### Task 6: `streamSSE` stall guard
+
+**Files:**
+- Modify: `frontend/src/lib/sse.ts:29-40`
+- Test: `frontend/src/lib/sse.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: existing `streamSSE(url, init)`.
+- Produces: `streamSSE(url, init, opts?: { idleTimeoutMs?: number })`. Task 7 passes `{ idleTimeoutMs: 45000 }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/lib/sse.test.ts`:
+
+```ts
+it('rejects when no event arrives within idleTimeoutMs', async () => {
+  const stalledBody = new ReadableStream({
+    start() { /* never enqueues, never closes */ },
+  });
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(stalledBody, { status: 200 }) as never,
+  );
+
+  const iterate = async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _e of streamSSE('/x', {}, { idleTimeoutMs: 20 })) { /* drain */ }
+  };
+  await expect(iterate()).rejects.toThrow(/stalled/i);
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run from `frontend/`: `npx vitest run src/lib/sse.test.ts`
+Expected: FAIL — the test times out or errors on the unexpected third argument.
+
+- [ ] **Step 3: Implement the guard**
+
+In `frontend/src/lib/sse.ts`, change the signature and the read loop:
+
+```ts
+export async function* streamSSE<T = unknown>(
+  url: string,
+  init: RequestInit,
+  opts: { idleTimeoutMs?: number } = {},
+): AsyncGenerator<SSEEvent<T>> {
+  const res = await fetch(url, init);
+  // ... unchanged through `const reader = res.body.getReader();`
+```
+
+Then wrap each `reader.read()`:
+
+```ts
+      // A stalled stream (proxy dropped it, backend wedged) otherwise hangs
+      // the composer forever with no error. Race each read against a timer.
+      const { value, done } = opts.idleTimeoutMs
+        ? await Promise.race([
+            reader.read(),
+            new Promise<never>((_, reject) =>
+              setTimeout(
+                () => reject(new Error('Stream stalled — no data received.')),
+                opts.idleTimeoutMs,
+              ),
+            ),
+          ])
+        : await reader.read();
+```
+
+The existing `finally { await reader.cancel(); reader.releaseLock(); }` already releases the reader when the race rejects.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run src/lib/sse.test.ts && npm run typecheck`
+Expected: PASS, including the pre-existing sse tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/sse.ts frontend/src/lib/sse.test.ts
+git commit -m "feat(sse): add optional idleTimeoutMs stall guard to streamSSE (#70)"
+```
+
+---
+
+### Task 7: `streamChat()` consumer
+
+**Files:**
+- Modify: `frontend/src/lib/api.ts` (add near `sendChat`, `:112-130`)
+- Test: `frontend/src/lib/api.stream.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `streamSSE` with `idleTimeoutMs` (Task 6).
+- Produces:
+  ```ts
+  type GraphDelta = { nodes: Record<string, unknown[]>; mastery_changes: MasteryChange[] };
+  type ChatResult = { reply: string; graph_update: any; mastery_changes: any[]; session_id?: string; graph_state?: any };
+  streamChat(sessionId, userId, message, mode, useSharedContext, modelPref, handlers): Promise<ChatResult>
+  ```
+  Task 9 (Learn.tsx) calls it.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/src/lib/api.stream.test.ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+function sseBody(blocks: string[]): ReadableStream {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(c) {
+      for (const b of blocks) c.enqueue(enc.encode(b));
+      c.close();
+    },
+  });
+}
+
+const ev = (name: string, data: unknown) =>
+  `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('streamChat', () => {
+  it('accumulates tokens, surfaces graph deltas, resolves on done', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([
+          ev('status', { type: 'status', step: 'start', message: '' }),
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'Hel' } }),
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'lo' } }),
+          ev('graph_update', {
+            type: 'graph_update', step: 'graph', message: '',
+            data: { nodes: { new_nodes: [{ name: 'Eigen' }] }, mastery_changes: [] },
+          }),
+          ev('done', {
+            type: 'done', step: 'reply', message: '',
+            data: { reply: 'Hello', graph_update: {}, mastery_changes: [] },
+          }),
+        ]),
+        { status: 200 },
+      ) as never,
+    );
+
+    const { streamChat } = await import('./api');
+    const tokens: string[] = [];
+    const deltas: unknown[] = [];
+    const result = await streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, {
+      onToken: (t) => tokens.push(t),
+      onGraphUpdate: (d) => deltas.push(d),
+    });
+
+    expect(tokens).toEqual(['Hel', 'lo']);
+    expect(deltas).toHaveLength(1);
+    expect(result.reply).toBe('Hello');
+  });
+
+  it('rejects on a mid-stream error event', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'Half' } }),
+          ev('error', { type: 'error', step: 'reply', message: 'Interrupted.', data: { request_id: 'r1' } }),
+        ]),
+        { status: 200 },
+      ) as never,
+    );
+    const { streamChat } = await import('./api');
+    await expect(
+      streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, { onToken: () => {} }),
+    ).rejects.toThrow(/interrupted/i);
+  });
+
+  it('rejects when the stream never sends done', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'x' } })]),
+        { status: 200 },
+      ) as never,
+    );
+    const { streamChat } = await import('./api');
+    await expect(
+      streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, { onToken: () => {} }),
+    ).rejects.toThrow(/without a done/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/lib/api.stream.test.ts`
+Expected: FAIL — `streamChat` is not exported.
+
+- [ ] **Step 3: Implement**
+
+Add to `frontend/src/lib/api.ts` below `sendChat`:
+
+```ts
+export interface MasteryChange { concept: string; before: number; after: number }
+
+export interface GraphDelta {
+  nodes: Record<string, Array<Record<string, unknown>>>;
+  mastery_changes: MasteryChange[];
+}
+
+export interface ChatResult {
+  reply: string;
+  graph_update: any;
+  mastery_changes: MasteryChange[];
+  session_id?: string;
+  graph_state?: any;
+}
+
+interface StreamEvent {
+  type: string;
+  step: string;
+  message: string;
+  data?: Record<string, any> | null;
+}
+
+export interface StreamChatHandlers {
+  onToken?: (delta: string) => void;
+  onGraphUpdate?: (delta: GraphDelta) => void;
+  signal?: AbortSignal;
+}
+
+const STREAM_IDLE_MS = 45_000;
+
+async function consumeChatStream(
+  path: string,
+  payload: Record<string, unknown>,
+  { onToken, onGraphUpdate, signal }: StreamChatHandlers,
+): Promise<ChatResult> {
+  const { streamSSE } = await import('./sse');
+  let result: ChatResult | null = null;
+
+  for await (const e of streamSSE<StreamEvent>(
+    `${API_URL}${path}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      credentials: 'include',
+      signal,
+    },
+    { idleTimeoutMs: STREAM_IDLE_MS },
+  )) {
+    const ev = e.data;
+    if (ev.type === 'token') onToken?.(String(ev.data?.delta ?? ''));
+    else if (ev.type === 'graph_update') onGraphUpdate?.(ev.data as unknown as GraphDelta);
+    else if (ev.type === 'error') throw new Error(ev.message || 'The tutor was interrupted.');
+    else if (ev.type === 'done') result = ev.data as unknown as ChatResult;
+  }
+
+  if (!result) throw new Error('Chat stream ended without a done event.');
+  return result;
+}
+
+export const streamChat = (
+  sessionId: string,
+  userId: string,
+  message: string,
+  mode: string,
+  useSharedContext = true,
+  modelPref?: ModelPref,
+  handlers: StreamChatHandlers = {},
+) =>
+  consumeChatStream(
+    '/api/learn/chat/stream',
+    {
+      session_id: sessionId,
+      user_id: userId,
+      message,
+      mode,
+      use_shared_context: useSharedContext,
+      ...(modelPref ? { model_pref: modelPref } : {}),
+    },
+    handlers,
+  );
+
+export const startSessionStream = (
+  userId: string,
+  topic: string,
+  mode: string,
+  useSharedContext = true,
+  courseId?: string,
+  modelPref?: ModelPref,
+  handlers: StreamChatHandlers = {},
+) =>
+  consumeChatStream(
+    '/api/learn/start-session/stream',
+    {
+      user_id: userId,
+      topic,
+      mode,
+      use_shared_context: useSharedContext,
+      course_id: courseId,
+      ...(modelPref ? { model_pref: modelPref } : {}),
+    },
+    handlers,
+  );
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run src/lib/api.stream.test.ts && npm run typecheck`
+Expected: 3 passed, typecheck clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/api.ts frontend/src/lib/api.stream.test.ts
+git commit -m "feat(api): add streamChat/startSessionStream SSE consumers (#70, #74)"
+```
+
+---
+
+### Task 8: ChatPanel streaming bubble
+
+**Files:**
+- Modify: `frontend/src/components/ChatPanel.tsx`
+
+**Interfaces:**
+- Consumes: nothing new from earlier tasks directly — Learn.tsx (Task 9) drives it via props.
+- Produces: `ChatPanel` accepts `streamingText?: string | null` and `onStop?: () => void`. Task 9 passes both.
+
+Read the file first — its existing message/props shape decides the exact edit.
+
+- [ ] **Step 1: Add the props and render the live bubble**
+
+Add to the component's props interface:
+
+```ts
+  /** Assistant text arriving token-by-token; null when not streaming.
+   *  Rendered as a live bubble below the settled messages, then replaced by
+   *  the real message once the `done` event lands. */
+  streamingText?: string | null;
+  /** Abort the in-flight turn. Shown only while streaming. */
+  onStop?: () => void;
+```
+
+Render after the settled-message list, before the composer, following the file's existing assistant-bubble markup (reuse `MarkdownChat` exactly as settled messages do — do not fork the renderer):
+
+```tsx
+{streamingText !== null && streamingText !== undefined && (
+  <div className="chat-bubble chat-bubble--assistant" aria-live="polite">
+    {streamingText === ''
+      ? <TypingIndicator />
+      : <MarkdownChat>{streamingText}</MarkdownChat>}
+  </div>
+)}
+```
+
+If no `TypingIndicator` exists in the codebase, use the file's existing loading affordance rather than inventing one.
+
+- [ ] **Step 2: Disable the composer and show Stop while streaming**
+
+Where the send button/composer disabled state is computed, include `streamingText !== null && streamingText !== undefined`. Render the Stop control next to send when streaming:
+
+```tsx
+{onStop && streamingText !== null && streamingText !== undefined && (
+  <button type="button" className="btn btn--sm" onClick={onStop}>Stop</button>
+)}
+```
+
+- [ ] **Step 3: Verify**
+
+Run from `frontend/`: `npm run typecheck && npx eslint src/components/ChatPanel.tsx`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/ChatPanel.tsx
+git commit -m "feat(chat): streaming assistant bubble + stop control (#70)"
+```
+
+---
+
+### Task 9: Wire Learn.tsx — stream, reduce deltas, fall back
+
+**Files:**
+- Modify: `frontend/src/components/screens/Learn.tsx` (the send handler at `:300` calls `sendChat` today; `graphNodes` state at `:128,147`)
+
+**Interfaces:**
+- Consumes: `streamChat`, `GraphDelta`, `ChatResult` (Task 7); `ChatPanel`'s `streamingText` / `onStop` (Task 8).
+- Produces: end-user behavior. Terminal task.
+
+- [ ] **Step 1: Add streaming state and the graph reducer**
+
+```tsx
+  const [streamingText, setStreamingText] = React.useState<string | null>(null);
+  const streamAbort = React.useRef<AbortController | null>(null);
+
+  // Upsert streamed graph deltas into graphNodes so the Progress card's
+  // existing useMemo recomputes — no refetch, no extra round-trip (#74).
+  const applyGraphDelta = React.useCallback((delta: GraphDelta) => {
+    const incoming = Object.values(delta.nodes ?? {}).flat() as Array<Record<string, any>>;
+    if (!incoming.length) return;
+    setGraphNodes((prev) => {
+      const byId = new Map(prev.map((n) => [n.id, n]));
+      for (const node of incoming) {
+        const id = node.id ?? node.node_id;
+        if (!id) continue;
+        const existing = byId.get(id);
+        byId.set(id, existing ? { ...existing, ...node } : (node as any));
+      }
+      return Array.from(byId.values());
+    });
+  }, []);
+```
+
+Import `streamChat` and the types alongside the existing `sendChat` import.
+
+- [ ] **Step 2: Stream the turn, with the Rung-3 fallback**
+
+Replace the `const res = await sendChat(...)` call at `:300` with:
+
+```tsx
+      const controller = new AbortController();
+      streamAbort.current = controller;
+      setStreamingText('');
+      let sawToken = false;
+      let res: ChatResult;
+      try {
+        res = await streamChat(sessionId, userId, userText, mode, sharedCtx, modelPref, {
+          onToken: (delta) => {
+            sawToken = true;
+            setStreamingText((t) => (t ?? '') + delta);
+          },
+          onGraphUpdate: applyGraphDelta,
+          signal: controller.signal,
+        });
+      } catch (err) {
+        if (controller.signal.aborted) throw err;   // user pressed Stop
+        if (sawToken) throw err;                    // Rung 2: interrupted, surface it
+        // Rung 3: the stream never produced text — retry non-streaming.
+        res = await sendChat(sessionId, userId, userText, mode, sharedCtx, modelPref);
+      } finally {
+        setStreamingText(null);
+        streamAbort.current = null;
+      }
+```
+
+The existing code after this point — appending the assistant message from `res.reply`, handling `res.mastery_changes` — is unchanged, because `done` returns the same shape the JSON route does.
+
+- [ ] **Step 3: Wire Stop and unmount cleanup**
+
+Pass to `<ChatPanel>`: `streamingText={streamingText}` and `onStop={() => streamAbort.current?.abort()}`.
+
+Add the cleanup effect (guards the #131/#133 leaked-stream class):
+
+```tsx
+  React.useEffect(() => () => streamAbort.current?.abort(), []);
+```
+
+- [ ] **Step 4: Verify**
+
+Run from `frontend/`: `npm run typecheck && npx eslint src/components/screens/Learn.tsx && npx vitest run`
+Expected: all clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/screens/Learn.tsx
+git commit -m "feat(learn): stream tutor replies with live graph deltas (#70, #74)"
+```
+
+- [ ] **Step 6: Manual e2e smoke (required before the PR)**
+
+Run the backend (`venv/bin/python main.py`) and frontend (`npm run dev`), then verify each:
+
+1. A tutor turn renders text progressively — not one blob at the end.
+2. When the tutor moves mastery, the Progress card updates **mid-turn**, with no refetch in the Network tab.
+3. Stop mid-generation halts the text; the message does not appear in history after a reload.
+4. Kill the backend mid-generation → the bubble shows interrupted; after restart+reload, **no phantom partial message** in history.
+5. Point the frontend at a backend with the stream route disabled (or return 500 from it) → the turn still completes via the JSON fallback.
+
+Record the results in the PR body. If #2 fails, check `deps.graph_updates` is actually populated at tool-result time — that is the #74 acceptance.
+
+- [ ] **Step 7: Open the PR**
+
+```bash
+git push -u origin feat/streaming-tutor
+gh pr create --base main \
+  --title "feat(learn): stream tutor replies over SSE with live graph deltas (#70, #74)" \
+  --body "Implements docs/superpowers/specs/2026-07-16-streaming-design.md.
+
+Closes #70
+Closes #74
+
+Also: migrates start_session onto chat_tutor_agent (closes ADR-0015's TODO, removes a legacy call_gemini_multiturn site from the primary path — progress on #152/#151).
+
+## Verification
+<paste the Step 6 smoke results>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** every spec section maps to a task — event vocabulary → 2; `chat_stream.py` incl. high-water marks, persistence contract, cancellation → 3, 4; `_prepare_chat_run` extraction, both routes, start-session `PENDING_SESSIONS` contract → 5; stall timeout → 6; consumer → 7; bubble states → 8; reducer, rollout with fallback, e2e smoke → 9. The ADR-0012 gate → 1.
+
+**Known gaps, deliberately left to the implementer:**
+- Task 8's exact JSX depends on `ChatPanel.tsx`'s current markup, which the task says to read first. The props contract is pinned; the markup is not.
+- The `failed/stopped` bubble state from the spec is implemented as "clear the streaming bubble and surface the error through Learn's existing error handling" rather than a bespoke interrupted-bubble UI. If the spec's "keep the partial text, mark it interrupted" affordance is wanted verbatim, it needs a follow-up task once ChatPanel's error surface is known.
+
+**Type consistency:** `stream_agent_turn`'s signature is identical across Tasks 3, 4, and 5 — `legacy_fallback` is `Callable[[], Awaitable[dict]] | None` everywhere, awaited in the module, async in the tests, and satisfied by `_legacy_chat` in the route. `GraphDelta` / `ChatResult` are defined in Task 7 and consumed with matching shapes in Task 9. `merge_graph_updates` is named identically throughout.
+
+**Verified against the installed stack, not assumed:** pydantic-ai is 1.89.1 in `backend/venv`; `Agent.run_stream_events` exists and yields both text and tool events; the event dataclass fields in Task 3's table came from `dataclasses.fields()` inspection. `requirements.txt` pins only `>=0.0.20`, so if a future bump changes these class names, `_text_from` / `_tool_name_from` degrade to returning `None` (silent truncation) rather than raising — Task 4's `test_first_chunk_from_part_start_is_not_dropped` is the canary.

--- a/docs/superpowers/specs/2026-07-16-streaming-design.md
+++ b/docs/superpowers/specs/2026-07-16-streaming-design.md
@@ -1,0 +1,298 @@
+# Streaming the tutor: SSE token streaming + live graph deltas
+
+**Date:** 2026-07-16
+**Owner:** Andres (AndresL230)
+**Issues:** #70 (streaming text in Learn), #74 (live progress card via SSE graph deltas)
+**Also advances:** #152 / #151 (retire `gemini_service`), ADR-0015's `start_session` follow-up TODO
+**Status:** design approved, ready for implementation plan
+
+## Problem
+
+The tutor chat is request/response. `POST /api/learn/chat` runs the model to completion and
+returns one JSON dict, so the student watches a spinner for the whole multi-second generation.
+`POST /api/learn/start-session` is worse: it blocks on the legacy `call_gemini_multiturn` while
+the model composes a greeting against a full system prompt, and that spinner opens every session.
+
+Meanwhile the Learn page's Progress card reads `graphNodes` fetched once at bootstrap. The tutor
+mutates mastery mid-session through `apply_graph_update`, but the card only reflects it after a
+page reload, so it feels stale exactly when the student is making progress.
+
+SSE plumbing already exists and is proven on the document-upload path. This design wires the same
+mechanism into chat, and — because both issues need the same terminal event — implements #70 and
+#74 together.
+
+## Scope
+
+**In scope**
+
+- SSE token streaming for `/api/learn/chat` (#70).
+- Live `graph_update` deltas on that same stream (#74).
+- A shared streaming seam (`services/chat_stream.py`) that both chat routes use, so a third
+  surface (notes chat) is a drop-in later.
+- Migrating `start_session` onto `chat_tutor_agent` and streaming its greeting.
+- One frontend consumer (`streamChat`) built on the existing `streamSSE`, plus the stall timeout
+  that `sse.ts` lacks today.
+
+**Out of scope**
+
+- `/action` and `/mode-switch` (#70 non-goals; they stay legacy).
+- Notes chat, quiz generation, study-guide streaming — the foundation makes them follow-ups.
+- Streaming tool-call *progress* to the UI beyond the graph deltas #74 asks for.
+- Reworking mastery computation or the agent tool surface.
+- Resumable streams / two-phase upload (ADR 0010's deferred design).
+- Retrofitting the document-upload pipeline. Its events are unchanged.
+
+## Constraints (from the vault — these bind the design)
+
+| Source | Constraint |
+|---|---|
+| ADR 0006 | SSE runs on `sse-starlette` + the `SaplingEvent` schema + `map_to_sapling_event`. New event types **extend** that vocabulary; we do not adopt another protocol. Frontend consumption goes through `streamSSE` — no second parser. |
+| ADR 0004 | All graph mutations flow through `graph_service.apply_graph_update`. Streamed deltas must be *sourced from* the tools' writes, never a parallel write path. |
+| ADR 0015 + CLAUDE.md | Encryption boundary: `_load_message_history` decrypts on read, `save_message` encrypts on write. The agent never sees ciphertext, and a token stream must not create a second, unencrypted persistence path. |
+| ADR 0001 / 0015 | Legacy fallback survives. `_legacy_chat` stays callable and correct; the rollback contract is that the JSON routes still work untouched. |
+| ADR 0011 | **Do not** wrap SSE stream routes in DBOS workflows — the asymmetry is deliberate. Retry safety comes from client retries + `X-Request-ID` idempotency. |
+| ADR 0009 | Every stream stamps `X-Request-ID`; error payloads carry it for Logfire correlation. |
+| ADR 0008 | Model choice stays in `agents/_providers.py` task slots + `SAPLING_MODEL_*` overrides. No hardcoded model in the stream module. |
+| `docs/attempts/2026-05-03-vault-gap-prompts-13-14.md` | FastAPI `BackgroundTasks` **does not fire** for streaming responses. Post-stream work uses `asyncio.create_task(asyncio.to_thread(...))`. |
+| ADR 0012 | Its empirical gate is still unanswered: nobody has verified that our Gemini + Pydantic AI versions emit usable incremental deltas via `run_stream`. **This design opens with a spike to close that gate.** |
+
+## Architecture
+
+One shared generator, two thin routes, unchanged JSON endpoints beneath as fallback.
+
+```
+Learn.tsx / ChatPanel          ← token / graph_update / done / error (SSE)
+  └─ api.ts streamChat()       ← wraps lib/sse.ts streamSSE (+ idle timeout)
+       └─ POST /api/learn/chat/stream · /api/learn/start-session/stream
+            └─ routes/learn.py (thin: auth, history load, context assembly)
+                 └─ services/chat_stream.py  ← NEW: run_stream → SaplingEvents
+                      └─ chat_tutor_agent (agent_for_mode)
+                           └─ apply_graph_update_tool / update_mastery_tool → deps
+```
+
+Routes stay thin: `require_self`, history load, RAG/catalog/constraint assembly (all unchanged
+from today), then hand an async generator to `EventSourceResponse`.
+
+### Event vocabulary
+
+Three new `SaplingEventType` members. Every event keeps the existing
+`{type, step, message, data}` envelope, so one parser and one switch serve every stream. The
+per-token envelope overhead (~40 bytes) is deliberate: uniformity beats terseness at chat volume.
+
+| type | status | `data` payload | meaning |
+|---|---|---|---|
+| `status` / `progress` / `result` / `error` | existing | unchanged | upload vocabulary, untouched; chat streams reuse `status:start`, `progress:<tool>`, and `error` |
+| **`token`** | new | `{"delta": "..."}`, `step="reply"` | one text delta; client appends to the live bubble |
+| **`graph_update`** | new | `{"nodes": {"new_nodes": [{concept_name, initial_mastery}], "updated_nodes": [{concept_name, mastery_delta}]}, "mastery_changes": [{concept, before, after}]}` | emitted after a graph tool result (#74); client matches by **concept name** — see the correction below |
+| **`done`** | new | `{"reply", "graph_update", "mastery_changes", "session_id"?}` | terminal; canonical reply reconciles token drift. Same dict the JSON route returns today |
+
+### Turn timeline
+
+1. Client `POST`s; stream opens; `X-Request-ID` stamped.
+2. `status:start`.
+3. `token` × N.
+4. `progress:update_mastery` when a graph tool fires.
+5. `graph_update` — the Progress card moves live.
+6. `token` × N (rest of the reply).
+7. Run completes → **persist**: `save_message(user)` then `save_message(assistant, graph_update)`,
+   through the existing encrypting boundary, in today's order.
+8. `done`.
+
+### Persistence contract
+
+Messages persist exactly when the agent run completes (step 7), **before** `done` is emitted —
+`done` delivery is best-effort. Consequences, stated explicitly:
+
+- Disconnect **during** generation: the generator is cancelled at its current `yield`,
+  `on_complete` never runs, nothing persists. The student resends. No partial replies in history.
+- Disconnect **after** completion but before `done` lands: the turn is saved; a history refetch
+  recovers it. No double-write, because persistence is keyed to run completion, not to delivery.
+
+## Backend
+
+### `services/chat_stream.py`
+
+```python
+async def stream_agent_turn(
+    *,
+    agent,                # agent_for_mode(mode)
+    user_message: str,    # already RAG/context/constraint-assembled
+    run_kwargs: dict,     # deps, message_history, usage_limits, model, model_settings
+    deps: SaplingDeps,    # watched for graph-tool accumulation
+    on_complete,          # (reply, merged_graph_update, mastery_changes) -> dict | None
+                          #   persists + returns extra `done` data
+    legacy_fallback,      # () -> dict | None — the route's own pre-agent path,
+                          #   used only by Rung 1; owns its persistence
+) -> AsyncIterator[SaplingEvent]
+```
+
+- **Context assembly stays in `learn.py`.** Today's `_chat_via_agent` splits into
+  `_prepare_chat_run()` — RAG retrieval, catalog block, shared-context constraint, model-pref
+  resolution — shared verbatim by the JSON and stream paths, and the run itself. No duplicated
+  prompt logic.
+- **Token deltas:** iterate the Pydantic AI stream (exact API pinned by the spike), yield `token`
+  events. This extends the `map_to_sapling_event` mapper family rather than replacing it; the
+  mapper keeps dispatching on `type(event).__name__` so version churn stays absorbed there.
+- **Graph deltas:** after each tool-result event, diff `deps.graph_updates` / `deps.mastery_changes`
+  against a high-water mark; yield one `graph_update` per new accumulation. The data originates
+  from `apply_graph_update` via the tools (ADR 0004).
+- **Completion:** build the same `{reply, graph_update, mastery_changes}` dict `_chat_via_agent`
+  returns today (including the `setdefault(...).extend(...)` merge of `deps.graph_updates`), call
+  `on_complete` (the route's persistence closure), yield `done`.
+- **Cancellation:** client disconnect cancels the generator at its current `yield`; `on_complete`
+  hasn't run, so nothing persists. No `BackgroundTasks`.
+- **No DBOS wrap** (ADR 0011).
+
+### Routes
+
+`POST /api/learn/chat/stream` and `POST /api/learn/start-session/stream`, both
+`EventSourceResponse`, both `require_self`-gated, both stamping `X-Request-ID`.
+
+`start_session` migrates onto `chat_tutor_agent`:
+
+- Same prompt assembly; `agent_for_mode(mode)`; greeting streams through `stream_agent_turn`.
+- Graph writes happen in-band via tools (and their deltas ride the stream) instead of via
+  `<graph_update>`-tag parsing.
+- `on_complete` stashes `PENDING_SESSIONS[session_id]` — the lazy-materialization contract and
+  `_consume_pending` are untouched.
+- `done` carries `{session_id, reply, graph_update, mastery_changes, graph_state}`.
+
+The JSON `/start-session` and `/chat` stay exactly as they are (ADR 0001/0015 rollback contract).
+
+### Fallback ladder
+
+1. **Agent fails before the first token** (`UsageLimitExceeded`, `UnexpectedModelBehavior`, any
+   exception) → run the route's legacy path *inside* the stream and emit its reply as a single
+   `token` plus a normal `done`. The client cannot tell the difference.
+
+   Each route supplies its own legacy callable, since the two differ: `/chat/stream` falls back to
+   `_legacy_chat` (which persists its own user + assistant rows); `/start-session/stream` falls
+   back to the existing `start_session` body (`call_gemini_multiturn` → `extract_graph_update` →
+   `apply_graph_update` → stash `PENDING_SESSIONS`).
+
+   **When Rung 1 fires, `on_complete` must not run** — the legacy callable already owns its
+   persistence, and calling both would double-write. `stream_agent_turn` therefore treats the
+   legacy callable and `on_complete` as mutually exclusive branches: exactly one runs per turn.
+2. **Failure mid-stream** (tokens already sent) → terminal `error` event carrying `request_id`;
+   persist nothing; client marks the bubble interrupted and offers Retry. No silent auto-retry
+   once text has been shown.
+3. **Stream fails to open** (HTTP/network/proxy) → `streamChat` throws before any event; Learn
+   transparently retries the turn via non-streaming `sendChat`, which keeps its own agent→legacy
+   ladder.
+
+## Frontend
+
+### `api.ts`
+
+```ts
+streamChat(sessionId, userId, message, mode, useSharedContext, modelPref, {
+  onToken:       (delta: string) => void,
+  onGraphUpdate: (u: GraphDelta) => void,
+  signal:        AbortSignal,
+}): Promise<ChatResult>   // resolves on `done`; rejects on `error`, stall, or open failure
+```
+
+- Built on the existing `streamSSE`, which gains one optional `idleTimeoutMs` (default 45s): no
+  event within the window aborts the reader and rejects. That is the streaming half of #192; the
+  error-classification half stays in #192.
+- `IS_LOCAL_MODE` never opens a stream — today's mock `sendChat` path is preserved.
+- `startSessionStream` mirrors the shape and resolves with the session payload.
+
+### `ChatPanel` — assistant bubble states
+
+| state | behavior |
+|---|---|
+| **waiting** | stream open, no token yet: typing indicator; composer disabled; Stop visible |
+| **streaming** | text grows per token through `MarkdownChat`; re-renders batched via `requestAnimationFrame` (one paint per frame, not per token) |
+| **final** | on `done`, swap to the canonical `reply`; re-enable composer |
+| **failed / stopped** | mid-stream `error` or user Stop: keep the partial text visually, mark it interrupted, offer Retry (nothing was persisted, so Retry re-sends the turn) |
+
+Cleanup: unmount and session-switch abort the in-flight reader through the same `AbortSignal`,
+guarding the #131/#133 leaked-stream bug class at one seam.
+
+### `Learn.tsx` — graph reducer (#74)
+
+`onGraphUpdate` upserts into `graphNodes`, and the Progress card recomputes through its existing
+`useMemo` — zero extra HTTP round-trips per turn, which is #74's acceptance criterion.
+`mastery_changes` accumulate in session state for the end-of-session summary, matching what the
+JSON path returns today.
+
+> **CORRECTION (2026-07-16, found during implementation — this design was wrong).**
+> This spec originally specified "upsert by node id" against a payload of
+> `{id, name, course_id, mastery_score, mastery_tier}`. **That payload does not exist.** The graph
+> tools (`backend/agents/tools/graph.py`) append `{"new_nodes": [{concept_name, initial_mastery}]}`
+> and `{"updated_nodes": [{concept_name, mastery_delta}]}` — there is **no node id** and **no
+> absolute mastery score** anywhere in them. Only the sibling `mastery_changes` array carries
+> authoritative absolute values, as `{concept, before, after}`.
+>
+> The shipped reducer therefore:
+> - **matches by concept name** (case/whitespace-normalized, mirroring the backend's
+>   `_normalize_concept`), keeping an id path only for forward compatibility;
+> - treats **`mastery_changes` as the authority** for score updates — `mastery_delta` has no safe
+>   client-side baseline to apply it against;
+> - inserts unknown concepts as a `stream-<slug>` placeholder, resolving color/subject/course and
+>   an edge to the subject root from the same `cardCourseId` the manual `addConcept` path uses
+>   (a placeholder without those renders black and orphaned in the 3D rail);
+> - ignores `new_edges` / `recommended_next` — the `GraphUpdate` type declares them, but only the
+>   legacy fallback path ever populates them.
+>
+> Consequence worth knowing: a turn that only *adds* concepts (`new_nodes`) moves no score, because
+> no `mastery_changes` are emitted. Only `update_mastery_tool` on an existing concept moves the
+> Progress card.
+
+### Rollout
+
+Default-on with automatic fallback. No feature flag: the fallback ladder is the safety mechanism,
+staging exists for pre-prod verification, and a flag would leave a cleanup chore behind.
+
+## Testing
+
+| Layer | Tool | What it proves |
+|---|---|---|
+| **Spike (first)** | throwaway script against a staging key | ADR-0012's gate: our Pydantic AI + Gemini versions really do emit incremental text deltas and mid-run tool events via `run_stream`. Pins which API the module uses. **Everything downstream depends on this.** |
+| chat_stream unit | pytest + fake agent stream | event ordering (`start` → `token` → `graph_update` → `done`); persistence fires exactly once, after completion; cancel-before-completion persists nothing; Rung-1 fallback emits the legacy reply as one token; graph-delta high-water-mark diffing (no re-emission) |
+| route | pytest + httpx, conftest mock Supabase | SSE wire format parses; `require_self` enforced on both stream routes; start-session stashes `PENDING_SESSIONS`; JSON routes behave identically to before |
+| frontend unit | vitest (following `sse.test.ts`) | `streamChat` token accumulation, `done` resolution, mid-stream error rejection, stall timeout; reducer upsert for both existing and new nodes |
+| e2e smoke | staging, manual checklist | a real tutor turn streams; the Progress card moves mid-turn; Stop works; killing the backend mid-turn yields a failed bubble and **no phantom message** in history |
+
+## Risks
+
+- ~~**The spike could fail**~~ — **RESOLVED 2026-07-16. ADR-0012's gate is closed.** Measured
+  against `gemini-2.5-pro` via `Agent.run_stream_events`, prompt "Explain what an eigenvalue is in
+  two sentences":
+
+  ```
+  EVENT COUNTS: {'PartStartEvent': 1, 'FinalResultEvent': 1, 'PartDeltaEvent': 2,
+                 'PartEndEvent': 1, 'AgentRunResultEvent': 1}
+  FIRST TEXT FROM: PartStartEvent -> 'An eigenvalue is the special number that tells you how much a'
+  ```
+
+  Text is genuinely incremental (multiple deltas, not one blob), so #70's premise holds. The spike
+  also caught two carrier traps that would have shipped as bugs, now encoded in the plan and
+  regression-tested:
+
+  1. The reply's **first** chunk arrives on `PartStartEvent`, not `PartDeltaEvent` — handling only
+     deltas drops the opening (here, the whole first sentence).
+  2. `PartEndEvent` carries the **full assembled reply** on the same `part.content` attribute —
+     emitting a token for it duplicates the entire reply (`"hello world"` → `"hello worldhello
+     world"`, reproduced live).
+
+  Hence `_text_from` dispatches on class name rather than duck-typing attributes.
+
+  Note the granularity is coarse (~4 chunks for two sentences), so the win is "text appears in
+  stages within ~1s" rather than a per-word typewriter. That is still a large improvement over a
+  multi-second spinner, but it is worth confirming against a long reply during the Task 9 smoke.
+- **Token-render cost** — a long reply re-rendering Markdown per token could jank. Mitigation:
+  rAF batching, measured during the e2e smoke.
+- **`learn.py` churn overlaps other work** — the file is active. Mitigation: land the spike and
+  `chat_stream.py` first (additive), then the route changes in a focused diff.
+
+## Acceptance
+
+- #70: a tutor turn renders tokens as they arrive; Stop aborts cleanly; nothing partial persists;
+  the legacy path still serves a correct turn when the agent trips.
+- #74: during a live session, a model-triggered graph update moves the Progress card with no page
+  reload and no extra REST round-trip.
+- `start_session` runs on `chat_tutor_agent`, streams its greeting, and keeps the
+  `PENDING_SESSIONS` contract intact.
+- The JSON `/chat` and `/start-session` routes remain byte-compatible for non-streaming clients.

--- a/frontend/e2e/upload.spec.ts
+++ b/frontend/e2e/upload.spec.ts
@@ -34,6 +34,13 @@
  *
  * Waiting is event-based only (no waitForTimeout): every wait is an
  * auto-retrying expect() on UI state that a pipeline event flips.
+ *
+ * Also carries the #435 library-course-filter regression coverage: once the
+ * uploaded document appears, the journey resolves its seeded course from
+ * Postgres and asserts filtering the library by that course still surfaces
+ * the document (and "Uncategorized" does not) — the regression being that
+ * GET /api/documents/user/{id} never returned course_id, so every upload
+ * silently miscategorized as "Uncategorized" regardless of its real course.
  */
 import path from "node:path";
 
@@ -153,4 +160,37 @@ test("upload → SSE → document appears in library and Postgres", async ({
   // The card renders the decrypted summary — the encryption round-trip
   // (encrypt at persist, decrypt at read) closed correctly.
   await expect(card).toContainText(SCRIPTED_ABSTRACT_SNIPPET);
+
+  // ── Library course filter matches the seeded course (#435) ────────────
+  // Regression: GET /api/documents/user/{id} used to return offering_id but
+  // never the abstract course_id that Library.tsx filters/labels on, so a
+  // freshly uploaded doc could never match a course filter — it always
+  // counted as "Uncategorized" no matter which course it was tagged with.
+  // Resolve the seeded course from the persisted row itself (offering_id →
+  // course_offerings.course_id) rather than assuming which enrolled course
+  // the upload modal defaulted to.
+  const offeringRows = await queryRaw(
+    `SELECT course_id FROM course_offerings WHERE id = $1`,
+    [doc.offering_id],
+  );
+  const courseId = (offeringRows[0] as { course_id: string } | undefined)
+    ?.course_id;
+  expect(
+    courseId,
+    "the document's offering must resolve to an abstract course",
+  ).toBeTruthy();
+
+  const courseFilter = page.getByTestId(`library-course-filter-${courseId}`);
+  await expect(courseFilter).toBeVisible();
+  await courseFilter.click();
+
+  // The uploaded doc matches its course's filter — not dropped, not stuck
+  // under "Uncategorized".
+  await expect(card).toBeVisible();
+
+  const uncategorizedFilter = page.getByTestId(
+    "library-course-filter-uncategorized",
+  );
+  await uncategorizedFilter.click();
+  await expect(card).not.toBeVisible();
 });

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -124,7 +124,7 @@
   },
   "src/lib/api.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 25
+      "count": 26
     }
   },
   "src/lib/useLayoutPref.ts": {

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -32,6 +32,13 @@ interface ChatPanelProps {
   // Optional seed for the input. Bump `draftSeedKey` to apply.
   draftSeed?: string;
   draftSeedKey?: number;
+  /** Assistant text arriving token-by-token; null/undefined = not streaming.
+   *  Empty string = stream open but no token yet (shows the typing affordance).
+   *  Rendered as a live bubble below the settled messages, then replaced by
+   *  the real message once the `done` event lands. */
+  streamingText?: string | null;
+  /** Abort the in-flight turn. Shown only while streaming. */
+  onStop?: () => void;
 }
 
 export function ChatPanel({
@@ -43,14 +50,17 @@ export function ChatPanel({
   header,
   draftSeed,
   draftSeedKey,
+  streamingText,
+  onStop,
 }: ChatPanelProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const isStreaming = streamingText !== null && streamingText !== undefined;
 
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
-  }, [messages]);
+  }, [messages, streamingText]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 0 }}>
@@ -73,15 +83,32 @@ export function ChatPanel({
         }}
       >
         {messages.map(m => <Message key={m.id} m={m} />)}
+        {streamingText !== null && streamingText !== undefined && (
+          // Reuse Message/MarkdownChat exactly as settled assistant messages
+          // do, so a streaming reply never styles differently from a
+          // finished one. The `loading` flag reuses the same "Thinking…"
+          // affordance Learn.tsx already shows for in-flight assistant
+          // turns (see ChatMsg loading: true) rather than inventing a new
+          // typing indicator. The scroll container above already declares
+          // role="log" aria-live="polite" aria-relevant="additions", so this
+          // bubble's appearance is announced without a second, nested
+          // aria-live region on the bubble itself.
+          <Message
+            key="streaming"
+            m={{ id: "streaming", role: "assistant", content: streamingText, loading: streamingText === "" }}
+          />
+        )}
       </div>
 
       <ChatInputBar
         onSend={onSend}
         onAction={onAction}
-        disabled={disabled}
+        disabled={disabled || isStreaming}
         placeholder={placeholder}
         draftSeed={draftSeed}
         draftSeedKey={draftSeedKey}
+        streaming={isStreaming}
+        onStop={onStop}
       />
     </div>
   );
@@ -94,6 +121,8 @@ interface ChatInputBarProps {
   placeholder: string;
   draftSeed?: string;
   draftSeedKey?: number;
+  streaming?: boolean;
+  onStop?: () => void;
 }
 
 const ChatInputBar = React.memo(function ChatInputBar({
@@ -103,6 +132,8 @@ const ChatInputBar = React.memo(function ChatInputBar({
   placeholder,
   draftSeed,
   draftSeedKey,
+  streaming,
+  onStop,
 }: ChatInputBarProps) {
   const [text, setText] = useState<string>(draftSeed ?? "");
 
@@ -182,6 +213,16 @@ const ChatInputBar = React.memo(function ChatInputBar({
           }}
           rows={1}
         />
+        {streaming && onStop && (
+          <button
+            data-testid="tutor-stop"
+            className="btn btn--sm"
+            onClick={onStop}
+            aria-label="Stop response"
+          >
+            Stop
+          </button>
+        )}
         <button
           data-testid="tutor-send"
           className="btn btn--primary btn--sm"

--- a/frontend/src/components/screens/Learn.applyGraphDelta.test.ts
+++ b/frontend/src/components/screens/Learn.applyGraphDelta.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { applyGraphDeltaAssembly } from './Learn';
+import type { GraphDelta } from '@/lib/api';
+import type { GraphEdge, GraphNode } from '@/lib/data';
+
+/**
+ * Fix pass 3 (task-9): covers `applyGraphDelta`'s CALL SITE, not just its
+ * already-extracted helpers.
+ *
+ * Learn.graph.test.ts (fix pass 2) proved `mergeGraphDelta`,
+ * `deltaPlaceholderEdges`, and `mergeGraphEdges` are individually correct,
+ * but two of its tests drove a hand-written `applyDelta` helper that
+ * *mirrored* the real `applyGraphDelta` assembly rather than calling it —
+ * its own comment admitted as much. A reviewer proved this was a real gap:
+ * you could revert `applyGraphDelta` to the old broken "thread a value out
+ * of a functional updater, then read it synchronously right after" shape
+ * and all of fix pass 2's tests would still pass, because none of them
+ * called the real assembly. Those two tests (and the mirror) were removed;
+ * see the NOTE at the top of Learn.graph.test.ts.
+ *
+ * This file exercises `applyGraphDeltaAssembly` — the actual body of
+ * `applyGraphDelta`'s useCallback, extracted to a standalone exported
+ * function that takes `setGraphNodes`/`setGraphEdges` as parameters so it
+ * is callable outside React (see Learn.tsx). `LearnInner` calls this exact
+ * function with its real `setGraphNodes`/`setGraphEdges` state setters — no
+ * second copy of the assembly logic exists anywhere.
+ *
+ * The fake setters below never invoke the updater function they are given
+ * — they only *capture* it, then `flush` applies it later against a chosen
+ * `prev`. This matches real React precisely: a functional `setState`
+ * updater is never guaranteed to run synchronously at the call site (per
+ * the comment on `applyGraphDeltaAssembly` in Learn.tsx, streaming
+ * guarantees deferral by keeping the fiber's lanes non-empty via the
+ * per-token `setStreamingText` calls). Modeling "always deferred" is the
+ * correct worst case to test against, since that's what actually happens
+ * during a real stream.
+ *
+ * Revert-proof (see task-9-report.md, "Fix pass 3" section, for the actual
+ * command output): temporarily replacing `applyGraphDeltaAssembly`'s body
+ * in Learn.tsx with the broken shape —
+ *
+ *   let newEdges: GraphEdge[] = [];
+ *   setGraphNodes(prev => {
+ *     newEdges = deltaPlaceholderEdges(prev, delta, courseId);
+ *     return mergeGraphDelta(prev, delta, courseId);
+ *   });
+ *   if (newEdges.length) setGraphEdges(prev => mergeGraphEdges(prev, newEdges));
+ *
+ * — makes every test below fail: our fakes never run the nodes updater
+ * inline, so `newEdges` is still `[]` at the `if` check, `setGraphEdges` is
+ * never called at all, and `edges.flush` (never captured) returns `prev`
+ * unchanged.
+ */
+
+const root = (courseId: string): GraphNode => ({
+  id: `root-${courseId}`,
+  name: `${courseId} root`,
+  subject: `${courseId} subject`,
+  color: '#123456',
+  is_subject_root: true,
+  mastery_tier: 'mastered',
+  mastery_score: 1,
+  course_id: courseId,
+});
+
+const newNodeDelta = (concept: string): GraphDelta => ({
+  nodes: { new_nodes: [{ concept_name: concept, initial_mastery: 0.2 }] },
+  mastery_changes: [],
+});
+
+// A fake React-style functional-updater setter: `set` only *records* the
+// updater it's given — it never invokes it — exactly matching real React's
+// contract (the updater runs later, during render, not synchronously at the
+// call site). `flush` applies the captured updater to `prev` to simulate
+// that eventual render; if `set` was never called, `flush` returns `prev`
+// unchanged — the observable behavior when a buggy call site skips the
+// setState call entirely (the broken shape's actual failure mode).
+function fakeSetter<T>() {
+  let captured: ((prev: T) => T) | null = null;
+  const set = (updater: (prev: T) => T) => { captured = updater; };
+  const flush = (prev: T): T => (captured ? captured(prev) : prev);
+  return { set, flush };
+}
+
+describe('applyGraphDeltaAssembly — the real applyGraphDelta call site (task-9 fix pass 3)', () => {
+  it('a new streamed concept yields both the placeholder node and its root edge', () => {
+    const nodes = fakeSetter<GraphNode[]>();
+    const edges = fakeSetter<GraphEdge[]>();
+    const snapshot = [root('math')];
+
+    applyGraphDeltaAssembly(newNodeDelta('Eigenvalues'), 'math', snapshot, nodes.set, edges.set);
+
+    const nextNodes = nodes.flush(snapshot);
+    const nextEdges = edges.flush([]);
+
+    const placeholder = nextNodes.find(n => n.id === 'stream-eigenvalues');
+    expect(placeholder).toBeDefined();
+    expect(placeholder?.course_id).toBe('math');
+
+    expect(nextEdges).toContainEqual({ source: 'root-math', target: 'stream-eigenvalues', strength: 0.4 });
+    expect(nextEdges).toHaveLength(1);
+  });
+
+  it('applying the same delta twice (two full call+flush cycles) yields exactly one edge', () => {
+    const delta = newNodeDelta('Eigenvalues');
+    const snapshot0 = [root('math')];
+
+    const nodes1 = fakeSetter<GraphNode[]>();
+    const edges1 = fakeSetter<GraphEdge[]>();
+    applyGraphDeltaAssembly(delta, 'math', snapshot0, nodes1.set, edges1.set);
+    const nodesAfter1 = nodes1.flush(snapshot0);
+    const edgesAfter1 = edges1.flush([]);
+
+    // Second cycle: the render-scope `graphNodes` closure is now
+    // `nodesAfter1`, exactly like the real component's next call to
+    // `applyGraphDelta` after the first delta's render has committed.
+    const nodes2 = fakeSetter<GraphNode[]>();
+    const edges2 = fakeSetter<GraphEdge[]>();
+    applyGraphDeltaAssembly(delta, 'math', nodesAfter1, nodes2.set, edges2.set);
+    const nodesAfter2 = nodes2.flush(nodesAfter1);
+    const edgesAfter2 = edges2.flush(edgesAfter1);
+
+    expect(edgesAfter2.filter(e => e.target === 'stream-eigenvalues')).toHaveLength(1);
+    expect(nodesAfter2.filter(n => n.id === 'stream-eigenvalues')).toHaveLength(1);
+  });
+
+  it('the edge is computed eagerly, not threaded out of the nodes updater: it lands even when the nodes updater is never flushed', () => {
+    const nodes = fakeSetter<GraphNode[]>();
+    const edges = fakeSetter<GraphEdge[]>();
+    const snapshot = [root('math')];
+
+    applyGraphDeltaAssembly(newNodeDelta('Eigenvalues'), 'math', snapshot, nodes.set, edges.set);
+
+    // Deliberately never flush `nodes` — proves the edge computation does
+    // not depend on the nodes updater having run. The broken shape can
+    // never pass this: it computes edges *inside* the nodes updater and
+    // only calls setGraphEdges if that (unflushed) value already looks
+    // non-empty at the synchronous call site, so it never calls setGraphEdges
+    // at all here, and `edges.flush` is a no-op returning `[]` unchanged.
+    const nextEdges = edges.flush([]);
+    expect(nextEdges).toContainEqual({ source: 'root-math', target: 'stream-eigenvalues', strength: 0.4 });
+  });
+});

--- a/frontend/src/components/screens/Learn.graph.test.ts
+++ b/frontend/src/components/screens/Learn.graph.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { deltaPlaceholderEdges, mergeGraphDelta, mergeGraphEdges, resolveCardCourseId } from './Learn';
+import type { GraphDelta } from '@/lib/api';
+import type { GraphEdge, GraphNode } from '@/lib/data';
+
+/**
+ * Fix-pass-2 findings (task-9):
+ *
+ * Finding A: streamed placeholder edges were silently dropped, non-
+ * deterministically, because `applyGraphDelta` read a value out of a
+ * `setGraphNodes` functional updater immediately after calling it — but React
+ * doesn't run that updater synchronously except in a bailout that streaming
+ * almost never hits. The fix makes `graphNodes` and `graphEdges` two
+ * independent, idempotent updates instead: `mergeGraphDelta` (nodes) and
+ * `deltaPlaceholderEdges` + `mergeGraphEdges` (edges) never read each other's
+ * result — each is a pure function of its own arguments. This file exercises
+ * that pipeline directly (no timers, no React rendering, no bailout to rely
+ * on) and proves the edge survives, and survives being applied twice.
+ *
+ * Finding B: the streamed-placeholder course fallback was computed but never
+ * actually used — the previous "fix" was a no-op because `...patch` was
+ * spread after the courseId, so it always evaluated to the same value the
+ * unfixed code produced. `resolveCardCourseId` is the real, stronger
+ * resolution (mirrors `addConcept`'s `cardCourseId`); this file proves it
+ * actually differs from the naive `selectedCourseId`-only fallback, and that
+ * `mergeGraphDelta` actually uses whatever fallback it's given.
+ *
+ * NOTE (fix pass 3, task-9): this file used to also assert end-to-end
+ * "applies a delta and gets a placeholder + edge" behavior via a
+ * hand-written `applyDelta` helper that *mirrored* `applyGraphDelta`'s
+ * shape rather than calling it. A reviewer proved that mirror was a gap: you
+ * could revert the real `applyGraphDelta` to a broken value-threaded-out-of-
+ * an-updater shape and every test in this file would still pass, because
+ * none of them called the real assembly. Those two tests (and the mirror)
+ * were removed in favor of Learn.applyGraphDelta.test.ts, which exercises
+ * the real exported `applyGraphDeltaAssembly` and strictly covers the same
+ * ground (placeholder + edge creation, idempotency across two applications)
+ * plus the revert-proof property this file never had. The helper-level
+ * tests below (`mergeGraphEdges`, `deltaPlaceholderEdges`,
+ * `resolveCardCourseId`, `mergeGraphDelta` used directly) are untouched —
+ * they test real exported functions, not a mirror, and remain valid.
+ */
+
+const root = (courseId: string): GraphNode => ({
+  id: `root-${courseId}`,
+  name: `${courseId} root`,
+  subject: `${courseId} subject`,
+  color: '#123456',
+  is_subject_root: true,
+  mastery_tier: 'mastered',
+  mastery_score: 1,
+  course_id: courseId,
+});
+
+const newNodeDelta = (concept: string): GraphDelta => ({
+  nodes: { new_nodes: [{ concept_name: concept, initial_mastery: 0.2 }] },
+  mastery_changes: [],
+});
+
+describe('Finding A — streamed placeholder edges (task-9 fix pass 2)', () => {
+  it('mergeGraphEdges is pure: calling it twice with the identical (prev, additions) — exactly what React 18 Strict Mode does to a dev updater — returns the same result both times', () => {
+    const additions: GraphEdge[] = [{ source: 'root-math', target: 'stream-eigenvalues', strength: 0.4 }];
+    const firstInvocation = mergeGraphEdges([], additions);
+    const secondInvocation = mergeGraphEdges([], additions); // same prev, same additions — the double-invoke case
+
+    expect(firstInvocation).toEqual(secondInvocation);
+    expect(firstInvocation).toHaveLength(1);
+  });
+
+  it('never re-adds an edge that is already present in graphEdges', () => {
+    const already: GraphEdge[] = [{ source: 'root-math', target: 'stream-eigenvalues', strength: 0.4 }];
+    const candidates: GraphEdge[] = [{ source: 'root-math', target: 'stream-eigenvalues', strength: 0.4 }];
+    expect(mergeGraphEdges(already, candidates)).toBe(already); // same reference: no-op, not just equal
+  });
+
+  it('does not synthesize an edge for a concept that already exists as a real node', () => {
+    const known: GraphNode = {
+      id: 'real-eigen',
+      name: 'Eigenvalues',
+      subject: 'math subject',
+      color: '#abcdef',
+      mastery_tier: 'learning',
+      mastery_score: 0.5,
+      course_id: 'math',
+    };
+    const nodes = [root('math'), known];
+    const edges = deltaPlaceholderEdges(nodes, newNodeDelta('Eigenvalues'), 'math');
+    expect(edges).toHaveLength(0);
+  });
+
+  it('adds no edge when no subject root exists for the resolved course (matches prior behavior)', () => {
+    const edges = deltaPlaceholderEdges([], newNodeDelta('Eigenvalues'), 'math');
+    expect(edges).toHaveLength(0);
+  });
+});
+
+describe('Finding B — placeholder course fallback (task-9 fix pass 2)', () => {
+  it('resolveCardCourseId prefers the focused node\'s own course over selectedCourseId', () => {
+    const topicNode: GraphNode = {
+      id: 'n1',
+      name: 'Some concept',
+      subject: 'chem subject',
+      color: '#000',
+      mastery_tier: 'learning',
+      mastery_score: 0.4,
+      course_id: 'chem',
+    };
+    expect(resolveCardCourseId(topicNode, 'bio')).toBe('chem');
+  });
+
+  it('resolveCardCourseId falls back to selectedCourseId when the focused node has no course', () => {
+    expect(resolveCardCourseId(undefined, 'bio')).toBe('bio');
+  });
+
+  it('resolveCardCourseId falls back to null when nothing resolves (keeps prior behavior for the "" case)', () => {
+    expect(resolveCardCourseId(undefined, '')).toBeNull();
+  });
+
+  it('mergeGraphDelta actually uses the fallback it is given — a stronger fallback changes the placeholder\'s course_id', () => {
+    const nodesFallback = mergeGraphDelta([root('chem')], newNodeDelta('Enzymes'), 'chem');
+    const placeholder = nodesFallback.find(n => n.id === 'stream-enzymes');
+    expect(placeholder?.course_id).toBe('chem');
+  });
+});

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -21,7 +21,9 @@ import { useIsMobile } from "@/lib/useIsMobile";
 import { useUser } from "@/context/UserContext";
 import {
   startSession,
+  startSessionStream,
   sendChat,
+  streamChat,
   getSessions,
   resumeSession,
   deleteSession,
@@ -36,6 +38,8 @@ import {
   type Session,
   type SessionSummaryData,
   type EnrolledCourse,
+  type ChatResult,
+  type GraphDelta,
 } from "@/lib/api";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
 import { apiToGraphNode, type GraphNode, type GraphEdge } from "@/lib/data";
@@ -75,6 +79,222 @@ function normalizeMode(input: string | null): Mode {
   return (VALID_MODES as string[]).includes(input) ? (input as Mode) : "socratic";
 }
 
+// Mirrors backend/config.py::get_mastery_tier so a streamed delta classifies
+// mastery the same way a full graph refetch would.
+function tierForScore(score: number): GraphNode["mastery_tier"] {
+  if (score >= 0.75) return "mastered";
+  if (score >= 0.45) return "learning";
+  if (score >= 0.1) return "struggling";
+  return "unexplored";
+}
+
+const normalizeConceptName = (s: string) => s.trim().toLowerCase().replace(/\s+/g, " ");
+
+// Shared, defensive identity extraction for a single raw graph_update node
+// entry: matched by `id`/`node_id` when present (future-proofing against a
+// payload shape change), otherwise by normalized concept name. Used by both
+// `mergeGraphDelta` and `deltaPlaceholderEdges` so their notions of "is this
+// concept already known" can't drift apart.
+function rawNodeIdentity(raw: Record<string, unknown>): { id?: string; name?: string } {
+  const id = typeof raw.id === "string" ? raw.id : typeof raw.node_id === "string" ? raw.node_id : undefined;
+  const name = typeof raw.concept_name === "string" ? raw.concept_name : typeof raw.name === "string" ? raw.name : undefined;
+  return { id, name };
+}
+
+// Upsert a streamed `graph_update` event into `graphNodes` so the knowledge-map
+// rail's "In this branch" / "Elsewhere in course" panels recompute through
+// their existing useMemo — no refetch, no extra HTTP round-trip (#74).
+//
+// NOTE on the real payload shape: `delta.nodes` is NOT the flat
+// {id, name, course_id, mastery_score, mastery_tier}[] the streaming-design
+// spec sketches. It's a dict keyed by which graph tool wrote
+// (backend/agents/tools/graph.py via services/chat_stream.py
+// merge_graph_updates): `new_nodes` entries are {concept_name,
+// initial_mastery}; `updated_nodes` entries are {concept_name,
+// mastery_delta, reason, event_type}. Neither carries an `id` or an
+// absolute post-update score. `delta.mastery_changes` ({concept, before,
+// after}) IS authoritative for an existing node's new score, so it drives
+// merges for updates; `nodes` entries are read defensively via
+// `rawNodeIdentity` — and any fields we don't recognize are ignored rather
+// than crashing.
+//
+// Pure function of its arguments only — no component state is read. It does
+// NOT compute placeholder edges; see `deltaPlaceholderEdges` below, which
+// `applyGraphDelta` runs as a second, independent, idempotent update instead
+// of threading a value out of this one. Exported for Learn.graph.test.ts.
+export function mergeGraphDelta(
+  prev: GraphNode[],
+  delta: GraphDelta,
+  fallbackCourseId: string,
+): GraphNode[] {
+  const rawNodes = Object.values(delta.nodes ?? {}).flat() as Array<Record<string, unknown>>;
+  const rawMasteryChanges = delta.mastery_changes ?? [];
+  if (!rawNodes.length && !rawMasteryChanges.length) return prev;
+
+  const byId = new Map(prev.map(n => [n.id, n] as const));
+  const byName = new Map(prev.map(n => [normalizeConceptName(n.name), n] as const));
+
+  const upsert = (existing: GraphNode | undefined, name: string, patch: Partial<GraphNode>) => {
+    if (existing) {
+      const merged: GraphNode = { ...existing, ...patch };
+      byId.set(existing.id, merged);
+      byName.set(normalizeConceptName(existing.name), merged);
+      return;
+    }
+    // Unknown concept: insert a placeholder so it's visible immediately; a
+    // later full graph refetch (session end / next visit) reconciles the
+    // real id. The raw payload carries no course_id, so anchor it to the
+    // session's active course when there is one. Mirrors `addConcept`
+    // (~:892): resolve color + subject from the course's subject-root node
+    // instead of a hardcoded `var(--…)` (the 3D rail can't resolve CSS
+    // custom properties — lib/data.ts:78-79 — so that rendered black). The
+    // root-anchoring edge is added separately by `deltaPlaceholderEdges`,
+    // not here.
+    const id = `stream-${normalizeConceptName(name)}`;
+    const already = byId.get(id);
+    const courseId = (typeof patch.course_id === "string" ? patch.course_id : undefined) ?? fallbackCourseId;
+    const root = prev.find(n => n.is_subject_root && n.course_id === courseId);
+    const placeholder: GraphNode = already
+      ? { ...already, ...patch }
+      : {
+          id,
+          name,
+          subject: root?.subject ?? "",
+          color: root?.color ?? "var(--c-sage)",
+          mastery_tier: "unexplored",
+          mastery_score: 0,
+          course_id: courseId,
+          ...patch,
+        };
+    byId.set(id, placeholder);
+    byName.set(normalizeConceptName(name), placeholder);
+  };
+
+  for (const raw of rawNodes) {
+    const { id, name } = rawNodeIdentity(raw);
+    if (!id && !name) continue;
+    const existing = id ? byId.get(id) : byName.get(normalizeConceptName(name as string));
+    const patch: Partial<GraphNode> = {};
+    const score = typeof raw.mastery_score === "number"
+      ? raw.mastery_score
+      : (!existing && typeof raw.initial_mastery === "number") ? raw.initial_mastery : undefined;
+    if (score !== undefined) {
+      patch.mastery_score = score;
+      patch.mastery_tier = tierForScore(score);
+    }
+    if (typeof raw.mastery_tier === "string") patch.mastery_tier = raw.mastery_tier as GraphNode["mastery_tier"];
+    if (typeof raw.course_id === "string") patch.course_id = raw.course_id;
+    upsert(existing, name ?? (id as string), patch);
+  }
+
+  for (const mc of rawMasteryChanges) {
+    const existing = byName.get(normalizeConceptName(mc.concept));
+    if (!existing) continue; // bare mastery_changes entries carry no id/course to synthesize a new node from
+    upsert(existing, mc.concept, { mastery_score: mc.after, mastery_tier: tierForScore(mc.after) });
+  }
+
+  return Array.from(byId.values());
+}
+
+function edgeKey(e: GraphEdge): string {
+  return `${e.source}\u0000${e.target}`;
+}
+
+// The root→placeholder edges a streamed `graph_update` implies, computed
+// against `nodes` — the caller's current `graphNodes` snapshot — rather than
+// against `mergeGraphDelta`'s `prev`: the two run as independent updates
+// (see `applyGraphDelta`), so this can't reach into the other's in-flight
+// result, and doesn't need to. A concept only gets a synthetic edge when it
+// has no existing id/name match in `nodes`, mirroring `mergeGraphDelta`'s
+// "unknown concept" branch; an already-known concept is updated in place by
+// `mergeGraphDelta` and never gets a new edge here. Pure and side-effect
+// free. Exported for Learn.graph.test.ts.
+export function deltaPlaceholderEdges(
+  nodes: GraphNode[],
+  delta: GraphDelta,
+  fallbackCourseId: string,
+): GraphEdge[] {
+  const rawNodes = Object.values(delta.nodes ?? {}).flat() as Array<Record<string, unknown>>;
+  if (!rawNodes.length) return [];
+
+  const byId = new Map(nodes.map(n => [n.id, n] as const));
+  const byName = new Map(nodes.map(n => [normalizeConceptName(n.name), n] as const));
+  const edges: GraphEdge[] = [];
+
+  for (const raw of rawNodes) {
+    const { id, name } = rawNodeIdentity(raw);
+    if (!id && !name) continue;
+    const existing = id ? byId.get(id) : byName.get(normalizeConceptName(name as string));
+    if (existing) continue;
+
+    const courseId = (typeof raw.course_id === "string" ? raw.course_id : undefined) ?? fallbackCourseId;
+    const root = nodes.find(n => n.is_subject_root && n.course_id === courseId);
+    if (!root) continue;
+
+    const label = (name ?? id) as string;
+    edges.push({ source: root.id, target: `stream-${normalizeConceptName(label)}`, strength: 0.4 });
+  }
+  return edges;
+}
+
+// Idempotent edge append: dedupes `additions` against `prev` AND against
+// each other by source+target, so calling this twice with identical inputs —
+// React 18 Strict Mode's dev double-invocation of a setState updater, or the
+// same `graph_update` replayed — leaves `prev` unchanged the second time.
+// Never mutates `prev`. Exported for Learn.graph.test.ts.
+export function mergeGraphEdges(prev: GraphEdge[], additions: GraphEdge[]): GraphEdge[] {
+  if (!additions.length) return prev;
+  const seen = new Set(prev.map(edgeKey));
+  const next: GraphEdge[] = [];
+  for (const e of additions) {
+    const key = edgeKey(e);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    next.push(e);
+  }
+  return next.length ? [...prev, ...next] : prev;
+}
+
+// Course resolution for a rail-focused node: prefer the node's own course,
+// fall back to the course picker's selection, else null. Used both for the
+// rail's focus card (`cardCourseId` in LearnInner) and, via that same value,
+// for the streamed-placeholder course fallback in `applyGraphDelta` — so a
+// streamed node lands in the same course bucket a manually-added one would
+// (Finding B). Exported for Learn.graph.test.ts.
+export function resolveCardCourseId(
+  topicNode: GraphNode | undefined,
+  selectedCourseId: string,
+): string | null {
+  return topicNode?.course_id || selectedCourseId || null;
+}
+
+// The actual call-site assembly `applyGraphDelta` (LearnInner, below) runs on
+// every streamed `graph_update`. Extracted to a standalone, exported function
+// — rather than left inline in the `useCallback` body — specifically so
+// Learn.applyGraphDelta.test.ts can invoke the REAL assembly with fake
+// `setGraphNodes`/`setGraphEdges` and prove the shape below is what actually
+// runs, instead of testing a hand-written mirror of it (fix pass 2's gap).
+//
+// `edges` MUST be computed before either setter is called: it is a plain,
+// eager read of `graphNodesSnapshot` (the caller's current `graphNodes`), not
+// a value threaded out of the `setGraphNodes` updater. That distinction is
+// the entire fix — see the big comment on `applyGraphDelta` for why reading
+// a value out of a functional updater immediately after calling it is
+// unsound (React never runs it synchronously at the call site).
+// `setGraphNodes`/`setGraphEdges` are typed to only the functional-updater
+// overload because that's the only form this call site ever uses.
+export function applyGraphDeltaAssembly(
+  delta: GraphDelta,
+  courseId: string,
+  graphNodesSnapshot: GraphNode[],
+  setGraphNodes: (updater: (prev: GraphNode[]) => GraphNode[]) => void,
+  setGraphEdges: (updater: (prev: GraphEdge[]) => GraphEdge[]) => void,
+): void {
+  const edges = deltaPlaceholderEdges(graphNodesSnapshot, delta, courseId);
+  setGraphNodes(prev => mergeGraphDelta(prev, delta, courseId));
+  setGraphEdges(prev => mergeGraphEdges(prev, edges));
+}
+
 export function Learn() {
   return (
     <Suspense fallback={<div style={{ padding: 40, color: "var(--text-dim)" }}>Loading…</div>}>
@@ -106,6 +326,11 @@ function LearnInner() {
   const [messages, setMessages] = useState<ChatMsg[]>([]);
   const [sending, setSending] = useState(false);
   const [starting, setStarting] = useState(false);
+  // Assistant text arriving token-by-token for the in-flight turn; null =
+  // not streaming, '' = stream open but no token yet, non-empty = live text.
+  // Passed straight through to ChatPanel's `streamingText` prop.
+  const [streamingText, setStreamingText] = useState<string | null>(null);
+  const streamAbort = useRef<AbortController | null>(null);
 
   const [recentSessions, setRecentSessions] = useState<Session[]>([]);
   const [courses, setCourses] = useState<EnrolledCourse[]>([]);
@@ -114,11 +339,70 @@ function LearnInner() {
   const [graphEdges, setGraphEdges] = useState<GraphEdge[]>([]);
 
   // The rail's focused node — independent of the active session's topic, so
-  // clicking around the map explores without touching the chat. Null means the
-  // focus follows the current session topic. `lastNodeClickRef` powers the
-  // double-click-to-switch shortcut.
+  // clicking around the map explores without touching the chat. Null means
+  // the focus follows the current session topic. `lastNodeClickRef` powers
+  // the double-click-to-switch shortcut. Declared here — ahead of the rest
+  // of the rail state below — because `applyGraphDelta`'s course resolution
+  // needs `cardCourseId`, which is derived from it.
   const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
   const lastNodeClickRef = useRef<{ id: string; t: number } | null>(null);
+
+  const suggestParam = searchParams.get("suggest");
+  const highlightId = useMemo(() => {
+    // Pre-revamp Learn honored ?suggest=<concept> from the Dashboard
+    // "Learn next" suggestion; restore that here, falling back to the
+    // current topic if no suggestion is active.
+    const suggestMatch = suggestParam
+      ? graphNodes.find(n => n.name.toLowerCase() === suggestParam.trim().toLowerCase())
+      : null;
+    if (suggestMatch) return suggestMatch.id;
+    return graphNodes.find(n => n.name.toLowerCase() === topic.trim().toLowerCase())?.id;
+  }, [suggestParam, graphNodes, topic]);
+
+  // The rail focus: an explicitly-clicked node when present, otherwise the
+  // node for the active session topic. Drives the graph highlight, focus
+  // card, "In this branch", and "Elsewhere".
+  const activeFocusId = focusedNodeId ?? highlightId;
+  const topicNode = useMemo(
+    () => graphNodes.find(n => n.id === activeFocusId),
+    [graphNodes, activeFocusId],
+  );
+
+  // Course resolution shared by the rail's focus card, `addConcept` (~:892
+  // below), and the streamed-placeholder fallback right below: prefer the
+  // focused concept's own course, fall back to the course picker. Extracted
+  // to a top-level function (rather than an inline expression) so it's
+  // directly testable — see Learn.graph.test.ts.
+  const cardCourseId = resolveCardCourseId(topicNode, selectedCourseId);
+
+  // Streamed graph_update handler (#74) — see mergeGraphDelta above for why
+  // the match key falls back to concept name. The course fallback is
+  // `cardCourseId`, the same resolution `addConcept` uses for a manually-
+  // added node, so a streamed placeholder lands in the same course bucket;
+  // when nothing resolves at all it falls back to `selectedCourseId`, same
+  // as before.
+  //
+  // The actual assembly lives in `applyGraphDeltaAssembly` (top-level,
+  // exported, above) — nodes and edges are two independent, idempotent
+  // functional updates there, NOT one updater's result threaded into the
+  // other. `setGraphNodes`'s updater runs against the true, always-current
+  // `prev`. `setGraphEdges`'s updater applies edges computed eagerly against
+  // the render-scope `graphNodes` snapshot passed in here — safe because
+  // subject-root nodes never change mid-stream, and any staleness in the "is
+  // this concept already known" check only produces a redundant candidate,
+  // which `mergeGraphEdges` dedupes by source+target rather than an
+  // incorrect edge. Both updaters are pure functions of their arguments, so
+  // calling either twice with the same input — React 18 Strict Mode's dev
+  // double-invocation, or the same delta arriving twice — produces the same
+  // result. No timing assumption, nothing smuggled out.
+  const applyGraphDelta = useCallback(
+    (delta: GraphDelta) => {
+      const courseId = cardCourseId ?? selectedCourseId;
+      applyGraphDeltaAssembly(delta, courseId, graphNodes, setGraphNodes, setGraphEdges);
+    },
+    [cardCourseId, selectedCourseId, graphNodes],
+  );
+
   // Inline "add concept" composer state for the knowledge-map rail.
   const [addingConcept, setAddingConcept] = useState(false);
   const [newConceptName, setNewConceptName] = useState("");
@@ -214,23 +498,80 @@ function LearnInner() {
   // Begins a fresh tutor session on `t`. Shared by the entry-screen Start
   // button and the knowledge-map switch flow. Clears any map focus so the rail
   // snaps back to following the (new) active topic.
+  //
+  // Streams the greeting over startSessionStream, mirroring `send`'s
+  // three-rung fallback ladder verbatim (see the big comment on `send`,
+  // above `send`'s definition, for the full rationale):
+  //   Rung 3 (stream never produced text) -> retry transparently via the
+  //     non-streaming JSON startSession; the user never sees an error.
+  //   Rung 2 (rejected AFTER tokens appeared) -> surface the error via the
+  //     same toast path this handler already used for JSON failures. Never
+  //     silently re-run.
+  //   Stop pressed -> distinguished via the AbortController's signal.aborted;
+  //     intentional, not an error, no fallback. No session exists yet on
+  //     this path (session_id is only set on success below), so aborting
+  //     just drops back to the entry screen once `starting` clears.
+  //
+  // Like `send`, no loading placeholder goes into `messages` up front — the
+  // greeting renders through ChatPanel's `streamingText` bubble instead, so
+  // it appears progressively rather than after a spinner (#70's premise,
+  // extended to session start).
+  //
+  // Field-name note: the JSON route returns `initial_message`; the stream's
+  // `done` event returns `reply` (ChatResult). Both are normalized into
+  // `replyText` below so the rest of this function doesn't care which path
+  // served the turn.
   const beginSession = async (t: string) => {
     const topicName = t.trim();
     if (!topicName || !userId) return;
     setFocusedNodeId(null);
     setTopic(topicName);
     setTopicDraft(topicName);
-    setMessages([{ id: msgId(), role: "assistant", content: "", loading: true }]);
+    setMessages([]);
     setStarting(true);
+    setStreamingText("");
+    // A stream may already be in flight (e.g. a graph-node click starting a
+    // new session while a reply streams) — abort it first so two streams
+    // never interleave writes into the same streamingText/messages state.
+    streamAbort.current?.abort();
+    const controller = new AbortController();
+    streamAbort.current = controller;
+    let sawToken = false;
     try {
-      const res = await startSession(userId, topicName, mode, selectedCourseId || undefined, sharedCtx, modelPref);
-      setSessionId(res.session_id);
-      setMessages([{ id: msgId(), role: "assistant", content: res.initial_message || "Let's begin." }]);
+      let newSessionId: string;
+      let replyText: string;
+      try {
+        const res = await startSessionStream(userId, topicName, mode, sharedCtx, selectedCourseId || undefined, modelPref, {
+          onToken: (delta) => {
+            sawToken = true;
+            setStreamingText(prev => (prev ?? "") + delta);
+          },
+          onGraphUpdate: applyGraphDelta,
+          signal: controller.signal,
+        });
+        if (!res.session_id) throw new Error("Session stream completed without a session_id.");
+        newSessionId = res.session_id;
+        replyText = res.reply || "Let's begin.";
+      } catch (err) {
+        if (controller.signal.aborted) { setMessages([]); return; } // Stop pressed — intentional, not an error.
+        if (sawToken) throw err; // Rung 2: interrupted after producing text — surface it, don't retry.
+        // Rung 3: the stream never produced text — retry transparently via
+        // the non-streaming JSON route. Clear streamingText first so
+        // ChatPanel drops the Stop affordance for this leg (mirrors `send`).
+        setStreamingText(null);
+        const res = await startSession(userId, topicName, mode, selectedCourseId || undefined, sharedCtx, modelPref);
+        newSessionId = res.session_id;
+        replyText = res.initial_message || "Let's begin.";
+      }
+      setSessionId(newSessionId);
+      setMessages([{ id: msgId(), role: "assistant", content: replyText }]);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Couldn't start session.");
       setMessages([]);
     } finally {
       setStarting(false);
+      setStreamingText(null);
+      if (streamAbort.current === controller) streamAbort.current = null;
     }
   };
 
@@ -287,31 +628,80 @@ function LearnInner() {
     }
   }, [userId, toast]);
 
+  // Sends one turn over the SSE stream, with a three-rung fallback ladder:
+  //   Rung 3 (stream never produced text) -> retry transparently via the
+  //     non-streaming sendChat; the user never sees an error.
+  //   Rung 2 (rejected AFTER tokens appeared) -> surface the error through
+  //     the same error-message path the old non-streaming send() used. Never
+  //     silently re-run: the user already saw partial text, and nothing was
+  //     persisted server-side, so re-running would restart the reply.
+  //   Stop pressed -> distinguished via the AbortController's signal.aborted;
+  //     intentional, not an error, no fallback, no message appended (nothing
+  //     was persisted, so the partial bubble just disappears).
+  //
+  // Unlike the old handler, no loading placeholder is pushed into `messages`
+  // up front — ChatPanel renders the in-flight turn itself via streamingText
+  // (a placeholder there would double up with that live bubble). The real
+  // assistant message is appended once, after the turn resolves one way or
+  // another.
   const send = useCallback(async (userText: string) => {
     if (!userText.trim() || !sessionId || !userId) return;
-    setMessages(m => [
-      ...m,
-      { id: msgId(), role: "user", content: userText },
-      { id: msgId(), role: "assistant", content: "", loading: true },
-    ]);
+    setMessages(m => [...m, { id: msgId(), role: "user", content: userText }]);
     setSending(true);
+    setStreamingText("");
+    // A stream may already be in flight (e.g. a graph-node click starting a
+    // new session while a reply streams) — abort it first so two streams
+    // never interleave writes into the same streamingText/messages state.
+    streamAbort.current?.abort();
+    const controller = new AbortController();
+    streamAbort.current = controller;
+    let sawToken = false;
     try {
-      const res = await sendChat(sessionId, userId, userText, mode, sharedCtx, modelPref);
-      setMessages(m => {
-        const next = [...m];
-        next[next.length - 1] = { id: next[next.length - 1].id, role: "assistant", content: res.reply || "" };
-        return next;
-      });
+      let res: ChatResult;
+      try {
+        res = await streamChat(sessionId, userId, userText, mode, sharedCtx, modelPref, {
+          onToken: (delta) => {
+            sawToken = true;
+            setStreamingText(t => (t ?? "") + delta);
+          },
+          onGraphUpdate: applyGraphDelta,
+          signal: controller.signal,
+        });
+      } catch (err) {
+        if (controller.signal.aborted) return; // Stop pressed — intentional, not an error.
+        if (sawToken) throw err; // Rung 2: interrupted after producing text — surface it, don't retry.
+        // Rung 3: the stream never produced text — retry transparently via the
+        // non-streaming JSON route. `sendChat`/`fetchJSON` (lib/api.ts) take
+        // no AbortSignal, and plumbing one through is out of scope for this
+        // fix — so the fallback request itself cannot actually be cancelled.
+        // Clear streamingText to null *before* issuing it so ChatPanel drops
+        // both the Stop button and the "Thinking…" bubble for this leg,
+        // rather than offering a Stop affordance that would abort an
+        // already-detached controller while the JSON call keeps running
+        // server-side regardless. `sending` stays true, so the input is
+        // still disabled — the turn just no longer looks interruptible,
+        // which is now the truth.
+        setStreamingText(null);
+        res = await sendChat(sessionId, userId, userText, mode, sharedCtx, modelPref);
+      }
+      setMessages(m => [...m, { id: msgId(), role: "assistant", content: res.reply || "" }]);
     } catch (err) {
-      setMessages(m => {
-        const next = [...m];
-        next[next.length - 1] = { id: next[next.length - 1].id, role: "assistant", content: `Error: ${err instanceof Error ? err.message : "unknown"}` };
-        return next;
-      });
+      setMessages(m => [...m, { id: msgId(), role: "assistant", content: `Error: ${err instanceof Error ? err.message : "unknown"}` }]);
     } finally {
       setSending(false);
+      setStreamingText(null);
+      if (streamAbort.current === controller) streamAbort.current = null;
     }
-  }, [sessionId, userId, mode, sharedCtx, modelPref]);
+  }, [sessionId, userId, mode, sharedCtx, modelPref, applyGraphDelta]);
+
+  // Abort any in-flight stream when the active session changes (including to
+  // none) and on unmount — guards the #131/#133 leaked-stream bug class. A
+  // plain unmount-only effect would miss the "switched sessions mid-stream"
+  // case, so this keys on sessionId: its cleanup fires both when sessionId
+  // changes and when the component unmounts.
+  useEffect(() => {
+    return () => streamAbort.current?.abort();
+  }, [sessionId]);
 
   const handleAction = async (action: "hint" | "confused" | "skip") => {
     if (!sessionId || !userId) return;
@@ -404,18 +794,6 @@ function LearnInner() {
 
   const modeOptions = useMemo(() => MODES.map(m => ({ value: m.id, label: m.name, description: m.tip })), []);
 
-  const suggestParam = searchParams.get("suggest");
-  const highlightId = useMemo(() => {
-    // Pre-revamp Learn honored ?suggest=<concept> from the Dashboard
-    // "Learn next" suggestion; restore that here, falling back to the
-    // current topic if no suggestion is active.
-    const suggestMatch = suggestParam
-      ? graphNodes.find(n => n.name.toLowerCase() === suggestParam.trim().toLowerCase())
-      : null;
-    if (suggestMatch) return suggestMatch.id;
-    return graphNodes.find(n => n.name.toLowerCase() === topic.trim().toLowerCase())?.id;
-  }, [suggestParam, graphNodes, topic]);
-
   // Jump the chat to `name`: resume an existing session on that concept if one
   // exists, otherwise start a fresh one. Both paths clear the map focus so the
   // rail follows the now-active session.
@@ -487,15 +865,6 @@ function LearnInner() {
     }
   };
 
-  // The rail focus: an explicitly-clicked node when present, otherwise the
-  // node for the active session topic. Drives the graph highlight, focus card,
-  // "In this branch", and "Elsewhere".
-  const activeFocusId = focusedNodeId ?? highlightId;
-  const topicNode = useMemo(
-    () => graphNodes.find(n => n.id === activeFocusId),
-    [graphNodes, activeFocusId],
-  );
-
   const neighborIds = useMemo(() => {
     if (!topicNode) return new Set<string>();
     const ids = new Set<string>();
@@ -506,7 +875,6 @@ function LearnInner() {
     return ids;
   }, [topicNode, graphEdges]);
 
-  const cardCourseId = topicNode?.course_id || selectedCourseId || null;
   const cardCourse = useMemo(
     () => courses.find(c => c.course_id === cardCourseId) ?? null,
     [courses, cardCourseId],
@@ -785,6 +1153,8 @@ function LearnInner() {
               onSend={send}
               onAction={handleAction}
               disabled={sending || starting}
+              streamingText={streamingText}
+              onStop={() => streamAbort.current?.abort()}
             />
           </div>
         )}

--- a/frontend/src/components/screens/Library.tsx
+++ b/frontend/src/components/screens/Library.tsx
@@ -122,11 +122,27 @@ export function Library() {
     });
   }, [documents, cat, courseFilter, query]);
 
+  // #449 (upstream, out of scope here): GET /api/graph/{userId}/courses
+  // returns one row per ENROLLMENT, so a course with two offerings (e.g.
+  // CS101 in both fall and spring) surfaces as two rows sharing the same
+  // course_id — the API can't collapse that itself since enrollment_id-
+  // keyed consumers (the gradebook) depend on the per-enrollment rows.
+  // This is the Library render-side dedupe: one filter pill / label per
+  // distinct abstract course, keeping the first enrollment's row (color,
+  // course_code, course_name) as the stable representative.
+  const dedupedCourses = React.useMemo(() => {
+    const byId = new Map<string, EnrolledCourse>();
+    for (const c of courses) {
+      if (!byId.has(c.course_id)) byId.set(c.course_id, c);
+    }
+    return [...byId.values()];
+  }, [courses]);
+
   const courseLookup = React.useMemo(() => {
     const map: Record<string, string> = {};
-    for (const c of courses) map[c.course_id] = c.course_code || c.course_name;
+    for (const c of dedupedCourses) map[c.course_id] = c.course_code || c.course_name;
     return map;
-  }, [courses]);
+  }, [dedupedCourses]);
 
   const groupedByCourse = React.useMemo(() => {
     const counts: Record<string, number> = { all: documents.length, uncategorized: 0 };
@@ -227,7 +243,7 @@ export function Library() {
               }}>
                 {filtered.map(d => {
                   const isSelected = detail?.id === d.id;
-                  const courseLabel = courseLookup[d.course_id];
+                  const courseLabel = courseLookup[d.course_id ?? ""];
                   return (
                     <button
                       key={d.id}
@@ -359,7 +375,7 @@ export function Library() {
             active={courseFilter === "uncategorized"}
             onClick={() => setCourseFilter("uncategorized")}
           />
-          {courses.map(c => (
+          {dedupedCourses.map(c => (
             <CourseRow
               key={c.course_id}
               testid={`library-course-filter-${c.course_id}`}

--- a/frontend/src/lib/api.stream.test.ts
+++ b/frontend/src/lib/api.stream.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+function sseBody(blocks: string[]): ReadableStream {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(c) {
+      for (const b of blocks) c.enqueue(enc.encode(b));
+      c.close();
+    },
+  });
+}
+
+const ev = (name: string, data: unknown) =>
+  `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('streamChat', () => {
+  it('accumulates tokens, surfaces graph deltas, resolves on done', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([
+          ev('status', { type: 'status', step: 'start', message: '' }),
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'Hel' } }),
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'lo' } }),
+          ev('graph_update', {
+            type: 'graph_update', step: 'graph', message: '',
+            data: { nodes: { new_nodes: [{ name: 'Eigen' }] }, mastery_changes: [] },
+          }),
+          ev('done', {
+            type: 'done', step: 'reply', message: '',
+            data: { reply: 'Hello', graph_update: {}, mastery_changes: [] },
+          }),
+        ]),
+        { status: 200 },
+      ) as never,
+    );
+
+    const { streamChat } = await import('./api');
+    const tokens: string[] = [];
+    const deltas: unknown[] = [];
+    const result = await streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, {
+      onToken: (t) => tokens.push(t),
+      onGraphUpdate: (d) => deltas.push(d),
+    });
+
+    expect(tokens).toEqual(['Hel', 'lo']);
+    expect(deltas).toHaveLength(1);
+    expect(result.reply).toBe('Hello');
+  });
+
+  it('rejects on a mid-stream error event', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'Half' } }),
+          ev('error', { type: 'error', step: 'reply', message: 'Interrupted.', data: { request_id: 'r1' } }),
+        ]),
+        { status: 200 },
+      ) as never,
+    );
+    const { streamChat } = await import('./api');
+    await expect(
+      streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, { onToken: () => {} }),
+    ).rejects.toThrow(/interrupted/i);
+  });
+
+  it('preserves request_id from a mid-stream error event on the thrown Error', async () => {
+    // ADR 0009: the backend deliberately includes request_id on error events
+    // for Logfire correlation. Losing it on the frontend throw makes a
+    // user-reported error untraceable — assert it survives as a property
+    // AND stays visible in the (still-readable) message.
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([
+          ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'Half' } }),
+          ev('error', { type: 'error', step: 'reply', message: 'Interrupted.', data: { request_id: 'trace-abc12345' } }),
+        ]),
+        { status: 200 },
+      ) as never,
+    );
+    const { streamChat } = await import('./api');
+    let caught: unknown;
+    try {
+      await streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, { onToken: () => {} });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as { requestId?: string }).requestId).toBe('trace-abc12345');
+    expect((caught as Error).message).toMatch(/interrupted/i);
+    expect((caught as Error).message).toContain('trace-abc');
+  });
+
+  it('rejects when the stream never sends done', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        sseBody([ev('token', { type: 'token', step: 'reply', message: '', data: { delta: 'x' } })]),
+        { status: 200 },
+      ) as never,
+    );
+    const { streamChat } = await import('./api');
+    await expect(
+      streamChat('s1', 'u1', 'hi', 'socratic', true, undefined, { onToken: () => {} }),
+    ).rejects.toThrow(/without a done/i);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   ExtractedSyllabusCategory,
   AllowlistEmail, AchievementTrigger, AdminAuditEntry, AnalyticsOverview, PaginatedUsers,
   Note, LinkedConcept,
+  GraphUpdate, MasteryChange,
 } from '@/lib/types';
 
 export const API_URL = '';
@@ -167,6 +168,130 @@ export const sendChat = (
       ...(modelPref ? { model_pref: modelPref } : {}),
     }),
   });
+
+export interface GraphDelta {
+  nodes: Record<string, Array<Record<string, unknown>>>;
+  mastery_changes: MasteryChange[];
+}
+
+export interface ChatResult {
+  reply: string;
+  graph_update: GraphUpdate;
+  mastery_changes: MasteryChange[];
+  session_id?: string;
+  graph_state?: any;
+}
+
+interface StreamEvent {
+  type: string;
+  step: string;
+  message: string;
+  data?: Record<string, unknown> | null;
+}
+
+// Thrown from consumeChatStream on a mid-stream `error` event. Carries the
+// backend's `request_id` (ADR 0009, stamped for Logfire correlation) as a
+// property — not just baked into the message string — so a caller that
+// wants to display or copy it (see DocumentUploadModal's "Reference:"
+// pattern) doesn't have to re-parse the message text for it.
+export class ChatStreamError extends Error {
+  requestId?: string;
+  constructor(message: string, requestId?: string) {
+    // Keep the full id here (correlation needs an exact match); a caller
+    // that wants a short display form truncates it itself, same as
+    // DocumentUploadModal's "Reference: {id.slice(0, 8)}…" pattern.
+    super(requestId ? `${message} (ref: ${requestId})` : message);
+    this.name = 'ChatStreamError';
+    this.requestId = requestId;
+  }
+}
+
+export interface StreamChatHandlers {
+  onToken?: (delta: string) => void;
+  onGraphUpdate?: (delta: GraphDelta) => void;
+  signal?: AbortSignal;
+}
+
+const STREAM_IDLE_MS = 45_000;
+
+async function consumeChatStream(
+  path: string,
+  payload: Record<string, unknown>,
+  { onToken, onGraphUpdate, signal }: StreamChatHandlers,
+): Promise<ChatResult> {
+  const { streamSSE } = await import('./sse');
+  let result: ChatResult | null = null;
+
+  for await (const e of streamSSE<StreamEvent>(
+    `${API_URL}${path}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      credentials: 'include',
+      signal,
+    },
+    { idleTimeoutMs: STREAM_IDLE_MS },
+  )) {
+    const ev = e.data;
+    if (ev.type === 'token') onToken?.(String(ev.data?.delta ?? ''));
+    else if (ev.type === 'graph_update') onGraphUpdate?.(ev.data as unknown as GraphDelta);
+    else if (ev.type === 'error') {
+      const requestId = typeof ev.data?.request_id === 'string' ? ev.data.request_id : undefined;
+      throw new ChatStreamError(ev.message || 'The tutor was interrupted.', requestId);
+    }
+    else if (ev.type === 'done') result = ev.data as unknown as ChatResult;
+  }
+
+  if (!result) throw new Error('Chat stream ended without a done event.');
+  return result;
+}
+
+export const streamChat = (
+  sessionId: string,
+  userId: string,
+  message: string,
+  mode: string,
+  useSharedContext = true,
+  modelPref?: ModelPref,
+  handlers: StreamChatHandlers = {},
+): Promise<ChatResult> => {
+  return consumeChatStream(
+    '/api/learn/chat/stream',
+    {
+      session_id: sessionId,
+      user_id: userId,
+      message,
+      mode,
+      use_shared_context: useSharedContext,
+      ...(modelPref ? { model_pref: modelPref } : {}),
+    },
+    handlers,
+  );
+};
+
+export const startSessionStream = (
+  userId: string,
+  topic: string,
+  mode: string,
+  useSharedContext = true,
+  courseId?: string,
+  modelPref?: ModelPref,
+  handlers: StreamChatHandlers = {},
+): Promise<ChatResult> => {
+  return consumeChatStream(
+    '/api/learn/start-session/stream',
+    {
+      user_id: userId,
+      topic,
+      mode,
+      use_shared_context: useSharedContext,
+      course_id: courseId,
+      ...(modelPref ? { model_pref: modelPref } : {}),
+    },
+    handlers,
+  );
+};
 
 export interface SessionSummaryData {
   concepts_covered: string[];

--- a/frontend/src/lib/sse.test.ts
+++ b/frontend/src/lib/sse.test.ts
@@ -171,4 +171,41 @@ describe('streamSSE', () => {
     expect(events[0]).toEqual({ event: 'a', data: { i: 1 } });
     expect(events[1]).toEqual({ event: 'b', data: { i: 2 } });
   });
+
+  it('rejects when no event arrives within idleTimeoutMs', async () => {
+    const stalledBody = new ReadableStream({
+      start() { /* never enqueues, never closes */ },
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(stalledBody, { status: 200 }) as never,
+    );
+
+    const iterate = async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _e of streamSSE('/x', {}, { idleTimeoutMs: 20 })) { /* drain */ }
+    };
+    await expect(iterate()).rejects.toThrow(/stalled/i);
+  });
+
+  it('clears the idle-timeout timer on every successful read (no leaked timers on the happy path)', async () => {
+    vi.useFakeTimers();
+    try {
+      const payload =
+        'event: progress\ndata: {"step":1}\n\n' +
+        'event: progress\ndata: {"step":2}\n\n' +
+        'event: progress\ndata: {"step":3}\n\n';
+      mockFetchResponse(makeStreamingResponse([payload]));
+
+      const events = await collect(
+        streamSSE<{ step: number }>('/x', { method: 'POST' }, { idleTimeoutMs: 45000 }),
+      );
+
+      expect(events).toHaveLength(3);
+      // Every reader.read() races a setTimeout when idleTimeoutMs is set.
+      // If the winning read doesn't clear its timer, this stays > 0.
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -25,10 +25,13 @@ export type SSEEvent<T = unknown> = {
  *
  * Throws on non-2xx responses or missing body. The generator completes
  * naturally when the server closes the connection.
+ *
+ * If opts.idleTimeoutMs is set, rejects if no data arrives within that time.
  */
 export async function* streamSSE<T = unknown>(
   url: string,
   init: RequestInit,
+  opts: { idleTimeoutMs?: number } = {},
 ): AsyncGenerator<SSEEvent<T>> {
   const res = await fetch(url, init);
   if (!res.ok) {
@@ -45,7 +48,12 @@ export async function* streamSSE<T = unknown>(
 
   try {
     while (true) {
-      const { value, done } = await reader.read();
+      // A stalled stream (proxy dropped it, backend wedged) otherwise hangs
+      // the composer forever with no error. Race each read against a timer,
+      // clearing the timer once the race settles so it never lingers.
+      const { value, done } = opts.idleTimeoutMs
+        ? await readWithTimeout(reader, opts.idleTimeoutMs)
+        : await reader.read();
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
 
@@ -68,6 +76,31 @@ export async function* streamSSE<T = unknown>(
   } finally {
     await reader.cancel().catch(() => { /* already closed */ });
     reader.releaseLock();
+  }
+}
+
+/**
+ * Race a single reader.read() against an idle timeout, clearing the timer
+ * on every path (read wins, read throws, or the timer itself fires) so no
+ * timer is ever left pending once the race settles.
+ */
+async function readWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  idleTimeoutMs: number,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error("Stream stalled — no data received.")),
+          idleTimeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -143,7 +143,7 @@ export interface ConceptNote {
 export interface Document {
   id: string;
   user_id: string;
-  course_id: string;
+  course_id: string | null;
   file_name: string;
   category: 'syllabus' | 'lecture_notes' | 'slides' | 'reading' | 'assignment' | 'study_guide' | 'other';
   summary: string | null;

--- a/scripts/explore/explorer-prompt.md
+++ b/scripts/explore/explorer-prompt.md
@@ -66,12 +66,19 @@ signed in (storage state). Today's in-app date is frozen at 2026-03-11.
 - severity guess: crash | wrong-data | annoyance
 ```
 
-## Known open bugs — do not re-report as new (re-confirming with NEW evidence is fine)
+## Known bugs — current status (do not re-report the open one as new; re-confirming with NEW evidence is fine)
 
-- #355 graph duplicates the CS subject-root hub (the oracle will flag this).
-- #430 cookie-only session renders an infinite dashboard skeleton.
-- #435, #436, #441 — open UI/infra bugs from Chapter 1.
-- #439 RAG indexing errors in the backend log are allowlisted noise.
+- **Known-open:** #449 — `get_courses` per-enrollment fan-out produces
+  duplicate `course_id` rows. Library's instance was fixed render-side in
+  #451; Tree/Dashboard/etc. and the `DocumentUploadModal` course picker still
+  show it.
+- **Recently fixed** — a regression on any of these is a genuine new finding,
+  not a known bug: #355 (graph's duplicated CS subject-root hub), #430
+  (cookie-only session infinite dashboard skeleton), #435 (unresolved
+  course_id), #436 + root cause #354 (Gemini provider event-loop flake),
+  #439 (RAG-indexing log noise — the allowlist entry stays as defense in
+  depth), #446 (concept-description 500), #441 (PG17/PG15 skew — local/CI
+  now pinned to PG15).
 
 ## End of session
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -39,7 +39,10 @@ shadow_port = 54320
 health_timeout = "2m"
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
-major_version = 17
+# Pinned to 15 to match staging/prod (#441) — the deterministic local/CI lane
+# should test what production actually runs. 15 is also the Supabase CLI's own
+# documented default for this key.
+major_version = 15
 
 [db.pooler]
 enabled = false


### PR DESCRIPTION
## What & why

Completes the extraction-accuracy eval harness for the migrated Pydantic AI agents. Closes **#148** (part of the agent-migration epic **#152**). This is the evidence base the final `gemini_service` cutover (#151) needs — it turns "did this prompt/model change make extraction worse?" from a smoke test into a measured, gated check.

The harness previously existed only as a non-functional scaffold: 4 of ~95 cases had cassettes, `quiz_generation`/`chat_tutor` had none, the runner failed on any evaluator score `< 1.0` (wrong for an accuracy harness), and the CI workflow was `workflow_dispatch`-only.

## Changes

- **80 cassettes recorded** against live Gemini across the five offline datasets (`document_classification`, `document_summary`, `concept_extraction`, `syllabus_extraction`, `quiz_generation`). Replay is now deterministic and needs no key.
- **Gate on regression, not perfection.** Replay is deterministic (model output frozen in the cassette), so a task's aggregate score only moves when an evaluator, expected output, or cassette changes. Runs fail when a score drops below its committed baseline in `baselines.json` or a cassette is missing — **not** on `< 1.0`. `SAPLING_EVAL_UPDATE_BASELINES=1` refreshes baselines.
- **Robustness:** retry transient 503/429/UNAVAILABLE while recording; force UTF-8 on stdout/stderr so non-ASCII cases (e.g. a Mandarin syllabus) don't crash `rich` on a Windows cp1252 console.
- **One command + CI:** `tests/evals/run_all.py` runs every offline dataset and prints a per-task accuracy summary; `evals.yml` runs it in replay mode on every PR touching `backend/agents/**` or the harness.
- **Docs:** `backend/tests/evals/README.md` (record/refresh workflow), README update, and **ADR 0020** (design + baseline numbers).
- **`chat_tutor` excluded** from the offline harness — its retrieval tool reads a live Supabase and can't run against cassettes; folded into the graph-grounded tutor work (**#149**).

## Baselines (2026-07-28, current per-task models)

| Dataset | Notable | Score |
|---|---|---|
| document_classification | Category / SyllabusFlag | 0.80 / 0.88 |
| document_summary | AbstractLength | 0.933 (others 1.00) |
| concept_extraction | all | 1.00 |
| syllabus_extraction | NoInventedDates | 0.933 (others 1.00) |
| quiz_generation | all | 1.00 |

These are a floor, not a target. Re-record and re-baseline when a prompt/model changes.

## Testing

- `python tests/evals/run_all.py` → **5/5 PASS** (replay, gate on baselines).
- Backend suite (CI ignore set): **1047 passed, 23 skipped**.
- `ruff check` clean on new files.

## Follow-ups (not in scope)

- **#149** — bring `chat_tutor` into the harness once it has an offline retrieval seam.
- Periodic `record` pass is still how live-model regressions surface (replay validates against a snapshot). Called out in ADR 0020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified offline evaluation runner covering concept extraction, document classification, summaries, quiz generation, and syllabus extraction.
  * Added deterministic replay datasets and accuracy baselines to detect regressions in AI-generated results.
  * Added retry handling for temporary evaluation service failures.

* **Documentation**
  * Updated evaluation instructions with replay, recording, and baseline-refresh workflows.
  * Documented CI gating and supported evaluation coverage.

* **Tests**
  * Expanded coverage with representative academic documents, multilingual content, edge cases, and quiz scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->