### PR TITLE
fix(frontend): surface the five swallowed failures — closes the #113 audit tail (#166 #185 #184 #183 #186)

### DIFF
--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -76,6 +76,7 @@ renders the element.
 | Study rooms | `social` | `frontend/src/components/screens/Social.tsx` (rooms sidebar, chat, overview, study match, directory — added with the #394 two-context journey) |
 | Dashboard | `dashboard` | `frontend/src/components/screens/Dashboard.tsx` (rendered by `(shell)/dashboard/page.tsx`) |
 | Library | `library` | `frontend/src/components/screens/Library.tsx` (the `/library` document screen — upload trigger, document cards/rows, filters, detail panel) |
+| Calendar | `calendar` | `frontend/src/components/screens/Calendar.tsx` (the `/calendar` screen — today just the #185 load-failure banner + retry) |
 
 Two surfaces do **not** carry their testids in the screen file named by the
 route:

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -237,6 +237,16 @@ never collide in the DOM.
 | `dashboard-courses-manage` | the cog inside the expanded key that opens the Courses & Semesters hub (the hub's own semester tabs are plain text buttons — journeys select them by role/name, e.g. "All semesters" / "Fall 2025") |
 | `dashboard-resume-{sessionId}` | a "Where you left off" card — deep-links to `/learn?resume={sessionId}` (#164), suffixed with the session's own id per the stable-domain-id rule |
 
+### `calendar`
+
+Added with the #185 load-failure fix (a failed initial fetch must be
+distinguishable from a genuinely empty calendar).
+
+| testid | element |
+| --- | --- |
+| `calendar-load-error` | the load-failure banner (`role="alert"`) rendered instead of the calendar views when the initial assignments/courses fetch fails |
+| `calendar-load-retry` | the banner's "Try again" button — re-runs the load through the skeleton state |
+
 ### `library`
 
 Added with the upload → SSE → library journey (#387).

--- a/frontend/e2e/quiz.spec.ts
+++ b/frontend/e2e/quiz.spec.ts
@@ -41,6 +41,45 @@ const CORRECT_LABELS = ["B", "C", "A"] as const;
 /** routes/quiz.py: 3 correct of 3 → delta = 3 × 0.03 = +0.09. */
 const EXPECTED_DELTA = 3 * 0.03;
 
+/**
+ * Journey (#184): a generation that returns ZERO questions must not strand
+ * the user on a blank, control-less panel. Before the fix, start() flipped
+ * to the active phase unconditionally; with an empty array the entire
+ * active branch (including quiz-exit) rendered nothing — a dead end.
+ *
+ * The empty response is forced at the network layer (route interception),
+ * NOT via the function-mode seam: the seam's quiz handler is deliberately a
+ * fixed 3-question quiz shared by the mastery journey above, and the guard
+ * under test is purely client-side.
+ */
+test("a zero-question generation stays on the select phase with a warning (#184)", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("sapling_disclaimer_ack", "true");
+  });
+  await page.route("**/api/quiz/generate", route =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ quiz_id: "e2e-empty-quiz", questions: [] }),
+    }),
+  );
+
+  await page.goto(`/quiz?concept=${NODE_ID}`);
+  const start = page.getByTestId("quiz-start");
+  await expect(start).toBeEnabled();
+  await start.click();
+
+  // The warning surfaces and the select phase survives: Start is still
+  // there, and the active phase never rendered.
+  await expect(
+    page.getByText("No questions were generated", { exact: false }),
+  ).toBeVisible();
+  await expect(page.getByTestId("quiz-start")).toBeVisible();
+  await expect(page.getByTestId("quiz-answer-options")).toHaveCount(0);
+});
+
 test("quiz journey: all-correct answers raise mastery in UI and DB, monotonically", async ({
   page,
 }) => {

--- a/frontend/e2e/upload.spec.ts
+++ b/frontend/e2e/upload.spec.ts
@@ -57,6 +57,59 @@ const SCRIPTED_CATEGORY = "lecture_notes";
 const SCRIPTED_ABSTRACT_SNIPPET = "deterministic fixture content";
 const SCRIPTED_CONCEPTS = ["Gradient Descent", "Learning Rate"];
 
+/**
+ * Journey (#186): a course added inline from the upload modal must be
+ * immediately selectable in the per-file Course dropdown — the whole point
+ * of the inline affordance. Before the fix, `courses` was a parent-owned
+ * prop refreshed only via onComplete (fired at done/close), so the freshly
+ * added course never appeared within the same modal session.
+ *
+ * Uses the REAL catalog search + enroll routes against the seeded catalog:
+ * HIST200 (rich-course-hist200, db/seed_local_rich.py) exists in the
+ * catalog but rich-user-active is NOT enrolled in it — exactly the state
+ * the inline add exists for. No LLM stage runs (no upload is started), so
+ * this journey needs only the stack, not the model seam.
+ */
+test("a course added inline is immediately selectable for the queued file (#186)", async ({
+  page,
+}) => {
+  await page.goto("/library");
+  const uploadButton = page.getByTestId("library-upload");
+  await expect(uploadButton).toBeEnabled();
+  await uploadButton.click();
+  await expect(page.getByTestId("upload-modal")).toBeVisible();
+
+  // Queue a file so a per-file Course dropdown exists to assert on.
+  await page.getByTestId("upload-modal-file-input").setInputFiles(FIXTURE_PDF);
+  await expect(page.getByTestId("upload-modal-file-row-0")).toBeVisible();
+
+  // Inline-add the unenrolled seeded catalog course through the real flow.
+  await page.getByTestId("upload-modal-course-search").fill("HIST200");
+  await page
+    .getByTestId("upload-modal-course-result-rich-course-hist200")
+    .click();
+
+  // The just-added course is selectable in the file row's dropdown NOW —
+  // without closing/reopening the modal.
+  await page
+    .getByTestId("upload-modal-file-row-0")
+    .getByRole("button", { name: "Course" })
+    .click();
+  await expect(
+    page.getByRole("option", { name: /HIST200/ }),
+  ).toBeVisible();
+
+  // And the enrollment really happened server-side (real route, real DB).
+  const enrollments = await queryRaw(
+    `SELECT e.id
+       FROM enrollments e
+       JOIN course_offerings o ON o.id = e.offering_id
+      WHERE e.user_id = $1 AND o.course_id = $2`,
+    [USER_ACTIVE, "rich-course-hist200"],
+  );
+  expect(enrollments.length).toBeGreaterThanOrEqual(1);
+});
+
 test("upload → SSE → document appears in library and Postgres", async ({
   page,
 }) => {

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -86,6 +86,11 @@
       "count": 2
     }
   },
+  "src/components/screens/Calendar.tsx": {
+    "no-restricted-syntax": {
+      "count": 20
+    }
+  },
   "src/components/screens/Dashboard.tsx": {
     "no-restricted-syntax": {
       "count": 20

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -65,6 +65,7 @@ const eslintConfig = [
       "src/components/screens/Dashboard.tsx",
       "src/components/screens/Learn.tsx",
       "src/components/screens/Library.tsx",
+      "src/components/screens/Calendar.tsx",
     ],
     rules: {
       "no-restricted-syntax": [

--- a/frontend/src/components/DocumentUploadModal.test.tsx
+++ b/frontend/src/components/DocumentUploadModal.test.tsx
@@ -6,6 +6,10 @@
  *   3. Retry button mints a fresh request_id on the second uploadDocumentStream call
  *   4. request_id is surfaced under the row with a working "copy" button
  *
+ * Plus the inline course-add flow (#186): a course added via the modal's
+ * search must be immediately selectable in the per-file Course dropdown,
+ * default new rows for zero-course users, and reset when the modal reopens.
+ *
  * The module-level vi.mock for "@/lib/api" replaces the real network helpers
  * with controllable spies so tests can drive arbitrary SSE event sequences.
  */
@@ -31,11 +35,16 @@ import { DocumentUploadModal } from "./DocumentUploadModal";
 import { ToastProvider } from "./ToastProvider";
 import {
   uploadDocumentStream,
+  addCourse,
+  onboardingCoursesSearch,
   type UploadEvent,
   type EnrolledCourse,
+  type OnboardingCourse,
 } from "@/lib/api";
 
 const mockedUpload = vi.mocked(uploadDocumentStream);
+const mockedAddCourse = vi.mocked(addCourse);
+const mockedSearch = vi.mocked(onboardingCoursesSearch);
 
 const COURSE: EnrolledCourse = {
   enrollment_id: "e1",
@@ -257,5 +266,109 @@ describe("DocumentUploadModal SSE error UX", () => {
     await waitFor(() => {
       expect(clipboardWrite).toHaveBeenCalledWith(RID);
     });
+  });
+});
+
+describe("DocumentUploadModal inline course add (#186)", () => {
+  const NEW_COURSE: OnboardingCourse = {
+    id: "c-2",
+    course_code: "MATH200",
+    course_name: "Calculus II",
+  };
+
+  beforeEach(() => {
+    mockedAddCourse.mockReset();
+    mockedAddCourse.mockResolvedValue({ course_id: "c-2", already_existed: false });
+    mockedSearch.mockReset();
+    mockedSearch.mockResolvedValue({ courses: [NEW_COURSE] });
+  });
+
+  afterEach(() => {
+    // Restore the hoisted-factory default so other describes see an empty
+    // search result set regardless of test ordering.
+    mockedSearch.mockReset();
+    mockedSearch.mockImplementation(async () => ({ courses: [] }));
+  });
+
+  /** Searches for NEW_COURSE and clicks its result row, waiting for the add to settle. */
+  async function inlineAddCourse(user: ReturnType<typeof userEvent.setup>) {
+    await user.type(screen.getByTestId("upload-modal-course-search"), "math");
+    // The search is debounced 200ms; findBy* polls past it.
+    const resultBtn = await screen.findByTestId(`upload-modal-course-result-${NEW_COURSE.id}`);
+    await user.click(resultBtn);
+    await waitFor(() => {
+      expect(mockedAddCourse).toHaveBeenCalledWith("u1", NEW_COURSE.id);
+      // addCourseInline clears the query + results once the add resolves.
+      expect(
+        screen.queryByTestId(`upload-modal-course-result-${NEW_COURSE.id}`),
+      ).not.toBeInTheDocument();
+    });
+  }
+
+  it("makes an inline-added course immediately selectable in the per-file Course dropdown", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await inlineAddCourse(user);
+    await addFile(user);
+
+    await user.click(screen.getByRole("button", { name: "Course" }));
+    // Both the enrolled course and the just-added one are options.
+    expect(screen.getByRole("option", { name: /CS101/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /MATH200/ })).toBeInTheDocument();
+  });
+
+  it("defaults new file rows to the inline-added course when the user had no courses", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <DocumentUploadModal
+          open
+          userId="u1"
+          courses={[]}
+          onClose={() => {}}
+          onComplete={() => {}}
+        />
+      </ToastProvider>,
+    );
+
+    await inlineAddCourse(user);
+    await addFile(user);
+
+    // The row's course select defaults to the just-added course, not the
+    // "Pick a course" placeholder (pre-#186 the default was courses[0] of
+    // the stale prop, i.e. empty).
+    expect(screen.getByRole("button", { name: "Course" })).toHaveTextContent("MATH200");
+  });
+
+  it("resets inline-added courses when the modal is closed and reopened", async () => {
+    const user = userEvent.setup();
+    const modal = (open: boolean) => (
+      <ToastProvider>
+        <DocumentUploadModal
+          open={open}
+          userId="u1"
+          courses={[COURSE]}
+          onClose={() => {}}
+          onComplete={() => {}}
+        />
+      </ToastProvider>
+    );
+    const { rerender } = render(modal(true));
+
+    await inlineAddCourse(user);
+    await addFile(user);
+    await user.click(screen.getByRole("button", { name: "Course" }));
+    expect(screen.getByRole("option", { name: /MATH200/ })).toBeInTheDocument();
+
+    // Close (parent refreshes `courses` via onComplete in the real flow)
+    // and reopen: the locally merged extras must be gone.
+    rerender(modal(false));
+    rerender(modal(true));
+
+    await addFile(user);
+    await user.click(screen.getByRole("button", { name: "Course" }));
+    expect(screen.getByRole("option", { name: /CS101/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /MATH200/ })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/DocumentUploadModal.tsx
+++ b/frontend/src/components/DocumentUploadModal.tsx
@@ -53,6 +53,9 @@ interface Props {
   onComplete: (uploaded: UploadItem[]) => void;
 }
 
+/** The slice of a course the per-file dropdown + inline-add flow need. */
+type CourseOption = Pick<EnrolledCourse, "course_id" | "course_code" | "course_name">;
+
 const CATEGORY_OPTIONS = [
   { value: "syllabus", label: "Syllabus" },
   { value: "lecture_notes", label: "Lecture notes" },
@@ -71,6 +74,10 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
   const [courseQuery, setCourseQuery] = React.useState("");
   const [courseResults, setCourseResults] = React.useState<OnboardingCourse[]>([]);
   const [addingCourse, setAddingCourse] = React.useState(false);
+  // Courses added inline this session (#186). `courses` is a read-only prop
+  // the parent only refreshes via onComplete (fired at done/close), so a
+  // just-added course must be merged locally to be selectable right away.
+  const [extraCourses, setExtraCourses] = React.useState<CourseOption[]>([]);
 
   React.useEffect(() => setMounted(true), []);
 
@@ -81,6 +88,7 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
       setItems([]);
       setCourseQuery("");
       setCourseResults([]);
+      setExtraCourses([]);
     }
   }, [open]);
 
@@ -91,6 +99,11 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
     }, 200);
     return () => clearTimeout(t);
   }, [courseQuery]);
+
+  const allCourses = React.useMemo<CourseOption[]>(() => {
+    const seen = new Set(courses.map(c => c.course_id));
+    return [...courses, ...extraCourses.filter(c => !seen.has(c.course_id))];
+  }, [courses, extraCourses]);
 
   const activeUploads = items.filter(it => it.status === "uploading").length;
 
@@ -103,7 +116,7 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
   };
 
   const addFiles = (fileList: File[]) => {
-    const defaultCourseId = courses[0]?.course_id || "";
+    const defaultCourseId = allCourses[0]?.course_id || "";
     const candidates = fileList
       .slice(0, MAX_FILES - items.length)
       .filter(f => {
@@ -256,11 +269,16 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
   const addCourseInline = async (course: OnboardingCourse) => {
     setAddingCourse(true);
     try {
-      await addCourse(userId, course.id);
+      const resp = await addCourse(userId, course.id);
       toast.success(`Added ${course.course_code}`);
       setCourseQuery("");
       setCourseResults([]);
-      // Parent refreshes courses via onComplete.
+      // Parent refreshes courses via onComplete (fired at done/close), so
+      // merge the new course locally to make it selectable this session.
+      const courseId = resp?.course_id || course.id;
+      setExtraCourses(prev => prev.some(c => c.course_id === courseId)
+        ? prev
+        : [...prev, { course_id: courseId, course_code: course.course_code, course_name: course.course_name }]);
     } catch (err) {
       toast.error(`Failed: ${String(err)}`);
     } finally {
@@ -340,7 +358,7 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
             </label>
           </div>
 
-          {courses.length < 10 && (
+          {allCourses.length < 10 && (
             <div style={{ marginTop: 16 }}>
               <div className="label-micro" style={{ marginBottom: 6 }}>+ Add a course</div>
               <input
@@ -425,7 +443,7 @@ export function DocumentUploadModal({ open, userId, courses, onClose, onComplete
                     onChange={(v) => setItemField(item.id, p => ({ ...p, courseId: v }))}
                     placeholder="Pick a course"
                     ariaLabel="Course"
-                    options={courses.map(c => ({ value: c.course_id, label: c.course_code || c.course_name }))}
+                    options={allCourses.map(c => ({ value: c.course_id, label: c.course_code || c.course_name }))}
                   />
                   {item.status === "processed" && (
                     <>

--- a/frontend/src/components/Gradebook/AssignmentModal.tsx
+++ b/frontend/src/components/Gradebook/AssignmentModal.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import type { GradedAssignment, GradeCategory } from "@/lib/types";
 import { Button } from "@/components/ui";
 import Dialog from "@/components/Dialog";
+import { useToast } from "@/components/ToastProvider";
+import { humanizeError } from "@/lib/errorMessage";
 
 export interface AssignmentDraft {
   title: string;
@@ -31,6 +33,7 @@ interface Props {
 export function AssignmentModal({
   open, initial, categories, onClose, onSave, onDelete,
 }: Props) {
+  const toast = useToast();
   const titleRef = React.useRef<HTMLInputElement>(null);
   const [draft, setDraft] = React.useState<AssignmentDraft>({
     title: "",
@@ -311,7 +314,15 @@ export function AssignmentModal({
           {onDelete && initial && (
             <button
               type="button"
-              onClick={async () => { await onDelete(); onClose(); }}
+              disabled={saving}
+              // On failure the modal stays open (no onClose) so the user can
+              // see the toast and retry — closing would look like success.
+              onClick={async () => {
+                setSaving(true);
+                try { await onDelete(); onClose(); }
+                catch (err) { toast.error(humanizeError(err, "Couldn't delete the assignment. Try again.")); }
+                finally { setSaving(false); }
+              }}
               style={{ color: "var(--err)" }}
             >
               Delete
@@ -327,6 +338,7 @@ export function AssignmentModal({
             onClick={async () => {
               setSaving(true);
               try { await onSave(draft); onClose(); }
+              catch (err) { toast.error(humanizeError(err, "Couldn't save the assignment. Try again.")); }
               finally { setSaving(false); }
             }}
           >

--- a/frontend/src/components/Gradebook/EditWeightsModal.tsx
+++ b/frontend/src/components/Gradebook/EditWeightsModal.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import type { GradeCategory } from "@/lib/types";
 import { Button } from "@/components/ui";
 import Dialog from "@/components/Dialog";
+import { useToast } from "@/components/ToastProvider";
+import { humanizeError } from "@/lib/errorMessage";
 
 interface Draft {
   id?: string;
@@ -20,6 +22,7 @@ interface Props {
 }
 
 export function EditWeightsModal({ open, initial, onClose, onSave }: Props) {
+  const toast = useToast();
   const [drafts, setDrafts] = React.useState<Draft[]>([]);
   const [saving, setSaving] = React.useState(false);
   const dragIndex = React.useRef<number | null>(null);
@@ -246,9 +249,12 @@ export function EditWeightsModal({ open, initial, onClose, onSave }: Props) {
             variant="primary"
             size="sm"
             disabled={!valid || saving}
+            // On failure the modal stays open (no onClose) so the user can
+            // see the toast and retry — closing would look like success.
             onClick={async () => {
               setSaving(true);
               try { await onSave(drafts); onClose(); }
+              catch (err) { toast.error(humanizeError(err, "Couldn't save categories. Try again.")); }
               finally { setSaving(false); }
             }}
           >

--- a/frontend/src/components/Gradebook/LetterScaleEditor.tsx
+++ b/frontend/src/components/Gradebook/LetterScaleEditor.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import type { LetterScaleTier } from "@/lib/types";
 import { Button } from "@/components/ui";
 import Dialog from "@/components/Dialog";
+import { useToast } from "@/components/ToastProvider";
+import { humanizeError } from "@/lib/errorMessage";
 
 const DEFAULT_SCALE: LetterScaleTier[] = [
   { min: 93, letter: "A" }, { min: 90, letter: "A-" },
@@ -20,6 +22,7 @@ interface Props {
 }
 
 export function LetterScaleEditor({ open, initial, onClose, onSave }: Props) {
+  const toast = useToast();
   const [tiers, setTiers] = React.useState<LetterScaleTier[]>(DEFAULT_SCALE);
   const [saving, setSaving] = React.useState(false);
 
@@ -70,7 +73,18 @@ export function LetterScaleEditor({ open, initial, onClose, onSave }: Props) {
           justifyContent: "space-between", alignItems: "center",
         }}
       >
-        <button type="button" onClick={() => onSave(null)} disabled={saving}>
+        <button
+          type="button"
+          disabled={saving}
+          // Deliberately no onClose: on success the modal stays open showing
+          // the restored default scale, as before.
+          onClick={async () => {
+            setSaving(true);
+            try { await onSave(null); }
+            catch (err) { toast.error(humanizeError(err, "Couldn't reset the letter scale. Try again.")); }
+            finally { setSaving(false); }
+          }}
+        >
           Reset to default
         </button>
         <div style={{ display: "flex", gap: 8 }}>
@@ -79,9 +93,12 @@ export function LetterScaleEditor({ open, initial, onClose, onSave }: Props) {
             variant="primary"
             size="sm"
             disabled={!monotonic || saving}
+            // On failure the modal stays open (no onClose) so the user can
+            // see the toast and retry — closing would look like success.
             onClick={async () => {
               setSaving(true);
               try { await onSave(tiers); onClose(); }
+              catch (err) { toast.error(humanizeError(err, "Couldn't save the letter scale. Try again.")); }
               finally { setSaving(false); }
             }}
           >

--- a/frontend/src/components/Gradebook/modals.dialog.test.tsx
+++ b/frontend/src/components/Gradebook/modals.dialog.test.tsx
@@ -5,9 +5,14 @@
  * a modal that silently stops opening, loses its submit handler, or drops the
  * accessible dialog role still typechecks perfectly.
  *
- * These assert the contract every consumer depends on — closed renders
- * nothing, open renders a labelled dialog with its controls wired — rather
- * than the internals of each form.
+ * Two layers of contract are asserted:
+ *
+ * 1. Dialog semantics every consumer depends on (#109) — closed renders
+ *    nothing, open renders a labelled dialog with its controls wired.
+ * 2. Failure surfacing (#166) — a rejected onSave/onDelete keeps the modal
+ *    OPEN, re-enables its button, and toasts the error instead of silently
+ *    looking like a dead button (the modals catch; the parent callbacks in
+ *    screens/Gradebook/Course.tsx deliberately don't).
  */
 
 import React from "react";
@@ -195,6 +200,26 @@ describe("Gradebook modals on the shared Dialog", () => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     // "Saving…" must give way to an enabled "Save" again so the user can retry.
     await waitFor(() => expect(screen.getByRole("button", { name: "Save" })).toBeEnabled());
+  });
+
+  it("LetterScaleEditor's Reset to default toasts on failure and stays usable", async () => {
+    // Reset is the third #166 swallow in this file's modals: a bare floating
+    // onSave(null) used to reject invisibly. On failure the dialog stays
+    // open, the toast says why, and the button re-enables.
+    const onSave = vi.fn(async () => {
+      throw new Error("HTTP 500: boom");
+    });
+    render(<LetterScaleEditor open initial={null} onClose={() => {}} onSave={onSave} />);
+
+    await screen.findByRole("dialog");
+    await userEvent.click(screen.getByRole("button", { name: "Reset to default" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith(null));
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Reset to default" })).toBeEnabled(),
+    );
   });
 
   it("keeps AssignmentModal open and toasts when onDelete rejects", async () => {

--- a/frontend/src/components/Gradebook/modals.dialog.test.tsx
+++ b/frontend/src/components/Gradebook/modals.dialog.test.tsx
@@ -18,14 +18,56 @@ import userEvent from "@testing-library/user-event";
 import { AssignmentModal } from "./AssignmentModal";
 import { EditWeightsModal } from "./EditWeightsModal";
 import { LetterScaleEditor } from "./LetterScaleEditor";
-import type { GradeCategory } from "@/lib/types";
+import type { GradeCategory, GradedAssignment } from "@/lib/types";
+
+// The modals toast their own save/delete failures (#166); render them without
+// the real ToastProvider and capture what they'd have shown the user.
+const toastError = vi.hoisted(() => vi.fn());
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({
+    show: vi.fn(),
+    dismiss: vi.fn(),
+    success: vi.fn(),
+    error: toastError,
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
 
 const CATEGORIES: GradeCategory[] = [
   { id: "c1", name: "Exams", weight: 0.6, sort_order: 0, drop_lowest: 0 },
   { id: "c2", name: "Homework", weight: 0.4, sort_order: 1, drop_lowest: 0 },
 ];
 
-afterEach(cleanup);
+// EditWeightsModal only enables Save when weights sum to 100.
+const WEIGHT_CATEGORIES: GradeCategory[] = [
+  { id: "c1", name: "Exams", weight: 60, sort_order: 0, drop_lowest: 0 },
+  { id: "c2", name: "Homework", weight: 40, sort_order: 1, drop_lowest: 0 },
+];
+
+// Prefilled edit target: gives AssignmentModal a valid draft (Save enabled)
+// and a Delete button without form interaction.
+const ASSIGNMENT: GradedAssignment = {
+  id: "a1",
+  title: "Midterm",
+  course_id: "course-1",
+  category_id: "c1",
+  points_possible: 100,
+  points_earned: 88,
+  due_date: null,
+  assignment_type: null,
+  notes: null,
+  source: "manual",
+  curve_class_mean: null,
+  curve_class_sd: null,
+  curve_avg_target: null,
+  curve_sd_delta: null,
+};
+
+afterEach(() => {
+  cleanup();
+  toastError.mockClear();
+});
 
 describe("Gradebook modals on the shared Dialog", () => {
   it("render nothing at all while closed", () => {
@@ -108,5 +150,76 @@ describe("Gradebook modals on the shared Dialog", () => {
     await screen.findByRole("dialog");
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  // #166 — a failed save must not look like a successful one (or a dead
+  // button): the dialog stays open, Save comes back, and a toast says why.
+  it.each([
+    [
+      "AssignmentModal",
+      (onClose: () => void, onSave: () => Promise<void>) => (
+        <AssignmentModal
+          open
+          initial={ASSIGNMENT}
+          categories={CATEGORIES}
+          onClose={onClose}
+          onSave={onSave}
+        />
+      ),
+    ],
+    [
+      "EditWeightsModal",
+      (onClose: () => void, onSave: () => Promise<void>) => (
+        <EditWeightsModal open initial={WEIGHT_CATEGORIES} onClose={onClose} onSave={onSave} />
+      ),
+    ],
+    [
+      "LetterScaleEditor",
+      (onClose: () => void, onSave: () => Promise<void>) => (
+        <LetterScaleEditor open initial={null} onClose={onClose} onSave={onSave} />
+      ),
+    ],
+  ])("%s stays open, re-enables Save, and toasts when onSave rejects", async (_name, renderModal) => {
+    const onClose = vi.fn();
+    const onSave = vi.fn(async () => {
+      throw new Error("HTTP 500: boom");
+    });
+    render(renderModal(onClose, onSave));
+
+    await screen.findByRole("dialog");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    // "Saving…" must give way to an enabled "Save" again so the user can retry.
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save" })).toBeEnabled());
+  });
+
+  it("keeps AssignmentModal open and toasts when onDelete rejects", async () => {
+    const onClose = vi.fn();
+    const onDelete = vi.fn(async () => {
+      throw new Error("HTTP 500: boom");
+    });
+    render(
+      <AssignmentModal
+        open
+        initial={ASSIGNMENT}
+        categories={CATEGORIES}
+        onClose={onClose}
+        onSave={async () => {}}
+        onDelete={onDelete}
+      />,
+    );
+
+    await screen.findByRole("dialog");
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(onDelete).toHaveBeenCalled());
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("button", { name: "Delete" })).toBeEnabled());
   });
 });

--- a/frontend/src/components/QuizPanel.test.tsx
+++ b/frontend/src/components/QuizPanel.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+/**
+ * Component tests for QuizPanel's start() flow (#184).
+ *
+ * Bug: start() did `setQuestions(res.questions || [])` then advanced to the
+ * "active" phase unconditionally. The active branch is gated on
+ * `currentQuestion`, and quiz-exit lives inside it — so a response with zero
+ * questions rendered a blank, control-less quiz-panel and stranded the user.
+ *
+ * Fix under test: when generateQuiz returns no questions, warn via toast and
+ * STAY in the select phase (quiz-start/quiz-cancel remain usable).
+ */
+
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+// Captured toast spies — hoisted so the vi.mock factory can close over them.
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("./ToastProvider", () => ({
+  useToast: () => toast,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+// The select-phase pickers aren't under test; initialConceptId preselects the
+// course + concept (via the real quizSelection helpers), so a passive stub is
+// enough and keeps the DOM simple.
+vi.mock("./CustomSelect", () => ({
+  CustomSelect: ({ value }: { value?: string }) => (
+    <div data-testid="custom-select">{value}</div>
+  ),
+}));
+
+vi.mock("@/lib/api", () => ({
+  generateQuiz: vi.fn(),
+  submitQuiz: vi.fn(),
+}));
+
+import { generateQuiz } from "@/lib/api";
+import { QuizPanel } from "./QuizPanel";
+
+const mockGenerateQuiz = vi.mocked(generateQuiz);
+
+const CONCEPTS = [
+  { id: "c1", name: "Gradient Descent", course_id: "course-1", course_code: "CS101" },
+];
+
+const COURSES = [
+  { course_id: "course-1", course_code: "CS101", course_name: "Intro to ML" },
+];
+
+const QUESTION = {
+  id: 1,
+  question: "What does gradient descent minimize?",
+  options: [
+    { label: "A", text: "The loss function", correct: true },
+    { label: "B", text: "The learning rate", correct: false },
+  ],
+  explanation: "It steps against the gradient of the loss.",
+  concept_tested: "Gradient Descent",
+  difficulty: "easy",
+};
+
+const renderPanel = () =>
+  render(
+    <QuizPanel
+      userId="u1"
+      concepts={CONCEPTS}
+      courses={COURSES}
+      initialConceptId="c1"
+      onExit={vi.fn()}
+    />,
+  );
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("QuizPanel — start() with no questions (#184)", () => {
+  // The declared wire type marks `questions` required, but the component's
+  // `res.questions || []` guard exists because the payload may omit it — the
+  // cast lets the test cover that runtime shape.
+  type QuizResponse = Awaited<ReturnType<typeof generateQuiz>>;
+  it.each([
+    ["an empty questions array", { quiz_id: "quiz-1", questions: [] }],
+    ["a missing questions field", { quiz_id: "quiz-1" }],
+  ])("stays in the select phase and warns on %s", async (_name, response) => {
+    mockGenerateQuiz.mockResolvedValue(response as QuizResponse);
+    renderPanel();
+
+    fireEvent.click(screen.getByTestId("quiz-start"));
+    await waitFor(() => expect(mockGenerateQuiz).toHaveBeenCalledTimes(1));
+
+    // The user is told why nothing happened…
+    await waitFor(() => expect(toast.warn).toHaveBeenCalledTimes(1));
+
+    // …and keeps the select-phase controls instead of a blank active panel.
+    expect(screen.getByTestId("quiz-start")).toBeInTheDocument();
+    expect(screen.getByTestId("quiz-cancel")).toBeInTheDocument();
+    expect(screen.queryByTestId("quiz-answer-options")).toBeNull();
+    expect(screen.queryByTestId("quiz-exit")).toBeNull();
+  });
+});
+
+describe("QuizPanel — start() happy path", () => {
+  it("advances to the active phase when questions come back", async () => {
+    mockGenerateQuiz.mockResolvedValue({ quiz_id: "quiz-1", questions: [QUESTION] });
+    renderPanel();
+
+    fireEvent.click(screen.getByTestId("quiz-start"));
+
+    expect(await screen.findByTestId("quiz-answer-options")).toBeInTheDocument();
+    expect(mockGenerateQuiz).toHaveBeenCalledWith("u1", "c1", 5, "medium");
+
+    // Select phase is gone; the active phase carries its own exit control.
+    expect(screen.queryByTestId("quiz-start")).toBeNull();
+    expect(screen.getByTestId("quiz-exit")).toBeInTheDocument();
+    expect(toast.warn).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/QuizPanel.tsx
+++ b/frontend/src/components/QuizPanel.tsx
@@ -118,8 +118,15 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
     setLoading(true);
     try {
       const res = await generateQuiz(userId, conceptId, Number(count), difficulty);
+      const nextQuestions = res.questions || [];
+      if (nextQuestions.length === 0) {
+        // Zero questions would render the "active" phase blank (it's gated on
+        // currentQuestion, and quiz-exit lives inside it) — stay in select (#184).
+        toast.warn("No questions were generated — try another concept or difficulty.");
+        return;
+      }
       setQuizId(res.quiz_id);
-      setQuestions(res.questions || []);
+      setQuestions(nextQuestions);
       setAnswers([]);
       setQIndex(0);
       setCurrentSelection(null);

--- a/frontend/src/components/flashcards/FlashcardImportModal.test.tsx
+++ b/frontend/src/components/flashcards/FlashcardImportModal.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+/**
+ * Tab-switch interaction tests for FlashcardImportModal (#183).
+ *
+ * The five import tabs share ONE deck (`cards` state) via `setCards`, and the
+ * modal mounts only the active tab. PasteTab's live re-parse effect used to
+ * fire `onCards([])` on a bare mount (its local `text` starts empty), so
+ * merely clicking back onto the Paste tab — the initial tab and the reset-to
+ * tab on open — silently wiped a deck built on the Upload/URL/AI/Photo tabs.
+ *
+ *   1. Regression: build a deck via the (mocked) URL tab, click Paste —
+ *      the deck must survive.
+ *   2. Control: typing into Paste and then deleting all text still clears
+ *      the deck — the intentional clear-by-deleting path keeps working.
+ *   3. Control: after switching back to Paste, typing still re-parses and
+ *      replaces the shared deck (the mount guard must not disable parsing).
+ *
+ * Real FlashcardImportModal + PasteTab + ParsedCardsTable + Dialog +
+ * ToastProvider (the portal pattern proven in DocumentUploadModal.test.tsx);
+ * the other tabs are mocked light, with the URL tab mock exposing a button
+ * that injects a fixed deck. Assertions read the real commit button label
+ * ("Import N cards") and the real ParsedCardsTable counter.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { EnrolledCourse } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  importCommit: vi.fn(),
+  importCloze: vi.fn(),
+  importCleanup: vi.fn(),
+}));
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => ({ userId: "u1" }),
+}));
+
+// Deck injected by the mocked URL tab — the simplest non-paste channel into
+// the shared `cards` state.
+const URL_CARDS = vi.hoisted(() => [
+  { front: "Mitochondria", back: "Powerhouse of the cell", row: 1 },
+  { front: "Ribosome", back: "Protein synthesis", row: 2 },
+]);
+
+vi.mock("./tabs/UrlTab", async () => {
+  const { createElement } = await import("react");
+  return {
+    UrlTab: ({ onCards }: { onCards: (next: typeof URL_CARDS) => void }) =>
+      createElement(
+        "button",
+        { type: "button", onClick: () => onCards(URL_CARDS) },
+        "Inject mock deck",
+      ),
+  };
+});
+vi.mock("./tabs/UploadTab", () => ({ UploadTab: () => null }));
+vi.mock("./tabs/AiTab", () => ({ AiTab: () => null }));
+vi.mock("./tabs/PhotoTab", () => ({ PhotoTab: () => null }));
+
+import { FlashcardImportModal } from "./FlashcardImportModal";
+import { ToastProvider } from "../ToastProvider";
+
+const COURSE: EnrolledCourse = {
+  enrollment_id: "e1",
+  course_id: "c-1",
+  course_code: "CS101",
+  course_name: "Intro",
+  school: "X",
+  department: "CS",
+  color: null,
+  nickname: null,
+  node_count: 0,
+  enrolled_at: "2026-01-01",
+  term: "Spring 2026",
+};
+
+function renderModal() {
+  return render(
+    <ToastProvider>
+      <FlashcardImportModal
+        open
+        onClose={() => {}}
+        courses={[COURSE]}
+        documents={[]}
+        onImported={() => {}}
+      />
+    </ToastProvider>,
+  );
+}
+
+// Accessible-name helpers. Tab buttons carry their bare label ("Paste",
+// "URL"); the commit button's label doubles as the deck-size readout.
+const tabButton = (label: string) => screen.getByRole("button", { name: label });
+const importButton = (count: number) =>
+  screen.getByRole("button", {
+    name: `Import ${count} card${count === 1 ? "" : "s"}`,
+  });
+
+const pasteTextarea = () =>
+  screen.getByPlaceholderText(/paste your cards here/i);
+
+afterEach(() => {
+  // Dialog and ToastProvider both portal into document.body; RTL cleanup
+  // alone leaves portal siblings behind (same pattern as
+  // DocumentUploadModal.test.tsx).
+  cleanupBody();
+  vi.clearAllMocks();
+});
+
+function cleanupBody() {
+  document.body.innerHTML = "";
+}
+
+describe("FlashcardImportModal shared deck across tabs (#183)", () => {
+  it("keeps a deck built on another tab when switching back to Paste", () => {
+    renderModal();
+
+    // Build the deck off-Paste.
+    fireEvent.click(tabButton("URL"));
+    fireEvent.click(screen.getByRole("button", { name: "Inject mock deck" }));
+    expect(importButton(2)).toBeInTheDocument();
+    expect(screen.getByText(/2 valid/)).toBeInTheDocument();
+
+    // Re-enter the Paste tab: its remount must NOT wipe the shared deck.
+    fireEvent.click(tabButton("Paste"));
+    expect(importButton(2)).toBeInTheDocument();
+    expect(screen.getByText(/2 valid/)).toBeInTheDocument();
+  });
+
+  it("still clears the deck when the user deletes all Paste text", () => {
+    renderModal();
+
+    // Default tab is Paste; type two rows (tab-separated, newline rows).
+    fireEvent.change(pasteTextarea(), {
+      target: { value: "alpha\tbeta\ngamma\tdelta" },
+    });
+    expect(importButton(2)).toBeInTheDocument();
+
+    // Deleting everything is an intentional clear — the deck must empty.
+    fireEvent.change(pasteTextarea(), { target: { value: "" } });
+    expect(importButton(0)).toBeInTheDocument();
+  });
+
+  it("re-parses on typing after switching back to Paste, replacing the deck", () => {
+    renderModal();
+
+    fireEvent.click(tabButton("URL"));
+    fireEvent.click(screen.getByRole("button", { name: "Inject mock deck" }));
+    expect(importButton(2)).toBeInTheDocument();
+
+    // Back on Paste, typing must still drive the shared deck as before.
+    fireEvent.click(tabButton("Paste"));
+    fireEvent.change(pasteTextarea(), { target: { value: "alpha\tbeta" } });
+    expect(importButton(1)).toBeInTheDocument();
+    expect(screen.getByText(/1 valid/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/flashcards/tabs/PasteTab.tsx
+++ b/frontend/src/components/flashcards/tabs/PasteTab.tsx
@@ -36,6 +36,11 @@ export function PasteTab({ cards, onCards }: Props) {
   const [autoDetectedOnce, setAutoDetectedOnce] = React.useState(false);
   const [clozeMode, setClozeMode] = React.useState(false);
   const [clozing, setClozing] = React.useState(false);
+  // True once the user has typed in THIS mount. The import tabs share one
+  // deck via onCards, and the modal remounts tabs on every switch — without
+  // this guard the live re-parse effect fires onCards([]) on a bare mount
+  // (text starts empty) and wipes a deck built on another tab (#183).
+  const dirtyRef = React.useRef(false);
 
   // Suppress unused warning — cards prop is available to parent via onCards
   void cards;
@@ -53,9 +58,12 @@ export function PasteTab({ cards, onCards }: Props) {
     setAutoDetectedOnce(true);
   }, [text, autoDetectedOnce]);
 
-  // Live re-parse
+  // Live re-parse. Emits only after the user has typed here, so a bare
+  // (re)mount never clears the shared deck, while deleting all text —
+  // dirtyRef already set — still does.
   React.useEffect(() => {
     if (clozeMode) return;
+    if (!dirtyRef.current) return;
     if (!text || !term || !card) { onCards([]); return; }
     const parsed = splitByDelimiters(text, term, card);
     onCards(parsed);
@@ -92,7 +100,7 @@ export function PasteTab({ cards, onCards }: Props) {
 
       <textarea
         value={text}
-        onChange={e => setText(e.target.value)}
+        onChange={e => { dirtyRef.current = true; setText(e.target.value); }}
         placeholder={clozeMode
           ? "Paste a paragraph. Claude will pick key terms to remove and generate fill-in-the-blank cards."
           : "Paste your cards here. Use Tab between term and definition, Enter between cards."}

--- a/frontend/src/components/screens/Calendar.test.tsx
+++ b/frontend/src/components/screens/Calendar.test.tsx
@@ -94,6 +94,7 @@ vi.mock("@/lib/api", () => ({
 }));
 
 import { Calendar } from "./Calendar";
+import { getAllAssignments } from "@/lib/api";
 
 afterEach(() => {
   cleanup();
@@ -162,6 +163,31 @@ describe("Calendar — view switch (#295)", () => {
     // Switching away must remove the Day body entirely.
     clickView("Month");
     await waitFor(() => expect(screen.queryByText("Nothing scheduled.")).toBeNull());
+    expect(screen.getByText("Mon")).toBeInTheDocument();
+  });
+});
+
+describe("Calendar — load failure (#185)", () => {
+  it("shows an error banner with retry instead of the empty calendar when load fails", async () => {
+    vi.mocked(getAllAssignments).mockRejectedValueOnce(new Error("HTTP 500"));
+    render(<Calendar />);
+    const banner = await screen.findByTestId("calendar-load-error");
+    expect(banner).toBeInTheDocument();
+    expect(screen.getByTestId("calendar-load-retry")).toBeInTheDocument();
+    // The failure must not masquerade as a legitimately empty account: no
+    // month grid, and none of the per-view empty-state copy.
+    expect(screen.queryByText("Mon")).toBeNull();
+    expect(screen.queryByText("No assignments yet.")).toBeNull();
+    expect(screen.queryByTestId("calendar-skeleton")).toBeNull();
+  });
+
+  it("retry re-fetches; a successful retry clears the banner and renders the calendar", async () => {
+    vi.mocked(getAllAssignments).mockRejectedValueOnce(new Error("HTTP 500"));
+    render(<Calendar />);
+    const retry = await screen.findByTestId("calendar-load-retry");
+    // The once-rejection is consumed; the base mock resolves from here on.
+    fireEvent.click(retry);
+    await waitFor(() => expect(screen.queryByTestId("calendar-load-error")).toBeNull());
     expect(screen.getByText("Mon")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/screens/Calendar.test.tsx
+++ b/frontend/src/components/screens/Calendar.test.tsx
@@ -1,14 +1,20 @@
 // @vitest-environment jsdom
 /**
- * Component tests for the Calendar view switch (#295).
+ * Component tests for the Calendar screen: the view switch (#295) and the
+ * load-failure surfacing (#185).
  *
- * The fix wraps the calendar body in `AnimatePresence` + a keyed
- * `motion.div` so switching Month/Week/Day/Table crossfades instead of
- * snapping. Animation itself isn't asserted here — framer-motion is
+ * View switch: the #295 fix wraps the calendar body in `AnimatePresence` +
+ * a keyed `motion.div` so switching Month/Week/Day/Table crossfades instead
+ * of snapping. Animation itself isn't asserted here — framer-motion is
  * stubbed to a passthrough so assertions don't race the real 220ms
  * transition. What these tests guard is the behavior the wrapper must
  * preserve: the correct view renders for each toggle state, the loading
  * skeleton still shows first, and nothing leaks between views.
+ *
+ * Load failure (#185): a failed INITIAL fetch renders the error banner +
+ * retry instead of a normal-looking empty calendar; a failed BACKGROUND
+ * reload (post-delete/export/reconnect) toasts and keeps the loaded view —
+ * it must never blank real data behind the banner (PR #463 review).
  *
  * Unique per-view markers used below (with zero assignments):
  *   - Month  : weekday header row ("Mon".."Sun"), and NO em-dash filler.
@@ -43,8 +49,15 @@ vi.mock("@/context/UserContext", () => ({
   useUser: () => ({ userId: "u1", userReady: true }),
 }));
 
+// Hoisted shared spies so tests can assert on toast traffic (the background
+// reload-failure path surfaces via toast.error, not the banner).
+const toastSpies = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+}));
 vi.mock("../ToastProvider", () => ({
-  useToast: () => ({ success: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+  useToast: () => toastSpies,
 }));
 
 vi.mock("@/lib/useConfirm", () => ({
@@ -189,5 +202,42 @@ describe("Calendar — load failure (#185)", () => {
     fireEvent.click(retry);
     await waitFor(() => expect(screen.queryByTestId("calendar-load-error")).toBeNull());
     expect(screen.getByText("Mon")).toBeInTheDocument();
+  });
+
+  it("a failing BACKGROUND reload toasts and keeps the loaded view — never the banner (PR #463 review)", async () => {
+    // Initial load succeeds with one real assignment…
+    vi.mocked(getAllAssignments).mockResolvedValueOnce({
+      assignments: [
+        {
+          id: "a-1",
+          title: "Problem Set 4",
+          course_id: "c-1",
+          course_code: "CS101",
+          course_name: "Intro CS",
+          due_date: "2026-03-20",
+          assignment_type: "homework",
+          notes: "",
+        },
+      ],
+    } as never);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<Calendar />);
+    clickView("Table");
+    await screen.findByText("Problem Set 4");
+
+    // …then the reload triggered by a successful delete fails.
+    vi.mocked(getAllAssignments).mockRejectedValueOnce(new Error("HTTP 500"));
+    fireEvent.click(screen.getByTitle("Delete"));
+
+    await waitFor(() =>
+      expect(toastSpies.error).toHaveBeenCalledWith(
+        expect.stringContaining("Couldn't refresh the calendar"),
+      ),
+    );
+    // The already-loaded view survives: no full-page banner, table intact
+    // (the row itself remains because the failed reload changed no data).
+    expect(screen.queryByTestId("calendar-load-error")).toBeNull();
+    expect(screen.getByText("Problem Set 4")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/screens/Calendar.tsx
+++ b/frontend/src/components/screens/Calendar.tsx
@@ -96,6 +96,14 @@ export function Calendar() {
   const [loading, setLoading] = React.useState(true);
   const [loadError, setLoadError] = React.useState<string | null>(null);
 
+  // True once a load has succeeded — gates HOW a later failure surfaces.
+  // `load` doubles as the background reload (AssignmentTable's onReload,
+  // the OAuth-reconnect effect, upload onComplete), and a reload failure
+  // must never blank an already-populated calendar behind the full-page
+  // banner (PR #463 review; same `error && !data` gating as the Gradebook
+  // screen's ErrorBanner).
+  const hasLoadedRef = React.useRef(false);
+
   const load = React.useCallback(async () => {
     if (!userId) return;
     try {
@@ -108,15 +116,23 @@ export function Calendar() {
       setCourses(c.courses || []);
       setGoogleConnected(Boolean(s.connected));
       setLoadError(null);
+      hasLoadedRef.current = true;
     } catch (err) {
       // Surface the failure (#185) — a swallowed error here renders a
-      // normal-looking empty calendar, indistinguishable from an empty account.
+      // normal-looking empty calendar, indistinguishable from an empty
+      // account. Initial load → full-page banner (there is nothing else to
+      // show); background reload → toast, keeping the loaded view intact.
       console.error("calendar load failed", err);
-      setLoadError(humanizeError(err, "Check your connection and try again."));
+      const message = humanizeError(err, "Check your connection and try again.");
+      if (hasLoadedRef.current) {
+        toast.error(`Couldn't refresh the calendar. ${message}`);
+      } else {
+        setLoadError(message);
+      }
     } finally {
       setLoading(false);
     }
-  }, [userId]);
+  }, [userId, toast]);
 
   const retryLoad = React.useCallback(() => {
     setLoading(true);

--- a/frontend/src/components/screens/Calendar.tsx
+++ b/frontend/src/components/screens/Calendar.tsx
@@ -36,6 +36,7 @@ import {
   type GoogleEvent,
 } from "@/lib/api";
 import { now } from "@/lib/testMode";
+import { humanizeError } from "@/lib/errorMessage";
 
 type View = "month" | "week" | "day" | "table";
 
@@ -93,6 +94,7 @@ export function Calendar() {
   const [googleEvents, setGoogleEvents] = React.useState<GoogleEvent[] | null>(null);
   const [importingGoogle, setImportingGoogle] = React.useState(false);
   const [loading, setLoading] = React.useState(true);
+  const [loadError, setLoadError] = React.useState<string | null>(null);
 
   const load = React.useCallback(async () => {
     if (!userId) return;
@@ -105,12 +107,21 @@ export function Calendar() {
       setAssignments(a.assignments || []);
       setCourses(c.courses || []);
       setGoogleConnected(Boolean(s.connected));
+      setLoadError(null);
     } catch (err) {
+      // Surface the failure (#185) — a swallowed error here renders a
+      // normal-looking empty calendar, indistinguishable from an empty account.
       console.error("calendar load failed", err);
+      setLoadError(humanizeError(err, "Check your connection and try again."));
     } finally {
       setLoading(false);
     }
   }, [userId]);
+
+  const retryLoad = React.useCallback(() => {
+    setLoading(true);
+    void load();
+  }, [load]);
 
   React.useEffect(() => {
     if (userReady && userId) load();
@@ -268,7 +279,7 @@ export function Calendar() {
           pattern so the swap settles instead of snapping (#295). */}
       <AnimatePresence mode="wait" initial={false}>
         <motion.div
-          key={loading ? "loading" : view}
+          key={loading ? "loading" : loadError ? "error" : view}
           initial={prefersReduced ? false : { opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           exit={prefersReduced ? { opacity: 1 } : { opacity: 0, y: -8 }}
@@ -276,6 +287,8 @@ export function Calendar() {
         >
           {loading ? (
             <CalendarMonthSkeleton />
+          ) : loadError ? (
+            <LoadErrorBanner message={loadError} onRetry={retryLoad} />
           ) : view === "month" ? (
             <MonthView cursor={cursor} byDate={byDate} today={today} courses={courses} />
           ) : view === "week" ? (
@@ -317,6 +330,46 @@ export function Calendar() {
           onClose={() => setGoogleEvents(null)}
         />
       )}
+    </div>
+  );
+}
+
+// Load-failure state distinct from a legitimately empty calendar (#185).
+// Mirrors the Gradebook course ErrorBanner: what went wrong + a retry.
+function LoadErrorBanner({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div style={{ padding: "20px 32px" }}>
+      <div
+        role="alert"
+        data-testid="calendar-load-error"
+        style={{
+          padding: "20px 24px",
+          borderRadius: "var(--r-md)",
+          background: "var(--err-soft)",
+          border: "1px solid color-mix(in oklab, var(--err) 20%, transparent)",
+          display: "flex",
+          gap: 16,
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+        }}
+      >
+        <div>
+          <div style={{ fontWeight: 600, color: "var(--err)", marginBottom: 4 }}>
+            We couldn&apos;t load your calendar.
+          </div>
+          <div style={{ fontSize: 13, color: "var(--text-dim)" }}>{message}</div>
+        </div>
+        <button
+          type="button"
+          className="btn btn--primary"
+          data-testid="calendar-load-retry"
+          onClick={onRetry}
+          style={{ padding: "8px 16px" }}
+        >
+          Try again
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/screens/Gradebook/Course.curveModal.test.tsx
+++ b/frontend/src/components/screens/Gradebook/Course.curveModal.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+/**
+ * CurveSettingsModal failure surfacing (#166) — the fourth gradebook modal
+ * with the same swallowed-save shape, private to Course.tsx (exported for
+ * this test only). A rejected onSave must keep the dialog open, re-enable
+ * Save, and toast the error; success closes. Course.tsx's screen-level
+ * concerns (data loading, tables, charts) are out of scope here, so every
+ * heavy sibling import is stubbed — this file exists to pin the modal's
+ * error contract, nothing else.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const toastError = vi.hoisted(() => vi.fn());
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({
+    show: vi.fn(),
+    dismiss: vi.fn(),
+    success: vi.fn(),
+    error: toastError,
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => ({ userId: "u1", userReady: true }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getGradebookCourse: vi.fn(),
+  bulkUpdateCategories: vi.fn(),
+  deleteCategory: vi.fn(),
+  createGradedAssignment: vi.fn(),
+  updateGradedAssignment: vi.fn(),
+  deleteGradedAssignment: vi.fn(),
+  setLetterScale: vi.fn(),
+  getGradescopeStatus: vi.fn(),
+  listGradescopeLinks: vi.fn(),
+  syncGradescopeCourse: vi.fn(),
+  setCurveSettings: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/components/TopBar", () => ({ TopBar: () => null }));
+vi.mock("@/components/Gradebook/AssignmentList", () => ({ AssignmentList: () => null }));
+vi.mock("@/components/Gradebook/GradescopeSyncModal", () => ({ GradescopeSyncModal: () => null }));
+vi.mock("@/components/Gradebook/GradePredictorPanel", () => ({ GradePredictorPanel: () => null }));
+vi.mock("@/components/Gradebook/AmbientOrbs", () => ({ AmbientOrbs: () => null }));
+
+import { CurveSettingsModal } from "./Course";
+import type { GradebookCourse } from "@/lib/types";
+
+const COURSE = {
+  curve_avg_target: null,
+  curve_sd_delta: null,
+} as GradebookCourse;
+
+afterEach(() => {
+  cleanup();
+  toastError.mockClear();
+});
+
+describe("CurveSettingsModal failure surfacing (#166)", () => {
+  it("stays open, re-enables Save, and toasts when onSave rejects", async () => {
+    const onClose = vi.fn();
+    const onSave = vi.fn(async () => {
+      throw new Error("HTTP 500: boom");
+    });
+    render(<CurveSettingsModal open course={COURSE} onClose={onClose} onSave={onSave} />);
+
+    await screen.findByRole("dialog");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save" })).toBeEnabled());
+  });
+
+  it("closes on a successful save (control)", async () => {
+    const onClose = vi.fn();
+    render(
+      <CurveSettingsModal open course={COURSE} onClose={onClose} onSave={async () => {}} />,
+    );
+
+    await screen.findByRole("dialog");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/screens/Gradebook/Course.tsx
+++ b/frontend/src/components/screens/Gradebook/Course.tsx
@@ -95,7 +95,9 @@ interface Props {
   courseId: string;
 }
 
-function CurveSettingsModal({
+// Exported for Course.curveModal.test.tsx (#166 failure-surfacing contract);
+// only GradebookCourseScreen below renders it in the app.
+export function CurveSettingsModal({
   open,
   course,
   onClose,

--- a/frontend/src/components/screens/Gradebook/Course.tsx
+++ b/frontend/src/components/screens/Gradebook/Course.tsx
@@ -18,6 +18,7 @@ import {
   syncGradescopeCourse,
   setCurveSettings,
 } from "@/lib/api";
+import { humanizeError } from "@/lib/errorMessage";
 import { applyCurveToAssignment, hasCurveData } from "@/components/Gradebook/curveUtils";
 import { EditWeightsModal } from "@/components/Gradebook/EditWeightsModal";
 import { AssignmentList } from "@/components/Gradebook/AssignmentList";
@@ -108,6 +109,7 @@ function CurveSettingsModal({
     curve_sd_delta: number | null;
   }) => Promise<void>;
 }) {
+  const toast = useToast();
   const [mounted, setMounted] = React.useState(false);
   const [avgTarget, setAvgTarget] = React.useState<string>(
     course.curve_avg_target != null ? (course.curve_avg_target * 100).toFixed(0) : "83"
@@ -173,6 +175,8 @@ function CurveSettingsModal({
             variant="primary"
             size="sm"
             disabled={saving}
+            // On failure the modal stays open (no onClose) so the user can
+            // see the toast and retry — closing would look like success.
             onClick={async () => {
               setSaving(true);
               try {
@@ -181,6 +185,8 @@ function CurveSettingsModal({
                   curve_sd_delta: toFloat(sdDelta),
                 });
                 onClose();
+              } catch (err) {
+                toast.error(humanizeError(err, "Couldn't save curve settings. Try again."));
               } finally { setSaving(false); }
             }}
           >
@@ -626,6 +632,8 @@ export function GradebookCourseScreen({ courseId }: Props) {
 
       {data && (
         <>
+          {/* The onSave/onDelete callbacks below deliberately don't catch:
+              each modal catches, toasts, and stays open on failure (#166). */}
           <EditWeightsModal
             open={editWeights}
             initial={data.categories}


### PR DESCRIPTION
## What

Bundle B2 of the backlog clear — the last five children of the frontend UI-audit epic #113, all the same shape: **a failure rendered as a plausible success**. Each fix pairs with a red-first component test pinning the failure path (per-issue detail in the commit message). Implemented as five parallel single-surface changes:

- **#166** Gradebook modal saves/deletes catch + toast (`humanizeError`) and keep the modal open on failure; covers the two adjacent instances of the same swallow (CurveSettingsModal, LetterScaleEditor reset). Parents keep bare awaits — rejections propagate to the modal's catch (documented in-code).
- **#185** Calendar load failure renders a distinct error banner + retry (`calendar-load-error`/`calendar-load-retry`, registered in `docs/frontend-testids.md` as a new surface) instead of a normal-looking empty calendar.
- **#184** A zero-question quiz response warns and stays in the select phase instead of stranding the user on a blank, control-less panel.
- **#183** PasteTab's mount no longer wipes the deck built on other tabs (per-mount dirty ref); deleting typed text still clears intentionally. First flashcards test infrastructure.
- **#186** Inline-added courses become immediately selectable in the upload modal's per-file dropdown (local `extraCourses` merged + deduped, reset on close); also fixes the zero-course default and the `<10` gate.

## Verification

- vitest **257 passed** (31 files; 15 new tests across 5 surfaces, each verified red-first against the bug)
- `tsc --noEmit` clean; lint 0 errors, no stale suppressions
- backend suite untouched-green
- Branch rebased onto `main` @ `9b000b5` (post-#461)
- Full local e2e cycle (Playwright + oracles under the stack flock): to run pre-merge; results will be posted below. The upload journey (`upload.spec.ts`) exercises the modified DocumentUploadModal directly.

Closes #166. Closes #185. Closes #184. Closes #183. Closes #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)