### PR TITLE
feat(agents): structured-output retry + validation hardening (#153)

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -4,12 +4,55 @@ Exposes the per-run cost guardrails every agent call site passes via
 the explicit `usage_limits=` kwarg. We keep two shapes: workers don't
 call tools (tool_calls_limit=0) and never need many requests; the
 orchestrator does call tools and may iterate.
+
+OUTPUT-SCHEMA BUDGET (#153, codifying
+docs/attempts/2026-05-03-orchestrator-schema-complexity.md)
+---------------------------------------------------------------------
+Gemini's native structured-output API compiles the output schema into a
+constrained-decoding automaton and REJECTS rich schemas outright ("too
+many states for serving") — the request fails before the model runs.
+The original document-orchestrator output (classification + summary +
+concepts + optional syllabus in one model) died exactly this way. Every
+agent `output_type` must therefore stay small and flat:
+
+- at most ~8 fields per object (aim for < 5), and one level of object
+  nesting below the root (root -> list[Item] is the ceiling);
+- no optional NESTED models (`Sub | None` fields — optional scalars are
+  fine); if a sub-result is conditional, run a second agent or compose
+  in route code;
+- enums as flat string Literals, not constrained/patterned strings;
+- rich results are composed deterministically in code from several
+  small agent runs (see agents/document.py), never asked for whole;
+- `PromptedOutput` is the escape hatch when a *specific* Pydantic
+  feature trips the provider (e.g. `date` fields on syllabus
+  extraction) — it moves enforcement into the prompt + local
+  validation but does NOT exempt the schema from this budget.
+
+`tests/test_agent_output_schemas.py` walks every registered agent and
+fails CI when an output schema exceeds the budget, so the next rich
+schema dies in review, not against Gemini's 400s.
+
+Validation-retry policy (#153): idempotent structured-output generation
+agents run with an output-retry budget of 2 (`retries=2` on tool-less
+workers; `output_retries=2` on quiz, whose tool retries stay at the
+default) so a transiently malformed output re-rolls instead of failing
+the request. Free-text agents (chat_tutor, note_chat, health,
+ocr_vision) have no output validation to retry — and the streaming
+tutor's failure handling belongs to `chat_stream.stream_agent_turn`'s
+rung ladder, never to a hidden re-roll. Successful-but-retried runs are
+logged by `agents.usage.record_agent_usage`.
 """
 
 from pydantic_ai.usage import UsageLimits
 
 WORKER_LIMITS = UsageLimits(
-    request_limit=2,
+    # 3, not 2: a worker's only extra requests are output-validation
+    # retries (#153 — output-retry budget of 2, so worst case is
+    # 1 initial + 2 retries). At 2 the second retry would trip
+    # UsageLimitExceeded instead of UnexpectedModelBehavior, which
+    # misfiles "model kept emitting garbage" as "input too long" at the
+    # routes that distinguish the two (routes/notes.py 413-vs-500).
+    request_limit=3,
     tool_calls_limit=0,
     total_tokens_limit=50_000,
 )

--- a/backend/agents/classifier.py
+++ b/backend/agents/classifier.py
@@ -94,6 +94,10 @@ classifier_agent = Agent[SaplingDeps, DocumentClassification](
     model=model_for("classifier"),
     deps_type=SaplingDeps,
     output_type=DocumentClassification,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_SYSTEM_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "classifier"},
 )

--- a/backend/agents/concept_describe.py
+++ b/backend/agents/concept_describe.py
@@ -55,6 +55,10 @@ concept_describe_agent = Agent[SaplingDeps, ConceptDescription](
     model=model_for("concept_describe"),
     deps_type=SaplingDeps,
     output_type=ConceptDescription,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_SYSTEM_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "concept_describe"},
 )

--- a/backend/agents/concept_extraction.py
+++ b/backend/agents/concept_extraction.py
@@ -57,6 +57,10 @@ concept_extraction_agent = Agent[SaplingDeps, ConceptList](
     model=model_for("concepts"),
     deps_type=SaplingDeps,
     output_type=ConceptList,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_SYSTEM_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "concept_extraction"},
 )

--- a/backend/agents/concept_scan.py
+++ b/backend/agents/concept_scan.py
@@ -58,6 +58,10 @@ concept_scan_agent = Agent[SaplingDeps, NewConcepts](
     model=model_for("concept_scan"),
     deps_type=SaplingDeps,
     output_type=NewConcepts,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_SYSTEM_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "concept_scan"},
 )

--- a/backend/agents/course_summary.py
+++ b/backend/agents/course_summary.py
@@ -38,6 +38,10 @@ _PROMPT_HASH = hashlib.sha256(_SYSTEM_PROMPT.encode("utf-8")).hexdigest()[:12]
 course_summary_agent = Agent[None, CourseSummary](
     model=model_for("course_summary"),
     output_type=CourseSummary,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_SYSTEM_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "course_summary"},
 )

--- a/backend/agents/flashcard.py
+++ b/backend/agents/flashcard.py
@@ -57,6 +57,10 @@ _FLASHCARD_SETTINGS = GoogleModelSettings(
 flashcard_agent = Agent[None, Flashcards](
     model=model_for("flashcard"),
     output_type=Flashcards,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_SYSTEM_PROMPT,
     model_settings=_FLASHCARD_SETTINGS,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "flashcard"},

--- a/backend/agents/note_concepts.py
+++ b/backend/agents/note_concepts.py
@@ -41,6 +41,10 @@ note_concepts_agent = Agent[SaplingDeps, NoteConcepts](
     model=model_for("note_concepts"),
     deps_type=SaplingDeps,
     output_type=NoteConcepts,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "note_concepts"},
 )

--- a/backend/agents/note_summary.py
+++ b/backend/agents/note_summary.py
@@ -35,6 +35,10 @@ note_summary_agent = Agent[SaplingDeps, NoteSummary](
     model=model_for("note_summary"),
     deps_type=SaplingDeps,
     output_type=NoteSummary,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "note_summary"},
 )

--- a/backend/agents/quiz.py
+++ b/backend/agents/quiz.py
@@ -159,6 +159,14 @@ quiz_agent = Agent[SaplingDeps, Quiz](
     model=model_for("quiz"),
     deps_type=SaplingDeps,
     output_type=Quiz,
+    # #153: bounded output-validation retry budget. `output_retries=`
+    # (not `retries=`) so the three read tools keep their default tool-
+    # retry budget. NB: pydantic-ai 1.107+ deprecates this kwarg for
+    # retries={"output": ...}, but the dict form silently breaks 1.89's
+    # retry accounting (the dict lands in the retry counter and raises
+    # TypeError at retry time) — keep the kwarg while the version floor
+    # spans both.
+    output_retries=2,
     system_prompt=_SYSTEM_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "quiz"},
     tools=[

--- a/backend/agents/quiz_context.py
+++ b/backend/agents/quiz_context.py
@@ -61,6 +61,10 @@ _PROMPT_HASH = hashlib.sha256(_SYSTEM_PROMPT.encode("utf-8")).hexdigest()[:12]
 quiz_context_agent = Agent[None, QuizContext](
     model=model_for("quiz_context"),
     output_type=QuizContext,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_SYSTEM_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "quiz_context"},
 )

--- a/backend/agents/social_summary.py
+++ b/backend/agents/social_summary.py
@@ -39,6 +39,10 @@ social_summary_agent = Agent[SaplingDeps, SocialSummary](
     model=model_for("social_summary"),
     deps_type=SaplingDeps,
     output_type=SocialSummary,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_SYSTEM_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "social_summary"},
 )

--- a/backend/agents/study_guide.py
+++ b/backend/agents/study_guide.py
@@ -57,6 +57,10 @@ study_guide_agent = Agent[SaplingDeps, StudyGuide](
     model=model_for("study_guide"),
     deps_type=SaplingDeps,
     output_type=StudyGuide,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_SYSTEM_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "study_guide"},
 )

--- a/backend/agents/summary.py
+++ b/backend/agents/summary.py
@@ -55,6 +55,10 @@ summary_agent = Agent[SaplingDeps, Summary](
     model=model_for("summary"),
     deps_type=SaplingDeps,
     output_type=Summary,
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_SYSTEM_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "summary"},
 )

--- a/backend/agents/syllabus_extraction.py
+++ b/backend/agents/syllabus_extraction.py
@@ -85,6 +85,10 @@ syllabus_extraction_agent = Agent[SaplingDeps, SyllabusAssignments](
     model=model_for("syllabus"),
     deps_type=SaplingDeps,
     output_type=PromptedOutput(SyllabusAssignments),
+    # #153: bounded output-validation retry budget for this idempotent
+    # generation task. Tool-less agent, so `retries=` IS the output budget
+    # (see the validation-retry policy note in agents/__init__.py).
+    retries=2,
     system_prompt=_SYSTEM_PROMPT,
     metadata={"prompt_version": _PROMPT_HASH, "agent": "syllabus_extraction"},
 )

--- a/backend/agents/usage.py
+++ b/backend/agents/usage.py
@@ -56,6 +56,37 @@ def _model_name(result: Any, task: AgentTask | None) -> str:
     return "unknown"
 
 
+def _log_recovered_retries(result: Any, task: AgentTask | None, feature: str) -> None:
+    """Make recovered validation retries observable (#153).
+
+    A run that needed output/tool validation retries but ultimately succeeded
+    is invisible today: pydantic-ai re-rolls internally and only exhaustion
+    surfaces (as UnexpectedModelBehavior in the route's logs). Count the
+    `RetryPromptPart`s in the final message history and WARN so a drifting
+    prompt/schema shows up in logs before it starts failing requests outright.
+    A log line, not a #117 event: the frozen taxonomy stays untouched.
+    """
+    retry_parts = [
+        part
+        for message in result.all_messages()
+        for part in getattr(message, "parts", [])
+        if type(part).__name__ == "RetryPromptPart"
+    ]
+    if retry_parts:
+        tools = sorted(
+            {t for t in (getattr(p, "tool_name", None) for p in retry_parts) if t}
+        )
+        logger.warning(
+            "agent run recovered after %d validation retr%s "
+            "(task=%s feature=%s tools=%s)",
+            len(retry_parts),
+            "y" if len(retry_parts) == 1 else "ies",
+            task,
+            feature,
+            tools or "output",
+        )
+
+
 def record_agent_usage(
     result: Any,
     *,
@@ -68,6 +99,9 @@ def record_agent_usage(
     ``user_id`` is optional: pass it where the actor is in scope (routes with a
     ``deps.user_id`` / request body) for per-user rollups; omit it and the
     request_id from the contextvar still attributes the row.
+
+    Also warns when the run only succeeded after validation retries (#153) —
+    same guarded, never-raises contract.
     """
     try:
         events_service.log_llm_usage(
@@ -79,4 +113,8 @@ def record_agent_usage(
         )
     except Exception:
         logger.debug("record_agent_usage: could not capture usage", exc_info=True)
+    try:
+        _log_recovered_retries(result, task, feature)
+    except Exception:
+        logger.debug("record_agent_usage: retry observability slipped", exc_info=True)
     return result

--- a/backend/routes/documents.py
+++ b/backend/routes/documents.py
@@ -179,7 +179,15 @@ def _extend_course_concepts(
         "administrative items.\n"
         "- concepts must be a JSON array of strings."
     )
-    raw = call_gemini_json(prompt, model=MODEL_LITE, feature="document")
+    try:
+        raw = call_gemini_json(prompt, model=MODEL_LITE, feature="document")
+    except ValueError:
+        # #153 defensive-parsing: call_gemini_json raises ValueError on
+        # non-JSON model output. This is the last-resort legacy path (the
+        # concept_scan agent already failed), so degrade to "no new
+        # concepts" rather than 500 the scan route. Until #151 retires it.
+        logger.exception("legacy concept scan returned non-JSON; degrading to []")
+        return []
     if not isinstance(raw, dict):
         return []
     return _coerce_str_list(raw.get("concepts"))
@@ -367,7 +375,19 @@ def _process_document(filename: str, extracted_text: str) -> dict:
         "\n"
         '"concept_notes" must be a JSON array of {"name": str, "description": str} objects.'
     )
-    raw = call_gemini_json(prompt, feature="document")
+    try:
+        raw = call_gemini_json(prompt, feature="document")
+    except ValueError:
+        # #153 defensive-parsing: non-JSON model output on the last-resort
+        # legacy pipeline (the agent path already failed) must not become a
+        # raw 500 on upload — degrade to the same safe shape a non-dict
+        # reply gets (category "other", empty summary/concepts), so the
+        # document row still persists. Until #151 retires this path.
+        logger.exception(
+            "legacy document processing returned non-JSON; degrading to "
+            "minimal shape"
+        )
+        raw = {}
     if not isinstance(raw, dict):
         raw = {}
 

--- a/backend/routes/learn.py
+++ b/backend/routes/learn.py
@@ -714,6 +714,18 @@ async def _chat_via_agent(
     )
     reply = result.output  # str — chat_tutor agents return plain Markdown.
 
+    if not reply.strip():
+        # #153 / ADR-0023 follow-up: gemini-2.5-pro occasionally follows an
+        # end-of-turn tool call with a bare-newline final text. On this JSON
+        # path that whitespace IS the run output; treat it as degenerate
+        # model output so the caller's UnexpectedModelBehavior handler
+        # degrades to the legacy pipeline instead of persisting an empty
+        # assistant row. (The streamed path handles the same quirk inside
+        # `stream_agent_turn`.) Usage was recorded above — tokens were spent.
+        raise UnexpectedModelBehavior(
+            "chat_tutor produced a whitespace-only reply"
+        )
+
     # Merge all graph update payloads accumulated by tools during this run
     # into a single dict so the route can persist graph_update_json and
     # end_session can derive concepts_covered correctly.

--- a/backend/services/chat_stream.py
+++ b/backend/services/chat_stream.py
@@ -101,6 +101,44 @@ def _tool_name_from(event: Any) -> str | None:
     return None
 
 
+async def _rung1_fallback_events(
+    legacy_fallback: Callable[[], Awaitable[dict]] | None,
+    request_id: str,
+) -> AsyncIterator[SaplingEvent]:
+    """The Rung-1 tail shared by 'agent failed before text' and 'agent
+    finished but produced a blank reply' (#153): degrade to the route's
+    legacy path when one exists, else a terminal `error`. The legacy path
+    owns its own persistence, so callers must NOT also run on_complete."""
+    if legacy_fallback is None:
+        yield SaplingEvent(
+            type="error",
+            step="reply",
+            message="The tutor is unavailable. Please retry.",
+            data={"request_id": request_id},
+        )
+        return
+    try:
+        legacy = await legacy_fallback()
+    except Exception:
+        logger.exception("Legacy fallback also failed")
+        yield SaplingEvent(
+            type="error",
+            step="reply",
+            message="The tutor is unavailable. Please retry.",
+            data={"request_id": request_id},
+        )
+        return
+    # legacy_fallback persisted its own rows; the caller must NOT call
+    # on_complete after this.
+    yield SaplingEvent(
+        type="token", step="reply", message="",
+        data={"delta": legacy.get("reply", "")},
+    )
+    yield SaplingEvent(
+        type="done", step="reply", message="Complete.", data=legacy
+    )
+
+
 async def stream_agent_turn(
     *,
     agent: Any,
@@ -123,9 +161,11 @@ async def stream_agent_turn(
     final `AgentRunResult` after the stream completes, BEFORE on_complete —
     tokens were spent even if persistence subsequently fails. Routes pass
     `agents.usage.record_agent_usage` here. Not called on the error rungs
-    (no result event was seen) nor on the legacy fallback, whose usage is
-    captured inside `call_gemini_multiturn` (feature=). A hook failure is
-    swallowed: usage capture must never break the stream.
+    (no result event was seen) nor on the Rung-1 legacy fallback, whose
+    usage is captured inside `call_gemini_multiturn` (feature=). It IS
+    called on the degenerate blank-reply rung (#153) — there the agent run
+    completed and billed before its output was judged unusable. A hook
+    failure is swallowed: usage capture must never break the stream.
 
     legacy_fallback() -> awaitable returning the route's pre-agent result,
     used ONLY when the agent fails before emitting any text (Rung 1). It is
@@ -138,6 +178,12 @@ async def stream_agent_turn(
     streamed), Rung 1 with no fallback, and a Rung-1 fallback that itself
     raises all yield an `error` event and persist nothing (regression-tested
     in test_chat_stream.py).
+
+    A run that COMPLETES with a whitespace-only reply (#153: gemini-2.5-pro
+    sometimes emits a bare-newline final text after an end-of-turn tool
+    call) is degenerate, not a success: the joined streamed chunks stand in
+    when they carry real text; otherwise the turn takes the Rung-1 ladder
+    above rather than persisting an empty assistant row.
     """
     yield SaplingEvent(type="status", step="start", message="Starting.")
 
@@ -207,47 +253,47 @@ async def stream_agent_turn(
 
         # Rung 1: nothing shown yet — degrade to the route's legacy path.
         logger.warning("Chat agent failed before first token; using legacy", exc_info=exc)
-        if legacy_fallback is None:
-            yield SaplingEvent(
-                type="error",
-                step="reply",
-                message="The tutor is unavailable. Please retry.",
-                data={"request_id": request_id},
-            )
-            return
-        try:
-            legacy = await legacy_fallback()
-        except Exception:
-            logger.exception("Legacy fallback also failed")
-            yield SaplingEvent(
-                type="error",
-                step="reply",
-                message="The tutor is unavailable. Please retry.",
-                data={"request_id": request_id},
-            )
-            return
-        # legacy_fallback persisted its own rows; do NOT call on_complete.
-        yield SaplingEvent(
-            type="token", step="reply", message="",
-            data={"delta": legacy.get("reply", "")},
-        )
-        yield SaplingEvent(
-            type="done", step="reply", message="Complete.", data=legacy
-        )
+        async for ev in _rung1_fallback_events(legacy_fallback, request_id):
+            yield ev
         return
 
-    reply = final_output if final_output is not None else "".join(chunks)
-    merged = merge_graph_updates(deps.graph_updates)
-    mastery = list(deps.mastery_changes)
+    joined = "".join(chunks)
+    reply = final_output if final_output is not None else joined
 
     # Usage first, persistence second: the tokens were spent regardless of
-    # whether on_complete manages to persist. Guarded — instrumentation must
-    # never turn a fully-streamed reply into an error event.
+    # whether on_complete manages to persist — including on the degenerate
+    # blank-reply rung below, where the agent run DID complete and bill.
+    # Guarded — instrumentation must never turn a streamed reply into an
+    # error event.
     if on_usage is not None and run_result is not None:
         try:
             on_usage(run_result)
         except Exception:
             logger.debug("on_usage hook failed; usage row dropped", exc_info=True)
+
+    if not reply.strip():
+        # Degenerate output (#153, ADR-0023 follow-up): gemini-2.5-pro
+        # occasionally follows an end-of-turn tool call with a bare-newline
+        # final text, making the run OUTPUT whitespace-only. The real reply
+        # may still have streamed earlier in the turn — prefer the joined
+        # chunks. If nothing non-blank streamed either, never persist an
+        # empty assistant row: degrade exactly like Rung 1 (legacy fallback
+        # owns the turn, or a terminal `error` without one). Tool writes
+        # that already landed stay, matching the existing Rung-1 contract
+        # for a failure after a tool write.
+        if joined.strip():
+            reply = joined
+        else:
+            logger.warning(
+                "Agent turn produced a blank reply (%d graph write(s) "
+                "already applied); degrading to Rung 1", graph_hw,
+            )
+            async for ev in _rung1_fallback_events(legacy_fallback, request_id):
+                yield ev
+            return
+
+    merged = merge_graph_updates(deps.graph_updates)
+    mastery = list(deps.mastery_changes)
 
     try:
         extra = on_complete(reply, merged, mastery) or {}

--- a/backend/services/chat_stream.py
+++ b/backend/services/chat_stream.py
@@ -283,10 +283,30 @@ async def stream_agent_turn(
         # for a failure after a tool write.
         if joined.strip():
             reply = joined
+        elif deps.graph_updates or deps.mastery_changes:
+            # Tool writes ALREADY LANDED this turn (append-only mastery
+            # events, graph upserts). The legacy fallback would re-run the
+            # whole turn and apply_graph_update AGAIN — double mastery for
+            # one student turn (PR #470 review). A terminal error is the
+            # honest degrade: the writes stay (they were real tool actions),
+            # nothing is persisted to the transcript, and the client's
+            # ADR-0020 interrupted+Retry treatment applies.
+            logger.warning(
+                "Agent turn produced a blank reply AFTER %d graph write(s); "
+                "terminal error instead of a fallback that would re-apply "
+                "them", len(deps.graph_updates) + len(deps.mastery_changes),
+            )
+            yield SaplingEvent(
+                type="error",
+                step="reply",
+                message="The tutor was interrupted. Please retry.",
+                data={"request_id": request_id},
+            )
+            return
         else:
             logger.warning(
-                "Agent turn produced a blank reply (%d graph write(s) "
-                "already applied); degrading to Rung 1", graph_hw,
+                "Agent turn produced a blank reply and no writes; "
+                "degrading to Rung 1",
             )
             async for ev in _rung1_fallback_events(legacy_fallback, request_id):
                 yield ev

--- a/backend/tests/test_agent_output_schemas.py
+++ b/backend/tests/test_agent_output_schemas.py
@@ -1,0 +1,284 @@
+"""Structural pins for every agent's output schema and retry budget (#153).
+
+Codifies docs/attempts/2026-05-03-orchestrator-schema-complexity.md: Gemini's
+native structured-output API compiles the output schema into a constrained-
+decoding automaton and rejects rich schemas outright ("too many states for
+serving") — the request 400s before the model runs. The budget lives in the
+agents/__init__.py docstring; this module makes it executable so the next
+rich schema fails in CI, not in production against Gemini.
+
+Two layers:
+
+1. Discovery — walk every module in ``backend/agents`` and collect every
+   ``pydantic_ai.Agent`` instance, then assert the roster matches the frozen
+   expectation. A new agent must be added here consciously, which is what
+   keeps the retry-policy sets below honest.
+2. Budget — every structured output model must satisfy:
+     - at most 8 properties per object;
+     - at most one level of object nesting below the root
+       (root -> list[Item] is the ceiling);
+     - no optional NESTED models (``Sub | None``) — optional scalars are fine;
+     - enum/const values are plain strings (flat enums, not patterned
+       strings);
+     - at most 20 properties across the whole schema.
+   ``DocumentProcessingResult`` — the exact schema Gemini rejected on
+   2026-05-03 — is kept as the negative control: the checker must flag it.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import pytest
+from pydantic import BaseModel
+from pydantic_ai import Agent
+
+import agents as agents_pkg
+from agents.document import DocumentProcessingResult
+
+# ── Budget constants (see agents/__init__.py docstring) ───────────────────
+
+MAX_PROPERTIES_PER_OBJECT = 8
+MAX_OBJECT_DEPTH = 2
+MAX_TOTAL_PROPERTIES = 20
+
+# Modules that never define agents. `function_handlers_e2e` self-registers
+# E2E seam handlers on import — never import it from the hermetic lane.
+_SKIP_MODULES = {"function_handlers_e2e"}
+
+# name -> has structured (BaseModel) output. Free-text (str) agents have no
+# output validation to retry; the streaming tutor's failure handling belongs
+# to chat_stream's rung ladder, never a hidden re-roll.
+EXPECTED_STRUCTURED_AGENTS = {
+    "classifier_agent",
+    "concept_describe_agent",
+    "concept_extraction_agent",
+    "concept_scan_agent",
+    "course_summary_agent",
+    "flashcard_agent",
+    "note_concepts_agent",
+    "note_summary_agent",
+    "quiz_agent",
+    "quiz_context_agent",
+    "social_summary_agent",
+    "study_guide_agent",
+    "summary_agent",
+    "syllabus_extraction_agent",
+}
+EXPECTED_TEXT_AGENTS = {
+    "expository_agent",
+    "health_probe_agent",
+    "note_chat_agent",
+    "ocr_vision_agent",
+    "socratic_agent",
+    "teachback_agent",
+}
+
+OUTPUT_RETRY_BUDGET = 2  # structured agents: 1 initial + 2 validation retries
+
+
+def _discover_agents() -> dict[str, Agent]:
+    """Every Agent instance defined anywhere in the agents package, deduped
+    by identity (workers are re-imported by agents/document.py)."""
+    found: dict[int, tuple[str, Agent]] = {}
+    for info in pkgutil.iter_modules(agents_pkg.__path__):
+        if info.name.startswith("_") or info.name in _SKIP_MODULES:
+            continue
+        module = importlib.import_module(f"agents.{info.name}")
+        for attr_name in dir(module):
+            if attr_name.startswith("_"):
+                continue
+            obj = getattr(module, attr_name)
+            if isinstance(obj, Agent):
+                found.setdefault(id(obj), (attr_name, obj))
+    return {name: agent for name, agent in found.values()}
+
+
+AGENTS = _discover_agents()
+
+
+def _output_model(agent: Agent) -> type[BaseModel] | None:
+    """The agent's declared output model, unwrapping PromptedOutput; None for
+    free-text (str) agents."""
+    output_type = agent.output_type
+    # PromptedOutput wraps the model in `.outputs` (same attribute on 1.89
+    # and 1.107).
+    output_type = getattr(output_type, "outputs", output_type)
+    if isinstance(output_type, type) and issubclass(output_type, BaseModel):
+        return output_type
+    assert output_type is str, (
+        f"unexpected output_type {output_type!r} — extend this test's "
+        "classification before shipping a new output shape"
+    )
+    return None
+
+
+def _output_retry_budget(agent: Agent) -> int:
+    """Version-portable read of the output-validation retry budget:
+    `_max_result_retries` on pydantic-ai 1.89, `_max_output_retries` on
+    1.107+. Must be an int — a dict here means someone configured
+    `retries={"output": ...}`, which 1.89 mis-stores into the retry counter
+    and blows up with TypeError at retry time."""
+    for attr in ("_max_output_retries", "_max_result_retries"):
+        value = getattr(agent, attr, None)
+        if value is not None:
+            assert isinstance(value, int), (
+                f"{attr} is {value!r} — dict-form retries break pydantic-ai "
+                "1.89; use output_retries=<int> (or retries=<int> on "
+                "tool-less agents)"
+            )
+            return value
+    raise AssertionError(
+        "could not read the output-retry budget off this pydantic-ai "
+        "version; update _output_retry_budget"
+    )
+
+
+# ── Schema walker ─────────────────────────────────────────────────────────
+
+
+def _resolve(node: dict, defs: dict) -> dict:
+    while "$ref" in node:
+        name = node["$ref"].split("/")[-1]
+        node = defs[name]
+    return node
+
+
+def schema_violations(model: type[BaseModel]) -> list[str]:
+    """All budget violations for a model's JSON schema (empty = conforms)."""
+    schema = model.model_json_schema()
+    defs = schema.get("$defs", {})
+    violations: list[str] = []
+    total_properties = 0
+
+    def walk(node: dict, depth: int, path: str, optional_ctx: bool) -> None:
+        nonlocal total_properties
+        node = _resolve(node, defs)
+
+        for key in ("anyOf", "oneOf", "allOf"):
+            if key in node:
+                branches = [_resolve(b, defs) for b in node[key]]
+                has_null = any(b.get("type") == "null" for b in branches)
+                for branch in branches:
+                    if branch.get("type") == "null":
+                        continue
+                    walk(branch, depth, path, optional_ctx or has_null)
+                return
+
+        if "enum" in node or "const" in node:
+            values = node.get("enum", [node.get("const")])
+            if not all(isinstance(v, str) for v in values):
+                violations.append(f"{path}: non-string enum values {values!r}")
+
+        node_type = node.get("type")
+        if node_type == "array":
+            walk(node.get("items", {}), depth, f"{path}[]", optional_ctx)
+            return
+        if node_type != "object" and "properties" not in node:
+            return
+
+        # An object below an Optional union is the "nested optional model"
+        # shape that helped kill the orchestrator schema.
+        if optional_ctx and depth >= 1:
+            violations.append(
+                f"{path}: optional nested model (Sub | None) — run a second "
+                "agent or compose in route code instead"
+            )
+        object_depth = depth + 1
+        if object_depth > MAX_OBJECT_DEPTH:
+            violations.append(
+                f"{path}: object nesting depth {object_depth} exceeds "
+                f"{MAX_OBJECT_DEPTH} (root -> list[Item] is the ceiling)"
+            )
+        properties = node.get("properties", {})
+        if len(properties) > MAX_PROPERTIES_PER_OBJECT:
+            violations.append(
+                f"{path}: {len(properties)} properties exceeds "
+                f"{MAX_PROPERTIES_PER_OBJECT} per object"
+            )
+        total_properties += len(properties)
+        for name, sub in properties.items():
+            walk(sub, object_depth, f"{path}.{name}", False)
+
+    walk(schema, 0, model.__name__, False)
+    if total_properties > MAX_TOTAL_PROPERTIES:
+        violations.append(
+            f"{model.__name__}: {total_properties} total properties exceeds "
+            f"{MAX_TOTAL_PROPERTIES}"
+        )
+    return violations
+
+
+# ── Roster ────────────────────────────────────────────────────────────────
+
+
+def test_agent_roster_is_frozen():
+    """Every Agent in backend/agents is classified here. A new agent must be
+    added to exactly one of the expected sets — that's the moment to decide
+    its output shape (budget above) and retry policy (#153)."""
+    assert set(AGENTS) == EXPECTED_STRUCTURED_AGENTS | EXPECTED_TEXT_AGENTS
+
+
+def test_roster_classification_matches_output_types():
+    for name in EXPECTED_STRUCTURED_AGENTS:
+        assert _output_model(AGENTS[name]) is not None, f"{name} is not structured"
+    for name in EXPECTED_TEXT_AGENTS:
+        assert _output_model(AGENTS[name]) is None, f"{name} is not free-text"
+
+
+# ── Budget ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_STRUCTURED_AGENTS))
+def test_output_schema_within_budget(name):
+    model = _output_model(AGENTS[name])
+    violations = schema_violations(model)
+    assert violations == [], (
+        f"{name} output schema exceeds the structured-output budget "
+        f"(agents/__init__.py):\n- " + "\n- ".join(violations)
+    )
+
+
+def test_negative_control_rich_schema_is_rejected():
+    """DocumentProcessingResult is the exact composed-result schema Gemini's
+    structured-output API rejected on 2026-05-03 (it is composed in code by
+    agents/document.py, never used as an output_type). The checker must flag
+    it — if this passes cleanly, the budget rules have gone soft."""
+    violations = schema_violations(DocumentProcessingResult)
+    assert violations, "the checker no longer catches the schema Gemini rejected"
+    text = "\n".join(violations)
+    assert "optional nested model" in text or "nesting depth" in text
+
+
+# ── Retry policy (#153) ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_STRUCTURED_AGENTS))
+def test_structured_agents_have_bounded_output_retries(name):
+    assert _output_retry_budget(AGENTS[name]) == OUTPUT_RETRY_BUDGET
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_TEXT_AGENTS))
+def test_text_agents_keep_default_retry_budget(name):
+    """Free-text agents have no output schema to retry against; the tutor
+    path in particular must never gain a hidden re-roll — its failure
+    handling is chat_stream's rung ladder."""
+    assert _output_retry_budget(AGENTS[name]) == 1
+
+
+def test_quiz_tool_retries_stay_default():
+    """quiz sets output_retries only — its three read tools keep the default
+    tool-retry budget (bumping tool retries was not in #153's scope)."""
+    assert AGENTS["quiz_agent"]._max_tool_retries == 1
+
+
+def test_worker_request_limit_fits_the_retry_ladder():
+    """WORKER_LIMITS must admit 1 initial request + OUTPUT_RETRY_BUDGET
+    retries: at request_limit=2 the final retry trips UsageLimitExceeded
+    instead of UnexpectedModelBehavior, which misfiles "model kept emitting
+    garbage" as "input too long" at routes that distinguish the two
+    (routes/notes.py 413-vs-500)."""
+    from agents import WORKER_LIMITS
+
+    assert WORKER_LIMITS.request_limit == 1 + OUTPUT_RETRY_BUDGET

--- a/backend/tests/test_chat_stream.py
+++ b/backend/tests/test_chat_stream.py
@@ -388,10 +388,12 @@ def test_blank_final_output_falls_back_to_streamed_chunks():
     asyncio.run(run())
 
 
-def test_blank_reply_after_tool_call_uses_legacy_fallback():
-    """Tool call then ONLY whitespace text: nothing meaningful was shown, so
-    the turn degrades like Rung 1 — legacy owns the reply and persistence;
-    on_complete must NOT run (an empty assistant row must never persist)."""
+def test_blank_reply_after_tool_call_with_writes_is_terminal_error():
+    """Tool call (which WROTE mastery) then only whitespace text: the legacy
+    fallback must NOT run — it would re-run the turn and apply_graph_update
+    AGAIN, double-counting one student turn in the append-only mastery
+    ledger (PR #470 review). Terminal error instead: the tool writes stay,
+    nothing persists to the transcript, the client offers Retry."""
     async def run():
         deps = make_deps()
 
@@ -406,8 +408,10 @@ def test_blank_reply_after_tool_call_uses_legacy_fallback():
         ])
         on_complete_calls = []
         usage_calls = []
+        fallback_calls = []
 
         async def fake_legacy():
+            fallback_calls.append(1)
             return {"reply": "legacy reply", "graph_update": {}, "mastery_changes": []}
 
         events = await collect(
@@ -416,15 +420,45 @@ def test_blank_reply_after_tool_call_uses_legacy_fallback():
             legacy_fallback=fake_legacy,
             on_usage=lambda res: usage_calls.append(res),
         )
-        assert events[-1].type == "done"
-        assert events[-1].data["reply"] == "legacy reply"
+        assert events[-1].type == "error"
+        assert fallback_calls == [], (
+            "a fallback after real tool writes would double-apply mastery"
+        )
         assert on_complete_calls == [], (
-            "legacy owns persistence — a blank agent turn must not also persist"
+            "nothing persists to the transcript on the terminal-error rung"
         )
         # The agent run completed and billed tokens even though its reply was
-        # blank — its usage is still recorded (legacy records its own inside
-        # call_gemini_multiturn).
+        # blank — its usage is still recorded.
         assert len(usage_calls) == 1
+        # The mastery write the tool made is untouched — it was a real action.
+        assert deps.mastery_changes
+
+    asyncio.run(run())
+
+
+def test_blank_reply_with_no_writes_still_takes_legacy_fallback():
+    """The no-writes twin: a blank turn whose tools wrote NOTHING degrades to
+    the legacy fallback exactly as before — re-running is safe when there is
+    nothing to double-apply."""
+    async def run():
+        deps = make_deps()
+        agent = FakeAgent([
+            PartStartEvent("\n"),
+            AgentRunResultEvent("\n"),
+        ])
+        on_complete_calls = []
+
+        async def fake_legacy():
+            return {"reply": "legacy reply", "graph_update": {}, "mastery_changes": []}
+
+        events = await collect(
+            agent, deps,
+            on_complete=lambda r, g, m: on_complete_calls.append(r),
+            legacy_fallback=fake_legacy,
+        )
+        assert events[-1].type == "done"
+        assert events[-1].data["reply"] == "legacy reply"
+        assert on_complete_calls == []
 
     asyncio.run(run())
 
@@ -546,3 +580,4 @@ def test_on_usage_not_called_on_error_rungs_or_legacy_fallback():
         assert usage_calls == [], "an aborted run has no result to record"
 
     asyncio.run(run())
+

--- a/backend/tests/test_chat_stream.py
+++ b/backend/tests/test_chat_stream.py
@@ -356,6 +356,122 @@ def test_on_complete_raising_yields_error_not_unhandled_exception():
     asyncio.run(run())
 
 
+# ── degenerate blank reply (#153, ADR-0023 follow-up) ─────────────────────
+#
+# Observed live while recording the #149 eval cassettes: with the "call
+# update_mastery at the END of the turn" guidance, gemini-2.5-pro sometimes
+# follows the final tool return with a bare-newline text part (2/3 rolls on
+# one expository case). Without special handling that whitespace becomes the
+# run OUTPUT, and the turn persists an empty assistant row + streams a blank
+# bubble. The rungs below pin the fix.
+
+def test_blank_final_output_falls_back_to_streamed_chunks():
+    """A whitespace-only final output after tool activity must not clobber
+    the real reply text that already streamed earlier in the turn."""
+    async def run():
+        agent = FakeAgent([
+            PartStartEvent("The slope tells you the direction. "),
+            FunctionToolCallEvent("update_mastery_tool"),
+            FunctionToolResultEvent(),
+            PartStartEvent("\n"),               # the degenerate final text
+            AgentRunResultEvent("\n"),          # output == bare newline
+        ])
+        saved = {}
+        events = await collect(agent, make_deps(), lambda r, g, m: saved.update(reply=r) or {})
+        assert events[-1].type == "done"
+        assert saved["reply"] == "The slope tells you the direction. \n", (
+            "the joined streamed chunks are the real reply — the blank "
+            "output must not be persisted in their place"
+        )
+        assert events[-1].data["reply"] == saved["reply"]
+
+    asyncio.run(run())
+
+
+def test_blank_reply_after_tool_call_uses_legacy_fallback():
+    """Tool call then ONLY whitespace text: nothing meaningful was shown, so
+    the turn degrades like Rung 1 — legacy owns the reply and persistence;
+    on_complete must NOT run (an empty assistant row must never persist)."""
+    async def run():
+        deps = make_deps()
+
+        def write():
+            deps.mastery_changes.append({"concept": "Slope", "before": 0.2, "after": 0.4})
+
+        agent = FakeAgent([
+            FunctionToolCallEvent("update_mastery_tool"),
+            FunctionToolResultEvent(on_fire=write),
+            PartStartEvent("\n"),
+            AgentRunResultEvent("\n"),
+        ])
+        on_complete_calls = []
+        usage_calls = []
+
+        async def fake_legacy():
+            return {"reply": "legacy reply", "graph_update": {}, "mastery_changes": []}
+
+        events = await collect(
+            agent, deps,
+            on_complete=lambda r, g, m: on_complete_calls.append(r),
+            legacy_fallback=fake_legacy,
+            on_usage=lambda res: usage_calls.append(res),
+        )
+        assert events[-1].type == "done"
+        assert events[-1].data["reply"] == "legacy reply"
+        assert on_complete_calls == [], (
+            "legacy owns persistence — a blank agent turn must not also persist"
+        )
+        # The agent run completed and billed tokens even though its reply was
+        # blank — its usage is still recorded (legacy records its own inside
+        # call_gemini_multiturn).
+        assert len(usage_calls) == 1
+
+    asyncio.run(run())
+
+
+def test_blank_reply_without_fallback_errors_and_persists_nothing():
+    async def run():
+        agent = FakeAgent([
+            FunctionToolCallEvent("update_mastery_tool"),
+            FunctionToolResultEvent(),
+            PartStartEvent("\n"),
+            AgentRunResultEvent("\n"),
+        ])
+        on_complete_calls = []
+        events = await collect(
+            agent, make_deps(),
+            on_complete=lambda r, g, m: on_complete_calls.append(r),
+        )
+        assert events[-1].type == "error"
+        assert events[-1].data["request_id"] == "r1"
+        assert all(e.type != "done" for e in events)
+        assert on_complete_calls == [], "an empty assistant row must never persist"
+
+    asyncio.run(run())
+
+
+def test_blank_reply_fallback_failure_is_terminal_error():
+    """Blank agent turn + a legacy fallback that itself raises → structured
+    error, nothing persisted (mirrors the Rung-1 fallback-failure contract)."""
+    async def run():
+        agent = FakeAgent([PartStartEvent("\n"), AgentRunResultEvent("\n")])
+        on_complete_calls = []
+
+        async def bad_legacy():
+            raise RuntimeError("legacy also down")
+
+        events = await collect(
+            agent, make_deps(),
+            on_complete=lambda r, g, m: on_complete_calls.append(r),
+            legacy_fallback=bad_legacy,
+        )
+        assert events[-1].type == "error"
+        assert all(e.type != "done" for e in events)
+        assert on_complete_calls == []
+
+    asyncio.run(run())
+
+
 # ── on_usage hook (#118) ──────────────────────────────────────────────────
 
 def test_on_usage_called_once_with_run_result_before_done():

--- a/backend/tests/test_documents_routes.py
+++ b/backend/tests/test_documents_routes.py
@@ -343,6 +343,44 @@ class TestProcessDocumentHelper:
         assert result["concept_notes"] == []
         assert result["assignments"] == []
 
+    def test_non_json_model_output_degrades_to_safe_shape(self):
+        """#153 defensive-parsing: `call_gemini_json` raises ValueError when
+        the model emits non-JSON. This helper runs on the LAST-RESORT legacy
+        path (the agent pipeline already failed), so a parse failure must
+        degrade to the same safe shape as a non-dict response — never
+        propagate into a raw 500 on upload."""
+        with patch(
+            "routes.documents.call_gemini_json",
+            side_effect=ValueError("Gemini response was not valid JSON"),
+        ):
+            result = _process_document("file.pdf", "text")
+
+        assert result["category"] == "other"
+        assert result["summary"] == ""
+        assert result["concepts"] == []
+        assert result["concept_notes"] == []
+        assert result["assignments"] == []
+        assert result["categories"] == []
+
+
+class TestExtendCourseConceptsLegacyParsing:
+    """#153 defensive-parsing for the OTHER remaining raw call_gemini_json
+    path: the legacy concept-scan fallback must swallow a non-JSON model
+    reply as 'no new concepts', not 500 the scan route (it only runs after
+    the concept_scan agent already failed)."""
+
+    def test_non_json_model_output_returns_empty_list(self):
+        from routes.documents import _extend_course_concepts
+
+        with patch(
+            "routes.documents.call_gemini_json",
+            side_effect=ValueError("Gemini response was not valid JSON"),
+        ):
+            assert _extend_course_concepts(
+                course_label="CS101",
+                existing_concepts=["Recursion"],
+            ) == []
+
 
 class TestUploadDocument:
     @pytest.fixture(autouse=True)

--- a/backend/tests/test_learn_routes.py
+++ b/backend/tests/test_learn_routes.py
@@ -571,6 +571,26 @@ class TestChatViaAgent:
         assert r.status_code == 200
         assert r.json()["reply"] == "L"
 
+    def test_blank_agent_reply_falls_back_to_legacy(self):
+        """#153 / ADR-0023 follow-up: a whitespace-only agent reply (the
+        bare-newline-after-tool-call quirk on the JSON path) is degenerate
+        model output, not a success — it must degrade to the legacy path
+        instead of persisting an empty assistant row."""
+        from types import SimpleNamespace
+        agent = MagicMock()
+        agent.run = AsyncMock(return_value=SimpleNamespace(output="\n"))
+        with (
+            patch("routes.learn.table", side_effect=self._make_table_factory()),
+            patch("routes.learn.agent_for_mode", return_value=agent),
+            patch("routes.learn.get_graph", return_value={"nodes": [], "edges": []}),
+            patch("routes.learn.apply_graph_update", return_value=[]),
+            patch("routes.learn.call_gemini_multiturn", return_value="LEGACY REPLY"),
+            patch("routes.learn.extract_graph_update", return_value=("LEGACY REPLY", {})),
+        ):
+            r = self._post()
+        assert r.status_code == 200
+        assert r.json()["reply"] == "LEGACY REPLY"
+
     def test_message_history_loaded_with_decryption(self):
         """`_load_message_history` calls `decrypt_if_present` on each row's
         `content` so the agent never receives ciphertext."""

--- a/backend/tests/test_output_retry_hardening.py
+++ b/backend/tests/test_output_retry_hardening.py
@@ -1,0 +1,165 @@
+"""Behavioral acceptance for #153: structured-output retry + degradation.
+
+The issue's acceptance criterion, pinned end to end: a deliberately malformed
+model output retries (bounded — the #153 budget of 2), then degrades to a
+TYPED error, never a raw 500. Runs on the SAPLING_MODEL_MODE=function seam so
+the REAL output-tool registration, schema validation, and retry loop execute
+(a mocked `agent.run` would prove nothing about retry behavior).
+
+Also pins the observability half: a run that only succeeded after a
+validation retry logs a warning via `record_agent_usage` (#153 chose a log
+line over a new #117 event — the frozen taxonomy stays untouched).
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+
+from agents import WORKER_LIMITS
+from agents._providers import (
+    clear_function_handlers,
+    model_for,
+    register_function_handler,
+)
+from agents.deps import SaplingDeps
+from agents.note_summary import note_summary_agent
+from agents.quiz import quiz_agent
+from agents.usage import record_agent_usage
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clean_function_registry():
+    clear_function_handlers()
+    yield
+    clear_function_handlers()
+
+
+def _deps() -> SaplingDeps:
+    return SaplingDeps(
+        user_id="retry-user",
+        course_id="retry-course",
+        supabase=None,
+        request_id="retry-req",
+    )
+
+
+def _garbage(messages, info) -> ModelResponse:
+    """A response that can never satisfy a structured output schema: plain
+    text where the output tool call is required."""
+    return ModelResponse(parts=[TextPart(content="i am not structured output")])
+
+
+def test_malformed_output_retries_twice_then_raises_umb_within_worker_budget(
+    monkeypatch,
+):
+    """1 initial + 2 validation retries, then UnexpectedModelBehavior — and
+    specifically NOT UsageLimitExceeded: WORKER_LIMITS.request_limit=3 must
+    admit the whole retry ladder, or routes that map the two exceptions
+    differently (notes' 413-vs-500) misfile persistent garbage as an
+    over-budget input."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    calls = {"n": 0}
+
+    def handler(messages, info) -> ModelResponse:
+        calls["n"] += 1
+        return _garbage(messages, info)
+
+    register_function_handler("note_summary", handler)
+    with note_summary_agent.override(model=model_for("note_summary")):
+        with pytest.raises(UnexpectedModelBehavior):
+            note_summary_agent.run_sync(
+                "Summarize this note.", deps=_deps(), usage_limits=WORKER_LIMITS
+            )
+    assert calls["n"] == 3, "expected 1 initial request + 2 bounded retries"
+
+
+def test_recovered_validation_retry_is_logged(monkeypatch, caplog):
+    """Garbage once, valid on the retry: the run succeeds and
+    record_agent_usage warns with the retry count — the #153 observability
+    contract for retries that would otherwise be invisible."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    calls = {"n": 0}
+
+    def handler(messages, info) -> ModelResponse:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _garbage(messages, info)
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name=info.output_tools[0].name,
+                    args={"summary": "The note explains gradient descent."},
+                )
+            ]
+        )
+
+    register_function_handler("note_summary", handler)
+    with note_summary_agent.override(model=model_for("note_summary")):
+        with caplog.at_level(logging.WARNING, logger="sapling.agents.usage"):
+            result = record_agent_usage(
+                note_summary_agent.run_sync(
+                    "Summarize this note.", deps=_deps(), usage_limits=WORKER_LIMITS
+                ),
+                feature="notes",
+                task="note_summary",
+            )
+    assert calls["n"] == 2
+    assert result.output.summary == "The note explains gradient descent."
+    assert "recovered after 1 validation retry" in caplog.text
+    assert "task=note_summary" in caplog.text
+
+
+def test_quiz_route_degrades_to_typed_502_after_bounded_retries(monkeypatch):
+    """The issue's acceptance criterion at the HTTP boundary: persistent
+    malformed output exhausts the bounded retries and surfaces as the
+    route's TYPED 502 (JSON detail + request-correlatable log), never a raw
+    500 traceback."""
+    monkeypatch.setenv("SAPLING_MODEL_MODE", "function")
+    calls = {"n": 0}
+
+    def handler(messages, info) -> ModelResponse:
+        calls["n"] += 1
+        return _garbage(messages, info)
+
+    register_function_handler("quiz", handler)
+
+    def factory(name):
+        mock = MagicMock()
+        if name == "graph_nodes":
+            mock.select.return_value = [{
+                "id": "node1",
+                "user_id": "user_andres",
+                "course_id": "course1",
+                "concept_name": "Derivatives",
+                "mastery_score": 0.4,
+            }]
+        else:
+            mock.select.return_value = []
+            mock.insert.return_value = []
+        return mock
+
+    with (
+        patch("routes.quiz.table", side_effect=factory),
+        patch("routes.quiz._course_material_block", return_value=""),
+        quiz_agent.override(model=model_for("quiz")),
+    ):
+        r = client.post("/api/quiz/generate", json={
+            "user_id": "user_andres",
+            "concept_node_id": "node1",
+            "num_questions": 3,
+            "difficulty": "medium",
+            "use_shared_context": False,
+        })
+
+    assert r.status_code == 502, r.text
+    assert "temporarily unavailable" in r.json()["detail"]
+    assert calls["n"] == 3, "expected 1 initial request + 2 bounded retries"

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -592,7 +592,10 @@ function LearnInner() {
       try {
         const res = await startSessionStream(userId, topicName, mode, sharedCtx, selectedCourseId || undefined, modelPref, {
           onToken: (delta) => {
-            sawToken = true;
+            // Whitespace-only deltas don't count as "the user saw content" —
+            // a degenerate blank stream must take the transparent Rung-3
+            // retry, not the manual-Retry Rung-2 branch (PR #470 review).
+            if (delta.trim()) sawToken = true;
             setStreamingText(prev => (prev ?? "") + delta);
           },
           onGraphUpdate: applyGraphDelta,
@@ -757,7 +760,8 @@ function LearnInner() {
       try {
         res = await streamChat(sessionId, userId, userText, mode, sharedCtx, modelPref, {
           onToken: (delta) => {
-            sawToken = true;
+            // Same whitespace rule as beginSession's onToken above.
+            if (delta.trim()) sawToken = true;
             acc += delta;
             setStreamingText(t => (t ?? "") + delta);
           },


### PR DESCRIPTION
## What

Second link of the B7 seam-endgame chain. The failure-mapping half of the issue was already true on this base (re-verified route by route); what landed:

- **The schema budget, codified and enforced**: a structural test auto-discovers all 20 registered agents and walks every structured output's JSON schema against the documented budget — with the exact schema Gemini rejected in the 2026-05-03 attempt kept as a negative control. A future rich schema fails in CI, not against provider 400s.
- **Output retries (2) on all 14 structured-output agents** — including a real dep-universe catch: pydantic-ai 1.107's recommended `retries={"output": 2}` dict form **silently breaks 1.89 at retry time** (reproduced empirically); the correct-everywhere kwarg is used and the structural test rejects the dict form. `WORKER_LIMITS` bumped so the last retry surfaces as `UnexpectedModelBehavior`, not a misfiled `UsageLimitExceeded`. Free-text agents (the streaming tutor especially) deliberately untouched — that's the rung ladder's jurisdiction. Recovered retries get a warning log; the #117 taxonomy is untouched.
- **The ADR-0023 bare-newline tutor reply**, fixed at the stream layer: whitespace-only completed replies prefer the joined streamed chunks, else take the Rung-1 ladder — never an empty persisted assistant row, `on_usage` still fires, and the at-most-one-of persistence invariant holds (all 13 prior invariant tests untouched-green).
- **Legacy `call_gemini_json` sites** degrade cleanly on non-JSON instead of 500ing the last-resort path (both retire in #151).

## Verification

- Backend **1490 passed** + ruff clean (1.89 venv); **354 passed** across all affected files under the lock-pinned **1.107** venv; evals replay green across all six datasets **under both venvs** (cassettes untouched by design — no prompt changes).
- 7 red-first tests (blank-reply ladder ×4, blank JSON-path fallback, non-JSON degrades ×2) + a function-mode acceptance suite pinning exactly-3-requests → typed 502.
- Full local e2e cycle pre-merge; results below.

Closes #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded validation retries for generated summaries, quizzes, flashcards, study materials, and other structured content.
  * Improved recovery when generated content is malformed or incomplete.

* **Bug Fixes**
  * Prevented blank responses from being saved as successful chat messages.
  * Added safe fallbacks for invalid model responses, including typed temporary-unavailability errors.
  * Improved streamed chat handling when responses contain only whitespace.

* **Reliability**
  * Added warnings when content succeeds after validation retries.
  * Expanded automated coverage for schema limits, retries, fallbacks, and streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->