### PR TITLE
feat(study): semester-scope the study-tool reads (#141 reframe)

### DIFF
--- a/backend/routes/flashcards.py
+++ b/backend/routes/flashcards.py
@@ -113,14 +113,17 @@ def _get_course_documents(
     user_id: str, course_name: str, semester: str | None = None
 ) -> list[dict]:
     """
-    Return all library documents for the user that belong to the course
-    matching `course_name`. Falls back to all user documents if no course match.
+    Return the library documents grounding generation for `course_name`.
 
     Documents key on the offering (0025): match the abstract course by name,
     resolve it to the current-term offering — or, with a ``semester`` (#141),
-    STRICTLY to that term's offering — then read documents by offering. A term
-    with no offering of the course contributes no documents; it never falls
-    back to another term's (or all of the user's) material.
+    STRICTLY to that term's offering — then read documents by offering.
+
+    Fallback rules (#475 F2): with a ``semester``, a term with no offering of
+    the course AND a course-name miss both contribute NO documents — an
+    explicit term gives the all-docs fallback nothing to anchor to. Without a
+    ``semester``, a course-name miss keeps the pre-existing fallback to all of
+    the user's documents, byte-identical.
     """
     try:
         course_rows = table("courses").select(
@@ -147,6 +150,10 @@ def _get_course_documents(
                         "deleted_at": "is.null",
                     },
                 )
+        elif semester:
+            # Course-name miss + explicit term: nothing to scope the fallback
+            # to — no documents (#475 F2).
+            docs = []
         else:
             docs = table("documents").select(
                 "file_name,category,summary,concept_notes",

--- a/backend/routes/flashcards.py
+++ b/backend/routes/flashcards.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from db.connection import table
-from services.academics import resolve_offering
+from services.academics import resolve_offering, term_id_for_label
 from services.auth_guard import require_self, get_session_user_id
 from services.achievement_service import check_achievements
 from services.encryption import decrypt_if_present, decrypt_json
@@ -39,6 +39,9 @@ class GenerateFlashcardsBody(BaseModel):
     topic: str
     count: int = 5
     session_id: str | None = None
+    # Optional term label (#141): grounds generation in the SELECTED term's
+    # course documents instead of always the current term's.
+    semester: str | None = None
 
 
 class FlashcardRatingBody(BaseModel):
@@ -106,28 +109,44 @@ def _get_session_summary(session_id: str) -> str:
         return ""
 
 
-def _get_course_documents(user_id: str, course_name: str) -> list[dict]:
+def _get_course_documents(
+    user_id: str, course_name: str, semester: str | None = None
+) -> list[dict]:
     """
     Return all library documents for the user that belong to the course
     matching `course_name`. Falls back to all user documents if no course match.
 
     Documents key on the offering (0025): match the abstract course by name,
-    resolve it to the current-term offering, then read documents by offering.
+    resolve it to the current-term offering — or, with a ``semester`` (#141),
+    STRICTLY to that term's offering — then read documents by offering. A term
+    with no offering of the course contributes no documents; it never falls
+    back to another term's (or all of the user's) material.
     """
     try:
         course_rows = table("courses").select(
             "id", filters={"user_id": f"eq.{user_id}", "course_name": f"eq.{course_name}"}, limit=1
         )
         if course_rows:
-            offering_id = resolve_offering(course_rows[0]["id"])
-            docs = table("documents").select(
-                "file_name,category,summary,concept_notes",
-                filters={
-                    "user_id": f"eq.{user_id}",
-                    "offering_id": f"eq.{offering_id}",
-                    "deleted_at": "is.null",
-                },
-            )
+            if semester:
+                term_id = term_id_for_label(semester)
+                offering_id = (
+                    resolve_offering(course_rows[0]["id"], term_id, fallback=False)
+                    if term_id
+                    else None
+                )
+            else:
+                offering_id = resolve_offering(course_rows[0]["id"])
+            if offering_id is None:
+                docs = []
+            else:
+                docs = table("documents").select(
+                    "file_name,category,summary,concept_notes",
+                    filters={
+                        "user_id": f"eq.{user_id}",
+                        "offering_id": f"eq.{offering_id}",
+                        "deleted_at": "is.null",
+                    },
+                )
         else:
             docs = table("documents").select(
                 "file_name,category,summary,concept_notes",
@@ -185,8 +204,9 @@ def generate(body: GenerateFlashcardsBody, request: Request):
     if body.session_id:
         context = _get_session_summary(body.session_id)
 
-    # 2. Library documents for this course
-    documents = _get_course_documents(body.user_id, body.topic)
+    # 2. Library documents for this course (term-scoped when a semester is
+    #    selected, #141)
+    documents = _get_course_documents(body.user_id, body.topic, semester=body.semester)
 
     # 3. Concepts the student is weak on
     weak_concepts = _get_weak_concepts(body.user_id, body.topic)
@@ -244,7 +264,12 @@ def generate(body: GenerateFlashcardsBody, request: Request):
 
 
 @router.get("/user/{user_id}")
-def get_flashcards(user_id: str, request: Request, topic: str | None = None):
+def get_flashcards(
+    user_id: str,
+    request: Request,
+    topic: str | None = None,
+    semester: str | None = None,
+):
     require_self(user_id, request)
 
     if not user_id:
@@ -258,8 +283,26 @@ def get_flashcards(user_id: str, request: Request, topic: str | None = None):
         rows = table("flashcards").select(
             "id,user_id,topic,offering_id,front,back,times_reviewed,last_rating,last_reviewed_at,created_at",
             filters=filters, order="created_at.desc"
-        )
-        return {"flashcards": rows or []}
+        ) or []
+        if semester:
+            # Term scoping (#141). This route is user-wide (no course id), so
+            # the filter works on the cards' offering: cards from the selected
+            # term stay, other terms' cards are hidden, and term-LESS cards
+            # (offering_id NULL — e.g. AI-generated) stay visible under any
+            # selection so picking a term never strands them. An unknown label
+            # degrades to term-less cards only — never a 500.
+            term_id = term_id_for_label(semester)
+            allowed: set[str] = set()
+            if term_id:
+                offs = table("course_offerings").select(
+                    "id", filters={"term_id": f"eq.{term_id}"}
+                ) or []
+                allowed = {o["id"] for o in offs if o.get("id")}
+            rows = [
+                r for r in rows
+                if r.get("offering_id") is None or r["offering_id"] in allowed
+            ]
+        return {"flashcards": rows}
     except Exception as e:
         err_str = str(e).lower()
         if "not found" in err_str or "does not exist" in err_str or "42p01" in err_str:
@@ -326,6 +369,8 @@ def import_commit(body: ImportCommitBody, request: Request):
 
     # The body carries an abstract course id (optional); flashcards key on the
     # offering. Resolve it (None stays None — flashcards.offering_id is nullable).
+    # CREATE path: imported cards land on the CURRENT term's offering by design
+    # (#141 scopes the reads only; new content belongs to the term it's made in).
     offering_id = resolve_offering(body.course_id) if body.course_id else None
 
     cards = [{"front": c.front, "back": c.back} for c in body.cards]

--- a/backend/routes/notes.py
+++ b/backend/routes/notes.py
@@ -234,8 +234,9 @@ async def patch(note_id: str, body: UpdateNoteBody, request: Request):
     if body.tags is not None:
         patch_dict["tags"] = body.tags
     if body.course_id is not None:
-        # Re-home the note onto the offering for the new abstract course.
-        # CREATE path: current-term by design, not semester-scoped (#141).
+        # RE-HOME path: moving a note onto another abstract course files it
+        # under that course's CURRENT-term offering — deliberately not
+        # semester-scoped (#141), like the create path above.
         patch_dict["offering_id"] = resolve_offering(body.course_id, create=True)
     if not patch_dict:
         raise HTTPException(status_code=400, detail="No fields to update.")

--- a/backend/routes/notes.py
+++ b/backend/routes/notes.py
@@ -20,7 +20,7 @@ from agents.tools.graph import apply_concepts_to_graph
 from agents.usage import record_agent_usage
 from db.connection import table
 from services import events_service
-from services.academics import offering_course_id, resolve_offering
+from services.academics import offering_course_id, resolve_offering, term_id_for_label
 from services.auth_guard import get_session_user_id, require_self
 from services.notes_service import (
     create_note,
@@ -129,12 +129,35 @@ async def list_user_notes(
     user_id: str,
     request: Request,
     course_id: str | None = None,
+    semester: str | None = None,
 ):
     require_self(user_id, request)
     # The API speaks abstract course ids; notes key on the offering. Resolve
-    # the (current-term) offering for the requested course before filtering.
-    offering_id = resolve_offering(course_id) if course_id else None
-    notes = await list_notes(user_id=user_id, offering_id=offering_id)
+    # the (current-term) offering for the requested course before filtering —
+    # or, with a `semester` (term label, #141), STRICTLY that term's offering:
+    # an unknown label or a term with no offering of the course answers with
+    # the empty shape, never a silent fall-back to another term. `semester`
+    # without `course_id` is ignored (this is the course-filtered read; the
+    # notetaker UI itself carries no semester context — the param exists for
+    # API completeness).
+    offering_id = None
+    semester_missed = False
+    if course_id:
+        if semester:
+            term_id = term_id_for_label(semester)
+            offering_id = (
+                resolve_offering(course_id, term_id, fallback=False)
+                if term_id
+                else None
+            )
+            semester_missed = offering_id is None
+        else:
+            offering_id = resolve_offering(course_id)
+    notes = (
+        []
+        if semester_missed
+        else await list_notes(user_id=user_id, offering_id=offering_id)
+    )
     # Attach the abstract course id + labels resolved from each note's offering.
     # The notetaker UI keys on course_id; without it every note shows "Unknown
     # course" (finding F4). Shared per-request memo so notes in the same course
@@ -160,6 +183,8 @@ async def create(body: CreateNoteBody, request: Request):
     require_self(body.user_id, request)
     # Abstract course id from the client → the current-term offering the note
     # is stored against (create=True so a fresh note lands in the real term).
+    # CREATE path: deliberately NOT semester-scoped (#141) — new content
+    # belongs to the current term by design.
     offering_id = resolve_offering(body.course_id, create=True)
     note = await create_note(
         user_id=body.user_id,
@@ -210,6 +235,7 @@ async def patch(note_id: str, body: UpdateNoteBody, request: Request):
         patch_dict["tags"] = body.tags
     if body.course_id is not None:
         # Re-home the note onto the offering for the new abstract course.
+        # CREATE path: current-term by design, not semester-scoped (#141).
         patch_dict["offering_id"] = resolve_offering(body.course_id, create=True)
     if not patch_dict:
         raise HTTPException(status_code=400, detail="No fields to update.")

--- a/backend/routes/study_guide.py
+++ b/backend/routes/study_guide.py
@@ -88,9 +88,15 @@ def _generate_and_insert(user_id: str, offering_id: str, exam_id: str) -> dict:
     the caller resolves the abstract course id to an offering first.
     """
     # 1. Fetch exam info. Assignments key on enrollment_id (no user_id/course_id
-    #    column); scope to the user's own enrollments so one user can't generate a
-    #    guide off another's exam.
-    enrollment_ids = [e["id"] for e in user_enrollment_ids(user_id)]
+    #    column); scope to the user's enrollment in THE RESOLVED OFFERING
+    #    (#475 F3, the #462 CodeRabbit fix) — not all of their enrollments, or
+    #    a multi-term user could generate (and persist) a guide keyed on one
+    #    term's offering from another term's exam.
+    enrollment_ids = [
+        e["id"]
+        for e in user_enrollment_ids(user_id)
+        if e.get("offering_id") == offering_id
+    ]
     exams = (
         table("assignments").select(
             "id,enrollment_id,title,due_date,assignment_type",
@@ -210,20 +216,26 @@ def get_cached_guides(user_id: str, request: Request):
     # ETag from the guides' (id, generated_at) — regenerate replaces rows with a
     # fresh id + timestamp, so this captures add/remove/regenerate. A matching
     # If-None-Match returns 304 and skips the per-offering course enrichment below.
-    etag = make_etag("guides", user_id, *sorted(f"{g['id']}:{g.get('generated_at')}" for g in guides))
+    # "guides.v2": the shape gained per-entry `semester` (#475 F1); the version
+    # bump revalidates bodies cached under the old shape.
+    etag = make_etag("guides.v2", user_id, *sorted(f"{g['id']}:{g.get('generated_at')}" for g in guides))
     not_modified = conditional(request, etag)
     if not_modified is not None:
         return not_modified
 
     # Each guide keys on an offering; the frontend speaks abstract course ids.
-    # Map each offering → its abstract course id, then enrich with course_name.
+    # Map each offering → its abstract course id + its term label (#475 F1: the
+    # client opens a recent entry AS ITS OWN TERM, so each entry says which term
+    # that is). Offering ids are deduped here; term_for_offering is lru-cached.
     offering_to_course: dict[str, str | None] = {}
+    offering_terms: dict[str, str | None] = {}
     course_map: dict[str, str] = {}
     for g in guides:
         off_id = g.get("offering_id")
         if off_id and off_id not in offering_to_course:
             cid = offering_course_id(off_id)
             offering_to_course[off_id] = cid
+            offering_terms[off_id] = (term_for_offering(off_id) or {}).get("label")
             if cid and cid not in course_map:
                 rows = table("courses").select(
                     "id,course_name", filters={"id": f"eq.{cid}"}, limit=1
@@ -243,6 +255,8 @@ def get_cached_guides(user_id: str, request: Request):
             "exam_title": content.get("exam", ""),
             "overview": content.get("overview", ""),
             "generated_at": g["generated_at"],
+            # The entry's OWN term label (null when the offering has no term).
+            "semester": offering_terms.get(g.get("offering_id")),
         })
     return cached_json({"guides": result}, etag)
 

--- a/backend/routes/study_guide.py
+++ b/backend/routes/study_guide.py
@@ -17,6 +17,8 @@ from db.connection import table
 from services.academics import (
     offering_course_id,
     resolve_offering,
+    term_for_offering,
+    term_id_for_label,
     user_enrollment_ids,
     user_offering_ids_for_course,
 )
@@ -29,7 +31,26 @@ from services.request_context import current_request_id
 router = APIRouter()
 
 
-def _course_enrollment_ids(user_id: str, course_id: str) -> list[str]:
+def _offering_for(course_id: str, semester: str | None) -> str | None:
+    """course → offering, term-aware (#141).
+
+    No ``semester`` → the existing current-term resolution (with the
+    any-offering fallback), byte-for-byte unchanged. An explicit ``semester``
+    (term label) → STRICT (course, term) lookup: an unknown label or a term
+    with no offering of the course returns None — never another term's
+    offering — so callers degrade to their empty/404 behavior.
+    """
+    if not semester:
+        return resolve_offering(course_id)
+    term_id = term_id_for_label(semester)
+    if not term_id:
+        return None
+    return resolve_offering(course_id, term_id, fallback=False)
+
+
+def _course_enrollment_ids(
+    user_id: str, course_id: str, semester: str | None = None
+) -> list[str]:
     """The user's enrollment ids for the given abstract ``course_id``.
 
     The ``assignments`` table is enrollment-keyed (the gradebook table has no
@@ -37,8 +58,19 @@ def _course_enrollment_ids(user_id: str, course_id: str) -> list[str]:
     boundary speaks the abstract course id, so we resolve
     course → the user's offering(s) of it → their enrollment rows, mirroring
     routes/calendar.py::_read_assignments.
+
+    With a ``semester`` (#141) only the offerings in that term survive; an
+    unknown label yields no enrollments (empty result, never a fallback).
     """
     course_offerings = set(user_offering_ids_for_course(user_id, course_id))
+    if semester:
+        term_id = term_id_for_label(semester)
+        if not term_id:
+            return []
+        course_offerings = {
+            o for o in course_offerings
+            if (term_for_offering(o) or {}).get("id") == term_id
+        }
     if not course_offerings:
         return []
     return [
@@ -226,9 +258,14 @@ def get_courses(user_id: str, request: Request):
 
 
 @router.get("/{user_id}/exams")
-def get_exams(user_id: str, request: Request, course_id: str = Query(...)):
+def get_exams(
+    user_id: str,
+    request: Request,
+    course_id: str = Query(...),
+    semester: str | None = Query(None),
+):
     require_self(user_id, request)
-    enrollment_ids = _course_enrollment_ids(user_id, course_id)
+    enrollment_ids = _course_enrollment_ids(user_id, course_id, semester)
     if not enrollment_ids:
         return {"exams": []}
     all_assignments = table("assignments").select(
@@ -254,11 +291,20 @@ def get_guide(
     request: Request,
     course_id: str = Query(...),
     exam_id: str = Query(...),
+    semester: str | None = Query(None),
 ):
     require_self(user_id, request)
     # The query param is the abstract course id; study guides key on the
-    # offering. Resolve to the current-term offering for cache + generation.
-    offering_id = resolve_offering(course_id)
+    # offering. Without `semester` that's the current-term offering; with one,
+    # the SELECTED term's (#141) — and a term with no offering is a 404, so a
+    # guide is never generated for (or cached against) an offering that isn't
+    # there.
+    offering_id = _offering_for(course_id, semester)
+    if semester and offering_id is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No offering of this course in that semester.",
+        )
     cached = table("study_guides").select(
         "id,user_id,offering_id,exam_id,content,generated_at",
         filters={
@@ -281,11 +327,19 @@ def regenerate_guide(request: Request, body: dict = Body(...)):
     user_id = body.get("user_id")
     course_id = body.get("course_id")
     exam_id = body.get("exam_id")
+    # Optional term label (#141): regenerating replaces the SELECTED term's
+    # guide, keyed on that term's offering.
+    semester = body.get("semester")
     if not user_id or not course_id or not exam_id:
         raise HTTPException(status_code=400, detail="user_id, course_id, and exam_id are required.")
     require_self(user_id, request)
 
-    offering_id = resolve_offering(course_id)
+    offering_id = _offering_for(course_id, semester)
+    if semester and offering_id is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No offering of this course in that semester.",
+        )
     table("study_guides").delete(
         filters={
             "user_id": f"eq.{user_id}",

--- a/backend/services/academics.py
+++ b/backend/services/academics.py
@@ -95,6 +95,7 @@ def resolve_offering(
     term_id: str | None = None,
     *,
     create: bool = False,
+    fallback: bool = True,
 ) -> str | None:
     """Return the offering id for (course, term).
 
@@ -104,7 +105,11 @@ def resolve_offering(
       Race-safe: losing a concurrent create to the partial unique index
       (migration 0036) re-selects and returns the winner's row instead of
       surfacing the conflict;
-    - ``create=False`` falls back to any existing offering of the course.
+    - ``create=False`` falls back to any existing offering of the course —
+      unless ``fallback=False`` (#141): a caller that explicitly targeted a
+      term (the study-tool semester scoping) gets None back rather than a
+      silent resolution to some OTHER term's offering, and degrades to its
+      own empty/404 behavior.
     Returns None only when the course has no offering and we can't/shouldn't make one.
     """
     if not course_id:
@@ -145,6 +150,9 @@ def resolve_offering(
             if rows:
                 return rows[0]["id"]
             raise
+
+    if not fallback:
+        return None
 
     # No offering in the target term and not creating — fall back to any offering
     # of this course so reads still resolve to something sensible.

--- a/backend/tests/test_academics.py
+++ b/backend/tests/test_academics.py
@@ -154,6 +154,28 @@ def test_resolve_offering_no_create_falls_back_to_any_offering():
         assert ac.resolve_offering("course-1", create=False) == "off-legacy"
 
 
+def test_resolve_offering_fallback_false_returns_none_on_term_miss():
+    """#141: an explicitly targeted term with no offering must NOT silently
+    resolve to another term's offering. fallback=False returns None so the
+    caller degrades to its own empty/404 behavior instead."""
+    factory = _factory(
+        {"terms": [{"id": "t1", "sort_key": 1}]},
+        # The any-offering row exists, proving the fallback would have hit it.
+        select_seqs={"course_offerings": [[], [{"id": "off-legacy"}]]},
+    )
+    with patch.object(ac, "table", side_effect=factory):
+        assert ac.resolve_offering("course-1", term_id="t1", fallback=False) is None
+
+
+def test_resolve_offering_fallback_false_still_returns_term_match():
+    factory = _factory(
+        {"terms": [{"id": "t1", "sort_key": 1}],
+         "course_offerings": [{"id": "off-t1"}]},
+    )
+    with patch.object(ac, "table", side_effect=factory):
+        assert ac.resolve_offering("course-1", term_id="t1", fallback=False) == "off-t1"
+
+
 # ── user_offering_ids_for_course ────────────────────────────────────────────
 
 def test_user_offering_ids_for_course_intersects():

--- a/backend/tests/test_flashcards_routes.py
+++ b/backend/tests/test_flashcards_routes.py
@@ -119,6 +119,57 @@ class TestCourseDocumentsTermScope:
         assert captured["filters"]["offering_id"] == "eq.off-f25"
         assert len(docs) == 1
 
+    def test_no_course_match_with_semester_yields_no_docs(self):
+        """#475 F2: with an explicit semester there is no term to anchor the
+        all-docs fallback to — a course-name miss returns NO documents, never
+        every document the user owns."""
+        captured = {}
+
+        def side_effect(name):
+            m = MagicMock()
+            if name == "courses":
+                m.select.return_value = []  # no course match
+            elif name == "documents":
+                def _select(cols, filters=None, order=None, limit=None):
+                    captured["filters"] = filters or {}
+                    return [{"file_name": "x", "category": None,
+                             "summary": None, "concept_notes": None}]
+                m.select.side_effect = _select
+            else:
+                m.select.return_value = []
+            return m
+
+        with patch("routes.flashcards.table", side_effect=side_effect):
+            docs = _get_course_documents(USER_ID, "Ghost Course", semester="Fall 2025")
+        assert docs == []
+        assert "filters" not in captured  # the all-docs query never ran
+
+    def test_no_course_match_without_semester_keeps_the_all_docs_fallback(self):
+        # Pre-existing behavior, byte-identical: no semester + no course match
+        # → every non-deleted document the user owns.
+        captured = {}
+
+        def side_effect(name):
+            m = MagicMock()
+            if name == "courses":
+                m.select.return_value = []
+            elif name == "documents":
+                def _select(cols, filters=None, order=None, limit=None):
+                    captured["filters"] = filters or {}
+                    return [{"file_name": "x", "category": None,
+                             "summary": None, "concept_notes": None}]
+                m.select.side_effect = _select
+            else:
+                m.select.return_value = []
+            return m
+
+        with patch("routes.flashcards.table", side_effect=side_effect):
+            docs = _get_course_documents(USER_ID, "Ghost Course")
+        assert len(docs) == 1
+        assert captured["filters"] == {
+            "user_id": f"eq.{USER_ID}", "deleted_at": "is.null",
+        }
+
     def test_semester_with_no_offering_yields_no_docs_not_all_docs(self):
         captured = {}
         with patch("routes.flashcards.table", side_effect=self._tables(

--- a/backend/tests/test_flashcards_routes.py
+++ b/backend/tests/test_flashcards_routes.py
@@ -1,0 +1,146 @@
+"""Route tests for /api/flashcards — the semester-scoped read/list and the
+term-scoped generation context (#141).
+
+The list route (`GET /user/{user_id}`) is user-wide (no course id), so its
+`semester` filter works on the cards' `offering_id`: cards whose offering
+belongs to the selected term stay, cards from other terms are hidden, and
+term-less cards (offering_id NULL — e.g. AI-generated ones) stay visible under
+ANY selection so picking a term never makes them unreachable. An unknown label
+degrades to "term-less cards only" — never a 500, never everything.
+
+Generation (`POST /generate`) grounds its context in the course's documents;
+with a `semester` those documents come from THAT term's offering — a term with
+no offering contributes no documents rather than falling back to another
+term's (or all of the user's) material.
+"""
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+from routes.flashcards import _get_course_documents
+
+client = TestClient(app)
+
+USER_ID = "user_test"
+
+CARDS = [
+    {"id": "f-fall", "user_id": USER_ID, "topic": "CS Basics",
+     "offering_id": "off-f25", "front": "q1", "back": "a1",
+     "times_reviewed": 0, "last_rating": None, "last_reviewed_at": None,
+     "created_at": "2026-01-03T00:00:00Z"},
+    {"id": "f-spring", "user_id": USER_ID, "topic": "Linear Algebra",
+     "offering_id": "off-s26", "front": "q2", "back": "a2",
+     "times_reviewed": 0, "last_rating": None, "last_reviewed_at": None,
+     "created_at": "2026-01-02T00:00:00Z"},
+    {"id": "f-unscoped", "user_id": USER_ID, "topic": "Trivia",
+     "offering_id": None, "front": "q3", "back": "a3",
+     "times_reviewed": 0, "last_rating": None, "last_reviewed_at": None,
+     "created_at": "2026-01-01T00:00:00Z"},
+]
+
+
+def _tables(term_offerings):
+    """table() stand-in: all CARDS for flashcards, `term_offerings` rows for
+    the course_offerings term lookup."""
+    def side_effect(name):
+        m = MagicMock()
+        if name == "flashcards":
+            m.select.return_value = list(CARDS)
+        elif name == "course_offerings":
+            m.select.return_value = term_offerings
+        else:
+            m.select.return_value = []
+        return m
+    return side_effect
+
+
+class TestListFlashcards:
+    def test_unscoped_returns_every_card(self):
+        with patch("routes.flashcards.table", side_effect=_tables([])):
+            r = client.get(f"/api/flashcards/user/{USER_ID}")
+        assert r.status_code == 200
+        assert [c["id"] for c in r.json()["flashcards"]] == [
+            "f-fall", "f-spring", "f-unscoped",
+        ]
+
+    def test_semester_keeps_that_terms_cards_plus_termless_ones(self):
+        with patch("routes.flashcards.table", side_effect=_tables([{"id": "off-f25"}])), \
+             patch("routes.flashcards.term_id_for_label", return_value="term-f25") as tl:
+            r = client.get(f"/api/flashcards/user/{USER_ID}?semester=Fall+2025")
+        assert r.status_code == 200
+        ids = [c["id"] for c in r.json()["flashcards"]]
+        assert ids == ["f-fall", "f-unscoped"]  # spring card hidden
+        tl.assert_called_once_with("Fall 2025")
+
+    def test_unknown_semester_degrades_to_termless_cards_only(self):
+        with patch("routes.flashcards.table", side_effect=_tables([])), \
+             patch("routes.flashcards.term_id_for_label", return_value=None):
+            r = client.get(f"/api/flashcards/user/{USER_ID}?semester=Never+2099")
+        assert r.status_code == 200
+        assert [c["id"] for c in r.json()["flashcards"]] == ["f-unscoped"]
+
+
+class TestCourseDocumentsTermScope:
+    @staticmethod
+    def _tables(docs, captured):
+        def side_effect(name):
+            m = MagicMock()
+            if name == "courses":
+                m.select.return_value = [{"id": "c1"}]
+            elif name == "documents":
+                def _select(cols, filters=None, order=None, limit=None):
+                    captured["filters"] = filters or {}
+                    return docs
+                m.select.side_effect = _select
+            else:
+                m.select.return_value = []
+            return m
+        return side_effect
+
+    def test_no_semester_keeps_current_term_resolution(self):
+        captured = {}
+        with patch("routes.flashcards.table", side_effect=self._tables([], captured)), \
+             patch("routes.flashcards.resolve_offering", return_value="off-cur") as ro:
+            _get_course_documents(USER_ID, "Intro CS")
+        ro.assert_called_once_with("c1")
+        assert captured["filters"]["offering_id"] == "eq.off-cur"
+
+    def test_semester_scopes_the_documents_to_that_terms_offering(self):
+        captured = {}
+        doc = {"file_name": "a.pdf", "category": "notes",
+               "summary": None, "concept_notes": None}
+        with patch("routes.flashcards.table", side_effect=self._tables([doc], captured)), \
+             patch("routes.flashcards.term_id_for_label", return_value="term-f25") as tl, \
+             patch("routes.flashcards.resolve_offering", return_value="off-f25") as ro:
+            docs = _get_course_documents(USER_ID, "Intro CS", semester="Fall 2025")
+        tl.assert_called_once_with("Fall 2025")
+        ro.assert_called_once_with("c1", "term-f25", fallback=False)
+        assert captured["filters"]["offering_id"] == "eq.off-f25"
+        assert len(docs) == 1
+
+    def test_semester_with_no_offering_yields_no_docs_not_all_docs(self):
+        captured = {}
+        with patch("routes.flashcards.table", side_effect=self._tables(
+                 [{"file_name": "x"}], captured)), \
+             patch("routes.flashcards.term_id_for_label", return_value="term-su26"), \
+             patch("routes.flashcards.resolve_offering", return_value=None):
+            docs = _get_course_documents(USER_ID, "Intro CS", semester="Summer 2026")
+        assert docs == []
+        # The all-user-documents fallback must NOT fire for a term miss.
+        assert "filters" not in captured
+
+
+class TestGenerateThreadsSemester:
+    def test_route_passes_the_semester_into_the_docs_context(self):
+        with patch("routes.flashcards._get_course_documents", return_value=[]) as gd, \
+             patch("routes.flashcards._get_weak_concepts", return_value=[]), \
+             patch("routes.flashcards._generate", return_value=[{"front": "q", "back": "a"}]), \
+             patch("routes.flashcards.table", side_effect=_tables([])), \
+             patch("services.achievement_service.check_achievements"):
+            r = client.post("/api/flashcards/generate", json={
+                "user_id": USER_ID, "topic": "Intro CS", "count": 1,
+                "semester": "Fall 2025",
+            })
+        assert r.status_code == 200
+        gd.assert_called_once_with(USER_ID, "Intro CS", semester="Fall 2025")

--- a/backend/tests/test_notes_routes.py
+++ b/backend/tests/test_notes_routes.py
@@ -100,6 +100,47 @@ class TestListNotes:
         assert note["course_name"] == "Intro Biology"
         oc.assert_called_once_with("off1")
 
+    # ── semester scoping (#141) — course-filtered read only ──────────────────
+
+    def test_course_filter_with_semester_resolves_strictly(self, client):
+        async def fake_list(user_id, offering_id=None):
+            assert offering_id == "off-f25"
+            return []
+        with (
+            patch("routes.notes.term_id_for_label", return_value="term-f25") as tl,
+            patch("routes.notes.resolve_offering", return_value="off-f25") as ro,
+            patch("routes.notes.list_notes", side_effect=fake_list),
+        ):
+            r = client.get("/api/notes/user/u1?course_id=c2&semester=Fall+2025")
+        assert r.status_code == 200
+        tl.assert_called_once_with("Fall 2025")
+        ro.assert_called_once_with("c2", "term-f25", fallback=False)
+
+    def test_semester_with_no_offering_is_empty_not_current_term(self, client):
+        # The term exists but the course has no offering in it: the route must
+        # answer with the empty shape, never silently resolve another term.
+        with (
+            patch("routes.notes.term_id_for_label", return_value="term-su26"),
+            patch("routes.notes.resolve_offering", return_value=None),
+            patch("routes.notes.list_notes") as ln,
+        ):
+            r = client.get("/api/notes/user/u1?course_id=c2&semester=Summer+2026")
+        assert r.status_code == 200
+        assert r.json() == {"notes": []}
+        ln.assert_not_called()
+
+    def test_unknown_semester_label_is_empty_not_500(self, client):
+        with (
+            patch("routes.notes.term_id_for_label", return_value=None),
+            patch("routes.notes.resolve_offering") as ro,
+            patch("routes.notes.list_notes") as ln,
+        ):
+            r = client.get("/api/notes/user/u1?course_id=c2&semester=Nope")
+        assert r.status_code == 200
+        assert r.json() == {"notes": []}
+        ro.assert_not_called()
+        ln.assert_not_called()
+
 
 class TestCreateNote:
     def test_creates_with_required_fields(self, client):

--- a/backend/tests/test_study_guide_routes.py
+++ b/backend/tests/test_study_guide_routes.py
@@ -293,6 +293,170 @@ class TestRegenerateGuide:
         assert r.status_code == 400
 
 
+# ── semester scoping (#141) ──────────────────────────────────────────────────
+#
+# The Study screen's semester selector scopes the course-scoped reads. An
+# explicit `semester` (term LABEL) resolves STRICTLY — an unknown label or a
+# term with no offering of the course degrades to the route's empty/404
+# behavior, never a silent fall-back to the current (or any other) term.
+
+class TestSemesterScoping:
+    def test_guide_resolves_the_requested_term_strictly(self):
+        cached_row = {
+            "id": "g1", "user_id": USER_ID, "offering_id": "off-f25",
+            "exam_id": EXAM_ID, "generated_at": "2026-04-01T00:00:00Z",
+            "content": {"exam": "Midterm", "topics": []},
+        }
+        captured = {}
+
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "study_guides":
+                def _select(cols, filters=None, order=None, limit=None):
+                    captured["filters"] = filters or {}
+                    return [cached_row]
+                m.select.side_effect = _select
+            else:
+                m.select.return_value = []
+            return m
+
+        with patch("routes.study_guide.table", side_effect=table_side_effect), \
+             patch("routes.study_guide.term_id_for_label", return_value="term-f25") as tl, \
+             patch("routes.study_guide.resolve_offering", return_value="off-f25") as ro:
+            r = client.get(
+                f"/api/study-guide/{USER_ID}/guide"
+                f"?course_id={COURSE_ID}&exam_id={EXAM_ID}&semester=Fall+2025"
+            )
+        assert r.status_code == 200
+        assert r.json()["cached"] is True
+        tl.assert_called_once_with("Fall 2025")
+        ro.assert_called_once_with(COURSE_ID, "term-f25", fallback=False)
+        assert captured["filters"]["offering_id"] == "eq.off-f25"
+
+    def test_guide_404s_when_the_term_has_no_offering(self):
+        agent_run = _agent_run_returning({"exam": "X", "topics": []})
+        with patch("routes.study_guide.table"), \
+             patch("routes.study_guide.term_id_for_label", return_value="term-su26"), \
+             patch("routes.study_guide.resolve_offering", return_value=None), \
+             patch("routes.study_guide.study_guide_agent.run", new=agent_run):
+            r = client.get(
+                f"/api/study-guide/{USER_ID}/guide"
+                f"?course_id={COURSE_ID}&exam_id={EXAM_ID}&semester=Summer+2026"
+            )
+        assert r.status_code == 404
+        # Never generate a guide for an offering that doesn't exist.
+        agent_run.assert_not_called()
+
+    def test_guide_404s_on_an_unknown_semester_label(self):
+        with patch("routes.study_guide.term_id_for_label", return_value=None), \
+             patch("routes.study_guide.resolve_offering") as ro:
+            r = client.get(
+                f"/api/study-guide/{USER_ID}/guide"
+                f"?course_id={COURSE_ID}&exam_id={EXAM_ID}&semester=Nonsense"
+            )
+        assert r.status_code == 404
+        ro.assert_not_called()
+
+    def test_regenerate_keys_on_the_requested_terms_offering(self):
+        fresh_content = {"exam": "Midterm", "topics": []}
+        captured = {}
+
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "study_guides":
+                m.select.return_value = []
+                m.insert.return_value = [{}]
+                def _delete(filters=None):
+                    captured["delete_filters"] = filters or {}
+                    return []
+                m.delete.side_effect = _delete
+            elif name == "assignments":
+                m.select.return_value = [{"title": "Midterm", "due_date": "2026-04-01"}]
+            else:
+                m.select.return_value = []
+            return m
+
+        with patch("routes.study_guide.table", side_effect=table_side_effect), \
+             patch("routes.study_guide.user_enrollment_ids", return_value=[{"id": "enr1", "offering_id": "off-f25"}]), \
+             patch("routes.study_guide.term_id_for_label", return_value="term-f25"), \
+             patch("routes.study_guide.resolve_offering", return_value="off-f25") as ro, \
+             patch("routes.study_guide.study_guide_agent.run", new=_agent_run_returning(fresh_content)):
+            r = client.post(
+                "/api/study-guide/regenerate",
+                json={"user_id": USER_ID, "course_id": COURSE_ID,
+                      "exam_id": EXAM_ID, "semester": "Fall 2025"},
+            )
+        assert r.status_code == 200
+        ro.assert_called_once_with(COURSE_ID, "term-f25", fallback=False)
+        assert captured["delete_filters"]["offering_id"] == "eq.off-f25"
+
+    def test_regenerate_404s_when_the_term_has_no_offering(self):
+        deleted = {"n": 0}
+
+        def table_side_effect(name):
+            m = MagicMock()
+            m.select.return_value = []
+            def _delete(filters=None):
+                deleted["n"] += 1
+                return []
+            m.delete.side_effect = _delete
+            return m
+
+        with patch("routes.study_guide.table", side_effect=table_side_effect), \
+             patch("routes.study_guide.term_id_for_label", return_value="term-su26"), \
+             patch("routes.study_guide.resolve_offering", return_value=None):
+            r = client.post(
+                "/api/study-guide/regenerate",
+                json={"user_id": USER_ID, "course_id": COURSE_ID,
+                      "exam_id": EXAM_ID, "semester": "Summer 2026"},
+            )
+        assert r.status_code == 404
+        assert deleted["n"] == 0  # nothing torn down for a term that isn't there
+
+    def test_exams_scoped_to_the_semesters_enrollment(self):
+        captured = {}
+
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "assignments":
+                def _select(cols, filters=None, order=None, limit=None):
+                    captured["filters"] = filters or {}
+                    return [{"id": "a1", "title": "Fall Final Exam",
+                             "due_date": "2025-12-10", "assignment_type": "exam"}]
+                m.select.side_effect = _select
+            else:
+                m.select.return_value = []
+            return m
+
+        terms = {"off-f25": {"id": "term-f25"}, "off-s26": {"id": "term-s26"}}
+        with patch("routes.study_guide.table", side_effect=table_side_effect), \
+             patch("routes.study_guide.user_offering_ids_for_course", return_value=["off-f25", "off-s26"]), \
+             patch("routes.study_guide.user_enrollment_ids", return_value=[
+                 {"id": "enr-f25", "offering_id": "off-f25"},
+                 {"id": "enr-s26", "offering_id": "off-s26"},
+             ]), \
+             patch("routes.study_guide.term_id_for_label", return_value="term-f25"), \
+             patch("routes.study_guide.term_for_offering", side_effect=lambda o: terms.get(o)):
+            r = client.get(
+                f"/api/study-guide/{USER_ID}/exams?course_id={COURSE_ID}&semester=Fall+2025"
+            )
+        assert r.status_code == 200
+        # Only the fall enrollment feeds the assignments query.
+        assert captured["filters"] == {"enrollment_id": "in.(enr-f25)"}
+        assert [e["title"] for e in r.json()["exams"]] == ["Fall Final Exam"]
+
+    def test_exams_empty_on_an_unknown_semester_label(self):
+        with patch("routes.study_guide.table") as t, \
+             patch("routes.study_guide.user_offering_ids_for_course", return_value=["off-f25"]), \
+             patch("routes.study_guide.term_id_for_label", return_value=None):
+            t.return_value.select.return_value = []
+            r = client.get(
+                f"/api/study-guide/{USER_ID}/exams?course_id={COURSE_ID}&semester=Nope"
+            )
+        assert r.status_code == 200
+        assert r.json() == {"exams": []}
+
+
 # ── agent-failure handling ───────────────────────────────────────────────────
 
 class TestGenerationFailure:

--- a/backend/tests/test_study_guide_routes.py
+++ b/backend/tests/test_study_guide_routes.py
@@ -128,14 +128,19 @@ class TestGetCourses:
 # ── GET /api/study-guide/{user_id}/cached ────────────────────────────────────
 
 class TestGetCachedGuides:
-    def test_enriches_with_course_name(self):
+    def test_enriches_with_course_name_and_term(self):
         # Guides key on the offering (0025); the response exposes the abstract
-        # course id (resolved via offering_course_id) and its course name.
-        guides = [{
-            "id": "g1", "offering_id": "off1", "exam_id": "e1",
-            "generated_at": "2026-04-01T00:00:00Z",
-            "content": {"exam": "Midterm", "overview": "Covers ch1-5"},
-        }]
+        # course id (resolved via offering_course_id), its course name, and —
+        # #475 F1 — the entry's OWN term label, so the client can open a recent
+        # guide as its own term instead of the active selector's.
+        guides = [
+            {"id": "g1", "offering_id": "off1", "exam_id": "e1",
+             "generated_at": "2026-04-01T00:00:00Z",
+             "content": {"exam": "Midterm", "overview": "Covers ch1-5"}},
+            {"id": "g2", "offering_id": "off-untermed", "exam_id": "e2",
+             "generated_at": "2026-03-01T00:00:00Z",
+             "content": {"exam": "Final", "overview": ""}},
+        ]
 
         def table_side_effect(name):
             m = MagicMock()
@@ -147,8 +152,11 @@ class TestGetCachedGuides:
                 m.select.return_value = []
             return m
 
+        terms = {"off1": {"id": "term-f25", "label": "Fall 2025"}}
         with patch("routes.study_guide.table", side_effect=table_side_effect), \
-             patch("routes.study_guide.offering_course_id", return_value="c1"):
+             patch("routes.study_guide.offering_course_id", return_value="c1"), \
+             patch("routes.study_guide.term_for_offering",
+                   side_effect=lambda o: terms.get(o)):
             r = client.get(f"/api/study-guide/{USER_ID}/cached")
 
         assert r.status_code == 200
@@ -157,6 +165,9 @@ class TestGetCachedGuides:
         assert out["course_name"] == "Calc II"
         assert out["exam_title"] == "Midterm"
         assert out["overview"] == "Covers ch1-5"
+        assert out["semester"] == "Fall 2025"
+        # An offering with no term joined degrades to null, never a KeyError.
+        assert r.json()["guides"][1]["semester"] is None
 
     def test_empty_when_no_guides(self):
         with patch("routes.study_guide.table") as t:
@@ -226,6 +237,50 @@ class TestGetGuide:
         ro.assert_called_once_with(COURSE_ID)
         assert captured["row"]["offering_id"] == "off1"
         assert "course_id" not in captured["row"]
+
+    def test_exam_must_belong_to_the_resolved_offering(self):
+        """#475 F3 (the #462 CodeRabbit fix): the exam lookup is scoped to the
+        RESOLVED offering's enrollment, not all of the user's enrollments — a
+        two-term user generating against offering A with an exam that belongs
+        to offering B gets a 404, and nothing is persisted."""
+        inserted = {"n": 0}
+
+        def table_side_effect(name):
+            m = MagicMock()
+            if name == "study_guides":
+                m.select.return_value = []  # no cache → would generate
+
+                def _insert(row):
+                    inserted["n"] += 1
+                    return [{}]
+                m.insert.side_effect = _insert
+            elif name == "assignments":
+                def _select(cols, filters=None, order=None, limit=None):
+                    # The exam belongs to enr-b; it is only visible when enr-b
+                    # is inside the enrollment_id filter.
+                    if "enr-b" in (filters or {}).get("enrollment_id", ""):
+                        return [{"id": EXAM_ID, "enrollment_id": "enr-b",
+                                 "title": "Final", "due_date": "2026-05-01"}]
+                    return []
+                m.select.side_effect = _select
+            else:
+                m.select.return_value = []
+            return m
+
+        agent_run = _agent_run_returning({"exam": "Final", "topics": []})
+        with patch("routes.study_guide.table", side_effect=table_side_effect), \
+             patch("routes.study_guide.user_enrollment_ids", return_value=[
+                 {"id": "enr-a", "offering_id": "off-a"},
+                 {"id": "enr-b", "offering_id": "off-b"},
+             ]), \
+             patch("routes.study_guide.resolve_offering", return_value="off-a"), \
+             patch("routes.study_guide.study_guide_agent.run", new=agent_run):
+            r = client.get(
+                f"/api/study-guide/{USER_ID}/guide?course_id={COURSE_ID}&exam_id={EXAM_ID}"
+            )
+        assert r.status_code == 404
+        agent_run.assert_not_called()
+        assert inserted["n"] == 0
 
     def test_unknown_exam_returns_404(self):
         def table_side_effect(name):

--- a/frontend/e2e/study-semester.spec.ts
+++ b/frontend/e2e/study-semester.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Journey #141 — the semester selector scopes the STUDY-TOOL reads.
+ *
+ * The reframe: NO Archive toggle. The existing selector (Courses & Semesters
+ * hub → lib/useActiveSemester; "" = All semesters, the e2e-pinned DEFAULT)
+ * scopes the study reads the same way it already scopes the graph — the
+ * study-tool endpoints used to hardcode current-term resolution
+ * (`resolve_offering(course_id)`), pinning every course-scoped read to
+ * spring-2026 under the frozen test clock (2026-03-11) regardless of the
+ * user's selection.
+ *
+ * Flashcards are the assertable read (no generation involved — the seam
+ * caution stands: nothing here may trigger flashcard/study-guide
+ * generation). Seeded data (db/seed_local_rich.py): rich-user-active has the
+ * "CS Basics" deck ×3 on the fall-2025 CS101 offering and the "Linear
+ * Algebra" deck ×3 on the spring-2026 MATH210 offering.
+ *
+ *   1. Default (All semesters): BOTH terms' decks are visible together —
+ *      cross-term data under the untouchable default (#360 contract).
+ *   2. Pick "Fall 2025" in the hub: /study serves the FALL deck (the #141
+ *      point — current-term resolution served spring only) and the
+ *      spring-only deck is gone.
+ *
+ * Selectors: topic pills are buttons named by seeded deck names (data, not
+ * copy); the hub is reached exactly as in semester-scope.spec.ts. The
+ * "Card 1 of N" counter pins the scoped deck SIZE (N is data; the phrasing
+ * is stable Study copy).
+ */
+import { expect, test } from "./support/fixtures";
+
+test("study flashcards follow the semester selection; All semesters shows every term", async ({
+  page,
+}) => {
+  // 1. Default = All semesters: fall AND spring decks render together.
+  await page.goto("/study?mode=cards");
+  await expect(page.getByRole("button", { name: "CS Basics" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Linear Algebra" })).toBeVisible();
+  await expect(page.getByText("Card 1 of 6")).toBeVisible();
+
+  // 2. Scope to Fall 2025 via the Courses & Semesters hub (dashboard).
+  await page.goto("/dashboard");
+  await page.getByTestId("dashboard-courses-key-toggle").click();
+  await page.getByTestId("dashboard-courses-manage").click();
+  await page.getByRole("button", { name: "Fall 2025" }).click();
+  await page.getByRole("button", { name: "Close" }).click();
+
+  // 3. /study now serves the fall-2025 deck — the read the current-term
+  //    resolution used to hide — and the spring-only deck is filtered out.
+  await page.goto("/study?mode=cards");
+  await expect(page.getByRole("button", { name: "CS Basics" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Linear Algebra" })).toHaveCount(0);
+  await expect(page.getByText("Card 1 of 3")).toBeVisible();
+});

--- a/frontend/e2e/study-semester.spec.ts
+++ b/frontend/e2e/study-semester.spec.ts
@@ -34,7 +34,10 @@ test("study flashcards follow the semester selection; All semesters shows every 
   // 1. Default = All semesters: fall AND spring decks render together.
   await page.goto("/study?mode=cards");
   await expect(page.getByRole("button", { name: "CS Basics" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Linear Algebra" })).toBeVisible();
+  // .first(): "Linear Algebra" is both MATH210's course pill and the deck's
+  // topic pill under All semesters — any match proves the spring deck
+  // surfaced; the "Card 1 of 6" counter is the actual scoping assertion.
+  await expect(page.getByRole("button", { name: "Linear Algebra" }).first()).toBeVisible();
   await expect(page.getByText("Card 1 of 6")).toBeVisible();
 
   // 2. Scope to Fall 2025 via the Courses & Semesters hub (dashboard).

--- a/frontend/src/components/screens/Study.semester.test.tsx
+++ b/frontend/src/components/screens/Study.semester.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+/**
+ * Study screen semester scoping (#141) — the existing semester selector
+ * (lib/useActiveSemester; "" = All semesters, the untouchable DEFAULT) must
+ * scope the study-tool READS the same way it already scopes the graph.
+ *
+ * Pins, following Dashboard.test.tsx's call-count pattern:
+ *   - the flashcards list fetch is gated on the hydrated flag and carries the
+ *     stored term: exactly ONE fetch, never unscoped-then-scoped;
+ *   - "" (All semesters) sends undefined — the default stays unscoped;
+ *   - the guide path (exams list, guide fetch, regenerate) threads the term.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Study reads ?mode= at mount; per-describe control without remocking.
+const search = { qs: "" };
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(search.qs),
+}));
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => ({ userId: "u1", userReady: true }),
+}));
+
+vi.mock("@/lib/useIsMobile", () => ({
+  useIsMobile: () => false,
+}));
+
+// Pulls in the whole import-tab tree (and more @/lib/api names) — out of
+// scope here.
+vi.mock("@/components/flashcards/FlashcardImportModal", () => ({
+  FlashcardImportModal: () => null,
+}));
+
+vi.mock("@/lib/api", () => ({
+  getCourses: vi.fn(async () => ({ courses: [] })),
+  getStudyGuideExams: vi.fn(async () => ({ exams: [] })),
+  getStudyGuide: vi.fn(async () => ({
+    guide: { exam: "Midterm 1", topics: [] },
+    generated_at: "2026-04-01T00:00:00Z",
+    cached: true,
+  })),
+  regenerateStudyGuide: vi.fn(async () => ({
+    success: true,
+    guide: { exam: "Midterm 1", topics: [] },
+    generated_at: "2026-04-02T00:00:00Z",
+  })),
+  getCachedStudyGuides: vi.fn(async () => ({ guides: [] })),
+  getFlashcards: vi.fn(async () => ({ flashcards: [] })),
+  generateFlashcards: vi.fn(),
+  rateFlashcard: vi.fn(),
+  deleteFlashcard: vi.fn(),
+  getDocuments: vi.fn(async () => ({ documents: [] })),
+}));
+
+import { Study } from "./Study";
+import { ToastProvider } from "../ToastProvider";
+import { ACTIVE_SEMESTER_STORAGE_KEY } from "@/lib/useActiveSemester";
+import {
+  getCachedStudyGuides,
+  getFlashcards,
+  getStudyGuide,
+  getStudyGuideExams,
+  regenerateStudyGuide,
+} from "@/lib/api";
+
+const mockedFlashcards = vi.mocked(getFlashcards);
+const mockedCached = vi.mocked(getCachedStudyGuides);
+const mockedGuide = vi.mocked(getStudyGuide);
+const mockedExams = vi.mocked(getStudyGuideExams);
+const mockedRegenerate = vi.mocked(regenerateStudyGuide);
+
+const RECENT = {
+  id: "g1",
+  course_id: "c1",
+  exam_id: "e1",
+  course_name: "Intro to CS",
+  exam_title: "Midterm 1",
+  overview: "",
+  generated_at: "2026-04-01T00:00:00Z",
+};
+
+function renderStudy() {
+  return render(
+    <ToastProvider>
+      <Study />
+    </ToastProvider>,
+  );
+}
+
+beforeEach(() => {
+  search.qs = "";
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.removeItem(ACTIVE_SEMESTER_STORAGE_KEY);
+  vi.clearAllMocks();
+});
+
+describe("Study flashcards fetch respects the active semester", () => {
+  beforeEach(() => {
+    search.qs = "mode=cards";
+  });
+
+  it("fetches once, scoped to the stored term — no unscoped first pass", async () => {
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Fall 2025");
+
+    renderStudy();
+
+    // The empty state renders only after the (resolved) fetch — a
+    // deterministic settle point for the call-count assert.
+    await screen.findByText("No cards here yet");
+    expect(mockedFlashcards).toHaveBeenCalledTimes(1);
+    expect(mockedFlashcards).toHaveBeenCalledWith("u1", undefined, "Fall 2025");
+    expect(mockedFlashcards).not.toHaveBeenCalledWith("u1", undefined, undefined);
+  });
+
+  it("All semesters (the default) fetches once, unscoped", async () => {
+    renderStudy();
+
+    await screen.findByText("No cards here yet");
+    expect(mockedFlashcards).toHaveBeenCalledTimes(1);
+    expect(mockedFlashcards).toHaveBeenCalledWith("u1", undefined, undefined);
+  });
+});
+
+describe("Study guide path threads the active semester", () => {
+  // Regenerate isn't drivable from here: opening a recent guide deliberately
+  // clears the exam selection (see GuideMode's openRecent), which leaves the
+  // Regenerate button disabled — its one-line `semester || undefined`
+  // threading matches the three read calls asserted below.
+  it("passes the stored term to the exams and guide fetches", async () => {
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Fall 2025");
+    mockedCached.mockResolvedValue({ guides: [RECENT] });
+
+    renderStudy();
+    await userEvent.click(await screen.findByText("Midterm 1"));
+
+    await waitFor(() =>
+      expect(mockedGuide).toHaveBeenCalledWith("u1", "c1", "e1", "Fall 2025"),
+    );
+    expect(mockedExams).toHaveBeenCalledWith("u1", "c1", "Fall 2025");
+    expect(mockedRegenerate).not.toHaveBeenCalled();
+  });
+
+  it("sends no semester while All semesters is active", async () => {
+    mockedCached.mockResolvedValue({ guides: [RECENT] });
+
+    renderStudy();
+    await userEvent.click(await screen.findByText("Midterm 1"));
+
+    await waitFor(() =>
+      expect(mockedGuide).toHaveBeenCalledWith("u1", "c1", "e1", undefined),
+    );
+    expect(mockedExams).toHaveBeenCalledWith("u1", "c1", undefined);
+  });
+});

--- a/frontend/src/components/screens/Study.semester.test.tsx
+++ b/frontend/src/components/screens/Study.semester.test.tsx
@@ -62,10 +62,12 @@ import { ToastProvider } from "../ToastProvider";
 import { ACTIVE_SEMESTER_STORAGE_KEY } from "@/lib/useActiveSemester";
 import {
   getCachedStudyGuides,
+  getCourses,
   getFlashcards,
   getStudyGuide,
   getStudyGuideExams,
   regenerateStudyGuide,
+  type EnrolledCourse,
 } from "@/lib/api";
 
 const mockedFlashcards = vi.mocked(getFlashcards);
@@ -73,6 +75,7 @@ const mockedCached = vi.mocked(getCachedStudyGuides);
 const mockedGuide = vi.mocked(getStudyGuide);
 const mockedExams = vi.mocked(getStudyGuideExams);
 const mockedRegenerate = vi.mocked(regenerateStudyGuide);
+const mockedCourses = vi.mocked(getCourses);
 
 const RECENT = {
   id: "g1",
@@ -82,6 +85,22 @@ const RECENT = {
   exam_title: "Midterm 1",
   overview: "",
   generated_at: "2026-04-01T00:00:00Z",
+};
+
+// Must survive the Fall 2025 scopedCourses filter (courseInTerm) so it shows
+// in the course picker.
+const COURSE_C1: EnrolledCourse = {
+  enrollment_id: "enr-1",
+  course_id: "c1",
+  course_code: "CS101",
+  course_name: "Intro to CS",
+  school: "BU",
+  department: "CS",
+  color: null,
+  nickname: null,
+  node_count: 0,
+  enrolled_at: "2025-09-01",
+  term: "Fall 2025",
 };
 
 function renderStudy() {
@@ -99,6 +118,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   window.localStorage.removeItem(ACTIVE_SEMESTER_STORAGE_KEY);
+  vi.restoreAllMocks(); // the console.error spy in the 404 test
   vi.clearAllMocks();
 });
 
@@ -129,12 +149,38 @@ describe("Study flashcards fetch respects the active semester", () => {
   });
 });
 
-describe("Study guide path threads the active semester", () => {
-  // Regenerate isn't drivable from here: opening a recent guide deliberately
-  // clears the exam selection (see GuideMode's openRecent), which leaves the
-  // Regenerate button disabled — its one-line `semester || undefined`
-  // threading matches the three read calls asserted below.
-  it("passes the stored term to the exams and guide fetches", async () => {
+describe("Study guide path threads the right term", () => {
+  // Regenerate isn't drivable from the recent-guides rail: openRecent SETS
+  // examId, but the courseId-keyed exams effect races it and clears the exam
+  // selection (the emergent behavior tracked as #476), which leaves the
+  // Regenerate button disabled. Its one-line `semester || undefined`
+  // threading matches the read calls asserted below.
+  it("opens a recent guide AS ITS OWN TERM, not the active selector's (#475 F1)", async () => {
+    // Active selector says Fall 2025; the rail entry is a Spring 2026 guide.
+    // Loading it under the active term would cache-miss on the (offering,
+    // exam) key and silently generate-and-persist a mismatched row.
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Fall 2025");
+    mockedCached.mockResolvedValue({
+      guides: [{ ...RECENT, semester: "Spring 2026" }],
+    });
+
+    renderStudy();
+    await userEvent.click(await screen.findByText("Midterm 1"));
+
+    await waitFor(() =>
+      expect(mockedGuide).toHaveBeenCalledWith("u1", "c1", "e1", "Spring 2026"),
+    );
+    expect(mockedGuide).not.toHaveBeenCalledWith("u1", "c1", "e1", "Fall 2025");
+    // The exams picker still follows the ACTIVE selector — only the recent
+    // open itself is pinned to the entry's term.
+    expect(mockedExams).toHaveBeenCalledWith("u1", "c1", "Fall 2025");
+    expect(mockedRegenerate).not.toHaveBeenCalled();
+  });
+
+  it("opens a term-less recent entry unscoped, even with an active term", async () => {
+    // Legacy cached shape (no semester field): the entry's own term is
+    // unknown, so the open falls back to unscoped current-term resolution —
+    // NOT the active selector's term, which the entry need not belong to.
     window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Fall 2025");
     mockedCached.mockResolvedValue({ guides: [RECENT] });
 
@@ -142,10 +188,26 @@ describe("Study guide path threads the active semester", () => {
     await userEvent.click(await screen.findByText("Midterm 1"));
 
     await waitFor(() =>
+      expect(mockedGuide).toHaveBeenCalledWith("u1", "c1", "e1", undefined),
+    );
+  });
+
+  it("picker-driven loads use the active semester", async () => {
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Fall 2025");
+    mockedCourses.mockResolvedValue({ courses: [COURSE_C1] });
+    mockedExams.mockResolvedValue({
+      exams: [{ id: "e1", title: "Midterm 1", due_date: "2026-04-01" }],
+    });
+
+    renderStudy();
+    await userEvent.click(await screen.findByRole("button", { name: /pick a course/i }));
+    await userEvent.click(await screen.findByRole("option", { name: /CS101/ }));
+    await userEvent.click(await screen.findByRole("button", { name: /pick an exam/i }));
+    await userEvent.click(await screen.findByRole("option", { name: /Midterm 1/ }));
+
+    await waitFor(() =>
       expect(mockedGuide).toHaveBeenCalledWith("u1", "c1", "e1", "Fall 2025"),
     );
-    expect(mockedExams).toHaveBeenCalledWith("u1", "c1", "Fall 2025");
-    expect(mockedRegenerate).not.toHaveBeenCalled();
   });
 
   it("sends no semester while All semesters is active", async () => {
@@ -158,5 +220,32 @@ describe("Study guide path threads the active semester", () => {
       expect(mockedGuide).toHaveBeenCalledWith("u1", "c1", "e1", undefined),
     );
     expect(mockedExams).toHaveBeenCalledWith("u1", "c1", undefined);
+  });
+});
+
+describe("Study guide 404 copy (#475 F4)", () => {
+  it("shows the backend sentence for a no-offering 404, not the deleted-exam copy", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockedCached.mockResolvedValue({
+      guides: [{ ...RECENT, semester: "Fall 2025" }],
+    });
+    // Like the real ApiError: body text as message + the HTTP status attached
+    // (the detail has no "not found" wording, so isNotFound needs the status).
+    mockedGuide.mockRejectedValue(
+      Object.assign(
+        new Error('{"detail":"No offering of this course in that semester."}'),
+        { status: 404 },
+      ),
+    );
+
+    renderStudy();
+    await userEvent.click(await screen.findByText("Midterm 1"));
+
+    expect(
+      await screen.findByText("No offering of this course in that semester."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/isn't around anymore/i)).toBeNull();
+    // 404s stay guidance, never a red toast (role="status").
+    expect(screen.queryAllByRole("status")).toHaveLength(0);
   });
 });

--- a/frontend/src/components/screens/Study.test.tsx
+++ b/frontend/src/components/screens/Study.test.tsx
@@ -139,6 +139,7 @@ describe("Study — study guide that genuinely fails to build", () => {
 
     expect(mockedGuide).toHaveBeenCalledTimes(2);
     // Retries the exam that failed, not whatever the selects currently hold.
-    expect(mockedGuide).toHaveBeenLastCalledWith("u1", "c1", "exam-deleted");
+    // (4th arg: the active semester — undefined here, All semesters, #141.)
+    expect(mockedGuide).toHaveBeenLastCalledWith("u1", "c1", "exam-deleted", undefined);
   });
 });

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -24,7 +24,7 @@ const MarkdownChat = dynamic(
 import { StudyGuideSkeleton, FlashcardsSkeleton } from "../Skeleton";
 import { useToast } from "../ToastProvider";
 import { useIsMobile } from "@/lib/useIsMobile";
-import { humanizeError, isNotFound } from "@/lib/errorMessage";
+import { extractErrorDetail, humanizeError, isNotFound } from "@/lib/errorMessage";
 import { useUser } from "@/context/UserContext";
 import { useActiveSemester, courseInTerm } from "@/lib/useActiveSemester";
 import {
@@ -47,14 +47,17 @@ import { FlashcardImportModal } from "../flashcards/FlashcardImportModal";
 
 type Mode = "guide" | "cards";
 
-// A guide load fails two ways that deserve different UI: the exam is gone
-// (normal — a deleted assignment, or a stale "recent guides" entry), or the
-// generation itself broke. Only the second is worth a red toast, and it carries
-// the ids it was built from because opening a recent guide clears the exam
-// selection — the selects are not a reliable retry target.
+// A guide load fails two ways that deserve different UI: the guide's target
+// isn't there (normal — a deleted exam, a stale "recent guides" entry, or a
+// term with no offering of the course, #475 F4; `message` carries the server's
+// sentence when it isn't the exam-deleted one), or the generation itself
+// broke. Only the second is worth a red toast, and it carries the ids + term
+// it was built from because opening a recent guide clears the exam selection —
+// the selects are not a reliable retry target. `semester` is the term the
+// failed load resolved with ("" = unscoped), so retry replays it exactly.
 type GuideProblem =
-  | { kind: "missing" }
-  | { kind: "failed"; message: string; courseId: string; examId: string };
+  | { kind: "missing"; message?: string }
+  | { kind: "failed"; message: string; courseId: string; examId: string; semester: string };
 
 type RawCard = {
   id: string;
@@ -236,12 +239,21 @@ function GuideMode({
       .finally(() => setLoadingExams(false));
   }, [courseId, userId, toast, semester, semesterReady]);
 
-  const loadGuide = React.useCallback(async (cid: string, eid: string) => {
+  // A pending recent-open's OWN term (#475 F1), consumed by exactly one load:
+  // null = no pending recent open; "" = the entry has no term label, open
+  // explicitly unscoped.
+  const recentTermRef = React.useRef<string | null>(null);
+
+  const loadGuide = React.useCallback(async (cid: string, eid: string, termOverride?: string) => {
     if (!userId) return;
+    // termOverride pins the term for THIS load ("" = explicitly unscoped):
+    // recent entries open as their own term (#475 F1) and retries replay the
+    // term that failed. Without it, the active selector applies.
+    const term = termOverride !== undefined ? (termOverride || undefined) : (semester || undefined);
     setLoadingGuide(true);
     setGuideProblem(null);
     try {
-      const r = await getStudyGuide(userId, cid, eid, semester || undefined);
+      const r = await getStudyGuide(userId, cid, eid, term);
       setGuide(r.guide);
       setGeneratedAt(r.generated_at);
       setCached(r.cached);
@@ -250,10 +262,19 @@ function GuideMode({
       console.error("study guide load failed", err);
       setGuide(null);
       if (isNotFound(err)) {
-        setGuideProblem({ kind: "missing" });
+        // #475 F4: not every 404 means "exam deleted" — strict semester
+        // resolution 404s when the course has no offering in the requested
+        // term. Surface the server's sentence unless it IS the exam-deleted
+        // one (or is absent).
+        const { detail } = extractErrorDetail(err);
+        setGuideProblem(
+          !detail || detail.startsWith("Exam not found")
+            ? { kind: "missing" }
+            : { kind: "missing", message: detail },
+        );
       } else {
         const message = humanizeError(err, "Couldn't build that study guide.");
-        setGuideProblem({ kind: "failed", message, courseId: cid, examId: eid });
+        setGuideProblem({ kind: "failed", message, courseId: cid, examId: eid, semester: term ?? "" });
         toast.error(message);
       }
     } finally {
@@ -262,10 +283,21 @@ function GuideMode({
   }, [userId, toast, loadRecent, semester]);
 
   React.useEffect(() => {
-    if (courseId && examId) loadGuide(courseId, examId);
+    if (courseId && examId) {
+      // Consume a pending recent-open term so ONLY this load is pinned to the
+      // entry's own term; later picker-driven loads follow the selector.
+      const recentTerm = recentTermRef.current;
+      recentTermRef.current = null;
+      loadGuide(courseId, examId, recentTerm ?? undefined);
+    }
   }, [courseId, examId, loadGuide]);
 
   const openRecent = (entry: StudyGuideCacheEntry) => {
+    // #475 F1: the entry's guide row keys on ITS offering/term, which need
+    // not match the active selector — a Spring guide in the rail must open as
+    // Spring, or the strict resolver cache-misses under the active term and
+    // silently generates (and persists) a mismatched row.
+    recentTermRef.current = entry.semester ?? "";
     setCourseId(entry.course_id);
     setExamId(entry.exam_id);
   };
@@ -384,10 +416,16 @@ function GuideMode({
           <EmptyHint title="Choose an exam" body="The guide will be generated from your course material the first time." />
         )}
         {!loadingGuide && !regenerating && guideProblem?.kind === "missing" && (
-          <EmptyHint
-            title="That exam isn't around anymore"
-            body="It was probably deleted. Pick another exam above, or add one on the Calendar page to build a guide for it."
-          />
+          guideProblem.message ? (
+            // #475 F4: the server said something more specific than "exam
+            // deleted" (e.g. no offering in the requested term) — show it.
+            <EmptyHint title="That guide isn't available" body={guideProblem.message} />
+          ) : (
+            <EmptyHint
+              title="That exam isn't around anymore"
+              body="It was probably deleted. Pick another exam above, or add one on the Calendar page to build a guide for it."
+            />
+          )
         )}
         {!loadingGuide && !regenerating && guideProblem?.kind === "failed" && (
           <EmptyHint
@@ -396,7 +434,10 @@ function GuideMode({
             action={
               <button
                 className="btn btn--sm btn--primary"
-                onClick={() => loadGuide(guideProblem.courseId, guideProblem.examId)}
+                // Replays the exact load that failed — ids AND term (#475 F1).
+                onClick={() =>
+                  loadGuide(guideProblem.courseId, guideProblem.examId, guideProblem.semester)
+                }
                 disabled={loadingGuide}
               >
                 Try again

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -77,7 +77,7 @@ export function Study() {
     searchParams.get("mode") === "cards" ? "cards" : "guide",
   );
   const [courses, setCourses] = React.useState<EnrolledCourse[]>([]);
-  const [activeSemester] = useActiveSemester();
+  const [activeSemester, , semesterHydrated] = useActiveSemester();
 
   React.useEffect(() => {
     if (!userReady || !userId) return;
@@ -158,9 +158,19 @@ export function Study() {
           style={{ display: "flex", flex: 1, minHeight: 0 }}
         >
           {mode === "guide" ? (
-            <GuideMode courses={scopedCourses} isMobile={isMobile} />
+            <GuideMode
+              courses={scopedCourses}
+              isMobile={isMobile}
+              semester={activeSemester}
+              semesterReady={semesterHydrated}
+            />
           ) : (
-            <FlashcardsMode courses={scopedCourses} isMobile={isMobile} />
+            <FlashcardsMode
+              courses={scopedCourses}
+              isMobile={isMobile}
+              semester={activeSemester}
+              semesterReady={semesterHydrated}
+            />
           )}
         </motion.div>
       </AnimatePresence>
@@ -170,7 +180,20 @@ export function Study() {
 
 // ── Study Guide mode ─────────────────────────────────────────────────────────
 
-function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile: boolean }) {
+function GuideMode({
+  courses,
+  isMobile,
+  semester,
+  semesterReady,
+}: {
+  courses: EnrolledCourse[];
+  isMobile: boolean;
+  // The active semester ("" = All semesters → unscoped fetches, #141) and its
+  // hydration flag — fetches wait for it so a stored term never produces an
+  // unscoped-then-scoped double fetch (the Dashboard pattern).
+  semester: string;
+  semesterReady: boolean;
+}) {
   const toast = useToast();
   const { userId } = useUser();
   const [courseId, setCourseId] = React.useState<string>("");
@@ -202,23 +225,23 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
     setExams([]);
     setGuide(null);
     setGuideProblem(null);
-    if (!courseId || !userId) return;
+    if (!courseId || !userId || !semesterReady) return;
     setLoadingExams(true);
-    getStudyGuideExams(userId, courseId)
+    getStudyGuideExams(userId, courseId, semester || undefined)
       .then(r => setExams(r.exams || []))
       .catch(err => {
         console.error("study exams load failed", err);
         toast.error(humanizeError(err, "Couldn't load the exams for this course."));
       })
       .finally(() => setLoadingExams(false));
-  }, [courseId, userId, toast]);
+  }, [courseId, userId, toast, semester, semesterReady]);
 
   const loadGuide = React.useCallback(async (cid: string, eid: string) => {
     if (!userId) return;
     setLoadingGuide(true);
     setGuideProblem(null);
     try {
-      const r = await getStudyGuide(userId, cid, eid);
+      const r = await getStudyGuide(userId, cid, eid, semester || undefined);
       setGuide(r.guide);
       setGeneratedAt(r.generated_at);
       setCached(r.cached);
@@ -236,7 +259,7 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
     } finally {
       setLoadingGuide(false);
     }
-  }, [userId, toast, loadRecent]);
+  }, [userId, toast, loadRecent, semester]);
 
   React.useEffect(() => {
     if (courseId && examId) loadGuide(courseId, examId);
@@ -254,7 +277,8 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
     setRegenerating(true);
     setGuideProblem(null);
     try {
-      const r = await regenerateStudyGuide(userId, courseId, examId);
+      // Regenerates the SELECTED term's guide — same offering the reads key on.
+      const r = await regenerateStudyGuide(userId, courseId, examId, semester || undefined);
       setGuide(r.guide);
       setGeneratedAt(r.generated_at);
       setCached(false);
@@ -463,7 +487,19 @@ function GuideMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile:
 
 // ── Flashcards mode ──────────────────────────────────────────────────────────
 
-function FlashcardsMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMobile: boolean }) {
+function FlashcardsMode({
+  courses,
+  isMobile,
+  semester,
+  semesterReady,
+}: {
+  courses: EnrolledCourse[];
+  isMobile: boolean;
+  // See GuideMode: "" = All semesters (unscoped); fetches gate on
+  // semesterReady so a stored term never double-fetches (#141).
+  semester: string;
+  semesterReady: boolean;
+}) {
   const toast = useToast();
   const { userId } = useUser();
   const [cards, setCards] = React.useState<RawCard[]>([]);
@@ -488,7 +524,7 @@ function FlashcardsMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMo
     if (!userId) return;
     setLoading(true);
     try {
-      const res = await getFlashcards(userId);
+      const res = await getFlashcards(userId, undefined, semester || undefined);
       setCards(res.flashcards || []);
       setIdx(0);
       setFlipped(false);
@@ -497,9 +533,11 @@ function FlashcardsMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMo
     } finally {
       setLoading(false);
     }
-  }, [userId]);
+  }, [userId, semester]);
 
-  React.useEffect(() => { load(); }, [load]);
+  React.useEffect(() => {
+    if (semesterReady) load();
+  }, [load, semesterReady]);
 
   const topics = React.useMemo(() => {
     const set = new Set<string>();
@@ -574,7 +612,8 @@ function FlashcardsMode({ courses, isMobile }: { courses: EnrolledCourse[]; isMo
     setGenerating(true);
     setDocsUsed(null);
     try {
-      const r = await generateFlashcards(userId, topic, 5);
+      // Term-scoped generation context: the selected term's course documents.
+      const r = await generateFlashcards(userId, topic, 5, semester || undefined);
       setDocsUsed(r.context_used?.documents_found ?? 0);
       await load();
       toast.success(`Added ${r.flashcards.length} new card${r.flashcards.length === 1 ? "" : "s"}.`);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -689,16 +689,25 @@ export interface GenerateFlashcardsResponse {
   context_used?: { documents_found: number; weak_concepts_found: number };
 }
 
-export const generateFlashcards = (userId: string, topic: string, count = 5) =>
+// `semester` (term label, #141) grounds generation in that term's course
+// documents; omitted = current term. JSON.stringify drops it when unset.
+export const generateFlashcards = (userId: string, topic: string, count = 5, semester?: string) =>
   fetchJSON<GenerateFlashcardsResponse>('/api/flashcards/generate', {
     method: 'POST',
-    body: JSON.stringify({ user_id: userId, topic, count }),
+    body: JSON.stringify({ user_id: userId, topic, count, semester }),
   });
 
-export const getFlashcards = (userId: string, topic?: string) =>
-  fetchJSON<{ flashcards: any[] }>(
-    `/api/flashcards/user/${userId}${topic ? `?topic=${encodeURIComponent(topic)}` : ''}`
+// `semester` scopes the list to that term's offerings (term-less cards stay
+// visible); ""/undefined = All semesters, the unscoped default (#141).
+export const getFlashcards = (userId: string, topic?: string, semester?: string) => {
+  const params = new URLSearchParams();
+  if (topic) params.set('topic', topic);
+  if (semester) params.set('semester', semester);
+  const qs = params.toString();
+  return fetchJSON<{ flashcards: any[] }>(
+    `/api/flashcards/user/${userId}${qs ? `?${qs}` : ''}`
   );
+};
 
 export const rateFlashcard = (userId: string, cardId: string, rating: number) =>
   fetchJSON<{ ok: boolean }>('/api/flashcards/rate', {
@@ -802,22 +811,27 @@ export interface StudyGuideCacheEntry {
   generated_at: string;
 }
 
-export const getStudyGuideExams = (userId: string, courseId: string) =>
+// The study-guide reads take an optional `semester` (term label, #141): the
+// guide keys on that term's offering instead of always the current term's.
+// Omitted/"" = the unchanged current-term resolution.
+export const getStudyGuideExams = (userId: string, courseId: string, semester?: string) =>
   fetchJSON<{ exams: StudyGuideExam[] }>(
-    `/api/study-guide/${encodeURIComponent(userId)}/exams?course_id=${encodeURIComponent(courseId)}`,
+    `/api/study-guide/${encodeURIComponent(userId)}/exams?course_id=${encodeURIComponent(courseId)}` +
+      (semester ? `&semester=${encodeURIComponent(semester)}` : ''),
   );
 
-export const getStudyGuide = (userId: string, courseId: string, examId: string) =>
+export const getStudyGuide = (userId: string, courseId: string, examId: string, semester?: string) =>
   fetchJSON<{ guide: StudyGuideContent; generated_at: string; cached: boolean }>(
-    `/api/study-guide/${encodeURIComponent(userId)}/guide?course_id=${encodeURIComponent(courseId)}&exam_id=${encodeURIComponent(examId)}`,
+    `/api/study-guide/${encodeURIComponent(userId)}/guide?course_id=${encodeURIComponent(courseId)}&exam_id=${encodeURIComponent(examId)}` +
+      (semester ? `&semester=${encodeURIComponent(semester)}` : ''),
   );
 
-export const regenerateStudyGuide = (userId: string, courseId: string, examId: string) =>
+export const regenerateStudyGuide = (userId: string, courseId: string, examId: string, semester?: string) =>
   fetchJSON<{ success: boolean; guide: StudyGuideContent; generated_at: string }>(
     '/api/study-guide/regenerate',
     {
       method: 'POST',
-      body: JSON.stringify({ user_id: userId, course_id: courseId, exam_id: examId }),
+      body: JSON.stringify({ user_id: userId, course_id: courseId, exam_id: examId, semester }),
     },
   );
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -809,11 +809,18 @@ export interface StudyGuideCacheEntry {
   exam_title: string;
   overview: string;
   generated_at: string;
+  // The entry's OWN term label (#475 F1): a recent guide opens as its own
+  // term, overriding the active selector for that open. null when the row's
+  // offering has no term; optional for bodies cached before the field shipped.
+  semester?: string | null;
 }
 
-// The study-guide reads take an optional `semester` (term label, #141): the
-// guide keys on that term's offering instead of always the current term's.
-// Omitted/"" = the unchanged current-term resolution.
+// The study-guide reads take an optional `semester` (term label, #141).
+// With it, each read resolves STRICTLY to that term's offering. Omitted/"":
+// getStudyGuide/regenerateStudyGuide fall back to current-term offering
+// resolution, while getStudyGuideExams lists exams across ALL of the user's
+// enrollments of the course (every term) — that asymmetry is pre-existing
+// behavior, documented as-is.
 export const getStudyGuideExams = (userId: string, courseId: string, semester?: string) =>
   fetchJSON<{ exams: StudyGuideExam[] }>(
     `/api/study-guide/${encodeURIComponent(userId)}/exams?course_id=${encodeURIComponent(courseId)}` +


### PR DESCRIPTION
## #141, reframed (approved by Andres on 2026-07-30)

Closes #141.

No Archive toggle. The existing semester selector (All-semesters default untouched — the #360 e2e-vetoed contract) now scopes the **study-tool read paths** the way it already scopes the graph. Full analysis + reframe rationale: the corrected-state comment on #141.

### Backend — optional `semester` (term label via `academics.term_id_for_label`), strict resolution
- **`services/academics.py`**: `resolve_offering(..., fallback: bool = True)` — new strict mode. The existing `create=False` path silently falls back to *any* offering of the course; with an explicit `semester` that would have silently served another term's content. `fallback=False` returns `None` on a term miss. Additive, default-preserving; resolver tests pin both modes.
- **`routes/study_guide.py`**: `GET /{user}/guide?semester=`, `POST /regenerate` (body), `GET /{user}/exams?semester=` — term miss → 404 (guide/regenerate) with the agent never invoked, exams filtered via `term_for_offering`.
- **`routes/flashcards.py`**: `GET /user/{user}?semester=` — cards filtered to the term's offerings; **term-less cards (offering_id NULL) stay visible under any selection**; unknown label degrades to term-less-only, never 500. `POST /generate` grounds its docs context in the selected term's offering. `import/commit` stays current-term (comment).
- **`routes/notes.py`**: course-filtered read takes `semester`; term miss → empty list. Create/re-home stay current-term by design (comments).
- **`routes/quiz.py`**: untouched — no term resolution exists; quiz scoping is already client-side via the graph picker.
- 17 new pytest cases (red-first): per-route current-term default / scoped / miss-degrades-not-500, plus the resolver modes.

### Frontend
- `lib/api.ts`: optional `semester` on `getStudyGuideExams` / `getStudyGuide` / `regenerateStudyGuide` / `getFlashcards` / `generateFlashcards`.
- `Study.tsx`: `useActiveSemester()` threaded into both modes, fetches gated on the hydrated flag (Dashboard pattern, call-count-pinned — no unscoped-then-scoped double fetch). Notetaker deliberately not wired (no semester context on that screen; the notes param is API-completeness).
- Journey `e2e/study-semester.spec.ts`: All-semesters default shows the fall + spring decks together; hub → "Fall 2025" → only the fall deck serves. No generation triggered (function-mode-seam safe); no new interactive elements → no surface registration needed.

### Gates
Backend `pytest tests/ -q` → 1499 passed, 32 skipped; `ruff check .` clean. Frontend vitest 47 files / 353 tests; `tsc --noEmit` clean; `eslint .` 0 errors. Based on main @ `9edfcf5`. Pre-merge flock'd e2e cycle to follow.

### Note for a follow-up issue
Found pre-existing (not fixed here): opening a guide from the "Recent guides" rail clears the exam selection, leaving Regenerate permanently disabled on that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added semester-aware filtering for flashcards, notes, exams, and study guides.
  * Flashcard generation and study-guide creation now use the selected semester’s course content.
  * Added support for switching between all semesters and a specific semester in Study.
  * Gracefully handles unknown semesters or courses without offerings.

* **Tests**
  * Added coverage for semester filtering, generation, study-guide retrieval, and regeneration flows.
  * Added end-to-end validation for semester-specific flashcard decks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->