### PR TITLE
fix(backend): close the #136 contract-audit tail + #340 + #72

### DIFF
--- a/backend/agents/chat_tutor.py
+++ b/backend/agents/chat_tutor.py
@@ -2,8 +2,10 @@
 
 Replaces routes/learn.py:152's build_system_prompt + call_gemini_multiturn
 with a typed Pydantic AI agent. Tools handle the data lookups that used
-to be string-stuffed: search_course_materials, read_session_history,
-read_user_progress, apply_graph_update_tool.
+to be string-stuffed — wire names: search_course_materials (registered
+under that prompt-facing name via Tool(..., name=...), #135),
+read_session_history_tool, read_user_progress_tool,
+apply_graph_update_tool, update_mastery_tool.
 
 Modes (Socratic, Expository, TeachBack) are gated by selecting different
 system prompts at construction time. The route picks the right agent
@@ -23,7 +25,7 @@ from __future__ import annotations
 import hashlib
 from typing import Literal
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, Tool
 
 from agents._providers import model_for
 from agents.deps import SaplingDeps
@@ -102,16 +104,23 @@ _PROMPT_HASHES: dict[TutorMode, str] = {
 # the frontend renders via MarkdownChat. No structured output here; that
 # is reserved for routes that grade or extract.
 
-# All four tools are registered on every mode. The system prompt steers
+# All five tools are registered on every mode. The system prompt steers
 # WHEN to call them; the surface stays uniform so a Pro-tier model can
 # decide for itself which lookups are worth the round trip.
-_TOOLS = [
-    search_course_materials_tool,
-    read_session_history_tool,
-    read_user_progress_tool,
-    apply_graph_update_tool,
-    update_mastery_tool,
-]
+
+
+def _build_tools() -> list:
+    # Fresh Tool instances per agent (rather than one shared module-level
+    # list) so no Tool object is registered on multiple agents.
+    return [
+        # #135: register under the prompt-facing name — the bare callable
+        # would derive the wire name "search_course_materials_tool".
+        Tool(search_course_materials_tool, name="search_course_materials", takes_ctx=True),
+        read_session_history_tool,
+        read_user_progress_tool,
+        apply_graph_update_tool,
+        update_mastery_tool,
+    ]
 
 
 def _build_agent(mode: TutorMode) -> Agent[SaplingDeps, str]:
@@ -125,7 +134,7 @@ def _build_agent(mode: TutorMode) -> Agent[SaplingDeps, str]:
             "agent": "chat_tutor",
             "mode": mode,
         },
-        tools=_TOOLS,
+        tools=_build_tools(),
     )
 
 

--- a/backend/agents/note_chat.py
+++ b/backend/agents/note_chat.py
@@ -5,11 +5,12 @@ Powers the AI Chat panel inside the notetaker. Distinct from
 tutoring session, and the system prompt nudges the agent to ground
 in what the student is actively writing.
 
-Tools:
+Tools (wire names — what the model sees):
   - read_active_note (note-specific; from agents/tools/note_context.py)
-  - search_course_materials (existing; reuses chat_tutor's grounding)
-  - apply_graph_update (existing; lets the agent mark new concepts
-    while answering, the same way the course tutor does)
+  - search_course_materials (chat_tutor's grounding; registered under the
+    prompt-facing name via Tool(..., name=...) — #135)
+  - apply_graph_update_tool (lets the agent mark new concepts while
+    answering, the same way the course tutor does)
 """
 from __future__ import annotations
 
@@ -47,7 +48,10 @@ note_chat_agent = Agent[SaplingDeps, str](
     metadata={"prompt_version": _PROMPT_HASH, "agent": "note_chat"},
     tools=[
         Tool(read_active_note_tool, name="read_active_note", takes_ctx=True),
-        search_course_materials_tool,
+        # #135: register under the prompt-facing name — the bare callable would
+        # derive the wire name "search_course_materials_tool", which the system
+        # prompt never mentions.
+        Tool(search_course_materials_tool, name="search_course_materials", takes_ctx=True),
         apply_graph_update_tool,
     ],
 )

--- a/backend/db/migrations/0037_share_class_context.sql
+++ b/backend/db/migrations/0037_share_class_context.sql
@@ -1,0 +1,16 @@
+-- 0037: persist the Class Intel opt-out (#72).
+--
+-- The "Class intel" toggle (frontend SharedContextToggle) lived only in
+-- localStorage and only gated the READ path — a per-request
+-- use_shared_context flag on the tutor/quiz calls. The WRITE path,
+-- course_context_service.update_course_context, kept aggregating EVERY
+-- enrolled student's graph into offering_concept_stats / offering_summary,
+-- so an opted-out student's mastery data still fed the shared class
+-- aggregates. Option 1 on the issue: make the opt-out a persisted per-user
+-- preference and enforce it at that single write chokepoint.
+--
+-- DEFAULT true = opted in, preserving current behavior for everyone who has
+-- never touched the toggle; the service also treats a missing user_settings
+-- row as opted in, matching this default.
+ALTER TABLE user_settings
+    ADD COLUMN IF NOT EXISTS share_class_context BOOLEAN NOT NULL DEFAULT true;

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -231,6 +231,8 @@ class UpdateSettingsBody(BaseModel):
     theme: Optional[str] = None
     font_size: Optional[str] = None
     accent_color: Optional[str] = None
+    # #72: Class Intel opt-out (user_settings.share_class_context, 0037)
+    share_class_context: Optional[bool] = None
 
 
 class EquipCosmeticBody(BaseModel):

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -458,6 +458,18 @@ def unapprove_user(user_id: str, request: Request):
 
 # ── Newsletter Allowlist ──────────────────────────────────────────────────────
 
+@router.get("/allowlist")
+def list_allowlist(request: Request):
+    # #130: the admin portal's adminListAllowlist() (frontend/src/lib/api.ts)
+    # reads this list; approve/revoke existed without the GET.
+    require_admin(request)
+    rows = table("newsletter_emails").select(
+        "id,email,created_at,approved_at",
+        order="created_at.desc",
+    )
+    return {"emails": rows or []}
+
+
 @router.post("/allowlist/approve")
 def approve_allowlist(body: AllowlistEmailBody, request: Request):
     require_admin(request)

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -695,7 +695,10 @@ async def upload_document_sync(
     if len(file_bytes) > MAX_FILE_SIZE:
         raise HTTPException(
             status_code=400,
-            detail="File exceeds the 100 MB limit. Please upload a smaller file.",
+            detail=(
+                f"File exceeds the {MAX_FILE_SIZE // (1024 * 1024)} MB limit. "
+                "Please upload a smaller file."
+            ),
         )
 
     extracted_text = _extract_text_or_422(file_bytes, filename, file.content_type or "")
@@ -755,13 +758,20 @@ async def upload_document_sync(
             request_id=request_id,
         )
 
-    _save_orchestrator_syllabus(user_id=user_id, course_id=course_id,
-                                filename=filename, result=result)
-    _graph_backstop(user_id=user_id, course_id=course_id,
-                    filename=filename, result=result)
-    _, full_row = _persist_document(user_id=user_id, offering_id=offering_id,
-                                    filename=filename, result=result,
-                                    request_id=request_id)
+    # async def route: these are synchronous PostgREST round-trips — keep them
+    # off the event loop, same as the SSE generator's post-roll (#132 item 22).
+    await asyncio.to_thread(
+        _save_orchestrator_syllabus, user_id=user_id, course_id=course_id,
+        filename=filename, result=result,
+    )
+    await asyncio.to_thread(
+        _graph_backstop, user_id=user_id, course_id=course_id,
+        filename=filename, result=result,
+    )
+    _, full_row = await asyncio.to_thread(
+        _persist_document, user_id=user_id, offering_id=offering_id,
+        filename=filename, result=result, request_id=request_id,
+    )
 
     background_tasks.add_task(_invalidate_study_guide_cache, user_id, offering_id)
     background_tasks.add_task(update_course_context, course_id)
@@ -802,7 +812,10 @@ async def upload_document(
     if len(file_bytes) > MAX_FILE_SIZE:
         raise HTTPException(
             status_code=400,
-            detail="File exceeds the 15 MB limit. Please upload a smaller file.",
+            detail=(
+                f"File exceeds the {MAX_FILE_SIZE // (1024 * 1024)} MB limit. "
+                "Please upload a smaller file."
+            ),
         )
 
     # Unify the agent-trace request_id with the middleware-stamped one so
@@ -997,32 +1010,6 @@ async def upload_document(
                 message="Processing complete.",
                 data=final_output.model_dump(mode="json"),
             ))
-
-            # ── Post-roll: side effects + persistence ─────────────────────────
-            _save_orchestrator_syllabus(user_id=user_id, course_id=course_id,
-                                        filename=filename, result=final_output)
-            _graph_backstop(user_id=user_id, course_id=course_id,
-                            filename=filename, result=final_output)
-            doc_id, _ = _persist_document(user_id=user_id, offering_id=offering_id,
-                                          filename=filename, result=final_output,
-                                          request_id=request_id)
-
-            # BackgroundTasks runs after response close — useless for SSE since
-            # the stream IS the response. _spawn_post_roll uses create_task
-            # but attaches a done-callback so exceptions land in the log
-            # instead of disappearing.
-            _spawn_post_roll(
-                ("invalidate_study_guide_cache", _invalidate_study_guide_cache, user_id, offering_id),
-                ("update_course_context", update_course_context, course_id),
-                ("check_upload_achievements", _check_upload_achievements, user_id),
-                ("index_document_chunks", _index_document_chunks, doc_id, course_id, user_id, extracted_text, classification.category, getattr(summary, "abstract", "")),
-            )
-
-            yield sapling_event_to_sse(SaplingEvent(
-                type="status", step="done",
-                message="Saved.",
-                data={"document_id": doc_id},
-            ))
         except (UsageLimitExceeded, UnexpectedModelBehavior) as e:
             logger.warning(
                 "Agent guardrails tripped during stream for '%s'; falling back",
@@ -1039,6 +1026,7 @@ async def upload_document(
                 request_id=request_id,
             ):
                 yield sse_event
+            return
         except Exception:
             logger.exception("Unexpected streaming failure for '%s'", filename)
             yield sapling_event_to_sse(SaplingEvent(
@@ -1052,6 +1040,72 @@ async def upload_document(
                 request_id=request_id,
             ):
                 yield sse_event
+            return
+
+        # ── Post-roll: side effects + persistence (#132 item 11) ──────────
+        # Runs AFTER the terminal `result` event is on the wire, in its own
+        # try/except: a failure here must NOT reach the legacy fallback
+        # above. The client already holds the processed document, so falling
+        # back would spend a second model call re-running the whole pipeline
+        # and emit a SECOND result (result → error → result → done). The
+        # legacy fallback stays reachable only for failures BEFORE the first
+        # result event. On post-roll failure, emit the same terminal
+        # error+done pair _stream_legacy_fallback's failure tail uses, then
+        # stop.
+        try:
+            # Synchronous PostgREST writes — threaded so they don't block
+            # the event loop serving this (and every other) SSE stream
+            # (#132 item 22; same pattern as the async-OCR extraction above).
+            await asyncio.to_thread(
+                _save_orchestrator_syllabus,
+                user_id=user_id, course_id=course_id,
+                filename=filename, result=final_output,
+            )
+            await asyncio.to_thread(
+                _graph_backstop,
+                user_id=user_id, course_id=course_id,
+                filename=filename, result=final_output,
+            )
+            doc_id, _ = await asyncio.to_thread(
+                _persist_document,
+                user_id=user_id, offering_id=offering_id,
+                filename=filename, result=final_output,
+                request_id=request_id,
+            )
+
+            # BackgroundTasks runs after response close — useless for SSE since
+            # the stream IS the response. _spawn_post_roll uses create_task
+            # but attaches a done-callback so exceptions land in the log
+            # instead of disappearing.
+            _spawn_post_roll(
+                ("invalidate_study_guide_cache", _invalidate_study_guide_cache, user_id, offering_id),
+                ("update_course_context", update_course_context, course_id),
+                ("check_upload_achievements", _check_upload_achievements, user_id),
+                ("index_document_chunks", _index_document_chunks, doc_id, course_id, user_id, extracted_text, classification.category, getattr(summary, "abstract", "")),
+            )
+        except Exception:
+            logger.exception(
+                "Post-result persistence failed for '%s' — result already "
+                "sent, so no legacy fallback (it would re-run the pipeline "
+                "and emit a second result)", filename,
+            )
+            yield sapling_event_to_sse(SaplingEvent(
+                type="error", step="failed",
+                message="The document was processed but could not be saved. "
+                        "Please try uploading it again.",
+                data={"request_id": request_id} if request_id else None,
+            ))
+            yield sapling_event_to_sse(SaplingEvent(
+                type="status", step="done",
+                message="Failed.",
+            ))
+            return
+
+        yield sapling_event_to_sse(SaplingEvent(
+            type="status", step="done",
+            message="Saved.",
+            data={"document_id": doc_id},
+        ))
 
     return EventSourceResponse(
         event_stream(), headers={"Cache-Control": SSE_CACHE_CONTROL}

--- a/backend/routes/feedback.py
+++ b/backend/routes/feedback.py
@@ -22,14 +22,19 @@ ALLOWED_SCREENSHOT_TYPES = {"image/png", "image/jpeg", "image/webp", "image/gif"
 
 
 @router.post("/feedback")
-def submit_feedback(body: SubmitFeedbackBody):
+def submit_feedback(body: SubmitFeedbackBody, request: Request):
+    # #134: attribute the row to the SESSION user — body.user_id stays on the
+    # wire for backward compatibility (the frontend sends it) but is never
+    # trusted; an unauthenticated caller gets a 401 instead of writing rows
+    # under an arbitrary user_id.
+    user_id = get_session_user_id(request)  # 401 if unauthenticated
     # 0026_ops: feedback.id is now a TEXT PK (was SERIAL). Follow the repo
     # convention (services/academics.py, graph_service.py) and hand-build it
     # rather than relying on the DB default. user_id/session_id now carry real
-    # FKs (users / sessions), which the request body / session already satisfy.
+    # FKs (users / sessions), which the session / request body satisfy.
     table("feedback").insert({
         "id": str(uuid.uuid4()),
-        "user_id": body.user_id,
+        "user_id": user_id,
         "type": body.type,
         "rating": body.rating,
         "selected_options": body.selected_options,
@@ -41,12 +46,15 @@ def submit_feedback(body: SubmitFeedbackBody):
 
 
 @router.post("/issue-reports")
-def submit_issue_report(body: SubmitIssueReportBody):
+def submit_issue_report(body: SubmitIssueReportBody, request: Request):
+    # #134: same contract as submit_feedback — the session, not the body,
+    # decides who the report is attributed to.
+    user_id = get_session_user_id(request)  # 401 if unauthenticated
     # 0026_ops: issue_reports.id is now a TEXT PK (was SERIAL); user_id now has
     # a real FK to users(id). Hand-build the text PK per repo convention.
     table("issue_reports").insert({
         "id": str(uuid.uuid4()),
-        "user_id": body.user_id,
+        "user_id": user_id,
         "topic": body.topic,
         "description": body.description,
         "screenshot_urls": body.screenshot_urls,

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -21,6 +21,7 @@ from models import (
     SetFeaturedAchievementsBody,
     DeleteAccountBody,
 )
+from services.academics import school_peer_user_ids
 from services.auth_guard import require_self, get_session_user_id
 from services.http_cache import cached_json, conditional, make_etag
 from services.storage_service import upload_avatar
@@ -76,7 +77,7 @@ _SETTINGS_COLS = (
     "user_id,"
     "profile_visibility,activity_status_visible,"
     "notification_email,notification_push,notification_in_app,"
-    "theme,font_size,accent_color,"
+    "theme,font_size,accent_color,share_class_context,"
     "equipped_avatar_frame_id,equipped_banner_id,equipped_name_color_id,equipped_title_id,"
     "featured_role_id,featured_achievement_ids,updated_at"
 )
@@ -198,11 +199,60 @@ def check_username(username: str = Query(...), user_id: Optional[str] = Query(No
 # ── Public Profile ───────────────────────────────────────────────────────────
 
 @router.get("/{user_id}")
-def get_public_profile(user_id: str):
+def get_public_profile(user_id: str, request: Request):
     user = _get_user_or_404(user_id)
     settings = _get_or_create_settings(user_id)
     roles = _get_user_roles(user_id)
     equipped = _get_equipped_cosmetics(settings)
+
+    # Resolve the viewer WITHOUT raising — profiles are viewable anonymously;
+    # identity only decides how much is revealed (#134).
+    try:
+        viewer_id = get_session_user_id(request)
+    except HTTPException:
+        viewer_id = None
+
+    is_owner = viewer_id is not None and viewer_id == user_id
+
+    # Effective visibility. The owner always sees everything. 'school' (0031)
+    # reveals the extended profile only to viewers sharing a school with the
+    # owner — resolved through services/academics.py, the same boundary the
+    # #342 school directory uses — and otherwise behaves as 'private'.
+    # Fail-closed: anonymous viewer / no shared school → private.
+    visibility = settings.get("profile_visibility") or "public"
+    if not is_owner and visibility == "school":
+        same_school = (
+            viewer_id is not None and viewer_id in school_peer_user_ids(user_id)
+        )
+        visibility = "public" if same_school else "private"
+
+    profile = {
+        "id": user["id"],
+        "username": user.get("username"),
+        "avatar_url": user.get("avatar_url"),
+        "created_at": user.get("created_at"),
+        "roles": roles,
+        "equipped_cosmetics": equipped,
+    }
+
+    if not is_owner and visibility == "private":
+        # Minimal stub: identity-adjacent decoration only. name/year/majors/
+        # minors/school are personal data and stay hidden alongside
+        # bio/location/website/featured/stats (#134). Keys are kept (nulled)
+        # so the frontend's response shape is unchanged.
+        profile.update({
+            "name": "",
+            "year": None,
+            "majors": [],
+            "minors": [],
+            "school": None,
+            "bio": None,
+            "location": None,
+            "website": None,
+            "featured_achievements": [],
+            "stats": {},
+        })
+        return profile
 
     # Resolve school from user's enrolled courses.
     # School now lives behind enrollments.offering_id → course_offerings.course_id
@@ -220,34 +270,18 @@ def get_public_profile(user_id: str):
         if isinstance(course, dict) and course.get("school_id"):
             school = course["school_id"]
 
-    profile = {
-        "id": user["id"],
+    profile.update({
         "name": user.get("name", ""),
-        "username": user.get("username"),
-        "avatar_url": user.get("avatar_url"),
-        "created_at": user.get("created_at"),
         "year": user.get("year"),
         "majors": user.get("majors") or [],
         "minors": user.get("minors") or [],
         "school": school,
-        "roles": roles,
-        "equipped_cosmetics": equipped,
-    }
-
-    # Respect profile visibility
-    if settings.get("profile_visibility") != "private":
-        profile["bio"] = user.get("bio")
-        profile["location"] = user.get("location")
-        profile["website"] = user.get("website")
-        profile["featured_achievements"] = _get_featured_achievements(user_id)
-        profile["stats"] = _get_user_stats(user_id)
-    else:
-        profile["bio"] = None
-        profile["location"] = None
-        profile["website"] = None
-        profile["featured_achievements"] = []
-        profile["stats"] = {}
-
+        "bio": user.get("bio"),
+        "location": user.get("location"),
+        "website": user.get("website"),
+        "featured_achievements": _get_featured_achievements(user_id),
+        "stats": _get_user_stats(user_id),
+    })
     return profile
 
 
@@ -376,6 +410,10 @@ def update_settings(user_id: str, body: UpdateSettingsBody, request: Request):
         "profile_visibility", "activity_status_visible",
         "notification_email", "notification_push", "notification_in_app",
         "theme", "font_size", "accent_color",
+        # #72: Class Intel opt-out — persisted so the WRITE path
+        # (course_context_service.update_course_context) can honor it; the
+        # SharedContextToggle PATCHes it best-effort (migration 0037).
+        "share_class_context",
     }
     incoming = body.model_dump(exclude_none=True)
     updates = {k: v for k, v in incoming.items() if k in ALLOWED}

--- a/backend/routes/profile.py
+++ b/backend/routes/profile.py
@@ -7,7 +7,9 @@ import re
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Request, UploadFile, File, Query
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, UploadFile, File, Query
+
+from services.course_context_service import update_course_context
 from pydantic import BaseModel, Field
 
 from config import MAX_AVATAR_SIZE
@@ -399,7 +401,12 @@ def get_settings(user_id: str, request: Request):
 
 
 @router.patch("/{user_id}/settings")
-def update_settings(user_id: str, body: UpdateSettingsBody, request: Request):
+def update_settings(
+    user_id: str,
+    body: UpdateSettingsBody,
+    background_tasks: BackgroundTasks,
+    request: Request,
+):
     require_self(user_id, request)
     _get_or_create_settings(user_id)
 
@@ -431,6 +438,19 @@ def update_settings(user_id: str, body: UpdateSettingsBody, request: Request):
     if updates:
         updates["updated_at"] = datetime.now(timezone.utc).isoformat()
         table("user_settings").update(updates, filters={"user_id": f"eq.{user_id}"})
+
+    # #72 (PR #464 review): flipping the Class Intel opt-out must take effect
+    # NOW, not whenever some classmate's activity next fires the aggregation.
+    # Refresh every offering the user is enrolled in as a post-response task —
+    # update_course_context re-reads user_settings, so the just-written value
+    # is what the chokepoint filter sees, and an opted-out user's data drops
+    # out of offering_concept_stats/offering_summary immediately.
+    if "share_class_context" in updates:
+        enrollment_rows = table("enrollments").select(
+            "offering_id", filters={"user_id": f"eq.{user_id}"}
+        )
+        for offering_id in {r["offering_id"] for r in enrollment_rows or []}:
+            background_tasks.add_task(update_course_context, offering_id)
 
     return _get_or_create_settings(user_id)
 

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -381,6 +381,21 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
         raise HTTPException(
             status_code=409, detail="Quiz attempt has already been submitted"
         )
+    # The read above is only the fast path — two CONCURRENT submits (a
+    # double-click on the final submit) would both pass it. The atomic claim
+    # below (conditional update on completed_at IS NULL, PR #464 review) is
+    # the real gate: exactly one request wins the row; the loser 409s before
+    # any mastery write. A crash after the claim leaves the attempt
+    # completed-but-scoreless (retry 409s) — strictly safer than double
+    # mastery. The final update further down fills score/total/answers_json.
+    claimed = table("quiz_attempts").update(
+        {"completed_at": datetime.utcnow().isoformat()},
+        filters={"id": f"eq.{body.quiz_id}", "completed_at": "is.null"},
+    )
+    if not claimed:
+        raise HTTPException(
+            status_code=409, detail="Quiz attempt has already been submitted"
+        )
 
     concept_node_id = attempt["concept_node_id"]
 
@@ -458,7 +473,7 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
             "score": score,
             "total": total,
             "answers_json": [a.model_dump() for a in body.answers],
-            "completed_at": datetime.utcnow().isoformat(),
+            # completed_at was already stamped by the atomic claim above.
         },
         filters={"id": f"eq.{body.quiz_id}"},
     )

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -370,6 +370,18 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
         questions = json.loads(questions)
     user_id = attempt["user_id"]
     require_self(user_id, request)
+
+    # #129: completed_at is written on the first successful submit. A re-POST
+    # of the same quiz_id must not re-run apply_graph_update (double mastery
+    # delta + duplicate node_mastery_events row + streak bump), the background
+    # quiz-context task, or achievements. 409 rather than replaying the original
+    # 200: quiz_attempts stores no mastery_before/after, so faithfully
+    # reconstructing the first response would need a migration.
+    if attempt.get("completed_at"):
+        raise HTTPException(
+            status_code=409, detail="Quiz attempt has already been submitted"
+        )
+
     concept_node_id = attempt["concept_node_id"]
 
     answer_map = {str(a.question_id): a.selected_label for a in body.answers}
@@ -380,7 +392,10 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
         selected = answer_map.get(qid, "")
         correct_opt = next((o for o in q["options"] if o.get("correct")), None)
         correct_label = correct_opt["label"] if correct_opt else ""
-        is_correct = selected == correct_label
+        # #129: a malformed item with NO correct option must never grade as
+        # correct — '' == '' would otherwise hand a free point whenever the
+        # answer is also missing.
+        is_correct = bool(correct_opt) and selected == correct_label
         if is_correct:
             score += 1
         results.append({

--- a/backend/services/course_context_service.py
+++ b/backend/services/course_context_service.py
@@ -2,9 +2,11 @@
 services/course_context_service.py
 
 Builds and caches shared class-level context from real DB data.
-Aggregates graph_nodes mastery data and quiz_context across all students in an
-offering (a course taught in a term). The graph is keyed on the abstract course;
-analytics are keyed on the offering.
+Aggregates graph_nodes mastery data and quiz_context across the students in an
+offering (a course taught in a term) who share class context (#72 — the
+persisted user_settings.share_class_context opt-out is enforced here, at the
+write chokepoint). The graph is keyed on the abstract course; analytics are
+keyed on the offering.
 
 Stores data in:
 - offering_concept_stats: per-concept aggregated metrics (per offering)
@@ -27,6 +29,33 @@ def _generate_data_hash(stats_rows: list) -> str:
     """Generate a hash of the stats data to detect changes."""
     data_str = json.dumps(stats_rows, sort_keys=True, default=str)
     return hashlib.sha256(data_str.encode()).hexdigest()
+
+
+def _filter_shared_context_users(user_ids: list) -> list:
+    """#72: keep only users who share class context.
+
+    The Class Intel toggle used to gate only the READ path (a per-request
+    flag); the persisted ``user_settings.share_class_context`` column (0037)
+    makes the opt-out durable, and this filter enforces it here — the single
+    write chokepoint every class-aggregate refresh funnels through. A user
+    with no settings row (or a row predating 0037) is opted IN, matching the
+    column default: only an explicit ``false`` excludes them.
+    """
+    if not user_ids:
+        return []
+    id_filter = ",".join(user_ids)
+    settings_rows = table("user_settings").select(
+        "user_id,share_class_context",
+        filters={"user_id": f"in.({id_filter})"},
+    )
+    opted_out = {
+        r["user_id"]
+        for r in (settings_rows or [])
+        if r.get("share_class_context") is False
+    }
+    if not opted_out:
+        return user_ids
+    return [uid for uid in user_ids if uid not in opted_out]
 
 
 def _generate_summary_with_gemini(
@@ -124,9 +153,11 @@ def clear_course_context_cache() -> None:
 
 def update_course_context(offering_id: str) -> None:
     """
-    Aggregate mastery + quiz data for all students enrolled in an **offering**
+    Aggregate mastery + quiz data for the students enrolled in an **offering**
     (a course taught in a term) and upsert into offering_concept_stats and
     offering_summary. Offering-scoped. Called automatically after any graph update.
+    Students who opted out of sharing (user_settings.share_class_context = false,
+    #72) are excluded before any of their graph data is read.
 
     The knowledge graph is keyed on the *abstract* course id, so we resolve the
     offering → its abstract course to read graph_nodes.
@@ -147,6 +178,18 @@ def update_course_context(offering_id: str) -> None:
         return
 
     user_ids = [r["user_id"] for r in enrollment_rows]
+
+    # ── 1b. Respect the persisted Class Intel opt-out (#72) ───────────────────
+    user_ids = _filter_shared_context_users(user_ids)
+    if not user_ids:
+        # Every enrolled student opted out — same treatment as "no students":
+        # purge any stale aggregates so previously shared data stops being
+        # served, rather than crashing or publishing stats nobody consented to.
+        table("offering_concept_stats").delete({"offering_id": f"eq.{offering_id}"})
+        table("offering_summary").delete({"offering_id": f"eq.{offering_id}"})
+        clear_course_context_cache()  # #98: aggregates changed → drop cached read
+        return
+
     student_count = len(user_ids)
 
     # ── 2. Resolve the offering → abstract course (graph key) + term label ────

--- a/backend/services/flashcard_import_service.py
+++ b/backend/services/flashcard_import_service.py
@@ -22,7 +22,11 @@ from typing import TypedDict
 import httpx
 from bs4 import BeautifulSoup
 from Levenshtein import distance as _levenshtein
-from pydantic_ai.exceptions import ModelHTTPError, UnexpectedModelBehavior
+from pydantic_ai.exceptions import (
+    ContentFilterError,
+    ModelHTTPError,
+    UnexpectedModelBehavior,
+)
 
 from db.connection import table
 from agents._run import run_agent_sync
@@ -244,6 +248,11 @@ def _run_flashcard_agent(prompt: str) -> list[Card]:
       matches the import seams' long-standing bad-JSON ``[]`` resilience; note
       it is a deliberate contract change for ``/generate``, whose legacy path
       *raised* (surfacing a 502) on malformed output.
+    * Provider content-filter blocks (``ContentFilterError``, e.g. a Gemini
+      RECITATION/SAFETY stop — which this prompt's close grounding to course
+      material invites) are carved out of that degrade: the exception
+      subclasses ``UnexpectedModelBehavior`` but propagates so the route
+      surfaces a 502 instead of a misleading success with zero cards (#340).
     * Transient provider errors (HTTP 429/5xx) are retried once with a ~2s
       backoff, then re-raised.
     * Every other failure — transport, missing GEMINI_API_KEY,
@@ -259,6 +268,12 @@ def _run_flashcard_agent(prompt: str) -> list[Card]:
                 feature="flashcard", task="flashcard",
             )
             break
+        except ContentFilterError:
+            # Subclasses UnexpectedModelBehavior, so this carve-out must come
+            # first: a content-filter block is not schema noncompliance and
+            # must reach the route's 502 handler, not degrade to [] (#340).
+            logger.exception("flashcard agent blocked by provider content filter")
+            raise
         except UnexpectedModelBehavior:
             logger.exception("flashcard agent produced unusable output; degrading to []")
             return []

--- a/backend/tests/test_admin_routes.py
+++ b/backend/tests/test_admin_routes.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from unittest.mock import MagicMock, patch
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from main import app
@@ -553,6 +554,49 @@ class TestCosmeticAudits:
             r = client.delete("/api/admin/cosmetics/c1")
         assert r.status_code == 200
         assert audit.call_args.kwargs["action"] == "cosmetic.delete"
+
+
+class TestListAllowlist:
+    """#130: GET /api/admin/allowlist — the listing route the admin portal's
+    adminListAllowlist() calls (frontend/src/lib/api.ts) was never written;
+    approve/revoke existed without a way to read the list back."""
+
+    def test_admin_gets_list_newest_first(self):
+        rows = [
+            {"id": "e2", "email": "b@x.co", "created_at": "2026-05-02T00:00:00Z",
+             "approved_at": None},
+            {"id": "e1", "email": "a@x.co", "created_at": "2026-05-01T00:00:00Z",
+             "approved_at": "2026-05-03T00:00:00Z"},
+        ]
+        with _mock_admin(), patch("routes.admin.table") as t:
+            t.return_value.select.return_value = rows
+            r = client.get("/api/admin/allowlist")
+        assert r.status_code == 200
+        assert r.json() == {"emails": rows}
+        t.assert_called_once_with("newsletter_emails")
+        call = t.return_value.select.call_args
+        columns = call.args[0] if call.args else call.kwargs["columns"]
+        # Shape matches the frontend AllowlistEmail type (types.ts).
+        assert {c.strip() for c in columns.split(",")} == {
+            "id", "email", "created_at", "approved_at",
+        }
+        assert call.kwargs.get("order") == "created_at.desc"
+
+    def test_empty_table_returns_empty_list(self):
+        with _mock_admin(), patch("routes.admin.table") as t:
+            t.return_value.select.return_value = []
+            r = client.get("/api/admin/allowlist")
+        assert r.status_code == 200
+        assert r.json() == {"emails": []}
+
+    def test_non_admin_gets_403(self):
+        with patch(
+            "routes.admin.require_admin",
+            side_effect=HTTPException(status_code=403, detail="Admin access required"),
+        ), patch("routes.admin.table") as t:
+            r = client.get("/api/admin/allowlist")
+        assert r.status_code == 403
+        t.assert_not_called()
 
 
 class TestAllowlistAudits:

--- a/backend/tests/test_chat_stream.py
+++ b/backend/tests/test_chat_stream.py
@@ -232,7 +232,7 @@ def test_graph_update_emitted_once_per_new_write():
             FunctionToolCallEvent("update_mastery_tool"),
             FunctionToolResultEvent(on_fire=first_write),
             PartStartEvent("Done."),
-            FunctionToolCallEvent("search_course_materials_tool"),
+            FunctionToolCallEvent("search_course_materials"),
             FunctionToolResultEvent(),          # writes nothing new
             AgentRunResultEvent("Done."),
         ])

--- a/backend/tests/test_chat_tutor_imports.py
+++ b/backend/tests/test_chat_tutor_imports.py
@@ -37,7 +37,7 @@ def test_unknown_mode_falls_back_to_socratic():
 def test_all_tools_registered():
     """Chat tutor needs three context tools + two graph tools (add and update mastery)."""
     expected = {
-        "search_course_materials_tool",
+        "search_course_materials",
         "read_session_history_tool",
         "read_user_progress_tool",
         "apply_graph_update_tool",

--- a/backend/tests/test_documents_routes.py
+++ b/backend/tests/test_documents_routes.py
@@ -371,18 +371,27 @@ class TestUploadDocument:
     def test_rejects_file_over_max_size(self):
         # Cap was raised from 15 MB → 100 MB in commit 9912a25. Don't
         # allocate 100MB here — it makes the test fragile under full-suite
-        # memory pressure. Instead, monkeypatch MAX_FILE_SIZE to 1 KB and
-        # pin the rejection-message contract.
+        # memory pressure. Instead, monkeypatch MAX_FILE_SIZE to 1 MB and
+        # pin that the rejection copy DERIVES from the constant (#132 item
+        # 21): a hardcoded "100 MB" in the detail string would not follow
+        # the patched cap. test_default_cap_is_100_mb pins the production
+        # value, so together they pin the production message.
         with (
             _mock_validate_user(),
-            patch("routes.documents.MAX_FILE_SIZE", 1024),
+            patch("routes.documents.MAX_FILE_SIZE", 1024 * 1024),
             patch("routes.documents.extract_text_from_file", return_value=""),
         ):
-            r = _make_upload(content=b"x" * 2048)
+            r = _make_upload(content=b"x" * (1024 * 1024 + 1))
         assert r.status_code == 400
-        # The error message names the actual cap (100 MB) — verifies the
-        # route's hardcoded copy in the detail string didn't drift.
-        assert "100 MB" in r.json()["detail"]
+        assert "1 MB" in r.json()["detail"]
+
+    def test_default_cap_is_100_mb(self):
+        """The rejection copy derives from MAX_FILE_SIZE (see
+        test_rejects_file_over_max_size), so pinning the constant pins the
+        production message ("File exceeds the 100 MB limit.")."""
+        from routes.documents import MAX_FILE_SIZE
+
+        assert MAX_FILE_SIZE == 100 * 1024 * 1024
 
     def test_accepts_pdf_by_extension(self):
         ai_result = {
@@ -1221,6 +1230,79 @@ class TestUploadDocumentStreaming:
             )
         assert r.status_code == 422
         assert "different file" in r.json().get("detail", "").lower()
+
+    def test_streaming_rejects_file_over_max_size_names_actual_cap(self):
+        """#132 item 21: the streaming route's 400 detail drifted to "15 MB"
+        while MAX_FILE_SIZE is 100 MB. The copy must derive from the constant
+        — patch the cap to 1 MB and the message must follow it. (Sync twin:
+        TestUploadDocument.test_rejects_file_over_max_size; the production
+        value is pinned by test_default_cap_is_100_mb.)"""
+        with (
+            _mock_validate_user(),
+            patch("routes.documents.MAX_FILE_SIZE", 1024 * 1024),
+            patch("routes.documents.extract_text_from_file", return_value=""),
+        ):
+            r = client.post(
+                "/api/documents/upload",
+                files={"file": ("notes.pdf", io.BytesIO(b"x" * (1024 * 1024 + 1)), "application/pdf")},
+                data={"course_id": "c-1", "user_id": "u1"},
+            )
+        assert r.status_code == 400
+        detail = r.json()["detail"]
+        assert "1 MB" in detail
+        assert "15 MB" not in detail
+
+    def test_post_result_persistence_failure_is_terminal_not_double_result(self):
+        """#132 item 11: a persistence failure AFTER the terminal result event
+        must NOT fall into the legacy fallback.
+
+        Before the fix, the post-roll block (syllabus save, graph backstop,
+        document insert) shared the pipeline's try/except, so a failed insert
+        re-ran the whole pipeline via _stream_legacy_fallback: the client saw
+        result → error → result → done, and a second model call was spent on
+        a document that had already been fully processed. Contract: exactly
+        ONE result event, then the same terminal error+done pair
+        _stream_legacy_fallback's own failure tail uses.
+        """
+        cls_p, sum_p, cpt_p, syl_p, doc_p = self._mock_agent_runs()
+        legacy_spy = AsyncMock(return_value={"id": "legacy-doc"})
+        with (
+            _mock_validate_user(),
+            patch("routes.documents.extract_text_from_file", return_value=_doc_text("text")),
+            cls_p, sum_p, cpt_p, syl_p, doc_p,
+            patch(
+                "routes.documents._persist_document",
+                side_effect=RuntimeError("documents insert blew up"),
+            ),
+            patch("routes.documents._legacy_upload_pipeline", legacy_spy),
+            patch("routes.documents.table") as t,
+            patch("routes.documents._spawn_post_roll") as spawn,
+        ):
+            t.return_value.select.return_value = []  # no idempotency cache hit
+            with client.stream(
+                "POST", "/api/documents/upload",
+                files={"file": ("notes.pdf", io.BytesIO(b"%PDF-1.4 x"), "application/pdf")},
+                data={"course_id": "c-1", "user_id": "u1"},
+            ) as r:
+                assert r.status_code == 200
+                body = r.read()
+
+        events = _parse_sse_stream(body)
+        types_steps = [(e["event"], json.loads(e["data"])["step"]) for e in events]
+        # Exactly ONE result event — never a second (legacy-fallback) one.
+        assert [ts for ts in types_steps if ts[0] == "result"] == [("result", "finalize")]
+        # Terminal shape mirrors _stream_legacy_fallback's failure tail.
+        assert types_steps[-2:] == [("error", "failed"), ("status", "done")]
+        # The legacy pipeline never ran — no second model call, no re-run.
+        legacy_spy.assert_not_called()
+        # Side-effect tasks are never spawned when persistence failed.
+        spawn.assert_not_called()
+        # The failure event carries the request_id for support.
+        failed_data = next(
+            json.loads(e["data"]) for e in events
+            if e["event"] == "error" and json.loads(e["data"])["step"] == "failed"
+        )
+        assert failed_data.get("data", {}).get("request_id")
 
 
 # ── X-Request-ID middleware + error-handler propagation ─────────────────────

--- a/backend/tests/test_feedback_routes.py
+++ b/backend/tests/test_feedback_routes.py
@@ -146,3 +146,75 @@ class TestSubmitIssueReport:
         assert set(data.keys()) == {
             "id", "user_id", "topic", "description", "screenshot_urls",
         }
+
+
+class TestFeedbackAuth:
+    """#134: the two write endpoints must derive user_id from the SESSION.
+
+    Before the fix they took no Request and inserted body.user_id verbatim, so
+    anyone could write rows attributed to any user. The wire body still carries
+    user_id for backward compatibility — it is accepted but never trusted.
+    Auth-restore pattern copied from tests/test_issue_screenshot_auth.py.
+    """
+
+    def test_unauthenticated_feedback_returns_401(self):
+        from services import auth_guard
+
+        recorded: list = []
+        with patch("routes.feedback.table", side_effect=_factory(recorded)), \
+             patch("routes.feedback.get_session_user_id", auth_guard._real_get_session_user_id), \
+             patch.object(auth_guard, "_decode_session", auth_guard._real_decode_session):
+            r = client.post(
+                "/api/feedback",
+                json={"user_id": "user_andres", "type": "global", "rating": 3},
+            )
+        assert r.status_code == 401
+        assert recorded == []
+
+    def test_unauthenticated_issue_report_returns_401(self):
+        from services import auth_guard
+
+        recorded: list = []
+        with patch("routes.feedback.table", side_effect=_factory(recorded)), \
+             patch("routes.feedback.get_session_user_id", auth_guard._real_get_session_user_id), \
+             patch.object(auth_guard, "_decode_session", auth_guard._real_decode_session):
+            r = client.post(
+                "/api/issue-reports",
+                json={
+                    "user_id": "user_andres",
+                    "topic": "bug",
+                    "description": "broke",
+                    "screenshot_urls": [],
+                },
+            )
+        assert r.status_code == 401
+        assert recorded == []
+
+    def test_feedback_attributed_to_session_user_not_body(self):
+        recorded: list = []
+        with patch("routes.feedback.table", side_effect=_factory(recorded)), \
+             patch("routes.feedback.get_session_user_id", return_value="session_user"):
+            r = client.post(
+                "/api/feedback",
+                json={"user_id": "someone_else", "type": "global", "rating": 3},
+            )
+        assert r.status_code == 200
+        _name, data = recorded[0]
+        assert data["user_id"] == "session_user"
+
+    def test_issue_report_attributed_to_session_user_not_body(self):
+        recorded: list = []
+        with patch("routes.feedback.table", side_effect=_factory(recorded)), \
+             patch("routes.feedback.get_session_user_id", return_value="session_user"):
+            r = client.post(
+                "/api/issue-reports",
+                json={
+                    "user_id": "someone_else",
+                    "topic": "bug",
+                    "description": "broke",
+                    "screenshot_urls": [],
+                },
+            )
+        assert r.status_code == 200
+        _name, data = recorded[0]
+        assert data["user_id"] == "session_user"

--- a/backend/tests/test_flashcard_import_routes.py
+++ b/backend/tests/test_flashcard_import_routes.py
@@ -1,6 +1,6 @@
 """Integration tests for /api/flashcards/import/* routes."""
 import base64
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -193,6 +193,21 @@ class TestImportGenerate:
         with _mock_self(), patch("routes.flashcards.check_rate_limit", return_value=None):
             r = client.post("/api/flashcards/import/generate", json=body)
         assert r.status_code == 400
+
+    def test_content_filter_block_returns_502(self):
+        # A Gemini content-filter block (e.g. RECITATION) raised at the agent
+        # seam must surface as the route's 502 — never 200 {"cards": []} with
+        # a success toast for zero cards (#340). Mocks the agent seam (not the
+        # service) so the service's exception handling is exercised end-to-end.
+        from pydantic_ai.exceptions import ContentFilterError
+        body = {"user_id": "u1", "source": "paste", "text": "notes", "count": 5, "difficulty": "recall"}
+        run = AsyncMock(side_effect=ContentFilterError("blocked: RECITATION"))
+        with _mock_self(), \
+             patch("services.flashcard_import_service.flashcard_agent.run", new=run), \
+             patch("routes.flashcards.check_rate_limit", return_value=None):
+            r = client.post("/api/flashcards/import/generate", json=body)
+        assert r.status_code == 502
+        assert "RECITATION" in r.json()["detail"]
 
     def test_library_doc_belonging_to_other_user_returns_404(self):
         body = {"user_id": "u1", "source": "library_doc", "document_id": "doc1", "count": 5, "difficulty": "recall"}

--- a/backend/tests/test_flashcard_import_service.py
+++ b/backend/tests/test_flashcard_import_service.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from pydantic_ai.exceptions import ModelHTTPError, UnexpectedModelBehavior
+from pydantic_ai.exceptions import ContentFilterError, ModelHTTPError, UnexpectedModelBehavior
 
 from services import flashcard_import_service as svc
 
@@ -310,6 +310,17 @@ class TestGenerateCards:
             with pytest.raises(RuntimeError):
                 svc.gemini_generate_cards("x", count=5, difficulty="recall")
 
+    def test_content_filter_propagates(self):
+        # A provider content-filter block (e.g. Gemini RECITATION, which the
+        # close-grounding flashcard prompt invites) is NOT schema noncompliance.
+        # ContentFilterError subclasses UnexpectedModelBehavior, so without its
+        # own carve-out it would degrade to [] and the route would answer a
+        # misleading 200 with zero cards; it must propagate → route 502 (#340).
+        run = AsyncMock(side_effect=ContentFilterError("blocked: RECITATION"))
+        with patch("services.flashcard_import_service.flashcard_agent.run", new=run):
+            with pytest.raises(ContentFilterError):
+                svc.gemini_generate_cards("x", count=5, difficulty="recall")
+
     def test_non_transient_http_error_propagates(self):
         run = AsyncMock(side_effect=ModelHTTPError(status_code=400, model_name="gemini-2.5-flash"))
         with patch("services.flashcard_import_service.flashcard_agent.run", new=run):
@@ -375,6 +386,16 @@ class TestCleanupCards:
         run = AsyncMock(side_effect=RuntimeError("boom"))
         with patch("services.flashcard_import_service.flashcard_agent.run", new=run):
             with pytest.raises(RuntimeError):
+                svc.gemini_cleanup_cards(cards)
+
+    def test_content_filter_propagates(self):
+        # A content-filter block propagates (→ route 502) even on the cleanup
+        # path — unlike schema-noncompliant output, which falls back to the
+        # user's original cards (#340).
+        cards = [{"front": "X", "back": "Y"}]
+        run = AsyncMock(side_effect=ContentFilterError("blocked: SAFETY"))
+        with patch("services.flashcard_import_service.flashcard_agent.run", new=run):
+            with pytest.raises(ContentFilterError):
                 svc.gemini_cleanup_cards(cards)
 
 

--- a/backend/tests/test_model_mode_seam.py
+++ b/backend/tests/test_model_mode_seam.py
@@ -164,12 +164,14 @@ def test_real_agent_driven_by_function_model_asserts_tool_call_args(monkeypatch)
         calls["n"] += 1
         if calls["n"] == 1:
             # First turn: script a call to a real function tool with real args.
-            # The tool is registered under its function name (note_chat.py wires
-            # `search_course_materials_tool` without a name= override).
+            # The tool is registered under its prompt-facing name (#135:
+            # note_chat.py wires Tool(search_course_materials_tool,
+            # name="search_course_materials") so the wire name matches the
+            # system prompt's `search_course_materials`).
             return ModelResponse(
                 parts=[
                     ToolCallPart(
-                        tool_name="search_course_materials_tool",
+                        tool_name="search_course_materials",
                         args={"query": "gradient descent", "limit": 3},
                     )
                 ]
@@ -185,7 +187,7 @@ def test_real_agent_driven_by_function_model_asserts_tool_call_args(monkeypatch)
         result = note_chat_agent.run_sync("How does gradient descent work?", deps=_deps())
 
     # The real tools were registered (registration ran through the agent).
-    assert "search_course_materials_tool" in seen_tools["names"]
+    assert "search_course_materials" in seen_tools["names"]
     assert "read_active_note" in seen_tools["names"]
     # The LLM-chosen tool-call arguments were schema-validated and dispatched to
     # the real tool body with the deps-scoped user/course fields injected.
@@ -372,7 +374,7 @@ def test_function_mode_streams_scripted_tool_calls(monkeypatch):
             return ModelResponse(
                 parts=[
                     ToolCallPart(
-                        tool_name="search_course_materials_tool",
+                        tool_name="search_course_materials",
                         args={"query": "eigenvalues", "limit": 2},
                     )
                 ]

--- a/backend/tests/test_profile_routes.py
+++ b/backend/tests/test_profile_routes.py
@@ -942,3 +942,53 @@ class TestUpdateSettingsShareClassContext:
             )
         assert r.status_code == 200
         assert captured["data"]["share_class_context"] is False
+
+
+class TestShareClassContextToggleRefresh:
+    """#72 (PR #464 review): persisting the opt-out is not enough — the
+    aggregates must refresh NOW, not whenever a classmate's activity next
+    fires update_course_context. The PATCH schedules one refresh per
+    enrolled offering; update_course_context re-reads user_settings, so the
+    just-written value is what its chokepoint filter sees."""
+
+    def _tables(self):
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "user_settings":
+                m.select.return_value = [{"user_id": USER_ID, "share_class_context": True}]
+                m.update.return_value = [{}]
+            elif name == "enrollments":
+                m.select.return_value = [
+                    {"offering_id": "off-1"},
+                    {"offering_id": "off-2"},
+                    {"offering_id": "off-1"},  # duplicate → deduped
+                ]
+            else:
+                m.select.return_value = []
+            return m
+
+        return table_side_effect
+
+    def test_toggling_share_class_context_refreshes_every_enrolled_offering(self):
+        with (
+            _mock_self(),
+            patch("routes.profile.table", side_effect=self._tables()),
+            patch("routes.profile.update_course_context") as refresh,
+        ):
+            r = client.patch(
+                f"/api/profile/{USER_ID}/settings", json={"share_class_context": False}
+            )
+        assert r.status_code == 200
+        # TestClient runs BackgroundTasks after the response: one refresh per
+        # distinct offering.
+        assert sorted(c.args[0] for c in refresh.call_args_list) == ["off-1", "off-2"]
+
+    def test_other_settings_do_not_trigger_refresh(self):
+        with (
+            _mock_self(),
+            patch("routes.profile.table", side_effect=self._tables()),
+            patch("routes.profile.update_course_context") as refresh,
+        ):
+            r = client.patch(f"/api/profile/{USER_ID}/settings", json={"theme": "dark"})
+        assert r.status_code == 200
+        refresh.assert_not_called()

--- a/backend/tests/test_profile_routes.py
+++ b/backend/tests/test_profile_routes.py
@@ -19,6 +19,7 @@ All DB access and auth guards are mocked.
 """
 import pytest
 from unittest.mock import MagicMock, patch
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from main import app
@@ -35,6 +36,77 @@ def _mock_self():
 
 def _mock_session_user():
     return patch("routes.profile.get_session_user_id", return_value=USER_ID)
+
+
+# ── Visibility-matrix helpers (#134) ────────────────────────────────────────
+
+VIEWER_ID = "viewer_user_9"
+
+FULL_PROFILE_ROW = {
+    "user_id": USER_ID, "name": "Test", "username": "tester",
+    "avatar_url": "https://cdn/a.png", "bio": "Secret", "location": "Hidden",
+    "website": "https://t.io", "year": "junior", "majors": ["Math"], "minors": ["CS"],
+}
+
+
+def _visibility_tables(visibility):
+    """table() factory for a user whose profile carries every sensitive field."""
+    user_row = {"id": USER_ID, "email": None, "streak_count": 3, "created_at": "2025-01-01"}
+    settings_row = {"user_id": USER_ID, "profile_visibility": visibility}
+
+    def table_side_effect(name):
+        m = MagicMock()
+        if name == "users":
+            m.select.return_value = [user_row]
+        elif name == "user_profiles":
+            m.select.return_value = [dict(FULL_PROFILE_ROW)]
+        elif name == "user_settings":
+            m.select.return_value = [settings_row]
+        else:
+            m.select.return_value = []
+        return m
+
+    return table_side_effect
+
+
+def _viewer(viewer_id):
+    """Patch the route's session read to a specific viewer (None = anonymous)."""
+    if viewer_id is None:
+        return patch(
+            "routes.profile.get_session_user_id",
+            side_effect=HTTPException(status_code=401, detail="Not authenticated"),
+        )
+    return patch("routes.profile.get_session_user_id", return_value=viewer_id)
+
+
+def _assert_private_stub(data):
+    """Restricted view: identity-adjacent decoration only; personal data out."""
+    assert data["id"] == USER_ID
+    assert data["username"] == "tester"
+    assert data["avatar_url"] == "https://cdn/a.png"
+    assert data["created_at"] == "2025-01-01"
+    # #134: these must never leak on a restricted profile.
+    assert data.get("name") in (None, "")
+    assert data.get("year") is None
+    assert data.get("majors") in (None, [])
+    assert data.get("minors") in (None, [])
+    assert data.get("school") is None
+    assert data.get("bio") is None
+    assert data.get("location") is None
+    assert data.get("website") is None
+    assert data.get("featured_achievements") in (None, [])
+    assert data.get("stats") in (None, {})
+
+
+def _assert_full_profile(data):
+    assert data["name"] == "Test"
+    assert data["year"] == "junior"
+    assert data["majors"] == ["Math"]
+    assert data["minors"] == ["CS"]
+    assert data["bio"] == "Secret"
+    assert data["location"] == "Hidden"
+    assert data["website"] == "https://t.io"
+    assert data["stats"].get("streak_count") == 3
 
 
 # ── GET /api/profile/{user_id} ─────────────────────────────────────────────
@@ -91,30 +163,78 @@ class TestGetPublicProfile:
         assert r.status_code == 404
 
     def test_private_profile_hides_bio_and_stats(self):
-        user_row = {"id": USER_ID, "email": None, "streak_count": 0, "created_at": "2025-01-01"}
-        profile_row = {"user_id": USER_ID, "name": "Test", "username": None, "avatar_url": None, "bio": "Secret", "location": "Hidden", "website": None}
-        settings_row = {"user_id": USER_ID, "profile_visibility": "private"}
-
-        def table_side_effect(name):
-            m = MagicMock()
-            if name == "users":
-                m.select.return_value = [user_row]
-            elif name == "user_profiles":
-                m.select.return_value = [profile_row]
-            elif name == "user_settings":
-                m.select.return_value = [settings_row]
-            else:
-                m.select.return_value = []
-            return m
-
-        with patch("routes.profile.table", side_effect=table_side_effect):
+        # #134 tightened: a private profile viewed by ANOTHER user returns only
+        # the minimal stub — name/year/majors/minors/school are personal data
+        # and must be hidden alongside bio/location/website/stats.
+        with _viewer("someone_else"), \
+             patch("routes.profile.table", side_effect=_visibility_tables("private")):
             r = client.get(f"/api/profile/{USER_ID}")
 
         assert r.status_code == 200
-        data = r.json()
-        assert data["bio"] is None
-        assert data["location"] is None
-        assert data["stats"] == {}
+        _assert_private_stub(r.json())
+
+
+# ── Visibility matrix: private/school × owner/peer/stranger/anonymous (#134) ─
+
+class TestProfileVisibilityMatrix:
+    def test_private_profile_hidden_from_anonymous(self):
+        with _viewer(None), \
+             patch("routes.profile.table", side_effect=_visibility_tables("private")):
+            r = client.get(f"/api/profile/{USER_ID}")
+        # Anonymous viewing stays allowed (public profiles are anonymous-
+        # visible); it must narrow the payload, never 401.
+        assert r.status_code == 200
+        _assert_private_stub(r.json())
+
+    def test_private_profile_owner_sees_everything(self):
+        with _viewer(USER_ID), \
+             patch("routes.profile.table", side_effect=_visibility_tables("private")):
+            r = client.get(f"/api/profile/{USER_ID}")
+        assert r.status_code == 200
+        _assert_full_profile(r.json())
+
+    def test_school_profile_same_school_sees_extended(self):
+        with _viewer(VIEWER_ID), \
+             patch("routes.profile.table", side_effect=_visibility_tables("school")), \
+             patch("routes.profile.school_peer_user_ids",
+                   return_value={USER_ID, VIEWER_ID}) as peers:
+            r = client.get(f"/api/profile/{USER_ID}")
+        assert r.status_code == 200
+        _assert_full_profile(r.json())
+        peers.assert_called_once_with(USER_ID)
+
+    def test_school_profile_different_school_gets_stub(self):
+        with _viewer(VIEWER_ID), \
+             patch("routes.profile.table", side_effect=_visibility_tables("school")), \
+             patch("routes.profile.school_peer_user_ids", return_value={USER_ID}):
+            r = client.get(f"/api/profile/{USER_ID}")
+        assert r.status_code == 200
+        _assert_private_stub(r.json())
+
+    def test_school_profile_anonymous_gets_stub(self):
+        with _viewer(None), \
+             patch("routes.profile.table", side_effect=_visibility_tables("school")), \
+             patch("routes.profile.school_peer_user_ids", return_value=set()):
+            r = client.get(f"/api/profile/{USER_ID}")
+        assert r.status_code == 200
+        _assert_private_stub(r.json())
+
+    def test_school_profile_owner_sees_everything_without_peer_lookup(self):
+        with _viewer(USER_ID), \
+             patch("routes.profile.table", side_effect=_visibility_tables("school")), \
+             patch("routes.profile.school_peer_user_ids", return_value=set()) as peers:
+            r = client.get(f"/api/profile/{USER_ID}")
+        assert r.status_code == 200
+        _assert_full_profile(r.json())
+        peers.assert_not_called()
+
+    def test_public_profile_anonymous_sees_extended(self):
+        # Guard: the viewer resolution must not narrow PUBLIC profiles.
+        with _viewer(None), \
+             patch("routes.profile.table", side_effect=_visibility_tables("public")):
+            r = client.get(f"/api/profile/{USER_ID}")
+        assert r.status_code == 200
+        _assert_full_profile(r.json())
 
 
 # ── PATCH /api/profile/{user_id} ───────────────────────────────────────────
@@ -792,3 +912,33 @@ class TestGetUserOr404SelectColumns:
             f"_get_user_or_404 SELECTs columns that don't exist on `user_profiles`: "
             f"{sorted(unknown_profiles)}."
         )
+
+
+class TestUpdateSettingsShareClassContext:
+    """#72: the Class Intel opt-out must be patchable — it's the persisted
+    preference the write chokepoint (course_context_service) filters on, and
+    SharedContextToggle PATCHes it best-effort. A whitelist miss here would
+    silently 400 the toggle's persistence forever (the frontend swallows it)."""
+
+    def _tables(self):
+        captured = {}
+
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "user_settings":
+                m.select.return_value = [{"user_id": USER_ID, "share_class_context": True}]
+                m.update.side_effect = lambda data, filters: captured.update({"data": data}) or [{}]
+            else:
+                m.select.return_value = []
+            return m
+
+        return table_side_effect, captured
+
+    def test_share_class_context_is_patchable(self):
+        table_side_effect, captured = self._tables()
+        with _mock_self(), patch("routes.profile.table", side_effect=table_side_effect):
+            r = client.patch(
+                f"/api/profile/{USER_ID}/settings", json={"share_class_context": False}
+            )
+        assert r.status_code == 200
+        assert captured["data"]["share_class_context"] is False

--- a/backend/tests/test_quiz_routes.py
+++ b/backend/tests/test_quiz_routes.py
@@ -106,7 +106,7 @@ def _make_table(questions=None):
             mock.select.return_value = [{"name": "Andres"}]
         else:
             mock.select.return_value = []
-        mock.update.return_value = []
+        mock.update.return_value = [{"id": "updated"}]
         return mock
 
     return factory
@@ -235,7 +235,7 @@ class TestSubmitQuiz:
                 mock.select.return_value = [{"name": "Andres"}]
             else:
                 mock.select.return_value = []
-            mock.update.return_value = []
+            mock.update.return_value = [{"id": "updated"}]
             return mock
 
         with patch("routes.quiz.table", side_effect=factory):
@@ -308,7 +308,7 @@ class TestSubmitQuizResubmit:
                 }]
             else:
                 mock.select.return_value = []
-            mock.update.return_value = []
+            mock.update.return_value = [{"id": "updated"}]
             return mock
 
         return factory
@@ -455,13 +455,13 @@ class TestQuizNodeOwnership:
                     "difficulty": "medium",
                     "questions_json": SAMPLE_QUESTIONS,
                 }]
-                mock.update.return_value = []
+                mock.update.return_value = [{"id": "updated"}]
             elif name == "graph_nodes":
                 mock.select.side_effect = self._ownership_aware_graph_select
                 mock.update.side_effect = lambda *a, **k: update_calls.append((a, k)) or []
             else:
                 mock.select.return_value = []
-                mock.update.return_value = []
+                mock.update.return_value = [{"id": "updated"}]
             return mock
 
         apply_mock = MagicMock()
@@ -644,7 +644,7 @@ class TestSubmitQuizMasteryWrite:
                 mock.select.return_value = [{"name": "Andres"}]
             else:
                 mock.select.return_value = []
-            mock.update.return_value = []
+            mock.update.return_value = [{"id": "updated"}]
             return mock
 
         with (
@@ -1238,3 +1238,112 @@ class TestQuizModelPref:
         assert _resolve_model_pref(None) is None
         assert _resolve_model_pref("") is None
         assert _resolve_model_pref("auto") is None  # not in the map
+
+
+class TestSubmitQuizConcurrentClaim:
+    """#129 (PR #464 review): the completed_at pre-read is only a fast path —
+    two CONCURRENT submits both pass it. The real gate is the atomic claim
+    (conditional update on completed_at IS NULL); the loser sees zero updated
+    rows and must 409 before any mastery write."""
+
+    def _race_loser_factory(self):
+        """Attempt reads as un-scored (completed_at None) — the pre-read
+        passes — but the atomic claim returns [] (another request already
+        stamped the row between our read and our write)."""
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                mock.select.return_value = [{
+                    "id": "quiz1",
+                    "user_id": "user_andres",
+                    "concept_node_id": "node1",
+                    "difficulty": "medium",
+                    "questions_json": SAMPLE_QUESTIONS,
+                    "completed_at": None,
+                }]
+                mock.update.return_value = []  # claim lost: no row matched is.null
+            elif name == "graph_nodes":
+                mock.select.return_value = [{
+                    "mastery_score": 0.5,
+                    "concept_name": "Loops",
+                    "course_id": "course1",
+                }]
+            else:
+                mock.select.return_value = []
+                mock.update.return_value = []
+            return mock
+
+        return factory
+
+    def test_losing_the_atomic_claim_409s_and_applies_nothing(self):
+        apply_mock = MagicMock()
+        ctx_run = _noop_ctx_agent()
+        with (
+            patch("routes.quiz.table", side_effect=self._race_loser_factory()),
+            patch("routes.quiz.apply_graph_update", new=apply_mock),
+            patch("routes.quiz.get_quiz_context", return_value={}),
+            patch("routes.quiz.quiz_context_agent.run", new=ctx_run),
+            patch("routes.quiz.save_quiz_context") as save_mock,
+        ):
+            r = client.post("/api/quiz/submit", json={
+                "quiz_id": "quiz1",
+                "answers": [
+                    {"question_id": 1, "selected_label": "A"},
+                    {"question_id": 2, "selected_label": "D"},
+                ],
+            })
+        assert r.status_code == 409
+        apply_mock.assert_not_called()
+        ctx_run.assert_not_called()
+        save_mock.assert_not_called()
+
+    def test_winning_the_claim_stamps_completed_at_with_is_null_filter(self):
+        """The claim must be the conditional-update idiom: filters carry
+        completed_at=is.null so PostgREST arbitrates, not app code."""
+        claim_calls = []
+
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                mock.select.return_value = [{
+                    "id": "quiz1",
+                    "user_id": "user_andres",
+                    "concept_node_id": "node1",
+                    "difficulty": "medium",
+                    "questions_json": SAMPLE_QUESTIONS,
+                    "completed_at": None,
+                }]
+                def _update(data, filters):
+                    claim_calls.append((data, filters))
+                    return [{"id": "quiz1"}]
+                mock.update.side_effect = _update
+            elif name == "graph_nodes":
+                mock.select.return_value = [{
+                    "mastery_score": 0.5,
+                    "concept_name": "Loops",
+                    "course_id": "course1",
+                }]
+            else:
+                mock.select.return_value = []
+                mock.update.return_value = []
+            return mock
+
+        with (
+            patch("routes.quiz.table", side_effect=factory),
+            patch("routes.quiz.apply_graph_update"),
+            patch("routes.quiz.get_quiz_context", return_value={}),
+            patch("routes.quiz.quiz_context_agent.run", new=_noop_ctx_agent()),
+            patch("routes.quiz.save_quiz_context"),
+        ):
+            r = client.post("/api/quiz/submit", json={
+                "quiz_id": "quiz1",
+                "answers": [
+                    {"question_id": 1, "selected_label": "A"},
+                    {"question_id": 2, "selected_label": "D"},
+                ],
+            })
+        assert r.status_code == 200
+        # First update is the claim: stamps completed_at, gated on is.null.
+        data, filters = claim_calls[0]
+        assert "completed_at" in data
+        assert filters.get("completed_at") == "is.null"

--- a/backend/tests/test_quiz_routes.py
+++ b/backend/tests/test_quiz_routes.py
@@ -254,6 +254,113 @@ class TestSubmitQuiz:
         assert r.json()["score"] == 2
 
 
+# ── POST /api/quiz/submit — resubmit + malformed-item grading (#129) ────────
+
+
+MALFORMED_QUESTIONS = [
+    {
+        "id": 1,
+        "text": "What does a for-loop do?",
+        "options": [
+            {"label": "A", "correct": True},
+            {"label": "B", "correct": False},
+        ],
+        "explanation": "A is correct.",
+    },
+    {
+        # Malformed: generation drift left NO option flagged correct. Before
+        # #129 this graded as correct whenever the answer was also missing
+        # ('' == '' — the free point).
+        "id": 2,
+        "text": "What is a function?",
+        "options": [
+            {"label": "C", "correct": False},
+            {"label": "D", "correct": False},
+        ],
+        "explanation": "Nothing is marked correct.",
+    },
+]
+
+
+class TestSubmitQuizResubmit:
+    """#129: the first submit writes quiz_attempts.completed_at; re-POSTing
+    the same quiz_id must 409 without re-running apply_graph_update (second
+    mastery delta + duplicate node_mastery_events row + streak bump), the
+    background quiz-context task, or achievements."""
+
+    def _completed_attempt_factory(self):
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                mock.select.return_value = [{
+                    "id": "quiz1",
+                    "user_id": "user_andres",
+                    "concept_node_id": "node1",
+                    "difficulty": "medium",
+                    "questions_json": SAMPLE_QUESTIONS,
+                    "completed_at": "2026-07-29T12:00:00",  # already scored
+                }]
+            elif name == "graph_nodes":
+                mock.select.return_value = [{
+                    "mastery_score": 0.5,
+                    "concept_name": "Loops",
+                    "course_id": "course1",
+                }]
+            else:
+                mock.select.return_value = []
+            mock.update.return_value = []
+            return mock
+
+        return factory
+
+    def test_resubmit_of_completed_attempt_returns_409_and_applies_nothing(self):
+        apply_mock = MagicMock()
+        ctx_run = _noop_ctx_agent()
+        with (
+            patch("routes.quiz.table", side_effect=self._completed_attempt_factory()),
+            patch("routes.quiz.apply_graph_update", new=apply_mock),
+            patch("routes.quiz.get_quiz_context", return_value={}),
+            patch("routes.quiz.quiz_context_agent.run", new=ctx_run),
+            patch("routes.quiz.save_quiz_context") as save_mock,
+        ):
+            r = client.post("/api/quiz/submit", json={
+                "quiz_id": "quiz1",
+                "answers": [
+                    {"question_id": 1, "selected_label": "A"},
+                    {"question_id": 2, "selected_label": "D"},
+                ],
+            })
+        assert r.status_code == 409
+        # No second mastery event: the sanctioned graph write must not fire.
+        apply_mock.assert_not_called()
+        # Nor the background context update behind it.
+        ctx_run.assert_not_called()
+        save_mock.assert_not_called()
+
+
+class TestSubmitQuizMalformedItem:
+    """#129: a malformed item (no option flagged correct) must never grade
+    as correct — before the fix, a missing answer matched the empty
+    correct label ('' == '') and handed out a free point."""
+
+    def test_missing_answer_on_item_without_correct_option_is_not_correct(self):
+        with _submit_quiz_mocks(questions=MALFORMED_QUESTIONS):
+            r = client.post("/api/quiz/submit", json={
+                "quiz_id": "quiz1",
+                # No answer at all for the malformed question 2.
+                "answers": [{"question_id": 1, "selected_label": "A"}],
+            })
+        assert r.status_code == 200
+        data = r.json()
+        assert data["score"] == 1, (
+            "free-point regression: an unanswered malformed item "
+            "(no correct option) was graded as correct"
+        )
+        flags = {res["question_id"]: res["correct"] for res in data["results"]}
+        assert flags["1"] is True
+        assert flags["2"] is False
+
+
 # ── Cross-user node ownership (IDOR regression, issue #157) ─────────────────
 
 

--- a/backend/tests/test_shared_course_context.py
+++ b/backend/tests/test_shared_course_context.py
@@ -292,6 +292,142 @@ class TestUpdateCourseContext(unittest.TestCase):
         self.assertEqual(len(upsert_payload["common_misconceptions"]), 1)
         self.assertEqual(len(upsert_payload["prerequisite_gaps"]), 1)
 
+    # ── #72: the persisted Class Intel opt-out gates the WRITE path ──────────
+
+    @staticmethod
+    def _table_factory(settings_rows, nodes_tbl, stats_tbl, summary_tbl):
+        """Dispatch table() by name for the share_class_context tests."""
+        enrollment_rows = [{"user_id": "u1"}, {"user_id": "u2"}]
+        course_rows = [{"course_code": "CS101", "course_name": "Intro CS"}]
+        offering_rows = [{"course_id": "abstract-cs101"}]
+        settings_tbl = MagicMock()
+        settings_tbl.select.return_value = settings_rows
+
+        def _table(name):
+            m = MagicMock()
+            if name == "enrollments":
+                m.select.return_value = enrollment_rows
+            elif name == "user_settings":
+                return settings_tbl
+            elif name == "course_offerings":
+                m.select.return_value = offering_rows
+            elif name == "courses":
+                m.select.return_value = course_rows
+            elif name == "graph_nodes":
+                return nodes_tbl
+            elif name == "quiz_context":
+                m.select.return_value = []
+            elif name == "offering_concept_stats":
+                return stats_tbl
+            elif name == "offering_summary":
+                return summary_tbl
+            else:
+                m.select.return_value = []
+            return m
+
+        return _table, settings_tbl
+
+    @patch("services.academics.table")
+    @patch("services.course_context_service.table")
+    def test_opted_out_user_excluded_from_aggregation(self, mock_table, mock_ac_table):
+        """A user whose user_settings.share_class_context is false must not
+        contribute graph data to the class aggregates (#72)."""
+        nodes_tbl = MagicMock()
+        nodes_tbl.select.return_value = [
+            {"id": "n1", "concept_name": "Loops", "mastery_score": 0.2,
+             "mastery_tier": "struggling", "user_id": "u1"},
+        ]
+        stats_tbl = MagicMock()
+        summary_tbl = MagicMock()
+        summary_tbl.select.return_value = []
+
+        _table, _ = self._table_factory(
+            [{"user_id": "u2", "share_class_context": False}],
+            nodes_tbl, stats_tbl, summary_tbl,
+        )
+        mock_table.side_effect = _table
+        mock_ac_table.side_effect = _table
+
+        with patch("services.course_context_service._generate_summary_with_gemini", return_value="summary"):
+            from services.course_context_service import update_course_context
+            update_course_context("off-1")
+
+        # graph_nodes must be filtered to opted-in users only — u2's graph is
+        # never queried.
+        nodes_tbl.select.assert_called_once()
+        node_filters = nodes_tbl.select.call_args.kwargs["filters"]
+        self.assertEqual(node_filters["user_id"], "in.(u1)")
+        # And the class summary counts only the opted-in student.
+        summary_tbl.upsert.assert_called_once()
+        self.assertEqual(summary_tbl.upsert.call_args[0][0]["student_count"], 1)
+
+    @patch("services.academics.table")
+    @patch("services.course_context_service.table")
+    def test_missing_settings_row_defaults_to_opt_in(self, mock_table, mock_ac_table):
+        """A user with NO user_settings row is opted in (matching the column
+        default) — only an explicit false excludes them."""
+        nodes_tbl = MagicMock()
+        nodes_tbl.select.return_value = [
+            {"id": "n1", "concept_name": "Loops", "mastery_score": 0.2,
+             "mastery_tier": "struggling", "user_id": "u1"},
+            {"id": "n2", "concept_name": "Loops", "mastery_score": 0.9,
+             "mastery_tier": "mastered", "user_id": "u2"},
+        ]
+        stats_tbl = MagicMock()
+        summary_tbl = MagicMock()
+        summary_tbl.select.return_value = []
+
+        # u1 has an explicit opt-in row; u2 has no settings row at all.
+        _table, settings_tbl = self._table_factory(
+            [{"user_id": "u1", "share_class_context": True}],
+            nodes_tbl, stats_tbl, summary_tbl,
+        )
+        mock_table.side_effect = _table
+        mock_ac_table.side_effect = _table
+
+        with patch("services.course_context_service._generate_summary_with_gemini", return_value="summary"):
+            from services.course_context_service import update_course_context
+            update_course_context("off-1")
+
+        # The settings lookup covers every enrolled user in one select…
+        settings_tbl.select.assert_called_once()
+        settings_filters = settings_tbl.select.call_args.kwargs["filters"]
+        self.assertEqual(settings_filters["user_id"], "in.(u1,u2)")
+        # …and both users are aggregated (u2 included despite no row).
+        node_filters = nodes_tbl.select.call_args.kwargs["filters"]
+        self.assertEqual(node_filters["user_id"], "in.(u1,u2)")
+        summary_tbl.upsert.assert_called_once()
+        self.assertEqual(summary_tbl.upsert.call_args[0][0]["student_count"], 2)
+
+    @patch("services.academics.table")
+    @patch("services.course_context_service.table")
+    def test_all_opted_out_purges_aggregates_without_crash(self, mock_table, mock_ac_table):
+        """When every enrolled student opted out, the refresh must not crash and
+        must not publish anything — stale aggregates are purged instead so
+        previously shared data stops being served."""
+        nodes_tbl = MagicMock()
+        stats_tbl = MagicMock()
+        summary_tbl = MagicMock()
+        summary_tbl.select.return_value = []
+
+        _table, _ = self._table_factory(
+            [{"user_id": "u1", "share_class_context": False},
+             {"user_id": "u2", "share_class_context": False}],
+            nodes_tbl, stats_tbl, summary_tbl,
+        )
+        mock_table.side_effect = _table
+        mock_ac_table.side_effect = _table
+
+        with patch("services.course_context_service._generate_summary_with_gemini", return_value="summary"):
+            from services.course_context_service import update_course_context
+            update_course_context("off-1")  # must not raise
+
+        nodes_tbl.select.assert_not_called()
+        stats_tbl.upsert.assert_not_called()
+        summary_tbl.upsert.assert_not_called()
+        stats_tbl.delete.assert_called_once_with({"offering_id": "eq.off-1"})
+        summary_tbl.delete.assert_called_once_with({"offering_id": "eq.off-1"})
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 3. graph_service — apply_graph_update side-effects on course context

--- a/frontend/e2e/quiz.spec.ts
+++ b/frontend/e2e/quiz.spec.ts
@@ -211,3 +211,108 @@ test("quiz journey: all-correct answers raise mastery in UI and DB, monotonicall
   expect(Number(attempts[0].total)).toBe(3);
   expect(attempts[0].completed_at).not.toBeNull();
 });
+
+/**
+ * Regression (#129): /api/quiz/submit must reject a replay of an already-
+ * completed attempt. Before the fix, re-POSTing the same quiz_id re-ran
+ * apply_graph_update — a second mastery delta, a duplicate
+ * node_mastery_events row, and a streak bump — plus the background
+ * quiz-context task and achievements.
+ *
+ * Lane-level pin: drive the same seeded fixture through the real UI flow,
+ * capture the exact wire body the UI sent to /api/quiz/submit
+ * ({ quiz_id, answers: [{ question_id, selected_label }] } —
+ * backend/models::SubmitQuizBody), then replay it via page.request.post
+ * (same-origin, so the sapling_session cookie rides along). The replay must
+ * 409, and the DB must be byte-for-byte where the first submit left it.
+ */
+test("quiz resubmit: replaying a completed submission returns 409 and re-applies no mastery", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+
+  // Same pre-ack as the journey above — the disclaimer is unrelated chrome.
+  await page.addInitScript(() => {
+    window.localStorage.setItem("sapling_disclaimer_ack", "true");
+  });
+
+  await page.goto(`/quiz?concept=${NODE_ID}`);
+  await expect(page.getByTestId("quiz-panel")).toBeVisible();
+
+  const start = page.getByTestId("quiz-start");
+  await expect(start).toBeEnabled();
+  await start.click();
+
+  await expect(page.getByTestId("quiz-answer-options")).toBeVisible({
+    timeout: 60_000,
+  });
+  // Mode guard, same as above: scripted fixture text proves function mode.
+  await expect(page.getByTestId("quiz-panel")).toContainText(
+    "E2E deterministic question 1",
+  );
+
+  // Arm the capture BEFORE the final click fires /api/quiz/submit.
+  const submitRequestPromise = page.waitForRequest(
+    (req) => req.url().includes("/api/quiz/submit") && req.method() === "POST",
+  );
+
+  for (const label of CORRECT_LABELS) {
+    await page.getByTestId(`quiz-answer-option-${label}`).click();
+    await page.getByTestId("quiz-submit-answer").click();
+    await expect(page.getByTestId("quiz-review-verdict")).toHaveText(
+      "Correct.",
+    );
+    await page.getByTestId("quiz-next").click();
+  }
+
+  // Results rendered ⇒ the first submit's synchronous mastery write landed.
+  await expect(page.getByTestId("quiz-results-score")).toHaveText("100%", {
+    timeout: 30_000,
+  });
+
+  const wireBody = (await submitRequestPromise).postDataJSON() as {
+    quiz_id: string;
+    answers: Array<{ question_id: number | string; selected_label: string }>;
+  };
+  expect(wireBody.quiz_id).toBeTruthy();
+  expect(wireBody.answers).toHaveLength(CORRECT_LABELS.length);
+
+  // First submit's DB state — the baseline the replay must not move.
+  const nodeAfterFirst = await queryRaw(
+    "SELECT mastery_score FROM graph_nodes WHERE id = $1",
+    [NODE_ID],
+  );
+  expect(nodeAfterFirst).toHaveLength(1);
+  const masteryAfterFirst = Number(nodeAfterFirst[0].mastery_score);
+  expect(masteryAfterFirst).toBeCloseTo(SEEDED_MASTERY + EXPECTED_DELTA, 10);
+
+  const eventsAfterFirst = await queryRaw(
+    "SELECT id FROM node_mastery_events WHERE node_id = $1",
+    [NODE_ID],
+  );
+  expect(eventsAfterFirst).toHaveLength(1);
+
+  // Replay the SAME submission over the page's cookie jar → 409, not 200.
+  const replay = await page.request.post("/api/quiz/submit", {
+    data: wireBody,
+  });
+  expect(replay.status()).toBe(409);
+
+  // The replay re-applied nothing: still exactly ONE mastery event…
+  const eventsAfterReplay = await queryRaw(
+    "SELECT id FROM node_mastery_events WHERE node_id = $1",
+    [NODE_ID],
+  );
+  expect(eventsAfterReplay).toHaveLength(1);
+
+  // …and the node's score is unchanged from the first submit.
+  const nodeAfterReplay = await queryRaw(
+    "SELECT mastery_score FROM graph_nodes WHERE id = $1",
+    [NODE_ID],
+  );
+  expect(nodeAfterReplay).toHaveLength(1);
+  expect(Number(nodeAfterReplay[0].mastery_score)).toBeCloseTo(
+    masteryAfterFirst,
+    10,
+  );
+});

--- a/frontend/src/components/SharedContextToggle.test.tsx
+++ b/frontend/src/components/SharedContextToggle.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+/**
+ * Tests for SharedContextToggle / useSharedContext (#72).
+ *
+ * The toggle keeps its localStorage read-path behavior, and additionally
+ * write-through persists `share_class_context` to user_settings so the
+ * backend can honor the opt-out on the WRITE path. Covered here:
+ *   1. Renders as a switch, defaulting to enabled
+ *   2. Toggling PATCHes { share_class_context } via updateSettings
+ *   3. A failed PATCH is swallowed (console.warn) — the toggle still flips
+ *   4. Mount hydrates from the server value when one is present
+ *
+ * Module mocks: @/lib/api (fetchSettings/updateSettings) and useUser.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+
+const { mockFetchSettings, mockUpdateSettings } = vi.hoisted(() => ({
+  mockFetchSettings: vi.fn(),
+  mockUpdateSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchSettings: mockFetchSettings,
+  updateSettings: mockUpdateSettings,
+}));
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => ({ userId: "u1", userReady: true }),
+}));
+
+import { SharedContextToggle, useSharedContext } from "./SharedContextToggle";
+
+// Drives the hook the same way Learn.tsx does.
+function Harness() {
+  const [enabled, setEnabled] = useSharedContext();
+  return <SharedContextToggle enabled={enabled} onChange={setEnabled} />;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockFetchSettings.mockResolvedValue({});
+  mockUpdateSettings.mockResolvedValue({});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("SharedContextToggle", () => {
+  it("renders an enabled switch by default", async () => {
+    render(<Harness />);
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(toggle).toHaveTextContent("Class intel");
+    await waitFor(() => expect(mockFetchSettings).toHaveBeenCalledWith("u1"));
+  });
+
+  it("toggling PATCHes share_class_context and updates localStorage", async () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    expect(localStorage.getItem("sapling_shared_ctx")).toBe("false");
+    await waitFor(() =>
+      expect(mockUpdateSettings).toHaveBeenCalledWith("u1", {
+        share_class_context: false,
+      }),
+    );
+  });
+
+  it("swallows a failed PATCH — the toggle still flips", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockUpdateSettings.mockRejectedValue(new Error("400 not whitelisted"));
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("switch"));
+    // The local flip is immediate even though the PATCH fails…
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    expect(localStorage.getItem("sapling_shared_ctx")).toBe("false");
+    // …and the rejection is caught and warned, never thrown.
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    warn.mockRestore();
+  });
+
+  it("hydrates from a persisted server opt-out on mount", async () => {
+    mockFetchSettings.mockResolvedValue({ share_class_context: false });
+    render(<Harness />);
+    await waitFor(() =>
+      expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false"),
+    );
+    expect(localStorage.getItem("sapling_shared_ctx")).toBe("false");
+  });
+});

--- a/frontend/src/components/SharedContextToggle.tsx
+++ b/frontend/src/components/SharedContextToggle.tsx
@@ -1,18 +1,72 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { useUser } from "@/context/UserContext";
+import { fetchSettings, updateSettings } from "@/lib/api";
+import type { UserSettings } from "@/lib/types";
 
 const STORAGE_KEY = "sapling_shared_ctx";
 
+// user_settings.share_class_context (migration 0037): the persisted form of
+// this toggle, enforced server-side at the class-aggregation write chokepoint
+// (#72). Not yet part of the UserSettings type in lib/types.ts, so widen it
+// locally.
+type ShareClassContextSettings = Partial<UserSettings> & {
+  share_class_context?: boolean;
+};
+
 export function useSharedContext(): [boolean, (v: boolean) => void] {
+  const { userId, userReady } = useUser();
   const [enabled, setEnabled] = useState(true);
+  // Once the user toggles locally, a late-arriving server hydration must not
+  // clobber their fresh choice.
+  const dirtyRef = useRef(false);
+
   useEffect(() => {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw === "false") setEnabled(false);
   }, []);
+
+  // Best-effort server hydration (#72): the preference persists on
+  // user_settings so it follows the user across devices and gates the WRITE
+  // path server-side. On any failure — offline, signed out, or a server that
+  // does not serve the column yet — the localStorage value above stands.
+  useEffect(() => {
+    if (!userReady || !userId) return;
+    let cancelled = false;
+    fetchSettings(userId)
+      .then((settings) => {
+        if (cancelled || dirtyRef.current) return;
+        const server = (settings as ShareClassContextSettings).share_class_context;
+        if (typeof server === "boolean") {
+          setEnabled(server);
+          localStorage.setItem(STORAGE_KEY, String(server));
+        }
+      })
+      .catch(() => {
+        /* keep the localStorage value */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userReady, userId]);
+
   const update = (v: boolean) => {
+    dirtyRef.current = true;
     setEnabled(v);
     localStorage.setItem(STORAGE_KEY, String(v));
+    // Best-effort write-through (#72). Swallow failures: the local toggle
+    // still gates this client's read path when offline or when the server
+    // does not accept the field yet.
+    if (userId) {
+      const patch: ShareClassContextSettings = { share_class_context: v };
+      updateSettings(userId, patch).catch((err) => {
+        console.warn(
+          "Failed to persist share_class_context; toggle applied locally only",
+          err,
+        );
+      });
+    }
   };
   return [enabled, update];
 }


### PR DESCRIPTION
## What

Bundle B3 of the backlog clear — the five remaining #136 audit findings plus the two same-shaped siblings, every claim re-verified against `main @ 9b000b5` before touching code (all seven still present; line numbers in the issue bodies had drifted). Implemented as five parallel single-surface changes; full detail in the commit message.

- **#130** — the missing `GET /api/admin/allowlist` (admin-gated, `AllowlistEmail` shape the frontend has been calling into a 404).
- **#134** — feedback/issue-report writes now authenticate (session-derived `user_id`, wire-compatible); private profiles no longer leak `name/majors/minors/year/school` to non-owners, and the `school` visibility tier — previously behaving as `public` — is enforced via the school-peer resolver, fail-closed. Owners always see everything.
- **#129** — quiz resubmission 409s before any scoring (no re-applied mastery / duplicate events / achievement re-fires; 409 chosen over replay because `quiz_attempts` stores no `mastery_before/after`), and malformed items can't earn a free `'' == ''` point. A lane journey replays the captured wire body via `page.request.post` and DB-asserts the single-event contract.
- **#132 remainder** — one `result` event per streamed upload, ever: post-result persistence failures now yield a terminal error instead of falling into the legacy fallback's second (billed) run + second `result`; the streaming route's "15 MB" message now derives from the real 100 MB constant; remaining synchronous PostgREST calls in both async upload paths moved off the event loop.
- **#135** — `search_course_materials` registered as the explicit wire name in both agents (prompt ↔ tool-list mismatch gone); seam/stream tests updated; evaluator semantics verified unchanged.
- **#340 (P1)** — `ContentFilterError` propagates to the routes' 502 instead of degrading to a `200 {"cards": []}` the UI toasts as "Generated 0 cards." (Import verified present and identically shaped in both pydantic-ai universes.)
- **#72** — Class Intel opt-out becomes `user_settings.share_class_context` (**migration 0037**, default true, whitelisted for PATCH), enforced at the one write chokepoint (`update_course_context` aggregates only opted-in users; all-opted-out purges the aggregates). The toggle keeps its hook/localStorage API and gains best-effort persistence + hydration.

## Verification

- Backend **1344 passed** + `ruff check .` clean; frontend **258 passed**, tsc clean, lint 0 errors.
- Agent-adjacent files (tool rename, flashcard service) re-run green on the lock-pinned **pydantic-ai 1.107** scratch venv.
- 30+ new tests, each verified red against its bug first; journey added to `quiz.spec.ts`.
- Full local e2e cycle queued (serialized behind the in-flight B2 cycle on the stack lock); results will be posted below. Migration 0037 will be exercised by the cycle's from-seed boot.

Closes #130. Closes #134. Closes #129. Closes #132. Closes #135. Closes #340. Closes #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Class Intel sharing toggle with account-level persistence and opt-out support.
  * Added stricter profile visibility controls for private and school-limited profiles.
  * Added an admin view for the newsletter allowlist.

* **Bug Fixes**
  * Prevented duplicate quiz submissions and incorrect grading of malformed questions.
  * Improved document upload limits and streaming error handling.
  * Ensured feedback and issue reports use the authenticated account.
  * Improved handling of blocked flashcard content generation.
  * Standardized tutor tool behavior for more reliable chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->