### PR TITLE
ci(e2e): pin the e2e lane to requirements.lock — pydantic-ai 2.x broke the streamed tutor on main

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: '3.13'
           cache: pip
-          cache-dependency-path: backend/requirements.txt
+          cache-dependency-path: backend/requirements.lock
       - uses: actions/setup-node@v4
         with:
           # node 22 to match ci.yml's frontend lane: node 20 bundles npm 10.8,
@@ -62,7 +62,14 @@ jobs:
         run: |
           cp .env.local.example .env
           python -m venv venv
-          venv/bin/pip install --quiet -r requirements.txt
+          # Install the HASH-PINNED lock, matching ci.yml's backend lane. This
+          # lane used to install requirements.txt, whose unpinned
+          # pydantic-ai-slim>=0.0.20 freshly resolved to the 2.x major on
+          # every run — where run_stream_events() returns an async context
+          # manager, so every streamed tutor turn TypeError'd pre-token and
+          # fell back to legacy, failing the tutor journey on every push to
+          # main since #349 while ci.yml (lock-pinned 1.107) stayed green.
+          venv/bin/pip install --quiet --require-hashes -r requirements.lock
       - name: Frontend deps + browser
         working-directory: frontend
         run: |

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -53,7 +53,13 @@ pytest-anyio==0.0.0
 ruff==0.15.18
 
 # Pydantic AI agents (see docs/decisions/0001-adopt-pydantic-ai.md)
-pydantic-ai-slim[google]>=0.0.20
+# <2: pydantic-ai 2.x changed run_stream_events() to return an async context
+# manager (async-for over it raises TypeError), breaking the streamed tutor
+# path the moment an unpinned resolve jumps majors — which is exactly how the
+# e2e CI lane went red on every push to main after #349 while the lock-pinned
+# lanes stayed green. Bump this ceiling only together with a chat_stream.py
+# migration and a fresh requirements.lock.
+pydantic-ai-slim[google]>=0.0.20,<2
 logfire[fastapi]>=2.0
 sse-starlette>=2.0
 


### PR DESCRIPTION
## Summary

Every `e2e.yml` run on main has been red since the #349 merge. Root cause: the e2e lane installs `requirements.txt`, whose unpinned `pydantic-ai-slim[google]>=0.0.20` now freshly resolves to the **2.x major** — where `run_stream_events()` returns an async context manager, so `chat_stream.py`'s `async for` raises `TypeError` before the first token. Every streamed tutor turn silently fell to the Rung-1 legacy fallback (which writes the user row, then dies on the CI dummy Gemini key), the client then succeeded via the JSON route, and the tutor journey failed its 6-row readback with 7 rows. `ci.yml`'s backend lane stayed green the whole time because it installs the hash-pinned lock (1.107).

Reproduced tonight by driving the real chat_tutor agent through `stream_agent_turn` on 2.20.0 (`TypeError: 'async for' requires an object with __aiter__ method, got _RunStreamEventsContext`), and verified the full app + journey request works on the locked set.

## Changes
- `e2e.yml`: install `--require-hashes -r requirements.lock` (cache keyed on the lock), matching ci.yml — one dependency universe across CI lanes.
- `requirements.txt`: `pydantic-ai-slim[google]>=0.0.20,<2` with a comment tying the ceiling to the `chat_stream.py` migration it requires.

## Verification
- e2e.yml is main-only, so the proof lands on the merge commit's run.
- Locally: full app boot + the exact tutor-journey `/chat/stream` request on the locked versions → 200, streamed constant, exactly 2 message rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)