### PR TITLE
feat(gradebook): term-aware course links + transcript & GPA (B6: #139)

### DIFF
--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -77,7 +77,7 @@ renders the element.
 | Dashboard | `dashboard` | `frontend/src/components/screens/Dashboard.tsx` (rendered by `(shell)/dashboard/page.tsx`) |
 | Library | `library` | `frontend/src/components/screens/Library.tsx` (the `/library` document screen — upload trigger, document cards/rows, filters, detail panel) |
 | Calendar | `calendar` | `frontend/src/components/screens/Calendar.tsx` (the `/calendar` screen — today just the #185 load-failure banner + retry) |
-| Gradebook | `gradebook` | `frontend/src/components/screens/Gradebook/Landing.tsx` + `Course.tsx` (the `/gradebook` screens), `frontend/src/components/Gradebook/TranscriptModal.tsx` (the transcript modal), `frontend/src/components/Gradebook/CourseCard.tsx` (the term-aware card links) — added with the #139 term-switcher/transcript journey |
+| Gradebook | `gradebook` | `frontend/src/components/screens/Gradebook/Landing.tsx` + `Course.tsx` (the `/gradebook` screens), `frontend/src/components/Gradebook/TranscriptModal.tsx` (the transcript modal), `frontend/src/components/Gradebook/CourseCard.tsx` (the term-aware card links), `frontend/src/components/Gradebook/AssignmentList.tsx` + `AssignmentModal.tsx` (the add-assignment flow the #468 mutation leg drives) — added with the #139 term-switcher/transcript journey |
 
 Two surfaces do **not** carry their testids in the screen file named by the
 route:
@@ -263,6 +263,9 @@ inside the `role="grid"` "Courses" grid.
 | `gradebook-transcript-open` | landing: "Transcript" button opening the transcript modal |
 | `gradebook-transcript-gpa` | transcript modal: the cumulative GPA value |
 | `gradebook-transcript-retry` | transcript modal: inline "Try again" after a failed load (#463 catch+toast pattern) |
+| `gradebook-add-assignment` | course page: "+ Add Assignment" (`AssignmentList.tsx`) — opens the assignment modal |
+| `gradebook-assignment-title` | assignment modal: the required title `<input>` |
+| `gradebook-assignment-save` | assignment modal: the Save button |
 
 ### `library`
 
@@ -330,8 +333,9 @@ coverage and regenerate with `npm run lint:baseline`.
 `files` list with the same treatment: its 21 pre-existing untagged elements are
 baselined, so only NEW interactive elements there must carry a testid.
 
-The four `gradebook` surface files (#139) get the same treatment:
-`screens/Gradebook/Course.tsx` and `Landing.tsx` carry pre-existing untagged
+The `gradebook` surface files (#139/#468) get the same treatment:
+`screens/Gradebook/Course.tsx`, `Landing.tsx`, `Gradebook/AssignmentList.tsx`
+and `Gradebook/AssignmentModal.tsx` carry pre-existing untagged
 buttons/inputs that are baselined in `eslint-suppressions.json`; only NEW
 interactive elements there must carry a testid.
 

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -77,6 +77,7 @@ renders the element.
 | Dashboard | `dashboard` | `frontend/src/components/screens/Dashboard.tsx` (rendered by `(shell)/dashboard/page.tsx`) |
 | Library | `library` | `frontend/src/components/screens/Library.tsx` (the `/library` document screen — upload trigger, document cards/rows, filters, detail panel) |
 | Calendar | `calendar` | `frontend/src/components/screens/Calendar.tsx` (the `/calendar` screen — today just the #185 load-failure banner + retry) |
+| Gradebook | `gradebook` | `frontend/src/components/screens/Gradebook/Landing.tsx` + `Course.tsx` (the `/gradebook` screens), `frontend/src/components/Gradebook/TranscriptModal.tsx` (the transcript modal), `frontend/src/components/Gradebook/CourseCard.tsx` (the term-aware card links) — added with the #139 term-switcher/transcript journey |
 
 Two surfaces do **not** carry their testids in the screen file named by the
 route:
@@ -248,6 +249,21 @@ distinguishable from a genuinely empty calendar).
 | `calendar-load-error` | the load-failure banner (`role="alert"`) rendered instead of the calendar views when the initial assignments/courses fetch fails |
 | `calendar-load-retry` | the banner's "Try again" button — re-runs the load through the skeleton state |
 
+### `gradebook`
+
+Added with the #139 term-switcher/transcript journey. The landing's semester
+chips and the course cards stay untagged on purpose: chips are `Toggle`
+buttons selected by role/name (the term label is seeded DATA, not copy —
+same posture as the Courses & Semesters hub tabs), and the cards are links
+inside the `role="grid"` "Courses" grid.
+
+| testid | element |
+| --- | --- |
+| `gradebook-term-gpa` | landing: the selected term's credit-weighted GPA next to the chips (absent while the term has no graded work) |
+| `gradebook-transcript-open` | landing: "Transcript" button opening the transcript modal |
+| `gradebook-transcript-gpa` | transcript modal: the cumulative GPA value |
+| `gradebook-transcript-retry` | transcript modal: inline "Try again" after a failed load (#463 catch+toast pattern) |
+
 ### `library`
 
 Added with the upload → SSE → library journey (#387).
@@ -313,6 +329,11 @@ coverage and regenerate with `npm run lint:baseline`.
 `src/components/screens/Learn.tsx` (the session-resume rows, #392) is in the
 `files` list with the same treatment: its 21 pre-existing untagged elements are
 baselined, so only NEW interactive elements there must carry a testid.
+
+The four `gradebook` surface files (#139) get the same treatment:
+`screens/Gradebook/Course.tsx` and `Landing.tsx` carry pre-existing untagged
+buttons/inputs that are baselined in `eslint-suppressions.json`; only NEW
+interactive elements there must carry a testid.
 
 ### Adding a surface
 

--- a/frontend/e2e/gradebook.spec.ts
+++ b/frontend/e2e/gradebook.spec.ts
@@ -13,7 +13,10 @@
  *    db/seed_local_rich.py) — the precondition that makes the ambiguity
  *    real. Then each chip's CS101 card must open THAT term's enrollment,
  *    told apart by seeded category names (Fall: Homework/Exams; Spring:
- *    Homework/Projects).
+ *    Homework/Projects). The Fall leg also WRITES (#468 review): an
+ *    assignment created from the Fall page must hang off the fall-2025
+ *    enrollment row — mutations used to resolve term-blind and would have
+ *    landed it on the CURRENT (spring-2026) enrollment.
  *
  * 2. Transcript — the landing's Transcript button opens the cumulative
  *    modal: a real x.xx GPA plus per-semester sections for both seeded
@@ -60,6 +63,25 @@ test("a course taken in two terms opens the right enrollment from each chip", as
   ).toBeVisible();
   await expect(page.getByText("Exams").first()).toBeVisible();
   await expect(page.getByText("We couldn't load this course.")).toHaveCount(0);
+
+  // Mutation leg (#468): a write from the Fall page must land on the FALL
+  // enrollment. Create an assignment through the modal, then assert the row
+  // hangs off rich-enr-active-cs101-f25 — NOT the spring enrollment the
+  // term-blind resolver would have picked (spring-2026 is the current term
+  // under the frozen clock).
+  await page.getByTestId("gradebook-add-assignment").click();
+  await page.getByTestId("gradebook-assignment-title").fill("Fall-only essay");
+  await page.getByTestId("gradebook-assignment-save").click();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect
+    .poll(async () => {
+      const rows = await queryRaw(
+        `SELECT enrollment_id FROM assignments WHERE title = $1`,
+        ["Fall-only essay"],
+      );
+      return rows.map((r) => r.enrollment_id);
+    })
+    .toEqual(["rich-enr-active-cs101-f25"]);
 
   // Back on the landing, pick Spring 2026 explicitly: its CS101 card must
   // load the OTHER enrollment — Projects only exists on spring-2026.

--- a/frontend/e2e/gradebook.spec.ts
+++ b/frontend/e2e/gradebook.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Journey #139 — gradebook term switcher + transcript.
+ *
+ * Two journeys over the `gradebook` testid surface (docs/frontend-testids.md):
+ *
+ * 1. Multi-term course resolution — the promoted regression for the #139
+ *    404. The card link used to drop the selected term, so
+ *    `_resolve_enrollment(user, course, None)` resolved the CURRENT term and
+ *    a course also taken in an archived term 404'd ("Course not in your
+ *    gradebook") from that term's chip. DB truth first (support/db.ts
+ *    ::queryRaw): rich-user-active holds TWO enrollments of
+ *    rich-course-cs101 (fall-2025 + spring-2026 offerings,
+ *    db/seed_local_rich.py) — the precondition that makes the ambiguity
+ *    real. Then each chip's CS101 card must open THAT term's enrollment,
+ *    told apart by seeded category names (Fall: Homework/Exams; Spring:
+ *    Homework/Projects).
+ *
+ * 2. Transcript — the landing's Transcript button opens the cumulative
+ *    modal: a real x.xx GPA plus per-semester sections for both seeded
+ *    terms.
+ *
+ * Test-mode clock note: the e2e frontend runs with the frozen clock
+ * 2026-03-11, so the landing's DEFAULT chip is Spring 2026. Chips are always
+ * selected explicitly here — never rely on the default.
+ */
+import { queryRaw } from "./support/db";
+import { expect, test } from "./support/fixtures";
+import { USER_ACTIVE } from "./support/stack";
+
+const COURSE_CS = "rich-course-cs101";
+
+test("a course taken in two terms opens the right enrollment from each chip", async ({
+  page,
+}) => {
+  // DB truth: the seeded ambiguity this journey exists for. If the seed ever
+  // stops enrolling the user in CS101 twice, this journey silently stops
+  // covering #139 — fail loudly instead.
+  const enrollments = await queryRaw(
+    `SELECT o.term_id
+       FROM enrollments e
+       JOIN course_offerings o ON o.id = e.offering_id
+      WHERE e.user_id = $1 AND o.course_id = $2
+      ORDER BY o.term_id`,
+    [USER_ACTIVE, COURSE_CS],
+  );
+  expect(enrollments.map((r) => r.term_id)).toEqual(["fall-2025", "spring-2026"]);
+
+  await page.goto("/gradebook");
+
+  const grid = page.getByRole("grid", { name: "Courses" });
+  const csCard = grid.getByRole("link").filter({ hasText: "CS101" });
+
+  // Fall 2025 — the ARCHIVED term under the frozen clock, i.e. the chip that
+  // used to 404. Its CS101 card must load the Fall enrollment: the Exams
+  // category exists only on the fall-2025 gradebook.
+  await page.getByRole("button", { name: "Fall 2025", exact: true }).click();
+  await csCard.click();
+  await expect(
+    page.getByRole("heading", { name: "Introduction to Computer Science" }),
+  ).toBeVisible();
+  await expect(page.getByText("Exams").first()).toBeVisible();
+  await expect(page.getByText("We couldn't load this course.")).toHaveCount(0);
+
+  // Back on the landing, pick Spring 2026 explicitly: its CS101 card must
+  // load the OTHER enrollment — Projects only exists on spring-2026.
+  await page.goBack();
+  await page.getByRole("button", { name: "Spring 2026", exact: true }).click();
+  await csCard.click();
+  await expect(
+    page.getByRole("heading", { name: "Introduction to Computer Science" }),
+  ).toBeVisible();
+  await expect(page.getByText("Projects").first()).toBeVisible();
+  await expect(page.getByText("We couldn't load this course.")).toHaveCount(0);
+});
+
+test("the transcript modal shows a cumulative GPA and every seeded term", async ({
+  page,
+}) => {
+  await page.goto("/gradebook");
+
+  await page.getByTestId("gradebook-transcript-open").click();
+
+  const dialog = page.getByRole("dialog");
+  // The seed has graded work (CS101 Fall homework, …), so the cumulative GPA
+  // is a real x.xx number — never the "—" placeholder.
+  await expect(page.getByTestId("gradebook-transcript-gpa")).toHaveText(/\d\.\d\d/);
+
+  // Per-semester sections for both multi-enrollment terms.
+  await expect(dialog.getByText("Fall 2025", { exact: true })).toBeVisible();
+  await expect(dialog.getByText("Spring 2026", { exact: true })).toBeVisible();
+});

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -35,6 +35,16 @@
       "count": 1
     }
   },
+  "src/components/Gradebook/AssignmentList.tsx": {
+    "no-restricted-syntax": {
+      "count": 7
+    }
+  },
+  "src/components/Gradebook/AssignmentModal.tsx": {
+    "no-restricted-syntax": {
+      "count": 12
+    }
+  },
   "src/components/Gradebook/SyllabusUploadFlow.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -99,6 +99,16 @@
       "count": 2
     }
   },
+  "src/components/screens/Gradebook/Course.tsx": {
+    "no-restricted-syntax": {
+      "count": 9
+    }
+  },
+  "src/components/screens/Gradebook/Landing.tsx": {
+    "no-restricted-syntax": {
+      "count": 1
+    }
+  },
   "src/components/screens/Learn.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -70,6 +70,8 @@ const eslintConfig = [
       "src/components/screens/Gradebook/Course.tsx",
       "src/components/Gradebook/TranscriptModal.tsx",
       "src/components/Gradebook/CourseCard.tsx",
+      "src/components/Gradebook/AssignmentList.tsx",
+      "src/components/Gradebook/AssignmentModal.tsx",
     ],
     rules: {
       "no-restricted-syntax": [

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -66,6 +66,10 @@ const eslintConfig = [
       "src/components/screens/Learn.tsx",
       "src/components/screens/Library.tsx",
       "src/components/screens/Calendar.tsx",
+      "src/components/screens/Gradebook/Landing.tsx",
+      "src/components/screens/Gradebook/Course.tsx",
+      "src/components/Gradebook/TranscriptModal.tsx",
+      "src/components/Gradebook/CourseCard.tsx",
     ],
     rules: {
       "no-restricted-syntax": [

--- a/frontend/src/components/Gradebook/AssignmentList.tsx
+++ b/frontend/src/components/Gradebook/AssignmentList.tsx
@@ -172,6 +172,7 @@ export function AssignmentList({
           )}
           <button
             type="button"
+            data-testid="gradebook-add-assignment"
             onClick={onAdd}
             className="btn btn--primary"
             style={{ padding: "8px 14px", fontSize: 13 }}

--- a/frontend/src/components/Gradebook/AssignmentModal.tsx
+++ b/frontend/src/components/Gradebook/AssignmentModal.tsx
@@ -95,6 +95,7 @@ export function AssignmentModal({
           Title <span style={{ color: "var(--err)" }}>*</span>
           <input
             ref={titleRef}
+            data-testid="gradebook-assignment-title"
             value={draft.title}
             onChange={(e) => setDraft({ ...draft, title: e.target.value })}
             onBlur={() => setTitleTouched(true)}
@@ -334,6 +335,7 @@ export function AssignmentModal({
           <Button
             variant="primary"
             size="sm"
+            data-testid="gradebook-assignment-save"
             disabled={!valid || saving}
             onClick={async () => {
               setSaving(true);

--- a/frontend/src/components/Gradebook/CourseCard.tsx
+++ b/frontend/src/components/Gradebook/CourseCard.tsx
@@ -108,9 +108,13 @@ interface CourseCardProps {
   course: GradebookCourseSummary;
   variant: "hero" | "default";
   courseColor: string;
+  // The landing's selected term. Carried on the link so a course enrolled in
+  // several terms opens THIS term's enrollment — without it the backend
+  // resolves the current term and an archived enrollment 404s (#139).
+  semester?: string;
 }
 
-export function CourseCard({ course, variant, courseColor }: CourseCardProps) {
+export function CourseCard({ course, variant, courseColor, semester }: CourseCardProps) {
   const isHero = variant === "hero";
   // Single canonical "no grades yet" signal. percent === null is the
   // upstream source of truth; letter follows it.
@@ -118,7 +122,9 @@ export function CourseCard({ course, variant, courseColor }: CourseCardProps) {
 
   return (
     <Link
-      href={`/gradebook/${encodeURIComponent(course.course_id)}`}
+      href={`/gradebook/${encodeURIComponent(course.course_id)}${
+        semester ? `?semester=${encodeURIComponent(semester)}` : ""
+      }`}
       className="course-card"
       style={{
         gridColumn: isHero ? "span 2" : undefined,

--- a/frontend/src/components/Gradebook/TranscriptModal.test.tsx
+++ b/frontend/src/components/Gradebook/TranscriptModal.test.tsx
@@ -71,7 +71,9 @@ const REPORT: GpaReport = {
       course_id: "bio110",
       course_code: "BIO110",
       semester: "Spring 2026",
-      credits: null,
+      // Zero credits: the display must show the 1 the GPA math would weigh
+      // (effectiveCredits), not a literal 0 (#468 review).
+      credits: 0,
       percent: null,
       letter: null,
       grade_points: null,
@@ -134,6 +136,11 @@ describe("TranscriptModal", () => {
     expect(screen.getByText("MATH210")).toBeInTheDocument();
     expect(screen.getByText("BIO110")).toBeInTheDocument();
     expect(screen.getByText(/in progress/i)).toBeInTheDocument();
+
+    // Credits display goes through effectiveCredits: BIO110's 0 credits
+    // render as the 1 the GPA math would weigh, never "0 cr".
+    expect(screen.getByText("1 cr")).toBeInTheDocument();
+    expect(screen.queryByText("0 cr")).toBeNull();
   });
 
   it("shows a loading state while the report is in flight", async () => {

--- a/frontend/src/components/Gradebook/TranscriptModal.test.tsx
+++ b/frontend/src/components/Gradebook/TranscriptModal.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+/**
+ * TranscriptModal (#139) — cumulative GPA + per-semester transcript over
+ * GET /api/gradebook/gpa. Pins the same two contract layers as
+ * modals.dialog.test.tsx:
+ *
+ * 1. Dialog semantics — closed renders nothing; open renders a labelled
+ *    dialog (aria-modal, aria-labelledby → visible heading), moves focus
+ *    inside, and closes on Escape.
+ * 2. Failure surfacing (#166/#463 pattern) — a rejected load toasts AND
+ *    leaves an inline retry that refetches; it must never render as an
+ *    empty-but-fine transcript.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const toastError = vi.hoisted(() => vi.fn());
+// One STABLE toast object across renders — the real ToastProvider memoizes
+// its context value, and the modal's load callback (an effect dep) keys on
+// that stability. A fresh object per render would re-fire the fetch effect
+// forever, which no real render does.
+const toastApi = vi.hoisted(() => ({
+  show: () => {},
+  dismiss: () => {},
+  success: () => {},
+  error: toastError,
+  info: () => {},
+  warn: () => {},
+}));
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => toastApi,
+}));
+
+vi.mock("@/lib/api", () => ({
+  getGpa: vi.fn(),
+}));
+
+import { TranscriptModal } from "./TranscriptModal";
+import { getGpa } from "@/lib/api";
+import type { GpaReport } from "@/lib/types";
+
+const mockedGetGpa = vi.mocked(getGpa);
+
+const REPORT: GpaReport = {
+  gpa: 3.42,
+  semester: null,
+  scope: "cumulative",
+  courses: [
+    {
+      course_id: "cs101",
+      course_code: "CS101",
+      semester: "Fall 2025",
+      credits: 4,
+      percent: 91.5,
+      letter: "A-",
+      grade_points: 3.7,
+    },
+    {
+      course_id: "math210",
+      course_code: "MATH210",
+      semester: "Spring 2026",
+      credits: 3,
+      percent: 84.0,
+      letter: "B",
+      grade_points: 3.0,
+    },
+    {
+      course_id: "bio110",
+      course_code: "BIO110",
+      semester: "Spring 2026",
+      credits: null,
+      percent: null,
+      letter: null,
+      grade_points: null,
+    },
+  ],
+};
+
+beforeEach(() => {
+  mockedGetGpa.mockResolvedValue(REPORT);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  toastError.mockClear();
+});
+
+describe("TranscriptModal", () => {
+  it("renders nothing while closed and never fetches", () => {
+    render(<TranscriptModal open={false} userId="u1" onClose={() => {}} />);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(mockedGetGpa).not.toHaveBeenCalled();
+  });
+
+  it("opens as a labelled dialog and closes on Escape", async () => {
+    const onClose = vi.fn();
+    render(<TranscriptModal open userId="u1" onClose={onClose} />);
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    const heading = screen.getByRole("heading", { name: "Transcript" });
+    expect(dialog.getAttribute("aria-labelledby")).toBe(heading.id);
+
+    // Dialog moves focus on a 20ms timer; Escape only reaches the handler
+    // once focus is inside the panel (same rationale as modals.dialog.test).
+    await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true));
+
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("fetches the cumulative report and renders GPA + per-semester sections", async () => {
+    render(<TranscriptModal open userId="u1" onClose={() => {}} />);
+
+    // Cumulative scope: getGpa is called WITHOUT a semester.
+    await waitFor(() => expect(mockedGetGpa).toHaveBeenCalledWith("u1"));
+
+    const gpa = await screen.findByTestId("gradebook-transcript-gpa");
+    expect(gpa.textContent).toMatch(/\d\.\d\d/);
+    expect(gpa.textContent).toContain("3.42");
+
+    // Sections group by term, most recent first.
+    expect(screen.getByText("Spring 2026")).toBeInTheDocument();
+    expect(screen.getByText("Fall 2025")).toBeInTheDocument();
+
+    // Course rows: code + letter, and the ungraded row reads as in-progress
+    // rather than pretending to be a 0.0.
+    expect(screen.getByText("CS101")).toBeInTheDocument();
+    expect(screen.getByText("MATH210")).toBeInTheDocument();
+    expect(screen.getByText("BIO110")).toBeInTheDocument();
+    expect(screen.getByText(/in progress/i)).toBeInTheDocument();
+  });
+
+  it("shows a loading state while the report is in flight", async () => {
+    let resolve!: (r: GpaReport) => void;
+    mockedGetGpa.mockReturnValue(
+      new Promise<GpaReport>((r) => {
+        resolve = r;
+      }),
+    );
+
+    render(<TranscriptModal open userId="u1" onClose={() => {}} />);
+
+    await screen.findByRole("dialog");
+    expect(screen.queryByTestId("gradebook-transcript-gpa")).toBeNull();
+
+    resolve(REPORT);
+    expect(await screen.findByTestId("gradebook-transcript-gpa")).toBeInTheDocument();
+  });
+
+  it("toasts on failure and retries from the inline button", async () => {
+    mockedGetGpa.mockRejectedValueOnce(new Error("HTTP 500: boom"));
+
+    render(<TranscriptModal open userId="u1" onClose={() => {}} />);
+
+    await screen.findByRole("dialog");
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+
+    // Failed load must not render as an empty transcript.
+    expect(screen.queryByTestId("gradebook-transcript-gpa")).toBeNull();
+
+    // Second call (the retry) resolves — beforeEach's mockResolvedValue.
+    await userEvent.click(screen.getByTestId("gradebook-transcript-retry"));
+
+    expect(await screen.findByTestId("gradebook-transcript-gpa")).toBeInTheDocument();
+    expect(mockedGetGpa).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/Gradebook/TranscriptModal.tsx
+++ b/frontend/src/components/Gradebook/TranscriptModal.tsx
@@ -4,7 +4,7 @@ import Dialog from "@/components/Dialog";
 import { useToast } from "@/components/ToastProvider";
 import { humanizeError } from "@/lib/errorMessage";
 import { getGpa } from "@/lib/api";
-import { buildTranscript } from "@/lib/transcript";
+import { buildTranscript, effectiveCredits } from "@/lib/transcript";
 import { percentColor } from "@/components/Gradebook/CourseCard";
 import type { GpaReport } from "@/lib/types";
 
@@ -188,7 +188,8 @@ function TranscriptBody({ report }: { report: GpaReport }) {
                     className="mono"
                     style={{ fontSize: 11, color: "var(--text-muted)" }}
                   >
-                    {c.credits ?? 1} cr
+                    {/* Same rule as the GPA math — display what is weighed. */}
+                    {effectiveCredits(c)} cr
                   </span>
                   {c.letter === null ? (
                     <span

--- a/frontend/src/components/Gradebook/TranscriptModal.tsx
+++ b/frontend/src/components/Gradebook/TranscriptModal.tsx
@@ -1,0 +1,224 @@
+"use client";
+import React from "react";
+import Dialog from "@/components/Dialog";
+import { useToast } from "@/components/ToastProvider";
+import { humanizeError } from "@/lib/errorMessage";
+import { getGpa } from "@/lib/api";
+import { buildTranscript } from "@/lib/transcript";
+import { percentColor } from "@/components/Gradebook/CourseCard";
+import type { GpaReport } from "@/lib/types";
+
+interface Props {
+  open: boolean;
+  userId: string;
+  onClose: () => void;
+}
+
+/**
+ * Cumulative transcript over GET /api/gradebook/gpa (#139): overall
+ * credit-weighted GPA plus per-semester sections, most recent term first.
+ * Ungraded enrollments are listed as "in progress" — they never count as 0.
+ */
+export function TranscriptModal({ open, userId, onClose }: Props) {
+  const toast = useToast();
+  const [report, setReport] = React.useState<GpaReport | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [failed, setFailed] = React.useState(false);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    setFailed(false);
+    try {
+      setReport(await getGpa(userId));
+    } catch (err) {
+      // #463 pattern: surface the failure (toast + inline retry), never
+      // render a failed load as an empty-but-fine transcript.
+      setFailed(true);
+      toast.error(humanizeError(err, "Couldn't load your transcript. Try again."));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId, toast]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setReport(null);
+    load();
+  }, [open, load]);
+
+  return (
+    <Dialog open={open} onClose={onClose} title="Transcript" size="md" padding="24px">
+      {loading ? (
+        <div aria-hidden="true">
+          <div className="skeleton" style={{ height: 40, borderRadius: 8, marginBottom: 16 }} />
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="skeleton" style={{ height: 22, borderRadius: 6, marginBottom: 10 }} />
+          ))}
+        </div>
+      ) : failed ? (
+        <div
+          role="alert"
+          style={{
+            padding: "14px 16px",
+            borderRadius: "var(--r-md)",
+            background: "var(--err-soft)",
+            border: "1px solid color-mix(in oklab, var(--err) 20%, transparent)",
+            display: "flex",
+            gap: 12,
+            alignItems: "center",
+            justifyContent: "space-between",
+            flexWrap: "wrap",
+          }}
+        >
+          <span style={{ fontSize: 13, color: "var(--text-dim)" }}>
+            We couldn&apos;t load your transcript.
+          </span>
+          <button
+            type="button"
+            data-testid="gradebook-transcript-retry"
+            className="btn btn--primary"
+            onClick={load}
+            style={{ padding: "6px 14px", fontSize: 13 }}
+          >
+            Try again
+          </button>
+        </div>
+      ) : report ? (
+        <TranscriptBody report={report} />
+      ) : null}
+    </Dialog>
+  );
+}
+
+function TranscriptBody({ report }: { report: GpaReport }) {
+  const semesters = buildTranscript(report.courses);
+
+  if (semesters.length === 0) {
+    return (
+      <p style={{ margin: 0, fontSize: 14, color: "var(--text-dim)", lineHeight: 1.55 }}>
+        Nothing on the transcript yet — grades appear here once your courses
+        have graded work.
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          gap: 12,
+          padding: "4px 0 14px",
+          borderBottom: "1px solid var(--border)",
+          marginBottom: 16,
+        }}
+      >
+        <span
+          className="mono"
+          style={{
+            fontSize: 10,
+            letterSpacing: "0.18em",
+            textTransform: "uppercase",
+            color: "var(--text-muted)",
+            fontWeight: 600,
+          }}
+        >
+          Cumulative GPA
+        </span>
+        <span
+          data-testid="gradebook-transcript-gpa"
+          style={{
+            fontFamily: "var(--font-display), 'Playfair Display', Georgia, serif",
+            fontWeight: 500,
+            fontSize: 32,
+            lineHeight: 1,
+            letterSpacing: "-0.02em",
+            color: "var(--text)",
+          }}
+        >
+          {report.gpa === null ? "—" : report.gpa.toFixed(2)}
+        </span>
+      </div>
+
+      {semesters.map((sem) => (
+        <section key={sem.label || "no-term"} style={{ marginBottom: 18 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              justifyContent: "space-between",
+              gap: 12,
+              marginBottom: 8,
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "var(--font-display), 'Playfair Display', Georgia, serif",
+                fontWeight: 500,
+                fontSize: 16,
+                color: "var(--text)",
+              }}
+            >
+              {sem.label || "No term"}
+            </span>
+            <span className="mono" style={{ fontSize: 12, color: "var(--text-dim)" }}>
+              GPA {sem.gpa === null ? "—" : sem.gpa.toFixed(2)}
+            </span>
+          </div>
+          <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+            {sem.courses.map((c) => (
+              <li
+                key={c.course_id}
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  justifyContent: "space-between",
+                  gap: 12,
+                  padding: "5px 0",
+                  borderBottom: "1px solid var(--border)",
+                }}
+              >
+                <span className="mono" style={{ fontSize: 12, color: "var(--text)" }}>
+                  {c.course_code}
+                </span>
+                <span style={{ display: "flex", alignItems: "baseline", gap: 14 }}>
+                  <span
+                    className="mono"
+                    style={{ fontSize: 11, color: "var(--text-muted)" }}
+                  >
+                    {c.credits ?? 1} cr
+                  </span>
+                  {c.letter === null ? (
+                    <span
+                      style={{
+                        fontSize: 12,
+                        fontStyle: "italic",
+                        color: "var(--text-muted)",
+                      }}
+                    >
+                      in progress
+                    </span>
+                  ) : (
+                    <span
+                      style={{
+                        fontFamily:
+                          "var(--font-display), 'Playfair Display', Georgia, serif",
+                        fontWeight: 500,
+                        fontSize: 15,
+                        color: percentColor(c.percent),
+                      }}
+                    >
+                      {c.letter}
+                    </span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/screens/Gradebook/Course.semester.test.tsx
+++ b/frontend/src/components/screens/Gradebook/Course.semester.test.tsx
@@ -1,19 +1,24 @@
 // @vitest-environment jsdom
 /**
- * GradebookCourseScreen ?semester= plumbing (#139).
+ * GradebookCourseScreen ?semester= plumbing (#139/#468).
  *
  * The landing's course cards carry the selected term
  * (`/gradebook/<id>?semester=<label>`) so a course the user took in TWO terms
  * resolves to the right enrollment — without it the backend's
  * `_resolve_enrollment(user, course, None)` picks the CURRENT term and the
  * archived enrollment 404s ("Course not in your gradebook"). This pins the
- * screen half of the fix: the query param must reach getGradebookCourse.
- * Screen rendering concerns live elsewhere; every heavy child is stubbed.
+ * screen half of the fix, READS and WRITES both: the query param must reach
+ * getGradebookCourse AND every course-keyed mutation (#468 review — a write
+ * that drops the term silently lands on the CURRENT term's enrollment).
+ * Screen rendering concerns live elsewhere; heavy children are stubbed,
+ * except the real EditWeightsModal/AssignmentModal, whose Save buttons drive
+ * the mutation call sites under test.
  */
 
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 const toastError = vi.hoisted(() => vi.fn());
 vi.mock("@/components/ToastProvider", () => ({
@@ -49,17 +54,32 @@ vi.mock("next/link", () => ({
   default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 vi.mock("@/components/TopBar", () => ({ TopBar: () => null }));
-vi.mock("@/components/Gradebook/AssignmentList", () => ({ AssignmentList: () => null }));
+// The stub exposes onAdd so the tests can open the REAL AssignmentModal
+// without rendering the full list.
+vi.mock("@/components/Gradebook/AssignmentList", () => ({
+  AssignmentList: ({ onAdd }: { onAdd: () => void }) => (
+    <button type="button" data-testid="stub-add-assignment" onClick={onAdd}>
+      add
+    </button>
+  ),
+}));
 vi.mock("@/components/Gradebook/GradescopeSyncModal", () => ({ GradescopeSyncModal: () => null }));
 vi.mock("@/components/Gradebook/GradePredictorPanel", () => ({ GradePredictorPanel: () => null }));
 vi.mock("@/components/Gradebook/AmbientOrbs", () => ({ AmbientOrbs: () => null }));
 
 import { GradebookCourseScreen } from "./Course";
-import { getGradebookCourse, getGradescopeStatus } from "@/lib/api";
-import type { GradebookCourse } from "@/lib/types";
+import {
+  getGradebookCourse,
+  getGradescopeStatus,
+  bulkUpdateCategories,
+  createGradedAssignment,
+} from "@/lib/api";
+import type { GradebookCourse, GradedAssignment } from "@/lib/types";
 
 const mockedGetCourse = vi.mocked(getGradebookCourse);
 const mockedGscopeStatus = vi.mocked(getGradescopeStatus);
+const mockedBulkUpdate = vi.mocked(bulkUpdateCategories);
+const mockedCreateAssignment = vi.mocked(createGradedAssignment);
 
 const COURSE: GradebookCourse = {
   course_id: "c1",
@@ -72,7 +92,9 @@ const COURSE: GradebookCourse = {
   curve_mode: "raw",
   curve_avg_target: null,
   curve_sd_delta: null,
-  categories: [],
+  // One 100%-weight category so EditWeightsModal's Save validity gate
+  // (weights must sum to 100) is already satisfied.
+  categories: [{ id: "cat1", name: "Homework", weight: 100, sort_order: 0, drop_lowest: 0 }],
   assignments: [],
   dropped_assignment_ids: [],
 };
@@ -84,6 +106,8 @@ beforeEach(() => {
     auth_mode: null,
     last_synced_at: null,
   });
+  mockedBulkUpdate.mockResolvedValue({ categories: [] });
+  mockedCreateAssignment.mockResolvedValue({ assignment: {} as GradedAssignment });
 });
 
 afterEach(() => {
@@ -108,6 +132,92 @@ describe("GradebookCourseScreen ?semester= (#139)", () => {
 
     await waitFor(() =>
       expect(mockedGetCourse).toHaveBeenCalledWith("u1", "c1", undefined),
+    );
+  });
+});
+
+// #468 review: mutations must resolve the SAME enrollment the page shows.
+// Each helper drives the real modal UI down to its Save click.
+async function saveWeightsThroughModal(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByRole("button", { name: "Edit Weights" }));
+  await screen.findByRole("dialog");
+  await user.click(screen.getByRole("button", { name: "Save" }));
+}
+
+async function createAssignmentThroughModal(
+  user: ReturnType<typeof userEvent.setup>,
+  title: string,
+) {
+  await user.click(await screen.findByTestId("stub-add-assignment"));
+  await screen.findByRole("dialog");
+  await user.type(screen.getByTestId("gradebook-assignment-title"), title);
+  await user.click(screen.getByTestId("gradebook-assignment-save"));
+}
+
+describe("GradebookCourseScreen term-scoped mutations (#468)", () => {
+  it("passes the URL's semester to bulkUpdateCategories", async () => {
+    window.history.replaceState({}, "", "/gradebook/c1?semester=Fall+2025");
+    const user = userEvent.setup();
+
+    render(<GradebookCourseScreen courseId="c1" />);
+    await saveWeightsThroughModal(user);
+
+    await waitFor(() =>
+      expect(mockedBulkUpdate).toHaveBeenCalledWith(
+        "u1",
+        "c1",
+        expect.any(Array),
+        "Fall 2025",
+      ),
+    );
+  });
+
+  it("omits the semester from bulkUpdateCategories when the URL carries none", async () => {
+    const user = userEvent.setup();
+
+    render(<GradebookCourseScreen courseId="c1" />);
+    await saveWeightsThroughModal(user);
+
+    await waitFor(() =>
+      expect(mockedBulkUpdate).toHaveBeenCalledWith(
+        "u1",
+        "c1",
+        expect.any(Array),
+        undefined,
+      ),
+    );
+  });
+
+  it("passes the URL's semester to createGradedAssignment", async () => {
+    window.history.replaceState({}, "", "/gradebook/c1?semester=Fall+2025");
+    const user = userEvent.setup();
+
+    render(<GradebookCourseScreen courseId="c1" />);
+    await createAssignmentThroughModal(user, "Essay 1");
+
+    await waitFor(() =>
+      expect(mockedCreateAssignment).toHaveBeenCalledWith(
+        "u1",
+        "c1",
+        expect.objectContaining({ title: "Essay 1" }),
+        "Fall 2025",
+      ),
+    );
+  });
+
+  it("omits the semester from createGradedAssignment when the URL carries none", async () => {
+    const user = userEvent.setup();
+
+    render(<GradebookCourseScreen courseId="c1" />);
+    await createAssignmentThroughModal(user, "Essay 1");
+
+    await waitFor(() =>
+      expect(mockedCreateAssignment).toHaveBeenCalledWith(
+        "u1",
+        "c1",
+        expect.objectContaining({ title: "Essay 1" }),
+        undefined,
+      ),
     );
   });
 });

--- a/frontend/src/components/screens/Gradebook/Course.semester.test.tsx
+++ b/frontend/src/components/screens/Gradebook/Course.semester.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+/**
+ * GradebookCourseScreen ?semester= plumbing (#139).
+ *
+ * The landing's course cards carry the selected term
+ * (`/gradebook/<id>?semester=<label>`) so a course the user took in TWO terms
+ * resolves to the right enrollment — without it the backend's
+ * `_resolve_enrollment(user, course, None)` picks the CURRENT term and the
+ * archived enrollment 404s ("Course not in your gradebook"). This pins the
+ * screen half of the fix: the query param must reach getGradebookCourse.
+ * Screen rendering concerns live elsewhere; every heavy child is stubbed.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, waitFor } from "@testing-library/react";
+
+const toastError = vi.hoisted(() => vi.fn());
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({
+    show: vi.fn(),
+    dismiss: vi.fn(),
+    success: vi.fn(),
+    error: toastError,
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => ({ userId: "u1", userReady: true }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getGradebookCourse: vi.fn(),
+  bulkUpdateCategories: vi.fn(),
+  deleteCategory: vi.fn(),
+  createGradedAssignment: vi.fn(),
+  updateGradedAssignment: vi.fn(),
+  deleteGradedAssignment: vi.fn(),
+  setLetterScale: vi.fn(),
+  getGradescopeStatus: vi.fn(),
+  listGradescopeLinks: vi.fn(),
+  syncGradescopeCourse: vi.fn(),
+  setCurveSettings: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/components/TopBar", () => ({ TopBar: () => null }));
+vi.mock("@/components/Gradebook/AssignmentList", () => ({ AssignmentList: () => null }));
+vi.mock("@/components/Gradebook/GradescopeSyncModal", () => ({ GradescopeSyncModal: () => null }));
+vi.mock("@/components/Gradebook/GradePredictorPanel", () => ({ GradePredictorPanel: () => null }));
+vi.mock("@/components/Gradebook/AmbientOrbs", () => ({ AmbientOrbs: () => null }));
+
+import { GradebookCourseScreen } from "./Course";
+import { getGradebookCourse, getGradescopeStatus } from "@/lib/api";
+import type { GradebookCourse } from "@/lib/types";
+
+const mockedGetCourse = vi.mocked(getGradebookCourse);
+const mockedGscopeStatus = vi.mocked(getGradescopeStatus);
+
+const COURSE: GradebookCourse = {
+  course_id: "c1",
+  course_code: "CS101",
+  course_name: "Intro to CS",
+  semester: "Fall 2025",
+  percent: null,
+  letter: null,
+  letter_scale: null,
+  curve_mode: "raw",
+  curve_avg_target: null,
+  curve_sd_delta: null,
+  categories: [],
+  assignments: [],
+  dropped_assignment_ids: [],
+};
+
+beforeEach(() => {
+  mockedGetCourse.mockResolvedValue(COURSE);
+  mockedGscopeStatus.mockResolvedValue({
+    has_credentials: false,
+    auth_mode: null,
+    last_synced_at: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  window.history.replaceState({}, "", "/gradebook/c1");
+});
+
+describe("GradebookCourseScreen ?semester= (#139)", () => {
+  it("passes the ?semester= label through to getGradebookCourse", async () => {
+    window.history.replaceState({}, "", "/gradebook/c1?semester=Fall+2025");
+
+    render(<GradebookCourseScreen courseId="c1" />);
+
+    await waitFor(() =>
+      expect(mockedGetCourse).toHaveBeenCalledWith("u1", "c1", "Fall 2025"),
+    );
+  });
+
+  it("omits the semester when the URL carries none", async () => {
+    render(<GradebookCourseScreen courseId="c1" />);
+
+    await waitFor(() =>
+      expect(mockedGetCourse).toHaveBeenCalledWith("u1", "c1", undefined),
+    );
+  });
+});

--- a/frontend/src/components/screens/Gradebook/Course.tsx
+++ b/frontend/src/components/screens/Gradebook/Course.tsx
@@ -95,6 +95,19 @@ interface Props {
   courseId: string;
 }
 
+// /gradebook/<id>?semester=<label> — the landing's cards carry the selected
+// term so a course enrolled in several terms resolves to that term's
+// enrollment instead of 404ing off the current one (#139). Read straight off
+// location (useSearchParams() would need a Suspense boundary in the route
+// shell, which this screen doesn't own), and read it at CALL time — every
+// fetch AND every course-keyed mutation below must see the URL the user is
+// actually on, not a mount-frozen copy. Writes that drop the term would
+// silently land on the CURRENT term's enrollment (#468 review).
+function currentSemesterParam(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return new URLSearchParams(window.location.search).get("semester") || undefined;
+}
+
 // Exported for Course.curveModal.test.tsx (#166 failure-surfacing contract);
 // only GradebookCourseScreen below renders it in the app.
 export function CurveSettingsModal({
@@ -209,17 +222,6 @@ export function GradebookCourseScreen({ courseId }: Props) {
   const [loading, setLoading] = React.useState(true);
   const [fetchError, setFetchError] = React.useState<string | null>(null);
 
-  // /gradebook/<id>?semester=<label> — the landing's cards carry the selected
-  // term so a course enrolled in several terms resolves to that term's
-  // enrollment instead of 404ing off the current one (#139). Read straight
-  // off location like Landing.tsx does: useSearchParams() would need a
-  // Suspense boundary in the route shell, which this component doesn't own.
-  const [requestedSemester] = React.useState(() =>
-    typeof window === "undefined"
-      ? ""
-      : new URLSearchParams(window.location.search).get("semester") ?? "",
-  );
-
   const skeletonCount = React.useMemo<number>(() => {
     if (typeof window === "undefined") return 4;
     const n = window.sessionStorage.getItem(`gb-cats-${courseId}`);
@@ -255,18 +257,14 @@ export function GradebookCourseScreen({ courseId }: Props) {
     if (!userId) return;
     setFetchError(null);
     try {
-      const fresh = await getGradebookCourse(
-        userId,
-        courseId,
-        requestedSemester || undefined,
-      );
+      const fresh = await getGradebookCourse(userId, courseId, currentSemesterParam());
       setData(fresh);
     } catch (err: unknown) {
       const errMsg = err instanceof Error ? err.message : "Unknown error";
       setFetchError(errMsg);
       toast.error(`Couldn't load course: ${errMsg}`);
     }
-  }, [userId, courseId, requestedSemester, toast]);
+  }, [userId, courseId, toast]);
 
   const loadInitial = React.useCallback(async () => {
     setLoading(true);
@@ -465,7 +463,12 @@ export function GradebookCourseScreen({ courseId }: Props) {
     const newMode = data.curve_mode === "curved" ? "raw" : "curved";
     setData((prev) => prev ? { ...prev, curve_mode: newMode } : prev);
     try {
-      await setCurveSettings(userId, courseId, { curve_mode: newMode });
+      await setCurveSettings(
+        userId,
+        courseId,
+        { curve_mode: newMode },
+        currentSemesterParam(),
+      );
       await refresh(); // Server recomputes data.percent with the new curve_mode
     } catch {
       setData((prev) => prev ? { ...prev, curve_mode: data.curve_mode } : prev);
@@ -478,10 +481,12 @@ export function GradebookCourseScreen({ courseId }: Props) {
       curve_sd_delta: number | null;
     }) => {
       if (!data || !userId) return;
-      await setCurveSettings(userId, courseId, {
-        curve_mode: data.curve_mode,
-        ...settings,
-      });
+      await setCurveSettings(
+        userId,
+        courseId,
+        { curve_mode: data.curve_mode, ...settings },
+        currentSemesterParam(),
+      );
       await refresh(); // Recompute server grade with new curve policy
     },
     [data, userId, courseId, refresh],
@@ -658,9 +663,11 @@ export function GradebookCourseScreen({ courseId }: Props) {
             onSave={async (drafts) => {
               const draftIds = new Set(drafts.map((d) => d.id).filter(Boolean) as string[]);
               for (const c of data.categories) {
+                // deleteCategory is id-keyed (ownership check server-side) —
+                // no term needed; the course-keyed bulk PATCH below is.
                 if (!draftIds.has(c.id)) await deleteCategory(userId, c.id);
               }
-              await bulkUpdateCategories(userId, courseId, drafts);
+              await bulkUpdateCategories(userId, courseId, drafts, currentSemesterParam());
               await refresh();
             }}
           />
@@ -672,9 +679,10 @@ export function GradebookCourseScreen({ courseId }: Props) {
             onClose={() => setAssignModal({ open: false, initial: null })}
             onSave={async (draft: AssignmentDraft) => {
               if (assignModal.initial) {
+                // Id-keyed — the existing assignment already pins its enrollment.
                 await updateGradedAssignment(userId, assignModal.initial.id, draft);
               } else {
-                await createGradedAssignment(userId, courseId, draft);
+                await createGradedAssignment(userId, courseId, draft, currentSemesterParam());
               }
               await refresh();
             }}
@@ -693,7 +701,7 @@ export function GradebookCourseScreen({ courseId }: Props) {
             initial={data.letter_scale}
             onClose={() => setEditScale(false)}
             onSave={async (scale) => {
-              await setLetterScale(userId, courseId, scale);
+              await setLetterScale(userId, courseId, scale, currentSemesterParam());
               await refresh();
             }}
           />

--- a/frontend/src/components/screens/Gradebook/Course.tsx
+++ b/frontend/src/components/screens/Gradebook/Course.tsx
@@ -209,6 +209,17 @@ export function GradebookCourseScreen({ courseId }: Props) {
   const [loading, setLoading] = React.useState(true);
   const [fetchError, setFetchError] = React.useState<string | null>(null);
 
+  // /gradebook/<id>?semester=<label> — the landing's cards carry the selected
+  // term so a course enrolled in several terms resolves to that term's
+  // enrollment instead of 404ing off the current one (#139). Read straight
+  // off location like Landing.tsx does: useSearchParams() would need a
+  // Suspense boundary in the route shell, which this component doesn't own.
+  const [requestedSemester] = React.useState(() =>
+    typeof window === "undefined"
+      ? ""
+      : new URLSearchParams(window.location.search).get("semester") ?? "",
+  );
+
   const skeletonCount = React.useMemo<number>(() => {
     if (typeof window === "undefined") return 4;
     const n = window.sessionStorage.getItem(`gb-cats-${courseId}`);
@@ -244,14 +255,18 @@ export function GradebookCourseScreen({ courseId }: Props) {
     if (!userId) return;
     setFetchError(null);
     try {
-      const fresh = await getGradebookCourse(userId, courseId);
+      const fresh = await getGradebookCourse(
+        userId,
+        courseId,
+        requestedSemester || undefined,
+      );
       setData(fresh);
     } catch (err: unknown) {
       const errMsg = err instanceof Error ? err.message : "Unknown error";
       setFetchError(errMsg);
       toast.error(`Couldn't load course: ${errMsg}`);
     }
-  }, [userId, courseId, toast]);
+  }, [userId, courseId, requestedSemester, toast]);
 
   const loadInitial = React.useCallback(async () => {
     setLoading(true);

--- a/frontend/src/components/screens/Gradebook/Landing.test.tsx
+++ b/frontend/src/components/screens/Gradebook/Landing.test.tsx
@@ -9,7 +9,7 @@
 
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, waitFor, fireEvent } from "@testing-library/react";
 import type { EnrolledCourse } from "@/lib/api";
 import type { GradebookCourseSummary } from "@/lib/types";
 
@@ -19,10 +19,28 @@ vi.mock("@/context/UserContext", () => ({
   useUser: () => mockUser,
 }));
 
+// TranscriptModal (rendered by the landing, #139) toasts its load failures;
+// the landing itself never toasts. No test here asserts on toasts — the modal
+// has its own suite — so a bare stub keeps useToast from throwing. Stable
+// object, like the real memoized provider: the modal's fetch effect keys on
+// toast identity.
+const toastApi = vi.hoisted(() => ({
+  show: () => {},
+  dismiss: () => {},
+  success: () => {},
+  error: () => {},
+  info: () => {},
+  warn: () => {},
+}));
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => toastApi,
+}));
+
 vi.mock("@/lib/api", () => ({
   getCourses: vi.fn(),
   getGradebookSummary: vi.fn(),
   getSemesters: vi.fn(),
+  getGpa: vi.fn(),
 }));
 
 // Presentational children — stubbed so the test only exercises the landing's
@@ -33,21 +51,24 @@ vi.mock("@/components/Gradebook/AmbientOrbs", () => ({
 vi.mock("@/components/Gradebook/SyllabusUploadFlow", () => ({
   SyllabusUploadFlow: () => null,
 }));
-vi.mock("@/components/Gradebook/CourseCard", () => ({
-  CourseCard: ({ course }: { course: GradebookCourseSummary }) => (
-    <a href="#">{course.course_name}</a>
+// The REAL CourseCard renders (its term-aware href is under test, #139);
+// only next/link is stubbed down to a plain anchor.
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children?: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
   ),
-  COURSE_CARD_GRID_GAP: 24,
-  COURSE_CARD_HEIGHT: 244,
 }));
 
 import { GradebookLanding } from "./Landing";
-import { getCourses, getGradebookSummary, getSemesters } from "@/lib/api";
+import { getCourses, getGradebookSummary, getSemesters, getGpa } from "@/lib/api";
 import type { Semester } from "@/lib/api";
 
 const mockedGetCourses = vi.mocked(getCourses);
 const mockedGetSummary = vi.mocked(getGradebookSummary);
 const mockedGetSemesters = vi.mocked(getSemesters);
+const mockedGetGpa = vi.mocked(getGpa);
 
 const SEMESTERS: Semester[] = [
   { id: "spring-2025", term: "Spring", year: 2025, label: "Spring 2025", start_date: "2025-01-05", end_date: "2025-05-17", sort_key: 20251 },
@@ -70,6 +91,19 @@ function course(course_id: string, term: string): EnrolledCourse {
   };
 }
 
+function summaryCourse(course_id: string, semester: string): GradebookCourseSummary {
+  return {
+    course_id,
+    course_code: course_id.toUpperCase(),
+    course_name: course_id,
+    semester,
+    percent: 90,
+    letter: "A-",
+    graded_count: 3,
+    total_count: 5,
+  };
+}
+
 // The chips are the only aria-pressed controls on the page, so this reads
 // the rendered semester list — and its order — without depending on styling.
 const chipLabels = () =>
@@ -80,8 +114,9 @@ const chipLabels = () =>
 
 beforeEach(() => {
   mockUser.userId = "u1";
-  mockedGetSummary.mockResolvedValue({ courses: [] });
+  mockedGetSummary.mockResolvedValue({ courses: [], gpa: null, semester: "" });
   mockedGetSemesters.mockResolvedValue({ semesters: SEMESTERS });
+  mockedGetGpa.mockResolvedValue({ gpa: null, courses: [], semester: null, scope: "cumulative" });
 });
 
 afterEach(() => {
@@ -202,5 +237,63 @@ describe("GradebookLanding semester chips", () => {
     await screen.findByRole("button", { name: "Spring 2026" });
     expect(chipLabels()).toEqual(["Spring 2026", "Fall 2025"]);
     expect(mockedGetCourses).not.toHaveBeenCalled();
+  });
+});
+
+describe("GradebookLanding term GPA + term-aware card links (#139)", () => {
+  it("surfaces the summary's term GPA next to the chips", async () => {
+    mockedGetCourses.mockResolvedValue({ courses: [course("bio", "Fall 2024")] });
+    mockedGetSummary.mockResolvedValue({
+      courses: [summaryCourse("bio", "Fall 2024")],
+      gpa: 3.7,
+      semester: "Fall 2024",
+    });
+
+    render(<GradebookLanding />);
+
+    const gpa = await screen.findByTestId("gradebook-term-gpa");
+    expect(gpa.textContent).toContain("3.70");
+  });
+
+  it("hides the term GPA when the summary has none", async () => {
+    mockedGetCourses.mockResolvedValue({ courses: [course("bio", "Fall 2024")] });
+    mockedGetSummary.mockResolvedValue({
+      courses: [summaryCourse("bio", "Fall 2024")],
+      gpa: null,
+      semester: "Fall 2024",
+    });
+
+    render(<GradebookLanding />);
+
+    await screen.findByRole("button", { name: "Fall 2024" });
+    await waitFor(() => expect(mockedGetSummary).toHaveBeenCalled());
+    expect(screen.queryByTestId("gradebook-term-gpa")).toBeNull();
+  });
+
+  it("carries the selected term on each course card link", async () => {
+    // The #139 bug: the card link dropped the term, so a course enrolled in
+    // two semesters always resolved to the CURRENT term's enrollment and the
+    // archived one 404'd. The href must pin the selected chip's term.
+    mockedGetCourses.mockResolvedValue({ courses: [course("bio", "Fall 2024")] });
+    mockedGetSummary.mockResolvedValue({
+      courses: [summaryCourse("bio", "Fall 2024")],
+      gpa: null,
+      semester: "Fall 2024",
+    });
+
+    render(<GradebookLanding />);
+
+    const card = await screen.findByRole("link", { name: /bio/i });
+    expect(card.getAttribute("href")).toBe("/gradebook/bio?semester=Fall%202024");
+  });
+
+  it("opens the transcript modal from the Transcript button", async () => {
+    mockedGetCourses.mockResolvedValue({ courses: [course("bio", "Fall 2024")] });
+
+    render(<GradebookLanding />);
+
+    const open = await screen.findByTestId("gradebook-transcript-open");
+    fireEvent.click(open);
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/screens/Gradebook/Landing.testmode.test.tsx
+++ b/frontend/src/components/screens/Gradebook/Landing.testmode.test.tsx
@@ -29,10 +29,20 @@ vi.mock("@/context/UserContext", () => ({
   useUser: () => ({ userId: "u1", userReady: true }),
 }));
 
+// TranscriptModal (rendered by the landing, #139) pulls useToast; a stable
+// stub keeps it from throwing outside a provider (same as Landing.test.tsx).
+const toastApi = {
+  error: vi.fn(), success: vi.fn(), info: vi.fn(), warn: vi.fn(), show: vi.fn(), dismiss: vi.fn(),
+};
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => toastApi,
+}));
+
 vi.mock("@/lib/api", () => ({
   getCourses: vi.fn(),
   getGradebookSummary: vi.fn(),
   getSemesters: vi.fn(),
+  getGpa: vi.fn(),
 }));
 
 // Presentational children — stubbed so the test only exercises the landing's
@@ -92,7 +102,7 @@ const pressedChip = () =>
 
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
-  mockedGetSummary.mockResolvedValue({ courses: [] });
+  mockedGetSummary.mockResolvedValue({ courses: [], gpa: null, semester: "" });
   mockedGetSemesters.mockResolvedValue({ semesters: SEMESTERS });
   mockedGetCourses.mockResolvedValue({
     courses: [course("bio", "Fall 2025"), course("psy", "Spring 2026")],

--- a/frontend/src/components/screens/Gradebook/Landing.tsx
+++ b/frontend/src/components/screens/Gradebook/Landing.tsx
@@ -14,6 +14,7 @@ import { courseTermLabels, currentTerm } from "@/lib/semesters";
 import { now } from "@/lib/testMode";
 import type { GradebookCourseSummary } from "@/lib/types";
 import { SyllabusUploadFlow } from "@/components/Gradebook/SyllabusUploadFlow";
+import { TranscriptModal } from "@/components/Gradebook/TranscriptModal";
 import { Button } from "@/components/ui";
 
 const SAMPLE_SEMESTERS = ["Spring 2026", "Fall 2025"];
@@ -100,10 +101,12 @@ export function GradebookLanding() {
   const [semesters, setSemesters] = React.useState<string[]>([]);
   const [selected, setSelected] = React.useState<string>("");
   const [courses, setCourses] = React.useState<GradebookCourseSummary[]>([]);
+  const [termGpa, setTermGpa] = React.useState<number | null>(null);
   const [colorMap, setColorMap] = React.useState<Record<string, string>>({});
   const [loading, setLoading] = React.useState(true);
   const [termsReady, setTermsReady] = React.useState(false);
   const [uploadOpen, setUploadOpen] = React.useState(false);
+  const [transcriptOpen, setTranscriptOpen] = React.useState(false);
 
   // /gradebook?semester=<label> is how the dashboard archive deep-links into a
   // past term. Read straight off location because useSearchParams() would need
@@ -157,11 +160,13 @@ export function GradebookLanding() {
     if (!termsReady) return;
     if (!selected) {
       setCourses([]);
+      setTermGpa(null);
       setLoading(false);
       return;
     }
     if (!userId) {
       setCourses(SAMPLE_COURSES[selected] ?? []);
+      setTermGpa(null);
       setLoading(false);
       return;
     }
@@ -169,9 +174,11 @@ export function GradebookLanding() {
     getGradebookSummary(userId, selected)
       .then((res) => {
         setCourses(res.courses.length ? res.courses : []);
+        setTermGpa(res.gpa ?? null);
       })
       .catch(() => {
         setCourses([]);
+        setTermGpa(null);
       })
       .finally(() => setLoading(false));
   }, [userId, selected, termsReady]);
@@ -237,11 +244,51 @@ export function GradebookLanding() {
       >
         <AmbientOrbs />
         <div style={{ position: "relative", zIndex: 1 }}>
-        <SemesterChips
-          semesters={semesters}
-          selected={selected}
-          onSelect={setSelected}
-        />
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            gap: 16,
+            flexWrap: "wrap",
+          }}
+        >
+          <SemesterChips
+            semesters={semesters}
+            selected={selected}
+            onSelect={setSelected}
+          />
+          {userId && (
+            <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+              {termGpa !== null && (
+                <span
+                  data-testid="gradebook-term-gpa"
+                  className="mono"
+                  title="Credit-weighted GPA for this semester"
+                  style={{
+                    fontSize: 12,
+                    letterSpacing: "0.02em",
+                    color: "var(--text-dim)",
+                  }}
+                >
+                  Term GPA{" "}
+                  <strong style={{ color: "var(--text)", fontWeight: 600 }}>
+                    {termGpa.toFixed(2)}
+                  </strong>
+                </span>
+              )}
+              <button
+                type="button"
+                data-testid="gradebook-transcript-open"
+                className="btn"
+                onClick={() => setTranscriptOpen(true)}
+                style={{ padding: "5px 14px", fontSize: 12 }}
+              >
+                Transcript
+              </button>
+            </div>
+          )}
+        </div>
         {loading ? (
           <LoadingSkeleton />
         ) : courses.length === 0 ? (
@@ -264,6 +311,7 @@ export function GradebookLanding() {
                 course={c}
                 variant="default"
                 courseColor={colorMap[c.course_id] || "var(--accent)"}
+                semester={selected}
               />
             ))}
           </div>
@@ -272,11 +320,18 @@ export function GradebookLanding() {
       </main>
 
       {userId && (
-        <SyllabusUploadFlow
-          open={uploadOpen}
-          userId={userId}
-          onClose={() => setUploadOpen(false)}
-        />
+        <>
+          <SyllabusUploadFlow
+            open={uploadOpen}
+            userId={userId}
+            onClose={() => setUploadOpen(false)}
+          />
+          <TranscriptModal
+            open={transcriptOpen}
+            userId={userId}
+            onClose={() => setTranscriptOpen(false)}
+          />
+        </>
       )}
     </>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,6 +3,7 @@ import type {
   UserProfile, UserSettings, UserRole, UserAchievement, Achievement,
   UserCosmetic, CosmeticType, Role, Cosmetic, RarityTier, AchievementCategory,
   GradebookSummary, GradebookCourse, GradeCategory, GradedAssignment, LetterScaleTier,
+  GpaReport,
   ExtractedSyllabusCategory,
   AllowlistEmail, AchievementTrigger, AdminAuditEntry, AnalyticsOverview, PaginatedUsers,
   Note, LinkedConcept,
@@ -1180,9 +1181,21 @@ export const getGradebookSummary = (userId: string, semester: string) =>
     `/api/gradebook/summary?user_id=${encodeURIComponent(userId)}&semester=${encodeURIComponent(semester)}`,
   );
 
-export const getGradebookCourse = (userId: string, courseId: string) =>
+// `semester` pins which enrollment of the course to load (a course can be
+// taken in several terms, #139); omitted = the backend resolves the current
+// term with its single-offering fallback.
+export const getGradebookCourse = (userId: string, courseId: string, semester?: string) =>
   fetchJSON<GradebookCourse>(
-    `/api/gradebook/courses/${encodeURIComponent(courseId)}?user_id=${encodeURIComponent(userId)}`,
+    `/api/gradebook/courses/${encodeURIComponent(courseId)}?user_id=${encodeURIComponent(userId)}` +
+      (semester ? `&semester=${encodeURIComponent(semester)}` : ''),
+  );
+
+// Credit-weighted GPA. Without `semester`: the cumulative/transcript report
+// across all terms (scope "cumulative"); with it: that one term.
+export const getGpa = (userId: string, semester?: string) =>
+  fetchJSON<GpaReport>(
+    `/api/gradebook/gpa?user_id=${encodeURIComponent(userId)}` +
+      (semester ? `&semester=${encodeURIComponent(semester)}` : ''),
   );
 
 export const createCategory = (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1198,25 +1198,35 @@ export const getGpa = (userId: string, semester?: string) =>
       (semester ? `&semester=${encodeURIComponent(semester)}` : ''),
   );
 
+// Course-keyed gradebook MUTATIONS below take the same optional `semester`
+// (term-label body field, matching the backend body models) as
+// getGradebookCourse: the backend resolves (course, semester) to ONE
+// enrollment, and without the term a write from an archived term's page
+// would silently land on the current term's enrollment (#139/#468).
+// Id-keyed calls (deleteCategory, update/deleteGradedAssignment) resolve by
+// row ownership and don't need it. `JSON.stringify` drops an undefined
+// `semester`, so the wire format is unchanged when unset.
 export const createCategory = (
   userId: string,
   courseId: string,
   name: string,
   weight: number,
+  semester?: string,
 ) =>
   fetchJSON<{ category: GradeCategory }>(
     `/api/gradebook/courses/${encodeURIComponent(courseId)}/categories`,
-    { method: 'POST', body: JSON.stringify({ user_id: userId, name, weight }) },
+    { method: 'POST', body: JSON.stringify({ user_id: userId, semester, name, weight }) },
   );
 
 export const bulkUpdateCategories = (
   userId: string,
   courseId: string,
   categories: { id?: string; name: string; weight: number; sort_order: number; drop_lowest: number }[],
+  semester?: string,
 ) =>
   fetchJSON<{ categories: GradeCategory[] }>(
     `/api/gradebook/courses/${encodeURIComponent(courseId)}/categories`,
-    { method: 'PATCH', body: JSON.stringify({ user_id: userId, categories }) },
+    { method: 'PATCH', body: JSON.stringify({ user_id: userId, semester, categories }) },
   );
 
 export const deleteCategory = (userId: string, categoryId: string) =>
@@ -1229,10 +1239,11 @@ export const createGradedAssignment = (
   userId: string,
   courseId: string,
   fields: Partial<Omit<GradedAssignment, 'id' | 'course_id' | 'source'>> & { title: string },
+  semester?: string,
 ) =>
   fetchJSON<{ assignment: GradedAssignment }>('/api/gradebook/assignments', {
     method: 'POST',
-    body: JSON.stringify({ user_id: userId, course_id: courseId, ...fields }),
+    body: JSON.stringify({ user_id: userId, course_id: courseId, semester, ...fields }),
   });
 
 export const updateGradedAssignment = (
@@ -1255,10 +1266,11 @@ export const setLetterScale = (
   userId: string,
   courseId: string,
   scale: LetterScaleTier[] | null,
+  semester?: string,
 ) =>
   fetchJSON<{ updated: true; letter_scale: LetterScaleTier[] | null }>(
     `/api/gradebook/courses/${encodeURIComponent(courseId)}/scale`,
-    { method: 'PATCH', body: JSON.stringify({ user_id: userId, scale }) },
+    { method: 'PATCH', body: JSON.stringify({ user_id: userId, semester, scale }) },
   );
 
 export async function setCurveSettings(
@@ -1271,11 +1283,12 @@ export async function setCurveSettings(
     curve_final_mean?: number | null;
     curve_final_sd?: number | null;
   },
+  semester?: string,
 ): Promise<{ updated: boolean }> {
   return fetchJSON(`/api/gradebook/courses/${encodeURIComponent(courseId)}/curve`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ user_id: userId, ...settings }),
+    body: JSON.stringify({ user_id: userId, semester, ...settings }),
   });
 }
 

--- a/frontend/src/lib/semesters.ts
+++ b/frontend/src/lib/semesters.ts
@@ -80,6 +80,17 @@ function compareLabels(a: string, b: string, index: Map<string, number>): number
   return a.localeCompare(b);
 }
 
+const NO_SEMESTER_INDEX: Map<string, number> = new Map();
+
+/**
+ * Most-recent-first comparator for bare term labels, for callers that have no
+ * `/api/semesters` rows to key on (e.g. the transcript's per-semester groups).
+ * Label-derived ranks only; unrankable labels sort to the end.
+ */
+export function compareTermLabels(a: string, b: string): number {
+  return compareLabels(a, b, NO_SEMESTER_INDEX);
+}
+
 /**
  * Distinct term labels off a course list, most recent first — the semester
  * chips on the gradebook landing. Courses with no term contribute nothing;

--- a/frontend/src/lib/transcript.test.ts
+++ b/frontend/src/lib/transcript.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect } from "vitest";
 
-import { buildTranscript, weightedGpa } from "./transcript";
+import { buildTranscript, effectiveCredits, weightedGpa } from "./transcript";
 import type { GpaCourseRow } from "./types";
 
 function row(overrides: Partial<GpaCourseRow>): GpaCourseRow {
@@ -22,6 +22,19 @@ function row(overrides: Partial<GpaCourseRow>): GpaCourseRow {
     ...overrides,
   };
 }
+
+describe("effectiveCredits", () => {
+  it("passes real credits through and defaults null/zero/negative to 1", () => {
+    // The shared display+math rule (#468 review): what the transcript SHOWS
+    // must be what the GPA WEIGHS. 0 was the divergence — `credits ?? 1`
+    // displayed 0 while the math counted 1.
+    expect(effectiveCredits({ credits: 3 })).toBe(3);
+    expect(effectiveCredits({ credits: 0.5 })).toBe(0.5);
+    expect(effectiveCredits({ credits: null })).toBe(1);
+    expect(effectiveCredits({ credits: 0 })).toBe(1);
+    expect(effectiveCredits({ credits: -2 })).toBe(1);
+  });
+});
 
 describe("weightedGpa", () => {
   it("credit-weights grade points (mirrors backend weighted_gpa)", () => {

--- a/frontend/src/lib/transcript.test.ts
+++ b/frontend/src/lib/transcript.test.ts
@@ -1,0 +1,125 @@
+/**
+ * buildTranscript (#139) — pure grouping + per-semester GPA for the
+ * transcript modal. The GPA math must mirror
+ * backend/services/gradebook_service.py::weighted_gpa exactly:
+ * grade_points == null rows are listed but excluded from the math,
+ * null/zero/negative credits count as 1, and an empty group yields null.
+ */
+import { describe, it, expect } from "vitest";
+
+import { buildTranscript, weightedGpa } from "./transcript";
+import type { GpaCourseRow } from "./types";
+
+function row(overrides: Partial<GpaCourseRow>): GpaCourseRow {
+  return {
+    course_id: "c1",
+    course_code: "CS101",
+    semester: "Fall 2025",
+    credits: 3,
+    percent: 90,
+    letter: "A-",
+    grade_points: 3.7,
+    ...overrides,
+  };
+}
+
+describe("weightedGpa", () => {
+  it("credit-weights grade points (mirrors backend weighted_gpa)", () => {
+    // (4.0 * 4 + 3.0 * 2) / 6 = 22 / 6
+    const gpa = weightedGpa([
+      row({ grade_points: 4.0, credits: 4 }),
+      row({ grade_points: 3.0, credits: 2 }),
+    ]);
+    expect(gpa).toBeCloseTo(22 / 6, 10);
+  });
+
+  it("defaults null credits to 1", () => {
+    // (4.0 * 1 + 2.0 * 3) / 4 = 10 / 4
+    const gpa = weightedGpa([
+      row({ grade_points: 4.0, credits: null }),
+      row({ grade_points: 2.0, credits: 3 }),
+    ]);
+    expect(gpa).toBeCloseTo(2.5, 10);
+  });
+
+  it("defaults zero credits to 1 (backend treats falsy credits as 1)", () => {
+    const gpa = weightedGpa([
+      row({ grade_points: 4.0, credits: 0 }),
+      row({ grade_points: 2.0, credits: 1 }),
+    ]);
+    expect(gpa).toBeCloseTo(3.0, 10);
+  });
+
+  it("excludes grade_points null rows from the math", () => {
+    const gpa = weightedGpa([
+      row({ grade_points: 4.0, credits: 3 }),
+      row({ grade_points: null, percent: null, letter: null, credits: 100 }),
+    ]);
+    expect(gpa).toBe(4.0);
+  });
+
+  it("returns null when nothing contributes", () => {
+    expect(weightedGpa([])).toBeNull();
+    expect(weightedGpa([row({ grade_points: null })])).toBeNull();
+  });
+});
+
+describe("buildTranscript", () => {
+  it("groups rows by semester label, most recent first", () => {
+    const transcript = buildTranscript([
+      row({ course_id: "a", semester: "Fall 2025" }),
+      row({ course_id: "b", semester: "Spring 2026" }),
+      row({ course_id: "c", semester: "Fall 2025" }),
+    ]);
+    expect(transcript.map((s) => s.label)).toEqual(["Spring 2026", "Fall 2025"]);
+    expect(transcript[1].courses.map((c) => c.course_id)).toEqual(["a", "c"]);
+  });
+
+  it("sorts labels it cannot rank to the end", () => {
+    const transcript = buildTranscript([
+      row({ course_id: "a", semester: "Mystery Term" }),
+      row({ course_id: "b", semester: "Spring 2026" }),
+    ]);
+    expect(transcript.map((s) => s.label)).toEqual(["Spring 2026", "Mystery Term"]);
+  });
+
+  it("computes a per-semester credit-weighted GPA", () => {
+    const transcript = buildTranscript([
+      row({ course_id: "a", semester: "Fall 2025", grade_points: 4.0, credits: 4 }),
+      row({ course_id: "b", semester: "Fall 2025", grade_points: 3.0, credits: 2 }),
+      row({ course_id: "c", semester: "Spring 2026", grade_points: 2.0, credits: 3 }),
+    ]);
+    const fall = transcript.find((s) => s.label === "Fall 2025")!;
+    const spring = transcript.find((s) => s.label === "Spring 2026")!;
+    expect(fall.gpa).toBeCloseTo(22 / 6, 10);
+    expect(spring.gpa).toBeCloseTo(2.0, 10);
+  });
+
+  it("still lists in-progress rows but leaves them out of the semester GPA", () => {
+    const transcript = buildTranscript([
+      row({ course_id: "a", semester: "Spring 2026", grade_points: 4.0, credits: 2 }),
+      row({
+        course_id: "b",
+        semester: "Spring 2026",
+        grade_points: null,
+        percent: null,
+        letter: null,
+        credits: 5,
+      }),
+    ]);
+    expect(transcript[0].courses).toHaveLength(2);
+    expect(transcript[0].gpa).toBe(4.0);
+  });
+
+  it("yields a null GPA for a semester with no graded rows", () => {
+    const transcript = buildTranscript([
+      row({ course_id: "a", grade_points: null, percent: null, letter: null }),
+    ]);
+    expect(transcript[0].gpa).toBeNull();
+    expect(transcript[0].courses).toHaveLength(1);
+  });
+
+  it("returns an empty transcript for no rows", () => {
+    expect(buildTranscript([])).toEqual([]);
+  });
+});

--- a/frontend/src/lib/transcript.ts
+++ b/frontend/src/lib/transcript.ts
@@ -1,0 +1,53 @@
+import { compareTermLabels } from "@/lib/semesters";
+import type { GpaCourseRow } from "@/lib/types";
+
+export interface TranscriptSemester {
+  label: string;
+  gpa: number | null;
+  courses: GpaCourseRow[];
+}
+
+/**
+ * Credit-weighted GPA over a set of course rows.
+ *
+ * Mirrors backend/services/gradebook_service.py::weighted_gpa and must stay
+ * in lock-step with it: rows with `grade_points == null` (in-progress) are
+ * skipped entirely; null/zero/negative credits count as 1 so a course always
+ * weighs at least once; nothing contributing → null, never 0.0.
+ */
+export function weightedGpa(rows: GpaCourseRow[]): number | null {
+  let totalCredits = 0;
+  let totalPoints = 0;
+  for (const row of rows) {
+    if (row.grade_points == null) continue;
+    const credits =
+      row.credits != null && row.credits > 0 ? row.credits : 1;
+    totalCredits += credits;
+    totalPoints += row.grade_points * credits;
+  }
+  if (totalCredits === 0) return null;
+  return totalPoints / totalCredits;
+}
+
+/**
+ * Group `/api/gradebook/gpa` rows into per-semester transcript sections,
+ * most recent term first (ordering via lib/semesters, the one place term
+ * order is defined). In-progress rows stay listed in their section but are
+ * excluded from that section's GPA by `weightedGpa` above.
+ */
+export function buildTranscript(rows: GpaCourseRow[]): TranscriptSemester[] {
+  const groups = new Map<string, GpaCourseRow[]>();
+  for (const row of rows) {
+    const label = (row.semester || "").trim();
+    const group = groups.get(label);
+    if (group) group.push(row);
+    else groups.set(label, [row]);
+  }
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => compareTermLabels(a, b))
+    .map(([label, courses]) => ({
+      label,
+      gpa: weightedGpa(courses),
+      courses,
+    }));
+}

--- a/frontend/src/lib/transcript.ts
+++ b/frontend/src/lib/transcript.ts
@@ -8,20 +8,30 @@ export interface TranscriptSemester {
 }
 
 /**
+ * The credits a row actually weighs: null/zero/negative count as 1, so a
+ * course always weighs at least once. Mirrors the falsy-credits default in
+ * backend/services/gradebook_service.py::weighted_gpa. The ONE place this
+ * rule lives — both the GPA math and the transcript's "N cr" display use it,
+ * so the number shown is always the number weighed.
+ */
+export function effectiveCredits(row: Pick<GpaCourseRow, "credits">): number {
+  return row.credits != null && row.credits > 0 ? row.credits : 1;
+}
+
+/**
  * Credit-weighted GPA over a set of course rows.
  *
  * Mirrors backend/services/gradebook_service.py::weighted_gpa and must stay
  * in lock-step with it: rows with `grade_points == null` (in-progress) are
- * skipped entirely; null/zero/negative credits count as 1 so a course always
- * weighs at least once; nothing contributing → null, never 0.0.
+ * skipped entirely; credits default via `effectiveCredits` above; nothing
+ * contributing → null, never 0.0.
  */
 export function weightedGpa(rows: GpaCourseRow[]): number | null {
   let totalCredits = 0;
   let totalPoints = 0;
   for (const row of rows) {
     if (row.grade_points == null) continue;
-    const credits =
-      row.credits != null && row.credits > 0 ? row.credits : 1;
+    const credits = effectiveCredits(row);
     totalCredits += credits;
     totalPoints += row.grade_points * credits;
   }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -310,6 +310,29 @@ export interface GradebookCourseSummary {
 
 export interface GradebookSummary {
   courses: GradebookCourseSummary[];
+  // Credit-weighted GPA for the requested term; null until something is graded.
+  gpa: number | null;
+  semester: string;
+}
+
+// One enrollment row of GET /api/gradebook/gpa. `grade_points` is null while
+// the course has no graded percent yet (rendered as in-progress, excluded
+// from GPA math); `credits` is null when the offering doesn't declare any.
+export interface GpaCourseRow {
+  course_id: string;
+  course_code: string;
+  semester: string;
+  credits: number | null;
+  percent: number | null;
+  letter: string | null;
+  grade_points: number | null;
+}
+
+export interface GpaReport {
+  gpa: number | null;
+  courses: GpaCourseRow[];
+  semester: string | null;
+  scope: "semester" | "cumulative";
 }
 
 export interface GradebookCourse {


### PR DESCRIPTION
## Bundle B6 — Semesters completion (#139)

Closes #139.

The issue body predates the terms/offerings redesign; built against shipped reality (epic #142's model is stale). The Landing term switcher already existed (#140); what this PR adds:

### The bug fix (term switcher half)
- Course cards now carry `?semester=<label>` and `getGradebookCourse` passes it through — fixing a live 404: with multiple offerings of one course (seeded CS101 is in fall-2025 AND spring-2026) and no term hint, `_resolve_enrollment` resolves the current term and 404s ("Course not in your gradebook") from either chip. `Course.tsx` reads the param exactly like Landing's deep-link handling.

### Transcript / GPA half
- `GradebookSummary` stops discarding the `gpa`/`semester` fields the backend already returns; Landing shows "Term GPA" (`gradebook-term-gpa`).
- New `TranscriptModal` (`gradebook-transcript-open`) consuming the existing-but-unconsumed `GET /api/gradebook/gpa`: cumulative GPA + per-semester sections with course rows (letter or "in progress", credits). Per-semester GPA computed in a pure `lib/transcript.ts` that mirrors `gradebook_service.weighted_gpa` exactly (lock-step comment; null grade_points listed-but-excluded, null credits → 1).
- Error path follows the #463 pattern: toast + inline retry, dialog stays open.

### Surface registration + journey
- `docs/frontend-testids.md` gains the `gradebook` surface; the four owning files joined the eslint testid enforcement block; `eslint-suppressions.json` regenerated for the pre-existing untagged elements (delta: Course.tsx 9, Landing.tsx 1).
- Promoted journey `e2e/gradebook.spec.ts` (first gradebook journey): (a) the multi-term regression with a DB-truth precondition via `queryRaw` (asserts the two CS101 enrollments' term ids), Fall→"Exams" / Spring→"Projects" discriminators from the rich seed; (b) transcript open → GPA + both term sections.

### Gates
- Rebased onto main @ `1102093` (#465). `vitest`: 39 files / 305 tests green; `tsc --noEmit` clean; `eslint .` 0 errors.
- No backend changes. #463/#464 modal behavior untouched (their tests green).
- Pre-merge flock'd e2e cycle to follow before merge.

Note: sibling issue #141 got a corrected-state STOP-note instead of code (design conflict with the shipped #360 contract + file collision with #465/B5) — see the issue comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * View GPA for the selected academic term directly from the Gradebook.
  * Open a transcript showing cumulative GPA, semester GPAs, course grades, credits, and in-progress courses.
  * Gradebook course links and actions now remain scoped to the selected term.

* **Bug Fixes**
  * Fixed term selection being lost when opening courses.
  * Fixed new assignments and grading updates being saved to the wrong enrollment.
  * Added retry handling when transcript data fails to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->