### PR TITLE
fix(explore): resolve F1–F8 from the Chapter 2 exploration sweep

### DIFF
--- a/backend/agents/function_handlers_e2e.py
+++ b/backend/agents/function_handlers_e2e.py
@@ -205,3 +205,53 @@ register_function_handler(
     "concept_describe",
     _structured_output({"description": E2E_CONCEPT_DESCRIPTION}),
 )
+
+
+# ── Notetaker agent actions (F5a) ───────────────────────────────────────────
+#
+# routes/notes.py runs three request-path notetaker actions the browser awaits
+# and renders:
+#   POST /api/notes/{id}/summarize        → note_summary  (structured)
+#   POST /api/notes/{id}/extract-concepts → note_concepts (structured)
+#   POST /api/notes/{id}/chat             → note_chat      (plain text)
+# None were registered here before, so function mode's dispatch raised
+# UnregisteredHandlerError and each route 500'd. All three are request-path
+# (the route awaits the agent and returns its output to the user), never a
+# post-response BackgroundTask, so registering them is correct — the same
+# reason concept_describe above is registered but quiz_context is not.
+#
+# note_summary/note_concepts have structured `output_type`s (NoteSummary /
+# NoteConcepts), so each emits its fixed payload through the agent's OUTPUT
+# tool via `_structured_output` — validated by the real output schema.
+# note_chat returns plain `str`, so it emits a text ModelResponse like
+# `_chat_tutor_handler`. note_chat carries function tools (read_active_note,
+# search_course_materials, apply_graph_update), but the scripted text reply
+# invokes none of them, holding this module's no-tool-calls / zero
+# model-driven-writes constraint.
+
+# NoteSummary.summary — a faithful 2–4 sentence Markdown summary.
+E2E_NOTE_SUMMARY = (
+    "[e2e-function-model] Deterministic note summary: the note captures "
+    "recursion as a function that calls itself on a smaller subproblem, and "
+    "flags the base case as the student's open question."
+)
+# NoteConcepts.concepts — Title-Case names (0–15) merged into the graph.
+E2E_NOTE_CONCEPTS = ["Recursion", "Base Case"]
+# note_chat plain-text reply, rendered in the notetaker's sidecar chat panel.
+E2E_NOTE_CHAT_REPLY = (
+    "[e2e-function-model] Deterministic note-chat reply: your note's base "
+    "case is what stops the recursion from calling itself forever."
+)
+
+
+def _note_chat_handler(messages, info) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content=E2E_NOTE_CHAT_REPLY)])
+
+
+register_function_handler(
+    "note_summary", _structured_output({"summary": E2E_NOTE_SUMMARY})
+)
+register_function_handler(
+    "note_concepts", _structured_output({"concepts": E2E_NOTE_CONCEPTS})
+)
+register_function_handler("note_chat", _note_chat_handler)

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -554,6 +554,23 @@ def google_callback(request: Request, code: str = Query(...), state: str = Query
         )
         return resp
 
+    # First-login achievement (F7). The login-streak achievements ("First Steps"
+    # and friends) were only ever evaluated at study-session end (learn.py), so a
+    # user who signs in but hasn't just finished a session sat at 100% progress
+    # yet stayed LOCKED forever — unlike Document Collector, whose upload path
+    # fires its own check. Fire the same grant check here on every approved
+    # sign-in. `check_achievements` dedups against user_achievements (and the
+    # (user_id, achievement_id) PK backstops it), so it awards at most once and is
+    # safe to call on every login. Best-effort: a grant failure must never break
+    # sign-in.
+    try:
+        from services.achievement_service import check_achievements
+        check_achievements(user_id, "login_streak", {})
+    except Exception:
+        logger.warning(
+            "sign-in achievement check failed for %r", user_id, exc_info=True
+        )
+
     # One-shot HMAC token so the frontend can verify this redirect without a
     # second round-trip. The frontend exchanges it for the real, long-lived
     # `sapling_session` cookie (see _REDIRECT_TOKEN_TTL_SECONDS above) — it is

--- a/backend/routes/notes.py
+++ b/backend/routes/notes.py
@@ -79,6 +79,34 @@ async def _run_note_worker(agent, user_prompt: str, deps: SaplingDeps, *, action
         ) from e
 
 
+def _course_meta(offering_id: str | None, cache: dict) -> dict:
+    """Resolve an offering to its abstract course id + human labels.
+
+    Notes key on the OFFERING (a course taught in a term), but the notetaker
+    UI keys on the abstract catalog course id (and shows a course label).
+    Without these fields every note renders as "Unknown course" (finding F4).
+    Mirrors calendar.py::_course_meta_cached: a per-request memo keyed on
+    offering_id so a list of notes sharing a course hits the DB once.
+    """
+    if not offering_id:
+        return {"course_id": None, "course_code": None, "course_name": None}
+    if offering_id not in cache:
+        course_id = offering_course_id(offering_id)
+        course = {}
+        if course_id:
+            rows = table("courses").select(
+                "id,course_code,course_name",
+                filters={"id": f"eq.{course_id}"}, limit=1,
+            )
+            course = rows[0] if rows else {}
+        cache[offering_id] = {
+            "course_id": course_id,
+            "course_code": course.get("course_code"),
+            "course_name": course.get("course_name"),
+        }
+    return cache[offering_id]
+
+
 class CreateNoteBody(BaseModel):
     user_id: str
     course_id: str
@@ -106,6 +134,13 @@ async def list_user_notes(
     # the (current-term) offering for the requested course before filtering.
     offering_id = resolve_offering(course_id) if course_id else None
     notes = await list_notes(user_id=user_id, offering_id=offering_id)
+    # Attach the abstract course id + labels resolved from each note's offering.
+    # The notetaker UI keys on course_id; without it every note shows "Unknown
+    # course" (finding F4). Shared per-request memo so notes in the same course
+    # resolve the courses row once.
+    meta_cache: dict = {}
+    for n in notes:
+        n.update(_course_meta(n.get("offering_id"), meta_cache))
     # ETag from each note's (id, updated_at) — any create/edit/delete changes the
     # set or bumps updated_at. A matching If-None-Match returns 304 and skips
     # re-serializing the (already-decrypted) note list.
@@ -132,6 +167,9 @@ async def create(body: CreateNoteBody, request: Request):
         body=body.body,
         tags=body.tags,
     )
+    # Same F4 enrichment as the read paths so a freshly created note carries its
+    # abstract course_id + labels (else it shows "Unknown course" until reload).
+    note.update(_course_meta(note.get("offering_id") or offering_id, {}))
     return note
 
 
@@ -141,6 +179,9 @@ async def read(note_id: str, request: Request, user_id: str):
     note = await get_note(note_id=note_id, user_id=user_id)
     if not note:
         raise HTTPException(status_code=404, detail="Note not found.")
+    # Same offering → course_id/label enrichment as the list route (F4), so a
+    # single-note read returns a consistent shape.
+    note.update(_course_meta(note.get("offering_id"), {}))
     return note
 
 

--- a/backend/routes/onboarding.py
+++ b/backend/routes/onboarding.py
@@ -13,7 +13,16 @@ router = APIRouter()
 
 @router.get("/courses")
 def search_courses(request: Request, q: str = Query("", min_length=0)):
-    """Search courses by name or code. Returns all if q is empty."""
+    """Search courses by name or code. Returns all if q is empty.
+
+    The catalog can hold DISTINCT abstract courses (different ids, sometimes
+    different names) that share a course_code — e.g. the seed-* and rich-* demo
+    schools each define their own "CS101"/"BIO110". Without disambiguation the
+    picker showed them as indistinguishable duplicates (finding F2). Collapse by
+    normalized course_code, keeping the first (name-ordered) row per code, so
+    each code appears exactly once. Rows with a blank code are never collapsed
+    together.
+    """
     filters = {}
     if q.strip():
         filters["or"] = f"(course_name.ilike.%{q}%,course_code.ilike.%{q}%)"
@@ -24,7 +33,18 @@ def search_courses(request: Request, q: str = Query("", min_length=0)):
         order="course_name.asc",
         limit=20,
     )
-    return {"courses": rows}
+
+    deduped = []
+    seen_codes = set()
+    for row in rows:
+        code = (row.get("course_code") or "").strip().casefold()
+        if code:
+            if code in seen_codes:
+                continue
+            seen_codes.add(code)
+        deduped.append(row)
+
+    return {"courses": deduped}
 
 
 @router.post("/profile")

--- a/backend/routes/study_guide.py
+++ b/backend/routes/study_guide.py
@@ -14,13 +14,38 @@ from agents.deps import SaplingDeps
 from agents.study_guide import study_guide_agent
 from agents.usage import record_agent_usage
 from db.connection import table
-from services.academics import offering_course_id, resolve_offering
+from services.academics import (
+    offering_course_id,
+    resolve_offering,
+    user_enrollment_ids,
+    user_offering_ids_for_course,
+)
+from services.graph_service import get_courses as graph_get_courses
 from services.auth_guard import require_self
 from services.encryption import decrypt_if_present, decrypt_json
 from services.http_cache import cached_json, conditional, make_etag
 from services.request_context import current_request_id
 
 router = APIRouter()
+
+
+def _course_enrollment_ids(user_id: str, course_id: str) -> list[str]:
+    """The user's enrollment ids for the given abstract ``course_id``.
+
+    The ``assignments`` table is enrollment-keyed (the gradebook table has no
+    ``user_id``/``course_id`` column — see routes/gradebook.py). The HTTP
+    boundary speaks the abstract course id, so we resolve
+    course → the user's offering(s) of it → their enrollment rows, mirroring
+    routes/calendar.py::_read_assignments.
+    """
+    course_offerings = set(user_offering_ids_for_course(user_id, course_id))
+    if not course_offerings:
+        return []
+    return [
+        e["id"]
+        for e in user_enrollment_ids(user_id)
+        if e.get("offering_id") in course_offerings
+    ]
 
 
 def _generate_and_insert(user_id: str, offering_id: str, exam_id: str) -> dict:
@@ -30,11 +55,21 @@ def _generate_and_insert(user_id: str, offering_id: str, exam_id: str) -> dict:
     Study guides + the documents that feed them key on the OFFERING (0025);
     the caller resolves the abstract course id to an offering first.
     """
-    # 1. Fetch exam info
-    exams = table("assignments").select(
-        "id,user_id,title,due_date,assignment_type,course_id",
-        filters={"id": f"eq.{exam_id}", "user_id": f"eq.{user_id}"},
-        limit=1,
+    # 1. Fetch exam info. Assignments key on enrollment_id (no user_id/course_id
+    #    column); scope to the user's own enrollments so one user can't generate a
+    #    guide off another's exam.
+    enrollment_ids = [e["id"] for e in user_enrollment_ids(user_id)]
+    exams = (
+        table("assignments").select(
+            "id,enrollment_id,title,due_date,assignment_type",
+            filters={
+                "id": f"eq.{exam_id}",
+                "enrollment_id": f"in.({','.join(enrollment_ids)})",
+            },
+            limit=1,
+        )
+        if enrollment_ids
+        else []
     )
     if not exams:
         # The frontend renders this detail verbatim, so it has to read like
@@ -183,21 +218,24 @@ def get_cached_guides(user_id: str, request: Request):
 @router.get("/{user_id}/courses")
 def get_courses(user_id: str, request: Request):
     require_self(user_id, request)
-    courses = table("courses").select(
-        "id,course_name,color",
-        filters={"user_id": f"eq.{user_id}"},
-    )
-    return {"courses": courses}
+    # The frontend enumerates courses via /api/graph/{user_id}/courses, so this
+    # endpoint is currently unreachable from the UI. Kept alive (and off the old
+    # non-existent courses.user_id filter that 500'd) by delegating to the same
+    # enrollment-resolving helper the graph endpoint uses.
+    return {"courses": graph_get_courses(user_id)}
 
 
 @router.get("/{user_id}/exams")
 def get_exams(user_id: str, request: Request, course_id: str = Query(...)):
     require_self(user_id, request)
+    enrollment_ids = _course_enrollment_ids(user_id, course_id)
+    if not enrollment_ids:
+        return {"exams": []}
     all_assignments = table("assignments").select(
         "id,title,due_date,assignment_type",
-        filters={"user_id": f"eq.{user_id}"},
+        filters={"enrollment_id": f"in.({','.join(enrollment_ids)})"},
         order="due_date.asc",
-    )
+    ) or []
 
     exam_keywords = ["exam", "midterm", "final", "quiz"]
     exams = []

--- a/backend/services/graph_service.py
+++ b/backend/services/graph_service.py
@@ -303,22 +303,68 @@ def get_graph(user_id: str, semester: str | None = None) -> dict:
 
 def get_courses(user_id: str) -> list:
     """
-    Return user's enrolled courses joined with abstract catalog data + term.
+    Return the user's enrolled courses, collapsed to ONE row per **abstract**
+    ``course_id``.
+
+    A user can hold the same abstract course across multiple terms (e.g. CS101 in
+    Fall 2025 *and* Spring 2026 = two enrollments/offerings sharing one abstract
+    ``course_id``). This list is consumed as *abstract courses* — the dashboard
+    course count, the /tree filter chips, and the quiz / study / notetaker /
+    upload course pickers all key on ``course_id`` — so the old per-enrollment
+    fan-out surfaced the same course twice (#449, findings F1/F3). We collapse
+    here instead of leaving every consumer to de-dupe.
+
+    Collapse rule: one row per ``course_id``; the **most recent** enrollment
+    (latest ``enrolled_at`` — rows arrive ordered ``enrolled_at.asc``, so the
+    last occurrence wins) is the representative for
+    ``enrollment_id``/``color``/``nickname``/``term``/``enrolled_at``.
+    ``node_count`` is the graph-node count for the abstract course (the graph
+    keys on ``course_id``), counted **once** — never doubled across offerings.
+    Per-enrollment detail is preserved, not dropped: ``enrollment_ids`` and
+    ``terms`` carry every offering the user holds for the course. (Gradebook /
+    analytics still resolve per-enrollment/term via their own enrollment-keyed
+    endpoints, not this abstract-course list.)
+
     Returns list of dicts with: enrollment_id, course_id (abstract), course_code,
-    course_name, school, department, color, nickname, term, node_count, enrolled_at.
+    course_name, school, department, color, nickname, term, node_count,
+    enrolled_at, enrollment_ids, terms.
     """
     rows = _user_enrolled_courses(user_id)
 
-    result = []
+    # Collapse enrollments to one representative row per abstract course_id,
+    # preserving first-seen order, while accumulating every enrollment id / term.
+    order: list[str] = []
+    reps: dict[str, dict] = {}
+    enrollment_ids: dict[str, list[str]] = {}
+    terms: dict[str, list[str]] = {}
     for r in rows:
-        course = r.get("courses", {}) if isinstance(r.get("courses"), dict) else {}
         course_id = r.get("course_id")  # abstract
+        if not course_id:
+            continue
+        if course_id not in reps:
+            order.append(course_id)
+            enrollment_ids[course_id] = []
+            terms[course_id] = []
+        reps[course_id] = r  # last (most recent enrolled_at) wins as representative
+        eid = r.get("id")
+        if eid and eid not in enrollment_ids[course_id]:
+            enrollment_ids[course_id].append(eid)
+        term_label = r.get("term")
+        if term_label and term_label not in terms[course_id]:
+            terms[course_id].append(term_label)
 
-        # Count nodes for this course (graph keys on the abstract course id)
+    result = []
+    for course_id in order:
+        r = reps[course_id]
+        course = r.get("courses", {}) if isinstance(r.get("courses"), dict) else {}
+
+        # Count nodes for this course (graph keys on the abstract course id).
+        # Counted once per distinct course — the fan-out used to run this per
+        # enrollment, double-counting the same abstract course's nodes.
         node_rows = table("graph_nodes").select(
             "id",
             filters={"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"},
-        ) if course_id else []
+        ) or []
 
         result.append({
             "enrollment_id": r["id"],
@@ -332,6 +378,8 @@ def get_courses(user_id: str) -> list:
             "term": r.get("term", ""),
             "node_count": len(node_rows),
             "enrolled_at": r.get("enrolled_at"),
+            "enrollment_ids": enrollment_ids[course_id],
+            "terms": terms[course_id],
         })
     return result
 

--- a/backend/tests/test_auth_first_login_achievement.py
+++ b/backend/tests/test_auth_first_login_achievement.py
@@ -1,0 +1,175 @@
+"""
+Regression test for F7 — "First Steps" (first_login) is stuck at 100% but never
+granted.
+
+The login-streak achievements (First Steps / Week Warrior / Monthly Master) were
+only ever *evaluated* at study-session end (learn.py fires
+`check_achievements(user_id, "login_streak", {})` when a session closes). The
+sign-in path itself never fired any achievement check, so a user who signs in —
+with a login streak already at 1, i.e. progress 1/1 — but has not just finished a
+study session stayed LOCKED on First Steps forever. (Document Collector works
+because the upload path in documents.py fires its own check.)
+
+The fix wires the same idempotent grant check into the real /google/callback
+sign-in path. These tests drive the REAL callback (only the Google network hops
+are mocked, mirroring test_auth_stub_promotion.py) and pin:
+
+  1. an approved sign-in with streak >= 1 grants First Steps (moves it to
+     user_achievements), and
+  2. the grant is idempotent — an already-earned First Steps is not re-inserted.
+"""
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import routes.auth as auth_module
+import services.achievement_service as ach_module
+
+# Mount ONLY the auth router — main.py pulls in the full stack (logfire etc.).
+_app = FastAPI()
+_app.include_router(auth_module.router, prefix="/api/auth")
+
+GOOGLE_ID = "112233445566778899000"
+USER_ID = f"user_{GOOGLE_ID}"
+EMAIL = "student@bu.edu"
+FIRST_STEPS_ID = "ach-first-steps"
+
+
+def _make_factory(user_rows, earned_rows, insert_sink):
+    """Per-table mocks shared by BOTH auth.py and achievement_service.py.
+
+    `users.select` returns `user_rows` for every call — the shape carries both
+    `id`/`is_approved` (the google_id lookup) and `streak_count` (the
+    login_streak stat lookup). `user_achievements.insert` is captured so the test
+    can assert First Steps actually moved to earned.
+    """
+    mocks: dict = {}
+
+    def factory(name):
+        if name not in mocks:
+            m = MagicMock(name=f"table:{name}")
+            m.select.return_value = []
+            m.insert.return_value = []
+            m.update.return_value = []
+            m.upsert.return_value = []
+            mocks[name] = m
+        return mocks[name]
+
+    factory("users").select.return_value = user_rows
+    # First Steps' seeded trigger: login_streak, threshold 1.
+    factory("achievement_triggers").select.return_value = [
+        {
+            "id": "trg-1",
+            "achievement_id": FIRST_STEPS_ID,
+            "trigger_type": "login_streak",
+            "trigger_threshold": 1,
+        },
+    ]
+    factory("user_achievements").select.return_value = earned_rows
+
+    def _capture_insert(payload):
+        insert_sink.append(payload)
+        return [{}]
+
+    factory("user_achievements").insert.side_effect = _capture_insert
+    factory("achievements").select.return_value = [{"slug": "first_login"}]
+    factory("achievement_cosmetics").select.return_value = []
+    return factory, mocks
+
+
+@pytest.fixture
+def drive_callback(monkeypatch):
+    """Drive the real /google/callback past the two Google network hops."""
+    monkeypatch.setattr(auth_module, "SESSION_SECRET", "test-secret-key")
+    monkeypatch.setattr(auth_module, "GOOGLE_AVAILABLE", True)
+
+    creds = MagicMock(token="access-tok", refresh_token="refresh-tok", expiry=None)
+    flow = MagicMock(credentials=creds)
+    fake_flow_cls = MagicMock()
+    fake_flow_cls.from_client_config.return_value = flow
+    monkeypatch.setattr(auth_module, "Flow", fake_flow_cls, raising=False)
+
+    userinfo = MagicMock()
+    userinfo.raise_for_status.return_value = None
+    userinfo.json.return_value = {
+        "id": GOOGLE_ID,
+        "email": EMAIL,
+        "name": "Ada Lovelace",
+        "picture": "https://example.com/a.png",
+    }
+    # auth.py does `import httpx` inside the function, so patch the module attr.
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: userinfo)
+
+    def _drive(user_rows, earned_rows):
+        insert_sink: list = []
+        factory, mocks = _make_factory(user_rows, earned_rows, insert_sink)
+        # Both modules resolve `table` independently; share one factory so the
+        # achievement check sees the same mocked DB the callback wrote to.
+        monkeypatch.setattr(auth_module, "table", factory)
+        monkeypatch.setattr(ach_module, "table", factory)
+
+        nonce = "nonce-xyz"
+        cookie = auth_module._encode_oauth_cookie(
+            {"n": nonce, "cv": "verifier", "popup_id": None}
+        )
+        state = auth_module._encode_state({"action": "signin", "n": nonce})
+        client = TestClient(_app)
+        client.cookies.set(auth_module.OAUTH_STATE_COOKIE, cookie)
+        resp = client.get(
+            f"/api/auth/google/callback?code=auth-code&state={state}",
+            follow_redirects=False,
+        )
+        return resp, mocks, insert_sink
+
+    return _drive
+
+
+def test_first_steps_granted_on_approved_signin(drive_callback):
+    """An approved sign-in with a login streak of 1 must grant First Steps."""
+    resp, _mocks, insert_sink = drive_callback(
+        user_rows=[{"id": USER_ID, "is_approved": True, "streak_count": 1}],
+        earned_rows=[],
+    )
+    # Sign-in still succeeds (redirect to the frontend callback, not /pending).
+    assert resp.status_code in (302, 307)
+    assert "/pending" not in resp.headers["location"]
+
+    granted = [p["achievement_id"] for p in insert_sink]
+    assert FIRST_STEPS_ID in granted, (
+        "First Steps must be granted on an approved sign-in — the login path "
+        "never fired the login_streak achievement check (F7)."
+    )
+
+
+def test_first_steps_grant_is_idempotent(drive_callback):
+    """A already-earned First Steps must not be re-inserted on the next sign-in."""
+    resp, _mocks, insert_sink = drive_callback(
+        user_rows=[{"id": USER_ID, "is_approved": True, "streak_count": 1}],
+        earned_rows=[{"achievement_id": FIRST_STEPS_ID}],
+    )
+    assert resp.status_code in (302, 307)
+
+    granted = [p["achievement_id"] for p in insert_sink]
+    assert FIRST_STEPS_ID not in granted, (
+        "check_achievements dedups against user_achievements, so an already-earned "
+        "achievement must never be inserted twice (award-once)."
+    )
+
+
+def test_signin_still_succeeds_when_achievement_check_raises(drive_callback, monkeypatch):
+    """The grant is best-effort: a failure in the check must not break sign-in."""
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("achievement backend down")
+
+    monkeypatch.setattr(ach_module, "check_achievements", _boom)
+
+    resp, _mocks, _sink = drive_callback(
+        user_rows=[{"id": USER_ID, "is_approved": True, "streak_count": 1}],
+        earned_rows=[],
+    )
+    assert resp.status_code in (302, 307)
+    assert "/pending" not in resp.headers["location"]

--- a/backend/tests/test_e2e_function_handlers.py
+++ b/backend/tests/test_e2e_function_handlers.py
@@ -25,6 +25,9 @@ from agents.chat_tutor import socratic_agent
 from agents.classifier import classifier_agent
 from agents.concept_describe import build_message, concept_describe_agent
 from agents.deps import SaplingDeps
+from agents.note_chat import note_chat_agent
+from agents.note_concepts import note_concepts_agent
+from agents.note_summary import note_summary_agent
 from agents.quiz import quiz_agent
 from agents.summary import summary_agent
 from routes.learn import _resolve_model_pref
@@ -325,3 +328,76 @@ def test_concept_describe_handler_passes_real_output_schema(monkeypatch):
 
     assert result.output.description == E2E_CONCEPT_DESCRIPTION
     assert len(E2E_CONCEPT_DESCRIPTION) <= 400
+
+
+# ── Notetaker agent actions (F5a) ─────────────────────────────────────────
+#
+# routes/notes.py's summarize / extract-concepts / chat run note_summary,
+# note_concepts, and note_chat — all request-path (the route awaits the agent
+# and returns its output to the user). Before F5a this module registered
+# seven tasks but none of these three, so function mode's dispatch raised
+# UnregisteredHandlerError and each route 500'd. These are the boot +
+# constants-sync contract tests: note_summary/note_concepts flow through the
+# REAL structured output tools, note_chat through a plain-text response.
+
+
+def test_env_module_registers_note_summary_handler_on_dispatch(monkeypatch):
+    """note_summary has a structured output (NoteSummary.summary): a real agent
+    run gets the module's fixed summary through the REAL output tool, with no
+    handler registered by the test itself."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv(
+        "SAPLING_FUNCTION_HANDLERS", "agents.function_handlers_e2e"
+    )
+
+    with note_summary_agent.override(model=model_for("note_summary")):
+        result = note_summary_agent.run_sync(
+            "Title: Recursion\n\nBody:\nA function that calls itself.",
+            deps=_deps(),
+        )
+
+    from agents.function_handlers_e2e import E2E_NOTE_SUMMARY
+
+    assert result.output.summary == E2E_NOTE_SUMMARY
+    assert "note_summary" in providers._FUNCTION_HANDLERS
+
+
+def test_env_module_registers_note_concepts_handler_on_dispatch(monkeypatch):
+    """note_concepts has a structured output (NoteConcepts.concepts, a list of
+    Title-Case names, 0–15 entries): the real agent returns the module's fixed
+    list through the REAL output tool, and it satisfies that schema bound."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv(
+        "SAPLING_FUNCTION_HANDLERS", "agents.function_handlers_e2e"
+    )
+
+    with note_concepts_agent.override(model=model_for("note_concepts")):
+        result = note_concepts_agent.run_sync(
+            "Title: Recursion\n\nBody:\nA function that calls itself.",
+            deps=_deps(),
+        )
+
+    from agents.function_handlers_e2e import E2E_NOTE_CONCEPTS
+
+    assert result.output.concepts == E2E_NOTE_CONCEPTS
+    assert all(isinstance(c, str) and c.strip() for c in result.output.concepts)
+    assert len(result.output.concepts) <= 15
+    assert "note_concepts" in providers._FUNCTION_HANDLERS
+
+
+def test_env_module_registers_note_chat_handler_on_dispatch(monkeypatch):
+    """note_chat returns plain str, so its handler emits a text ModelResponse
+    (like chat_tutor): the real agent run yields the module's fixed reply with
+    none of its function tools (read_active_note, ...) fired."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    monkeypatch.setenv(
+        "SAPLING_FUNCTION_HANDLERS", "agents.function_handlers_e2e"
+    )
+
+    with note_chat_agent.override(model=model_for("note_chat")):
+        result = note_chat_agent.run_sync("What is a base case?", deps=_deps())
+
+    from agents.function_handlers_e2e import E2E_NOTE_CHAT_REPLY
+
+    assert result.output == E2E_NOTE_CHAT_REPLY
+    assert "note_chat" in providers._FUNCTION_HANDLERS

--- a/backend/tests/test_graph_service.py
+++ b/backend/tests/test_graph_service.py
@@ -341,6 +341,50 @@ class TestGetCourses:
         assert result[0]["term"] == "Spring 2026"      # term surfaced
         assert result[0]["node_count"] == 2
 
+    def test_collapses_duplicate_course_across_terms(self):
+        """#449 (findings F1/F3): a user enrolled in the SAME abstract course in
+        two terms (CS101 Fall 2025 + CS101 Spring 2026) has two enrollments/
+        offerings sharing one abstract course_id. get_courses must collapse them
+        to ONE row per course_id — not fan out one row per enrollment."""
+        fall = _enrollment_row("cs101", "CS101", "Intro CS",
+                               term="Fall 2025", offering_id="off-fall")
+        fall["id"] = "enr-fall"
+        fall["enrolled_at"] = "2025-09-01"
+        spring = _enrollment_row("cs101", "CS101", "Intro CS",
+                                 term="Spring 2026", offering_id="off-spring")
+        spring["id"] = "enr-spring"
+        spring["enrolled_at"] = "2026-01-15"
+
+        def factory(name):
+            mock = MagicMock()
+            if name == "enrollments":
+                # _user_enrolled_courses orders enrolled_at.asc
+                mock.select.return_value = [fall, spring]
+            elif name == "graph_nodes":
+                mock.select.return_value = [{"id": "n1"}, {"id": "n2"}, {"id": "n3"}]
+            else:
+                mock.select.return_value = []
+            return mock
+
+        with patch("services.graph_service.table", side_effect=factory):
+            result = get_courses("u1")
+
+        # exactly one row per DISTINCT abstract course_id
+        assert len(result) == 1
+        course_ids = [c["course_id"] for c in result]
+        assert course_ids == ["cs101"]
+        row = result[0]
+        # representative = most recent enrollment (latest enrolled_at = Spring 2026)
+        assert row["term"] == "Spring 2026"
+        assert row["enrollment_id"] == "enr-spring"
+        # node_count is the abstract course's count, counted ONCE — not doubled
+        # across the two offerings.
+        assert row["node_count"] == 3
+        # per-enrollment detail is preserved (not silently dropped) for any
+        # enrollment-keyed consumer.
+        assert set(row["enrollment_ids"]) == {"enr-fall", "enr-spring"}
+        assert set(row["terms"]) == {"Fall 2025", "Spring 2026"}
+
     def test_returns_empty_on_exception(self):
         def factory(name):
             mock = MagicMock()

--- a/backend/tests/test_notes_routes.py
+++ b/backend/tests/test_notes_routes.py
@@ -66,6 +66,40 @@ class TestListNotes:
         assert r.status_code == 200
         ro.assert_called_once_with("c2")
 
+    def test_notes_carry_resolved_course_id_and_labels(self, client):
+        # Finding F4: notes key on the OFFERING, but the notetaker UI keys on
+        # the abstract course id (and shows a course label). The list route
+        # must resolve each note's offering → course_id/course_code/course_name,
+        # else every note renders as "Unknown course".
+        async def fake_list(user_id, offering_id=None):
+            return [
+                {"id": "n1", "user_id": "u1", "offering_id": "off1",
+                 "title": "A", "body": "", "tags": [],
+                 "last_summary": None, "last_summary_at": None,
+                 "created_at": "2026-05-11T00:00:00Z",
+                 "updated_at": "2026-05-11T00:00:00Z"},
+            ]
+
+        class _FakeCoursesTable:
+            def select(self, *_a, **_k):
+                return [{"id": "c1", "course_code": "BIO101",
+                         "course_name": "Intro Biology"}]
+
+        with (
+            patch("routes.notes.list_notes", side_effect=fake_list),
+            patch("routes.notes.offering_course_id", return_value="c1") as oc,
+            patch("routes.notes.table", return_value=_FakeCoursesTable()),
+        ):
+            r = client.get("/api/notes/user/u1")
+        assert r.status_code == 200
+        note = r.json()["notes"][0]
+        # The abstract course id the frontend looks up in its courses list.
+        assert note["course_id"] == "c1"
+        # Belt-and-suspenders labels resolved from the courses row.
+        assert note["course_code"] == "BIO101"
+        assert note["course_name"] == "Intro Biology"
+        oc.assert_called_once_with("off1")
+
 
 class TestCreateNote:
     def test_creates_with_required_fields(self, client):
@@ -118,6 +152,34 @@ class TestGetNote:
         with patch("routes.notes.get_note", side_effect=fake_get):
             r = client.get("/api/notes/missing?user_id=u1")
         assert r.status_code == 404
+
+    def test_single_read_carries_resolved_course_id(self, client):
+        # Same enrichment as the list route (finding F4): a single-note read
+        # resolves its offering → abstract course id + labels so any consumer
+        # gets a consistent note shape.
+        async def fake_get(note_id, user_id):
+            return {"id": note_id, "user_id": user_id, "offering_id": "off1",
+                    "title": "T", "body": "B", "tags": [],
+                    "last_summary": None, "last_summary_at": None,
+                    "created_at": "2026-05-11T00:00:00Z",
+                    "updated_at": "2026-05-11T00:00:00Z"}
+
+        class _FakeCoursesTable:
+            def select(self, *_a, **_k):
+                return [{"id": "c1", "course_code": "BIO101",
+                         "course_name": "Intro Biology"}]
+
+        with (
+            patch("routes.notes.get_note", side_effect=fake_get),
+            patch("routes.notes.offering_course_id", return_value="c1"),
+            patch("routes.notes.table", return_value=_FakeCoursesTable()),
+        ):
+            r = client.get("/api/notes/n1?user_id=u1")
+        assert r.status_code == 200
+        note = r.json()
+        assert note["course_id"] == "c1"
+        assert note["course_code"] == "BIO101"
+        assert note["course_name"] == "Intro Biology"
 
 
 class TestUpdateNote:

--- a/backend/tests/test_onboarding_routes.py
+++ b/backend/tests/test_onboarding_routes.py
@@ -49,6 +49,53 @@ class TestSearchCourses:
         assert res.status_code == 200
         assert len(res.json()["courses"]) == 2
 
+    def test_collapses_duplicate_course_codes(self):
+        # The catalog can hold two DISTINCT abstract courses (different ids,
+        # possibly different names) that share a course_code — e.g. the seed-*
+        # (Sapling Demo University) and rich-* (Rich Local University) demo
+        # schools both define CS101 / BIO110. The picker must not surface them
+        # as visually-indistinguishable duplicates (finding F2): collapse by
+        # course_code so each code appears once.
+        mock = MagicMock()
+        mock.select.return_value = [
+            {"id": "seed-course-cs101", "course_code": "CS101",
+             "course_name": "Intro to Computer Science"},
+            {"id": "rich-course-cs101", "course_code": "CS101",
+             "course_name": "Introduction to Computer Science"},
+            {"id": "seed-course-bio110", "course_code": "BIO110",
+             "course_name": "Cell Biology"},
+            {"id": "rich-course-bio110", "course_code": "BIO110",
+             "course_name": "Cell Biology"},
+        ]
+        with patch("routes.onboarding.table", return_value=mock):
+            res = client.get("/api/onboarding/courses?q=c")
+
+        assert res.status_code == 200
+        courses = res.json()["courses"]
+        codes = [c["course_code"] for c in courses]
+        # No two returned entries share a course_code.
+        assert len(codes) == len(set(codes)), f"duplicate course codes leaked: {codes}"
+        assert sorted(codes) == ["BIO110", "CS101"]
+
+    def test_distinct_codes_are_all_kept(self):
+        # Dedup keys on course_code only; distinct codes (even with blank codes)
+        # must all survive so the picker still lists every real course.
+        mock = MagicMock()
+        mock.select.return_value = [
+            {"id": "a", "course_code": "CS101", "course_name": "Intro CS"},
+            {"id": "b", "course_code": "MATH210", "course_name": "Linear Algebra"},
+            {"id": "c", "course_code": "", "course_name": "Uncoded One"},
+            {"id": "d", "course_code": "", "course_name": "Uncoded Two"},
+        ]
+        with patch("routes.onboarding.table", return_value=mock):
+            res = client.get("/api/onboarding/courses")
+
+        assert res.status_code == 200
+        ids = [c["id"] for c in res.json()["courses"]]
+        # All four survive: two distinct codes + two blank-code rows are not
+        # collapsed into each other.
+        assert ids == ["a", "b", "c", "d"]
+
 
 def _make_factory(tables, *, course_rows, enrollment_rows, offering_rows=None):
     """Build a shared table() mock factory across onboarding + academics.

--- a/backend/tests/test_study_guide_routes.py
+++ b/backend/tests/test_study_guide_routes.py
@@ -34,6 +34,29 @@ def _agent_run_returning(content):
 # ── GET /api/study-guide/{user_id}/exams ─────────────────────────────────────
 
 class TestGetExams:
+    @staticmethod
+    def _exam_stack(all_assignments, captured):
+        """A table() side_effect (shared by routes.study_guide + services.academics)
+        that resolves course_1 → offering off1 → enrollment enr1, and records the
+        filters the assignments query is issued with in ``captured``."""
+
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "course_offerings":
+                m.select.return_value = [{"id": "off1"}]
+            elif name == "enrollments":
+                m.select.return_value = [{"id": "enr1", "offering_id": "off1"}]
+            elif name == "assignments":
+                def _select(cols, filters=None, order=None, limit=None):
+                    captured["filters"] = filters or {}
+                    return all_assignments
+                m.select.side_effect = _select
+            else:
+                m.select.return_value = []
+            return m
+
+        return table_side_effect
+
     def test_filters_by_type_and_keywords(self):
         all_assignments = [
             {"id": "a1", "title": "Midterm Exam", "due_date": "2026-04-01", "assignment_type": "exam"},
@@ -41,8 +64,10 @@ class TestGetExams:
             {"id": "a3", "title": "Reading quiz", "due_date": "2026-04-03", "assignment_type": "other"},
             {"id": "a4", "title": "Project B",   "due_date": "2026-04-04", "assignment_type": "project"},
         ]
-        with patch("routes.study_guide.table") as t:
-            t.return_value.select.return_value = all_assignments
+        captured = {}
+        side_effect = self._exam_stack(all_assignments, captured)
+        with patch("routes.study_guide.table", side_effect=side_effect), \
+             patch("services.academics.table", side_effect=side_effect):
             r = client.get(f"/api/study-guide/{USER_ID}/exams?course_id={COURSE_ID}")
         assert r.status_code == 200
         slugs = {e["title"] for e in r.json()["exams"]}
@@ -50,6 +75,54 @@ class TestGetExams:
         assert "Reading quiz" in slugs  # title contains "quiz"
         assert "Homework 3" not in slugs
         assert "Project B" not in slugs
+
+    def test_scopes_assignments_by_enrollment_id_not_user_id(self):
+        """Regression (F6): the assignments table is enrollment-keyed (no user_id/
+        course_id column). Filtering by user_id makes PostgREST 500 the request, so
+        study guides were bricked for every course. The query must scope by
+        enrollment_id resolved from the abstract course_id."""
+        all_assignments = [
+            {"id": "a1", "title": "Final Exam", "due_date": "2026-05-01", "assignment_type": "exam"},
+        ]
+        captured = {}
+        side_effect = self._exam_stack(all_assignments, captured)
+        with patch("routes.study_guide.table", side_effect=side_effect), \
+             patch("services.academics.table", side_effect=side_effect):
+            r = client.get(f"/api/study-guide/{USER_ID}/exams?course_id={COURSE_ID}")
+        assert r.status_code == 200
+        # The assignments read filters by enrollment_id (the user's enrollment in
+        # an offering of course_1), never by the non-existent user_id column.
+        assert captured["filters"] == {"enrollment_id": "in.(enr1)"}
+        assert "user_id" not in captured["filters"]
+        assert [e["title"] for e in r.json()["exams"]] == ["Final Exam"]
+
+    def test_returns_empty_when_not_enrolled(self):
+        """No enrollment in the course → no assignments query, empty list, 200."""
+        def side_effect(name):
+            m = MagicMock()
+            m.select.return_value = []  # no offerings/enrollments for the course
+            return m
+
+        with patch("routes.study_guide.table", side_effect=side_effect), \
+             patch("services.academics.table", side_effect=side_effect):
+            r = client.get(f"/api/study-guide/{USER_ID}/exams?course_id={COURSE_ID}")
+        assert r.status_code == 200
+        assert r.json() == {"exams": []}
+
+
+# ── GET /api/study-guide/{user_id}/courses ───────────────────────────────────
+
+class TestGetCourses:
+    def test_delegates_to_enrollment_helper(self):
+        """The route is UI-dead (the frontend uses /api/graph/.../courses) but must
+        not 500 on the old courses.user_id filter — it delegates to the shared
+        enrollment-resolving helper instead."""
+        courses = [{"course_id": "c1", "course_name": "Calc II", "color": "#abc"}]
+        with patch("routes.study_guide.graph_get_courses", return_value=courses) as g:
+            r = client.get(f"/api/study-guide/{USER_ID}/courses")
+        assert r.status_code == 200
+        assert r.json() == {"courses": courses}
+        g.assert_called_once_with(USER_ID)
 
 
 # ── GET /api/study-guide/{user_id}/cached ────────────────────────────────────
@@ -128,6 +201,10 @@ class TestGetGuide:
                 m.insert.side_effect = _insert
             elif name == "assignments":
                 m.select.return_value = [{"title": "Final", "due_date": "2026-05-01"}]
+            elif name == "enrollments":
+                # Assignments key on enrollment_id — the exam lookup scopes to the
+                # user's enrollments.
+                m.select.return_value = [{"id": "enr1", "offering_id": "off1"}]
             elif name == "documents":
                 m.select.return_value = []
             else:
@@ -136,6 +213,7 @@ class TestGetGuide:
 
         agent_run = _agent_run_returning(fresh_content)
         with patch("routes.study_guide.table", side_effect=table_side_effect), \
+             patch("routes.study_guide.user_enrollment_ids", return_value=[{"id": "enr1", "offering_id": "off1"}]), \
              patch("routes.study_guide.resolve_offering", return_value="off1") as ro, \
              patch("routes.study_guide.study_guide_agent.run", new=agent_run):
             r = client.get(f"/api/study-guide/{USER_ID}/guide?course_id={COURSE_ID}&exam_id={EXAM_ID}")
@@ -197,6 +275,8 @@ class TestRegenerateGuide:
             return m
 
         with patch("routes.study_guide.table", side_effect=table_side_effect), \
+             patch("routes.study_guide.user_enrollment_ids", return_value=[{"id": "enr1", "offering_id": "off1"}]), \
+             patch("routes.study_guide.resolve_offering", return_value="off1"), \
              patch("routes.study_guide.study_guide_agent.run", new=_agent_run_returning(fresh_content)):
             r = client.post(
                 "/api/study-guide/regenerate",
@@ -230,6 +310,7 @@ class TestGenerationFailure:
 
         boom = AsyncMock(side_effect=RuntimeError("gemini exploded"))
         with patch("routes.study_guide.table", side_effect=table_side_effect), \
+             patch("routes.study_guide.user_enrollment_ids", return_value=[{"id": "enr1", "offering_id": "off1"}]), \
              patch("routes.study_guide.resolve_offering", return_value="off1"), \
              patch("routes.study_guide.study_guide_agent.run", new=boom):
             r = client.get(f"/api/study-guide/{USER_ID}/guide?course_id={COURSE_ID}&exam_id={EXAM_ID}")

--- a/frontend/src/app/(shell)/notetaker/page.tsx
+++ b/frontend/src/app/(shell)/notetaker/page.tsx
@@ -26,6 +26,8 @@ import type {
   GraphNode,
 } from "@/lib/types";
 import { now } from "@/lib/testMode";
+import { useToast } from "@/components/ToastProvider";
+import { humanizeError } from "@/lib/errorMessage";
 
 type Mastery = "mastered" | "learning" | "struggling" | "unexplored";
 
@@ -113,6 +115,7 @@ function apiConceptToConcept(c: ApiLinkedConcept, courseCode: string): Concept {
 export default function NotetakerPage() {
   const { userId, userReady } = useUser();
   const router = useRouter();
+  const toast = useToast();
 
   const [courses, setCourses] = React.useState<Course[]>([]);
   const [notes, setNotes] = React.useState<Note[]>([]);
@@ -374,6 +377,7 @@ export default function NotetakerPage() {
       );
     } catch (e) {
       console.error("Summarize failed", e);
+      toast.error(humanizeError(e, "Couldn't summarize this note."));
     } finally {
       setBusy(null);
     }
@@ -387,6 +391,7 @@ export default function NotetakerPage() {
       await refreshActiveConcepts();
     } catch (e) {
       console.error("Extract failed", e);
+      toast.error(humanizeError(e, "Couldn't extract concepts from this note."));
     } finally {
       setBusy(null);
     }
@@ -401,6 +406,7 @@ export default function NotetakerPage() {
       router.push(`/quiz?concept=${encodeURIComponent(concept_node_id)}`);
     } catch (e) {
       console.error("Quiz failed", e);
+      toast.error(humanizeError(e, "Couldn't generate a quiz from this note."));
       setBusy(null);
     }
   };
@@ -416,6 +422,7 @@ export default function NotetakerPage() {
       );
     } catch (e) {
       console.error("Send to tutor failed", e);
+      toast.error(humanizeError(e, "Couldn't send this note to the tutor."));
       setBusy(null);
     }
   };

--- a/frontend/src/components/ManageCoursesModal.tsx
+++ b/frontend/src/components/ManageCoursesModal.tsx
@@ -14,7 +14,7 @@ import {
   type EnrolledCourse,
   type OnboardingCourse,
 } from "@/lib/api";
-import { useActiveSemester, distinctTerms } from "@/lib/useActiveSemester";
+import { useActiveSemester, distinctTerms, courseInTerm } from "@/lib/useActiveSemester";
 
 const COLOR_RE = /^#[0-9a-fA-F]{6}$/;
 
@@ -174,13 +174,13 @@ export function ManageCoursesModal({ open, userId, courses, onClose, onChanged }
             {activeTerm ? `Courses · ${activeTerm}` : "Your courses"}
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 20 }}>
-            {courses.filter((c) => !activeTerm || c.term === activeTerm).length === 0 && (
+            {courses.filter((c) => courseInTerm(c, activeTerm)).length === 0 && (
               <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
                 No courses in this semester yet.
               </div>
             )}
             {courses
-              .filter((c) => !activeTerm || c.term === activeTerm)
+              .filter((c) => courseInTerm(c, activeTerm))
               .map((c) => (
                 <EnrolledRow key={c.course_id} userId={userId} course={c} onChanged={onChanged} />
               ))}

--- a/frontend/src/components/screens/Dashboard.tsx
+++ b/frontend/src/components/screens/Dashboard.tsx
@@ -11,7 +11,7 @@ import { DashboardSkeleton } from "../Skeleton";
 import { useUser } from "@/context/UserContext";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { useLayoutPref } from "@/lib/useLayoutPref";
-import { useActiveSemester } from "@/lib/useActiveSemester";
+import { useActiveSemester, courseInTerm } from "@/lib/useActiveSemester";
 import {
   getGraph,
   getCourses,
@@ -336,7 +336,7 @@ export function Dashboard() {
   // makes the Dashboard feel like an arrival page, not a tool page.
 
   const scopedCourses = React.useMemo(
-    () => (activeSemester ? courses.filter((c) => c.term === activeSemester) : courses),
+    () => (activeSemester ? courses.filter((c) => courseInTerm(c, activeSemester)) : courses),
     [courses, activeSemester],
   );
 

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -18,7 +18,7 @@ import { KnowledgeGraph } from "../KnowledgeGraph";
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
 import { useIsMobile } from "@/lib/useIsMobile";
-import { useActiveSemester } from "@/lib/useActiveSemester";
+import { useActiveSemester, courseInTerm } from "@/lib/useActiveSemester";
 import { useUser } from "@/context/UserContext";
 import {
   startSession,
@@ -336,7 +336,7 @@ function LearnInner() {
 
   const [recentSessions, setRecentSessions] = useState<Session[]>([]);
   const [courses, setCourses] = useState<EnrolledCourse[]>([]);
-  const [concepts, setConcepts] = useState<{ id: string; name: string; course_id: string | null; course_code: string | null; term: string | null }[]>([]);
+  const [concepts, setConcepts] = useState<{ id: string; name: string; course_id: string | null; course_code: string | null; term: string | null; terms: string[] | null }[]>([]);
   const [graphNodes, setGraphNodes] = useState<GraphNode[]>([]);
   const [graphEdges, setGraphEdges] = useState<GraphEdge[]>([]);
 
@@ -459,6 +459,7 @@ function LearnInner() {
               course_id: n.course_id ?? null,
               course_code: n.course_id ? (courseById.get(n.course_id)?.course_code ?? null) : null,
               term: n.course_id ? (courseById.get(n.course_id)?.term ?? null) : null,
+              terms: n.course_id ? (courseById.get(n.course_id)?.terms ?? null) : null,
             })),
         );
         const apiNodes = (gRes.nodes ?? []) as ApiNode[];
@@ -803,7 +804,7 @@ function LearnInner() {
   // courses when no semester is selected). The suggest/highlight logic that
   // sat next to this pre-revamp now lives up top with the rail-focus state.
   const scopedCourses = useMemo(
-    () => (activeSemester ? courses.filter(c => c.term === activeSemester) : courses),
+    () => (activeSemester ? courses.filter(c => courseInTerm(c, activeSemester)) : courses),
     [courses, activeSemester],
   );
 
@@ -1771,7 +1772,7 @@ function TopicPicker({
     const q = query.trim().toLowerCase();
     return concepts
       .filter(c => !selectedCourseId || c.course_id === selectedCourseId)
-      .filter(c => (activeSemester ? c.term === activeSemester : true))
+      .filter(c => courseInTerm(c, activeSemester))
       .filter(c => !q || c.name.toLowerCase().includes(q))
       .slice(0, 80);
   }, [concepts, query, selectedCourseId, activeSemester]);

--- a/frontend/src/components/screens/Quiz.tsx
+++ b/frontend/src/components/screens/Quiz.tsx
@@ -8,11 +8,11 @@ import { AIDisclaimerChip } from "../AIDisclaimerChip";
 import { DisclaimerModal } from "../DisclaimerModal";
 import { QuizPanel } from "../QuizPanel";
 import { useUser } from "@/context/UserContext";
-import { useActiveSemester } from "@/lib/useActiveSemester";
+import { useActiveSemester, courseInTerm } from "@/lib/useActiveSemester";
 import { getCourses, getGraph, type EnrolledCourse } from "@/lib/api";
 import type { GraphNode as ApiNode } from "@/lib/types";
 
-type Concept = { id: string; name: string; course_id: string | null; course_code: string | null; term: string | null };
+type Concept = { id: string; name: string; course_id: string | null; course_code: string | null; term: string | null; terms: string[] | null };
 
 export function Quiz() {
   return (
@@ -57,6 +57,7 @@ function QuizInner() {
               course_id: n.course_id ?? null,
               course_code: n.course_id ? (courseById.get(n.course_id)?.course_code ?? null) : null,
               term: n.course_id ? (courseById.get(n.course_id)?.term ?? null) : null,
+              terms: n.course_id ? (courseById.get(n.course_id)?.terms ?? null) : null,
             })),
         );
       } catch (err) {
@@ -71,14 +72,14 @@ function QuizInner() {
   // The graph fetch above is already scoped to the active semester, so this
   // is defensive rather than load-bearing — matches the Tree/Learn pickers.
   const scopedConcepts = useMemo(
-    () => (activeSemester ? concepts.filter(c => c.term === activeSemester) : concepts),
+    () => (activeSemester ? concepts.filter(c => courseInTerm(c, activeSemester)) : concepts),
     [concepts, activeSemester],
   );
 
   // Scope the course picker to the active semester too, so it stays consistent
   // with the concept list the quiz draws from.
   const scopedCourses = useMemo(
-    () => (activeSemester ? courses.filter(c => c.term === activeSemester) : courses),
+    () => (activeSemester ? courses.filter(c => courseInTerm(c, activeSemester)) : courses),
     [courses, activeSemester],
   );
 

--- a/frontend/src/components/screens/Settings.test.tsx
+++ b/frontend/src/components/screens/Settings.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+/**
+ * Profile-form prefill (finding F8): the Settings profile form must render the
+ * user's CURRENT display name / username / bio / location / website, not empty
+ * inputs. Blank inputs risk a save wiping the stored values.
+ *
+ * The `/settings` payload can come back with those identity fields unset even
+ * though `GET /api/profile/{user}` carries them; the component seeds the form
+ * from the public profile as a fallback so the inputs reflect what's stored.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type { UserProfile, UserSettings } from "@/lib/types";
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => ({
+    userId: "u1",
+    userName: "Rich Active",
+    avatarUrl: null,
+    userReady: true,
+    signOut: vi.fn(),
+    refreshProfile: vi.fn(),
+    setAvatarUrl: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/useLayoutPref", () => ({ useLayoutPref: () => ["sidebar", vi.fn()] }));
+vi.mock("@/lib/useScrollLock", () => ({ useScrollLock: () => {} }));
+
+vi.mock("../ToastProvider", () => ({
+  useToast: () => ({
+    error: vi.fn(), success: vi.fn(), info: vi.fn(), warn: vi.fn(), show: vi.fn(), dismiss: vi.fn(),
+  }),
+}));
+
+// Stub presentational children so this exercises the profile form only.
+vi.mock("../TopBar", () => ({ TopBar: () => null }));
+vi.mock("../FullHeightScreen", () => ({ FullHeightScreen: ({ children }: { children: React.ReactNode }) => <div>{children}</div> }));
+vi.mock("../Icon", () => ({ Icon: () => null }));
+vi.mock("../Avatar", () => ({ Avatar: () => null }));
+vi.mock("../CustomSelect", () => ({ CustomSelect: () => null }));
+vi.mock("../ProfileView", () => ({ ProfileView: () => null }));
+vi.mock("../Skeleton", () => ({ SettingsFormSkeleton: () => null }));
+vi.mock("next/link", () => ({ default: ({ children }: { children: React.ReactNode }) => children }));
+
+vi.mock("@/lib/api", () => ({
+  fetchSettings: vi.fn(),
+  fetchPublicProfile: vi.fn(),
+  updateSettings: vi.fn(),
+  deleteAccount: vi.fn(),
+  updateProfile: vi.fn(),
+  checkUsername: vi.fn(),
+  uploadAvatar: vi.fn(),
+  fetchCosmetics: vi.fn(),
+  fetchCosmeticsCatalog: vi.fn(),
+  equipCosmetic: vi.fn(),
+  exportData: vi.fn(),
+}));
+
+import { Settings } from "./Settings";
+import { fetchSettings, fetchPublicProfile } from "@/lib/api";
+
+function settings(overrides: Partial<UserSettings> = {}): UserSettings {
+  return {
+    display_name: null,
+    username: null,
+    bio: null,
+    location: null,
+    website: null,
+    notification_email: true,
+    notification_push: false,
+    notification_in_app: true,
+    theme: "light",
+    font_size: "medium",
+    accent_color: "#2b5221",
+    profile_visibility: "public",
+    activity_status_visible: true,
+    ...overrides,
+  };
+}
+
+function profile(overrides: Partial<UserProfile> = {}): UserProfile {
+  return {
+    id: "u1",
+    name: "Rich Active",
+    username: "rich-active",
+    bio: "Learning things",
+    location: "Boston, MA",
+    website: "example.com",
+    avatar_url: null,
+    created_at: null,
+    year: null,
+    majors: [],
+    minors: [],
+    school: null,
+    roles: [],
+    featured_achievements: [],
+    equipped_cosmetics: {},
+    stats: {} as UserProfile["stats"],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("Settings profile form prefill (F8)", () => {
+  it("seeds the inputs from the public profile when /settings omits the identity fields", async () => {
+    // Bug scenario: /settings returns the identity fields unset …
+    vi.mocked(fetchSettings).mockResolvedValue(settings());
+    // … but the profile carries the stored values.
+    vi.mocked(fetchPublicProfile).mockResolvedValue(profile());
+
+    render(<Settings />);
+
+    // Display name / bio / location / website (uncontrolled defaultValue inputs).
+    expect(await screen.findByDisplayValue("Rich Active")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Learning things")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Boston, MA")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("example.com")).toBeInTheDocument();
+    // Username (controlled input, seeded via usernameDraft).
+    expect(screen.getByPlaceholderText("your-handle")).toHaveValue("rich-active");
+  });
+
+  it("prefers the /settings values when they are already populated", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(
+      settings({
+        display_name: "Settings Name",
+        username: "settings-handle",
+        bio: "Settings bio",
+      }),
+    );
+    vi.mocked(fetchPublicProfile).mockResolvedValue(
+      profile({ name: "Profile Name", username: "profile-handle", bio: "Profile bio" }),
+    );
+
+    render(<Settings />);
+
+    expect(await screen.findByDisplayValue("Settings Name")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Settings bio")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("your-handle")).toHaveValue("settings-handle");
+    expect(screen.queryByDisplayValue("Profile Name")).toBeNull();
+  });
+});

--- a/frontend/src/components/screens/Settings.tsx
+++ b/frontend/src/components/screens/Settings.tsx
@@ -78,12 +78,29 @@ export function Settings() {
 
   React.useEffect(() => {
     if (!userReady || !userId) return;
-    fetchSettings(userId)
-      .then(s => {
-        setSettings(s);
-        setUsernameDraft(s.username || "");
-        if (s.accent_color) {
-          document.documentElement.style.setProperty("--accent", s.accent_color);
+    // The `/settings` payload can come back with the profile identity fields
+    // (display name, username, bio, location, website) unset, which would
+    // leave the Profile form blank and risk a save wiping the stored values.
+    // Seed those fields from the public profile as a fallback so the inputs
+    // reflect what's actually stored. The profile fetch is best-effort — a
+    // failure there must not block settings from loading.
+    Promise.all([
+      fetchSettings(userId),
+      fetchPublicProfile(userId).catch(() => null),
+    ])
+      .then(([s, profile]) => {
+        const seeded: UserSettings = {
+          ...s,
+          display_name: s.display_name || profile?.name || null,
+          username: s.username || profile?.username || null,
+          bio: s.bio || profile?.bio || null,
+          location: s.location || profile?.location || null,
+          website: s.website || profile?.website || null,
+        };
+        setSettings(seeded);
+        setUsernameDraft(seeded.username || "");
+        if (seeded.accent_color) {
+          document.documentElement.style.setProperty("--accent", seeded.accent_color);
         }
       })
       .catch((e) => console.error("settings load", e));

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -26,7 +26,7 @@ import { useToast } from "../ToastProvider";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { humanizeError, isNotFound } from "@/lib/errorMessage";
 import { useUser } from "@/context/UserContext";
-import { useActiveSemester } from "@/lib/useActiveSemester";
+import { useActiveSemester, courseInTerm } from "@/lib/useActiveSemester";
 import {
   getCourses,
   getStudyGuideExams,
@@ -90,7 +90,7 @@ export function Study() {
   // guide/flashcard generation). Study has no graph fetch of its own, so this
   // client-side filter is all the scoping it needs.
   const scopedCourses = React.useMemo(
-    () => (activeSemester ? courses.filter(c => c.term === activeSemester) : courses),
+    () => (activeSemester ? courses.filter(c => courseInTerm(c, activeSemester)) : courses),
     [courses, activeSemester],
   );
 

--- a/frontend/src/components/screens/Tree.tsx
+++ b/frontend/src/components/screens/Tree.tsx
@@ -10,7 +10,7 @@ import { KnowledgeGraph } from "../KnowledgeGraph";
 import { GraphPanelSkeleton } from "../Skeleton";
 import { useUser } from "@/context/UserContext";
 import { useIsMobile } from "@/lib/useIsMobile";
-import { useActiveSemester } from "@/lib/useActiveSemester";
+import { useActiveSemester, courseInTerm } from "@/lib/useActiveSemester";
 import { getGraph, getCourses, getSessions, deleteGraphNode, type EnrolledCourse, type Session } from "@/lib/api";
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
@@ -108,7 +108,7 @@ export function Tree() {
   }, [fullscreen]);
 
   const scopedCourses = React.useMemo(
-    () => (activeSemester ? courses.filter((c) => c.term === activeSemester) : courses),
+    () => (activeSemester ? courses.filter((c) => courseInTerm(c, activeSemester)) : courses),
     [courses, activeSemester],
   );
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -93,8 +93,15 @@ export interface EnrolledCourse {
   enrolled_at: string;
   // Human term label of the offering the enrollment hangs off, e.g. "Fall 2025".
   // The backend emits "" when the offering has no term joined — treat it as unknown,
-  // never as a past term.
+  // never as a past term. This is the REPRESENTATIVE (most-recent) term of a course
+  // that the backend collapses to one row per abstract course_id (#449); use `terms`
+  // (below) for semester membership so a course enrolled across terms shows on each.
   term: string;
+  // Every term label this abstract course is enrolled in (Fall 2025 + Spring 2026 for
+  // a re-take), alongside `enrollment_ids`. Present since the get_courses collapse;
+  // optional for backward-compat. Filter/scope by membership, not the singular `term`.
+  terms?: string[];
+  enrollment_ids?: string[];
 }
 
 export const getCourses = (userId: string) =>

--- a/frontend/src/lib/useActiveSemester.test.ts
+++ b/frontend/src/lib/useActiveSemester.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { distinctTerms } from "./useActiveSemester";
+import { distinctTerms, courseInTerm } from "./useActiveSemester";
 
 const c = (term: string) => ({ term });
 
@@ -12,5 +12,34 @@ describe("distinctTerms", () => {
   it("dedups preserving first-seen order and drops blanks", () => {
     expect(distinctTerms([c("Fall 2025"), c("Spring 2026"), c("Fall 2025"), c("")]))
       .toEqual(["Fall 2025", "Spring 2026"]);
+  });
+
+  it("flattens the per-course terms[] so every enrolled term surfaces (#449 fix)", () => {
+    // A course collapsed across enrollments carries all its terms; the
+    // singular `term` is only the most-recent representative.
+    const cs101 = { term: "Spring 2026", terms: ["Fall 2025", "Spring 2026"] };
+    const bio110 = { term: "Fall 2025", terms: ["Fall 2025"] };
+    expect(distinctTerms([cs101, bio110])).toEqual(["Fall 2025", "Spring 2026"]);
+  });
+});
+
+describe("courseInTerm", () => {
+  const cs101 = { term: "Spring 2026", terms: ["Fall 2025", "Spring 2026"] };
+
+  it("empty activeSemester (All semesters) matches every course", () => {
+    expect(courseInTerm(cs101, "")).toBe(true);
+  });
+
+  it("matches by term MEMBERSHIP, not just the representative term (regression: #462 review)", () => {
+    // The bug: filtering by the singular `term` ("Spring 2026") dropped a
+    // Fall-2025-enrolled course from the Fall 2025 tab.
+    expect(courseInTerm(cs101, "Fall 2025")).toBe(true);
+    expect(courseInTerm(cs101, "Spring 2026")).toBe(true);
+    expect(courseInTerm(cs101, "Summer 2026")).toBe(false);
+  });
+
+  it("falls back to the singular term for payloads without terms[]", () => {
+    expect(courseInTerm({ term: "Fall 2025" }, "Fall 2025")).toBe(true);
+    expect(courseInTerm({ term: "Fall 2025" }, "Spring 2026")).toBe(false);
   });
 });

--- a/frontend/src/lib/useActiveSemester.ts
+++ b/frontend/src/lib/useActiveSemester.ts
@@ -5,14 +5,36 @@ import { useCallback, useEffect, useState } from "react";
 export const ACTIVE_SEMESTER_STORAGE_KEY = "sapling_active_semester";
 const CHANGE_EVENT = "sapling-active-semester-change";
 
-/** Distinct term labels in first-seen order, dropping blanks. */
-export function distinctTerms(courses: { term: string }[]): string[] {
+type TermScoped = { term?: string | null; terms?: string[] | null };
+
+/** Every term label a course/concept belongs to. Prefers the `terms` array (a
+ *  course collapsed across enrollments carries all its terms, #449); falls back
+ *  to the singular `term` for older payloads. */
+function termsOf(c: TermScoped): string[] {
+  if (c.terms && c.terms.length) return c.terms;
+  return c.term ? [c.term] : [];
+}
+
+/** True if the course/concept belongs to `activeSemester`. The empty string
+ *  ("All semesters") always matches. Uses term MEMBERSHIP, so a course enrolled
+ *  in both Fall 2025 and Spring 2026 shows on either tab (not just its
+ *  most-recent representative term). */
+export function courseInTerm(c: TermScoped, activeSemester: string): boolean {
+  if (!activeSemester) return true;
+  return termsOf(c).includes(activeSemester);
+}
+
+/** Distinct term labels in first-seen order, dropping blanks. Flattens the
+ *  per-course `terms` array so every enrolled term surfaces as a tab. */
+export function distinctTerms(courses: TermScoped[]): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const c of courses) {
-    if (c.term && !seen.has(c.term)) {
-      seen.add(c.term);
-      out.push(c.term);
+    for (const t of termsOf(c)) {
+      if (t && !seen.has(t)) {
+        seen.add(t);
+        out.push(t);
+      }
     }
   }
   return out;


### PR DESCRIPTION
## What

Fixes all eight findings from the 2026-07-29 Chapter 2 `/explore` sweep (`.explore/findings.md`). Each fix was built by an isolated subagent (disjoint files), following systematic-debugging + TDD.

| # | Finding | Fix |
|---|---|---|
| **F6** | Study-guide feature 500-bricked for every course | `routes/study_guide.py` queries `assignments` by `enrollment_id` (was the phantom `user_id`/`course_id` columns on the enrollment-keyed table). `get_exams`, `_generate_and_insert`, and `get_courses` (now delegates to `graph_service.get_courses`). |
| **F5a** | Notetaker agent actions 500 in function-mode | Registered `note_summary` / `note_concepts` / `note_chat` handlers in `agents/function_handlers_e2e.py` (request-path tasks were unregistered → `UnregisteredHandlerError`). |
| **F4** | Every note shows "Unknown course" | `routes/notes.py` list + single-read + create now return the abstract `course_id` + `course_code`/`course_name` resolved from the note's offering. |
| **F1/F3** | #449 duplicate courses (dashboard count, tree chips, every picker) | `graph_service.get_courses` collapses the per-enrollment fan-out to one row per `course_id` (most-recent enrollment as representative, `node_count` counted once, additive `enrollment_ids`/`terms` lists). |
| **F2** | Onboarding search shows indistinguishable duplicate courses | `routes/onboarding.py` dedups results by course code (rich/base seeds define same-code courses under different schools). |
| **F7** | "First Steps" achievement stuck at 100%, never granted | `routes/auth.py` fires an idempotent login-streak achievement check on approved Google sign-in. (`test-login` untouched — it contractually performs no DB writes.) |
| **F5b** | Notetaker actions fail silently | `notetaker/page.tsx` surfaces `toast.error(humanizeError(...))` on failed Summarize/Extract/Generate-quiz/Send-to-tutor. |
| **F8** | Settings profile form blank → data-loss risk on save | `Settings.tsx` prefills name/username (and bio/location/website) from the profile fetch. |

## Verification

- **Backend:** `1325 passed` (baseline 1311 + **14 new regression tests**), `ruff` clean.
- **Frontend:** `tsc --noEmit` clean; new `Settings.test.tsx` (2 cases) + `errorMessage` (32) pass.
- **Live backend re-check** (function-mode stack + e2e oracles): F6 exams → 200, F4 notes carry `MATH210`/`CS101`, F5a note actions → 200, F1/F3 courses → 4 rows/4 unique, F2 onboarding dedup → no code dupes, **oracles: 0 findings (down from 6)**.

## Follow-ups deliberately left out of scope (flagged for triage)

- **F2:** dedup runs after the `limit=20` cap and the endpoint has no school scoping — a genuine multi-school production catalog with two real same-code courses would over-collapse. Correct long-term fix is a distinguishing school label, not dedup.
- **F7:** a brand-new user with `streak_count = 0` still won't be granted on their very first login — the `login_streak` threshold (1) vs. the "log in for the first time" wording is a mismatch in the 0007 seed trigger definition (needs a migration).
- **F5b:** other notetaker handlers (`createNoteIn`, `deleteActive`, link/unlink concept, autosave) still only `console.error` on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notetaker actions now reliably support summaries, concepts, and tutor chat.
  * Profile settings prefill missing fields from the public profile.
  * Approved Google sign-in now awards the **“First Steps”** achievement.
* **Bug Fixes**
  * Notes now immediately show resolved course details (no “unknown” until refresh).
  * Onboarding course listings deduplicate by course code (blank codes are preserved).
  * Study guides and exam lists are now correctly scoped to your enrollments.
  * Active-semester filtering is now consistent across dashboards and study surfaces, and Notetaker failures show clear toast errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->