### PR TITLE
feat(analytics): #121 data layer — bucket param, typed client, hooks, raw admin page

### DIFF
--- a/backend/routes/admin_analytics.py
+++ b/backend/routes/admin_analytics.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from db.connection import table
 from services.auth_guard import require_admin
@@ -39,12 +39,18 @@ _SCAN_CAP = 100_000
 GroupBy = Literal["user", "feature", "model"]
 _GROUP_COLUMN = {"user": "user_id", "feature": "feature", "model": "model"}
 
+# Day is the only bucket the dashboard needs (#121); the Literal keeps the
+# param 422-validated so a future "week"/"hour" is an explicit contract change.
+Bucket = Literal["day"]
+
 
 # ── Response models ──────────────────────────────────────────────────────────
 
 
 class Range(BaseModel):
-    from_: str
+    # Serialized as "from" to match the query param — the reserved word only
+    # forces the underscore on the Python side, never on the wire.
+    from_: str = Field(serialization_alias="from")
     to: str
 
 
@@ -53,12 +59,27 @@ class EventTypeCount(BaseModel):
     count: int
 
 
+class DayCount(BaseModel):
+    date: str  # YYYY-MM-DD, UTC
+    count: int
+
+
+class CostDayPoint(BaseModel):
+    date: str  # YYYY-MM-DD, UTC
+    calls: int
+    total_tokens: int
+    cost_usd: float
+
+
 class UsageSummary(BaseModel):
     range: Range
     total_events: int
     distinct_active_users: int
     by_event_type: list[EventTypeCount]
     truncated: bool = False
+    # Present only when ?bucket=day. Sparse: days with no rows are omitted —
+    # the client zero-fills the axis from `range`.
+    series: list[DayCount] | None = None
 
 
 class UserUsage(BaseModel):
@@ -101,6 +122,8 @@ class LLMCost(BaseModel):
     rows: list[CostRow]
     totals: CostTotals
     truncated: bool = False
+    # Present only when ?bucket=day; sparse (see UsageSummary.series).
+    series: list[CostDayPoint] | None = None
 
 
 class ErrorEvent(BaseModel):
@@ -120,6 +143,11 @@ class ErrorsPage(BaseModel):
     limit: int
     offset: int
     errors: list[ErrorEvent]
+    # `series` needs its own range scan (the feed is paginated server-side),
+    # so unlike the feed it can hit the scan cap — `truncated` refers to the
+    # series only and stays False when no bucket was requested.
+    truncated: bool = False
+    series: list[DayCount] | None = None
 
 
 # ── Date range helpers ───────────────────────────────────────────────────────
@@ -204,6 +232,48 @@ def _as_int(value) -> int:
         return 0
 
 
+# ── Day bucketing (#121) ─────────────────────────────────────────────────────
+
+
+def _bucket_date(raw) -> str | None:
+    """UTC calendar day (YYYY-MM-DD) for a created_at value; None if unparseable."""
+    if not raw:
+        return None
+    try:
+        ts = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        # Legacy naive rows are UTC by construction (pre-#248 writes).
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc).date().isoformat()
+
+
+def _count_series(rows: list[dict]) -> list[DayCount]:
+    counts: dict[str, int] = defaultdict(int)
+    for r in rows:
+        day = _bucket_date(r.get("created_at"))
+        if day:
+            counts[day] += 1
+    return [DayCount(date=d, count=c) for d, c in sorted(counts.items())]
+
+
+def _cost_series(rows: list[dict]) -> list[CostDayPoint]:
+    days: dict[str, dict] = defaultdict(lambda: {"calls": 0, "total_tokens": 0, "cost_usd": 0.0})
+    for r in rows:
+        day = _bucket_date(r.get("created_at"))
+        if not day:
+            continue
+        d = days[day]
+        d["calls"] += 1
+        d["total_tokens"] += _as_int(r.get("total_tokens"))
+        d["cost_usd"] += _as_float(r.get("cost_usd"))
+    return [
+        CostDayPoint(date=k, calls=v["calls"], total_tokens=v["total_tokens"], cost_usd=round(v["cost_usd"], 6))
+        for k, v in sorted(days.items())
+    ]
+
+
 # ── Endpoints ────────────────────────────────────────────────────────────────
 
 
@@ -213,6 +283,7 @@ def usage_summary(
     response: Response,
     from_: str | None = Query(None, alias="from"),
     to: str | None = Query(None),
+    bucket: Bucket | None = Query(None),
 ) -> UsageSummary:
     """Event totals for the range; `truncated: true` means the scan cap cut the aggregation short."""
     require_admin(request)
@@ -236,6 +307,7 @@ def usage_summary(
             key=lambda e: e.count, reverse=True,
         ),
         truncated=truncated,
+        series=_count_series(rows) if bucket else None,
     )
 
 
@@ -309,6 +381,7 @@ def llm_cost(
     from_: str | None = Query(None, alias="from"),
     to: str | None = Query(None),
     group_by: GroupBy = Query("feature"),
+    bucket: Bucket | None = Query(None),
 ) -> LLMCost:
     """LLM token/cost rollup; `truncated: true` means the scan cap cut the aggregation short."""
     require_admin(request)
@@ -354,6 +427,7 @@ def llm_cost(
     return LLMCost(
         range=Range(from_=from_iso, to=to_iso), group_by=group_by,
         rows=cost_rows, totals=totals, truncated=truncated,
+        series=_cost_series(rows) if bucket else None,
     )
 
 
@@ -365,8 +439,9 @@ def errors(
     to: str | None = Query(None),
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
+    bucket: Bucket | None = Query(None),
 ) -> ErrorsPage:
-    """Paginated error.* event feed (server-side pagination — no range scan, so no cap)."""
+    """Paginated error.* event feed; `?bucket=day` adds a per-day series (its own capped scan)."""
     require_admin(request)
     response.headers["Cache-Control"] = "private"
     from_iso, to_iso = _resolve_range(from_, to)
@@ -376,6 +451,14 @@ def errors(
         filters={"created_at": [f"gte.{from_iso}", f"lte.{to_iso}"], "event_type": "like.error.*"},
         order="created_at.desc", limit=limit, offset=offset,
     )
+    series = None
+    series_truncated = False
+    if bucket:
+        scan_rows, series_truncated = _scan_range(
+            "events", "created_at", from_iso, to_iso,
+            extra_filters={"event_type": "like.error.*"},
+        )
+        series = _count_series(scan_rows)
     items = []
     for r in rows:
         payload = r.get("payload") or {}
@@ -392,4 +475,5 @@ def errors(
     return ErrorsPage(
         range=Range(from_=from_iso, to=to_iso),
         total=total, limit=limit, offset=offset, errors=items,
+        truncated=series_truncated, series=series,
     )

--- a/backend/tests/test_admin_analytics_routes.py
+++ b/backend/tests/test_admin_analytics_routes.py
@@ -264,6 +264,80 @@ def test_responses_are_cache_control_private(seeded):
         assert r.headers.get("Cache-Control") == "private", path
 
 
+# ── range serialization + day bucketing (#121 backend) ───────────────────────
+
+
+def test_range_serializes_as_from(seeded):
+    # The wire key must be "from" (matching the query param), not the Python
+    # field name "from_" — the TS client types freeze on this shape.
+    r = client.get(f"{BASE}/usage/summary", params=RANGE)
+    assert r.json()["range"] == {"from": RANGE["from"], "to": RANGE["to"]}
+
+
+def test_usage_summary_bucket_day_series(seeded):
+    r = client.get(f"{BASE}/usage/summary", params={**RANGE, "bucket": "day"})
+    assert r.status_code == 200
+    body = r.json()
+    assert [p["date"] for p in body["series"]] == ["2026-07-10", "2026-07-12", "2026-07-15"]
+    assert [p["count"] for p in body["series"]] == [1, 1, 2]
+    # Bucketing adds the series; it must not change the aggregate fields.
+    assert body["total_events"] == 4
+    assert body["distinct_active_users"] == 2
+
+
+def test_usage_summary_without_bucket_has_no_series(seeded):
+    r = client.get(f"{BASE}/usage/summary", params=RANGE)
+    assert r.json()["series"] is None
+
+
+def test_llm_cost_bucket_day_series(seeded):
+    r = client.get(f"{BASE}/llm/cost", params={**RANGE, "bucket": "day"})
+    assert r.status_code == 200
+    series = r.json()["series"]
+    assert [p["date"] for p in series] == ["2026-07-10", "2026-07-12", "2026-07-15"]
+    assert [p["calls"] for p in series] == [1, 1, 1]
+    assert [p["total_tokens"] for p in series] == [150, 300, 120]
+    assert series[0]["cost_usd"] == pytest.approx(0.01)
+    assert series[1]["cost_usd"] == pytest.approx(0.05)
+    assert series[2]["cost_usd"] == pytest.approx(0.02)
+
+
+def test_errors_bucket_day_series(seeded):
+    r = client.get(f"{BASE}/errors", params={**RANGE, "bucket": "day"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["series"] == [{"date": "2026-07-15", "count": 1}]
+    assert body["total"] == 1
+    assert body["truncated"] is False
+
+
+def test_bucket_rejects_invalid_value(seeded):
+    r = client.get(f"{BASE}/usage/summary", params={**RANGE, "bucket": "hour"})
+    assert r.status_code == 422
+
+
+def test_errors_bucket_series_truncation_is_surfaced(monkeypatch):
+    # The errors series needs its own range scan (the feed itself is paginated
+    # server-side); that scan can hit the cap and must say so, never silently.
+    store = {
+        "events": [
+            {"event_type": "error.5xx", "category": "error", "user_id": "u1", "request_id": f"r{i}",
+             "payload": {"path": "/api/x", "method": "GET", "status_code": 500, "duration_ms": 1.0},
+             "created_at": ts}
+            for i, ts in enumerate([IN1, IN2, IN3])
+        ],
+        "llm_usage": [],
+    }
+    monkeypatch.setattr(analytics, "table", lambda name: _FakeTable(store.get(name, [])))
+    monkeypatch.setattr(analytics, "_PAGE", 1)
+    monkeypatch.setattr(analytics, "_SCAN_CAP", 2)
+    r = client.get(f"{BASE}/errors", params={**RANGE, "bucket": "day"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["truncated"] is True
+    assert [p["count"] for p in body["series"]] == [1, 1]  # capped at 2 scanned rows
+
+
 # ── admin gating ─────────────────────────────────────────────────────────────
 
 

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -78,6 +78,7 @@ renders the element.
 | Library | `library` | `frontend/src/components/screens/Library.tsx` (the `/library` document screen — upload trigger, document cards/rows, filters, detail panel) |
 | Calendar | `calendar` | `frontend/src/components/screens/Calendar.tsx` (the `/calendar` screen — today just the #185 load-failure banner + retry) |
 | Gradebook | `gradebook` | `frontend/src/components/screens/Gradebook/Landing.tsx` + `Course.tsx` (the `/gradebook` screens), `frontend/src/components/Gradebook/TranscriptModal.tsx` (the transcript modal), `frontend/src/components/Gradebook/CourseCard.tsx` (the term-aware card links), `frontend/src/components/Gradebook/AssignmentList.tsx` + `AssignmentModal.tsx` (the add-assignment flow the #468 mutation leg drives) — added with the #139 term-switcher/transcript journey |
+| Admin analytics | `admin-analytics` | `frontend/src/components/screens/AdminAnalytics.tsx` (the `/admin/analytics` dashboard — range presets/inputs, cost group-by toggle, per-panel retry) — added with the #121 data layer |
 
 Two surfaces do **not** carry their testids in the screen file named by the
 route:
@@ -269,6 +270,19 @@ inside the `role="grid"` "Courses" grid.
 | `gradebook-add-assignment` | course page: "+ Add Assignment" (`AssignmentList.tsx`) — opens the assignment modal |
 | `gradebook-assignment-title` | assignment modal: the required title `<input>` |
 | `gradebook-assignment-save` | assignment modal: the Save button |
+
+### `admin-analytics`
+
+Added with the #121 data layer (raw tables; #122 replaces the tables with
+charts on the same testids). Every interactive element is tagged — the file
+entered the lint block new, so there is no baselined backlog.
+
+| testid | element |
+| --- | --- |
+| `admin-analytics-range-7d` / `-30d` / `-90d` | the last-N-days range presets — each re-queries every panel |
+| `admin-analytics-range-from` / `-to` | the custom date inputs (UTC day start/end) |
+| `admin-analytics-costgroup-feature` / `-user` / `-model` | the LLM-cost group-by toggle (drives the `group_by` query) |
+| `admin-analytics-usage-retry` / `-users-retry` / `-cost-retry` / `-errors-retry` | per-panel "Try again" after a failed load (`error && !data` gate) |
 
 ### `library`
 

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -281,7 +281,7 @@ entered the lint block new, so there is no baselined backlog.
 | --- | --- |
 | `admin-analytics-range-7d` / `-30d` / `-90d` | the last-N-days range presets — each re-queries every panel |
 | `admin-analytics-range-from` / `-to` | the custom date inputs (UTC day start/end) |
-| `admin-analytics-costgroup-feature` / `-user` / `-model` | the LLM-cost group-by toggle (drives the `group_by` query) |
+| `admin-analytics-cost-group-feature` / `-user` / `-model` | the LLM-cost group-by toggle (drives the `group_by` query) |
 | `admin-analytics-usage-retry` / `-users-retry` / `-cost-retry` / `-errors-retry` | per-panel "Try again" after a failed load (`error && !data` gate) |
 
 ### `library`

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -72,6 +72,7 @@ const eslintConfig = [
       "src/components/Gradebook/CourseCard.tsx",
       "src/components/Gradebook/AssignmentList.tsx",
       "src/components/Gradebook/AssignmentModal.tsx",
+      "src/components/screens/AdminAnalytics.tsx",
     ],
     rules: {
       "no-restricted-syntax": [

--- a/frontend/src/app/(shell)/admin/analytics/page.tsx
+++ b/frontend/src/app/(shell)/admin/analytics/page.tsx
@@ -1,0 +1,5 @@
+import { AdminAnalytics } from "@/components/screens/AdminAnalytics";
+
+export default function AdminAnalyticsPage() {
+  return <AdminAnalytics />;
+}

--- a/frontend/src/components/screens/AdminAnalytics.test.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.test.tsx
@@ -25,6 +25,17 @@ vi.mock("../TopBar", () => ({
   TopBar: ({ title }: { title: string }) => <div>{title}</div>,
 }));
 
+// Hoisted toast spies — background-reload failures surface via toast.error
+// (the #463 Calendar convention), never via the banner once data exists.
+const toastSpies = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+}));
+vi.mock("../ToastProvider", () => ({
+  useToast: () => toastSpies,
+}));
+
 vi.mock("../Icon", () => ({
   Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
 }));
@@ -143,5 +154,48 @@ describe("AdminAnalytics", () => {
     render(<AdminAnalytics />);
     await screen.findByText("quiz");
     expect(screen.getByText(/truncated/i)).toBeTruthy();
+  });
+
+  it("toasts a failed background reload and keeps the loaded view (no banner)", async () => {
+    primeHappyPath();
+    render(<AdminAnalytics />);
+    await screen.findByText("42");
+    api.adminUsageSummary.mockRejectedValueOnce(new Error("reload boom"));
+    fireEvent.click(screen.getByTestId("admin-analytics-range-7d"));
+    await waitFor(() => expect(toastSpies.error).toHaveBeenCalled());
+    // Stale-but-loaded data stays visible; the initial-load banner never appears.
+    expect(screen.getByText("42")).toBeTruthy();
+    expect(screen.queryByTestId("admin-analytics-usage-retry")).toBeNull();
+  });
+
+  it("ignores a stale response that resolves after a newer request", async () => {
+    primeHappyPath();
+    let resolveStale!: (v: typeof summaryFixture) => void;
+    // First (30d) summary request hangs; the later (7d) one resolves first.
+    api.adminUsageSummary
+      .mockReturnValueOnce(new Promise((r) => { resolveStale = r; }))
+      .mockResolvedValueOnce({ ...summaryFixture, total_events: 99 });
+    render(<AdminAnalytics />);
+    await screen.findByText("u-alpha"); // other panels loaded
+    fireEvent.click(screen.getByTestId("admin-analytics-range-7d"));
+    await screen.findByText("99");
+    resolveStale(summaryFixture); // the out-of-order 30d response lands late
+    await waitFor(() => expect(screen.queryByText("42")).toBeNull());
+    expect(screen.getByText("99")).toBeTruthy();
+  });
+
+  it("clamps an inverted custom range instead of sending from > to", async () => {
+    primeHappyPath();
+    render(<AdminAnalytics />);
+    await screen.findByText("42");
+    // Move `from` past the current `to` — the `to` edge must be dragged along.
+    fireEvent.change(screen.getByTestId("admin-analytics-range-from"), {
+      target: { value: "2099-09-01" },
+    });
+    await waitFor(() => {
+      const last = api.adminUsageSummary.mock.calls.at(-1)![0];
+      expect(last.from).toBe("2099-09-01T00:00:00.000Z");
+      expect(last.to >= last.from).toBe(true);
+    });
   });
 });

--- a/frontend/src/components/screens/AdminAnalytics.test.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+/**
+ * Component tests for the admin analytics screen (#121 — data layer + raw
+ * tables; charts come with #122).
+ *
+ * What these pin:
+ *   - the admin gate (non-admins get the Admin-screen refusal, zero fetches);
+ *   - all four panels render live data from the /api/admin/analytics wrappers;
+ *   - a failed panel load shows a banner + retry that refetches (the house
+ *     "error && !data" pattern), without blanking the other panels;
+ *   - the range presets drive every query (new `from` on refetch);
+ *   - a truncated aggregation surfaces its badge (never silent partial data).
+ */
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const userState = vi.hoisted(() => ({ isAdmin: true, userReady: true, userId: "admin-1" }));
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => userState,
+}));
+
+vi.mock("../TopBar", () => ({
+  TopBar: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock("../Icon", () => ({
+  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+}));
+
+const api = vi.hoisted(() => ({
+  adminUsageSummary: vi.fn(),
+  adminUsageByUser: vi.fn(),
+  adminLlmCost: vi.fn(),
+  adminErrors: vi.fn(),
+}));
+vi.mock("@/lib/api", () => api);
+
+import { AdminAnalytics } from "./AdminAnalytics";
+
+const RANGE = { from: "2026-06-30T12:00:00.000Z", to: "2026-07-30T12:00:00.000Z" };
+
+const summaryFixture = {
+  range: RANGE,
+  total_events: 42,
+  distinct_active_users: 7,
+  by_event_type: [{ event_type: "note.created", count: 20 }],
+  truncated: false,
+  series: null,
+};
+const byUserFixture = {
+  range: RANGE,
+  total_users: 1,
+  limit: 50,
+  offset: 0,
+  users: [{ user_id: "u-alpha", event_count: 5, by_category: { usage: 5 }, llm_cost_usd: 1.23, total_tokens: 456 }],
+  truncated: false,
+};
+const costFixture = {
+  range: RANGE,
+  group_by: "feature",
+  rows: [{ key: "quiz", calls: 3, prompt_tokens: 10, completion_tokens: 5, total_tokens: 15, cost_usd: 0.5 }],
+  totals: { calls: 3, prompt_tokens: 10, completion_tokens: 5, total_tokens: 15, cost_usd: 0.5 },
+  truncated: true,
+  series: null,
+};
+const errorsFixture = {
+  range: RANGE,
+  total: 1,
+  limit: 50,
+  offset: 0,
+  errors: [{
+    created_at: "2026-07-15T09:00:00+00:00", event_type: "error.5xx", request_id: "r1",
+    user_id: "u-alpha", path: "/api/quiz", method: "POST", status_code: 500, duration_ms: 12.3,
+  }],
+  truncated: false,
+  series: null,
+};
+
+function primeHappyPath() {
+  api.adminUsageSummary.mockResolvedValue(summaryFixture);
+  api.adminUsageByUser.mockResolvedValue(byUserFixture);
+  api.adminLlmCost.mockResolvedValue(costFixture);
+  api.adminErrors.mockResolvedValue(errorsFixture);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  userState.isAdmin = true;
+});
+
+describe("AdminAnalytics", () => {
+  it("refuses non-admins without fetching anything", () => {
+    userState.isAdmin = false;
+    render(<AdminAnalytics />);
+    expect(screen.getByText(/don't have admin access/i)).toBeTruthy();
+    expect(api.adminUsageSummary).not.toHaveBeenCalled();
+    expect(api.adminErrors).not.toHaveBeenCalled();
+  });
+
+  it("renders all four panels from the live wrappers", async () => {
+    primeHappyPath();
+    render(<AdminAnalytics />);
+    await waitFor(() => {
+      expect(screen.getByText("42")).toBeTruthy(); // total events
+      expect(screen.getByText("note.created")).toBeTruthy();
+      expect(screen.getByText("u-alpha")).toBeTruthy();
+      expect(screen.getByText("quiz")).toBeTruthy();
+      expect(screen.getByText("error.5xx")).toBeTruthy();
+    });
+  });
+
+  it("shows a banner + retry for a failed panel and refetches on retry", async () => {
+    primeHappyPath();
+    api.adminUsageSummary.mockRejectedValueOnce(new Error("boom"));
+    render(<AdminAnalytics />);
+    const retry = await screen.findByTestId("admin-analytics-usage-retry");
+    // The other panels keep their data — a single failed panel never blanks the page.
+    expect(screen.getByText("u-alpha")).toBeTruthy();
+    fireEvent.click(retry);
+    await waitFor(() => expect(screen.getByText("42")).toBeTruthy());
+    expect(api.adminUsageSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it("range presets drive every query", async () => {
+    primeHappyPath();
+    render(<AdminAnalytics />);
+    await screen.findByText("42");
+    const before = api.adminUsageSummary.mock.calls.length;
+    fireEvent.click(screen.getByTestId("admin-analytics-range-7d"));
+    await waitFor(() => expect(api.adminUsageSummary.mock.calls.length).toBeGreaterThan(before));
+    const lastSummary = api.adminUsageSummary.mock.calls.at(-1)![0];
+    const lastErrors = api.adminErrors.mock.calls.at(-1)![0];
+    expect(lastSummary.from).toBe(lastErrors.from); // one range drives all panels
+    const spanMs = new Date(lastSummary.to).getTime() - new Date(lastSummary.from).getTime();
+    expect(spanMs).toBe(7 * 86_400_000);
+  });
+
+  it("surfaces the truncation badge when an aggregation was capped", async () => {
+    primeHappyPath();
+    render(<AdminAnalytics />);
+    await screen.findByText("quiz");
+    expect(screen.getByText(/truncated/i)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/screens/AdminAnalytics.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.tsx
@@ -10,6 +10,7 @@
 
 import React from "react";
 import { TopBar } from "../TopBar";
+import { useToast } from "../ToastProvider";
 import { useUser } from "@/context/UserContext";
 import {
   presetRange,
@@ -40,9 +41,12 @@ const td: React.CSSProperties = {
 const tdNum: React.CSSProperties = { ...td, textAlign: "right", fontVariantNumeric: "tabular-nums" };
 
 function TruncatedBadge() {
+  // Copy stays meaning-neutral: on the aggregation panels `truncated` means
+  // the visible aggregates are partial; on the errors panel it refers to the
+  // (bucket=day) series scan only — the feed and total stay exact.
   return (
-    <span className="chip chip--err" title="The range was too large for a full scan — aggregates are partial.">
-      Truncated — partial aggregation
+    <span className="chip chip--err" title="The range was too large for a full scan — some of this panel's data is partial.">
+      Truncated — partial data
     </span>
   );
 }
@@ -102,18 +106,33 @@ export function AdminAnalytics() {
 function AnalyticsBody() {
   const [range, setRange] = React.useState<AnalyticsRangeValue>(() => presetRange(30));
   const [groupBy, setGroupBy] = React.useState<LlmCostGroupBy>("feature");
+  const toast = useToast();
+  // Failed BACKGROUND reloads keep the loaded view and toast (#463 convention).
+  const onBackgroundError = React.useCallback(
+    (message: string) => toast.error(message),
+    [toast],
+  );
 
-  const summary = useUsageSummary(range);
-  const byUser = useUsageByUser(range);
-  const cost = useLlmCost(range, groupBy);
-  const errs = useErrorsFeed(range);
+  const summary = useUsageSummary(range, { onBackgroundError });
+  const byUser = useUsageByUser(range, { onBackgroundError });
+  const cost = useLlmCost(range, { groupBy, onBackgroundError });
+  const errs = useErrorsFeed(range, { onBackgroundError });
 
   const setCustom = (edge: "from" | "to", day: string) => {
     if (!day) return;
-    setRange((r) => ({
-      ...r,
-      [edge]: edge === "from" ? `${day}T00:00:00.000Z` : `${day}T23:59:59.999Z`,
-    }));
+    setRange((r) => {
+      const next = {
+        ...r,
+        [edge]: edge === "from" ? `${day}T00:00:00.000Z` : `${day}T23:59:59.999Z`,
+      };
+      // Keep the window valid (the backend 422s from > to): moving one edge
+      // past the other drags the other edge to the same day.
+      if (next.from > next.to) {
+        if (edge === "from") next.to = `${day}T23:59:59.999Z`;
+        else next.from = `${day}T00:00:00.000Z`;
+      }
+      return next;
+    });
   };
 
   return (
@@ -144,6 +163,7 @@ function AnalyticsBody() {
           type="date"
           aria-label="Range start"
           value={range.from.slice(0, 10)}
+          max={range.to.slice(0, 10)}
           onChange={(e) => setCustom("from", e.target.value)}
           style={{ fontSize: 13 }}
         />
@@ -153,6 +173,7 @@ function AnalyticsBody() {
           type="date"
           aria-label="Range end"
           value={range.to.slice(0, 10)}
+          min={range.from.slice(0, 10)}
           onChange={(e) => setCustom("to", e.target.value)}
           style={{ fontSize: 13 }}
         />
@@ -228,7 +249,7 @@ function AnalyticsBody() {
                 {GROUPS.map((g) => (
                   <button
                     key={g}
-                    data-testid={`admin-analytics-costgroup-${g}`}
+                    data-testid={`admin-analytics-cost-group-${g}`}
                     className="btn btn--sm"
                     style={g === groupBy ? { fontWeight: 600, borderColor: "var(--accent)" } : undefined}
                     onClick={() => setGroupBy(g)}

--- a/frontend/src/components/screens/AdminAnalytics.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+/**
+ * Admin analytics screen (#121): typed data layer + raw tables over
+ * /api/admin/analytics (usage summary, per-user rollup, LLM cost, errors).
+ * One date range drives every panel; each panel owns its loading/error/empty
+ * state so a single failed query never blanks the page. Charts and visual
+ * polish are #122 — this screen deliberately renders plain numbers/tables.
+ */
+
+import React from "react";
+import { TopBar } from "../TopBar";
+import { useUser } from "@/context/UserContext";
+import {
+  presetRange,
+  useErrorsFeed,
+  useLlmCost,
+  useUsageByUser,
+  useUsageSummary,
+  type AnalyticsQuery,
+  type AnalyticsRangeValue,
+} from "@/lib/useAdminAnalytics";
+import type { LlmCostGroupBy } from "@/lib/types";
+
+const PRESETS = [
+  { days: 7, label: "7d" },
+  { days: 30, label: "30d" },
+  { days: 90, label: "90d" },
+] as const;
+
+const GROUPS: LlmCostGroupBy[] = ["feature", "user", "model"];
+
+const th: React.CSSProperties = {
+  textAlign: "left", fontSize: 11, textTransform: "uppercase", letterSpacing: "0.08em",
+  color: "var(--text-muted)", padding: "4px 8px",
+};
+const td: React.CSSProperties = {
+  fontSize: 13, padding: "6px 8px", borderTop: "1px solid var(--border)",
+};
+const tdNum: React.CSSProperties = { ...td, textAlign: "right", fontVariantNumeric: "tabular-nums" };
+
+function TruncatedBadge() {
+  return (
+    <span className="chip chip--err" title="The range was too large for a full scan — aggregates are partial.">
+      Truncated — partial aggregation
+    </span>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <div className="label-micro">{label}</div>
+      <div style={{ fontSize: 24, fontWeight: 600 }}>{value}</div>
+    </div>
+  );
+}
+
+function Panel<T>({ title, query, testid, children }: {
+  title: string;
+  query: AnalyticsQuery<T>;
+  testid: string;
+  children: (data: T) => React.ReactNode;
+}) {
+  return (
+    <section className="card" style={{ padding: "var(--pad-lg)" }}>
+      <h2 className="h-serif" style={{ fontSize: 18, marginBottom: 12 }}>{title}</h2>
+      {query.error && !query.data ? (
+        <div role="alert" style={{ display: "flex", alignItems: "center", gap: 12, color: "var(--text-muted)", fontSize: 13 }}>
+          <span>{query.error}</span>
+          <button data-testid={`${testid}-retry`} className="btn btn--sm" onClick={query.reload}>
+            Try again
+          </button>
+        </div>
+      ) : !query.data ? (
+        <div style={{ color: "var(--text-muted)", fontSize: 13 }}>Loading…</div>
+      ) : (
+        children(query.data)
+      )}
+    </section>
+  );
+}
+
+export function AdminAnalytics() {
+  // The gate lives OUTSIDE the hook-owning body: hooks fire their fetches on
+  // mount, and a non-admin visit must not fire four requests that 403 (each
+  // minting an auth.permission_denied audit event on the backend).
+  const { isAdmin } = useUser();
+  if (!isAdmin) {
+    return (
+      <div>
+        <TopBar breadcrumb="Admin" title="Analytics" subtitle="Staff only" />
+        <div style={{ padding: 60, textAlign: "center", color: "var(--text-muted)" }}>
+          You don&apos;t have admin access.
+        </div>
+      </div>
+    );
+  }
+  return <AnalyticsBody />;
+}
+
+function AnalyticsBody() {
+  const [range, setRange] = React.useState<AnalyticsRangeValue>(() => presetRange(30));
+  const [groupBy, setGroupBy] = React.useState<LlmCostGroupBy>("feature");
+
+  const summary = useUsageSummary(range);
+  const byUser = useUsageByUser(range);
+  const cost = useLlmCost(range, groupBy);
+  const errs = useErrorsFeed(range);
+
+  const setCustom = (edge: "from" | "to", day: string) => {
+    if (!day) return;
+    setRange((r) => ({
+      ...r,
+      [edge]: edge === "from" ? `${day}T00:00:00.000Z` : `${day}T23:59:59.999Z`,
+    }));
+  };
+
+  return (
+    <div>
+      <TopBar
+        breadcrumb="Admin"
+        title="Analytics"
+        subtitle="Usage, LLM cost, and errors"
+        actions={<span className="chip chip--err">Staff only</span>}
+      />
+      <div style={{
+        padding: "12px 32px", borderBottom: "1px solid var(--border)",
+        display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap",
+      }}>
+        <span className="label-micro">Range</span>
+        {PRESETS.map((p) => (
+          <button
+            key={p.days}
+            data-testid={`admin-analytics-range-${p.label}`}
+            className="btn btn--sm"
+            onClick={() => setRange(presetRange(p.days))}
+          >
+            {p.label}
+          </button>
+        ))}
+        <input
+          data-testid="admin-analytics-range-from"
+          type="date"
+          aria-label="Range start"
+          value={range.from.slice(0, 10)}
+          onChange={(e) => setCustom("from", e.target.value)}
+          style={{ fontSize: 13 }}
+        />
+        <span style={{ color: "var(--text-muted)", fontSize: 13 }}>→</span>
+        <input
+          data-testid="admin-analytics-range-to"
+          type="date"
+          aria-label="Range end"
+          value={range.to.slice(0, 10)}
+          onChange={(e) => setCustom("to", e.target.value)}
+          style={{ fontSize: 13 }}
+        />
+      </div>
+
+      <div style={{ padding: "24px 32px", display: "grid", gap: 16 }}>
+        <Panel title="Usage" query={summary} testid="admin-analytics-usage">
+          {(d) => (
+            <>
+              {d.truncated && <TruncatedBadge />}
+              <div style={{ display: "flex", gap: 32, margin: "8px 0 16px" }}>
+                <Stat label="Total events" value={d.total_events} />
+                <Stat label="Active users" value={d.distinct_active_users} />
+              </div>
+              {d.by_event_type.length === 0 ? (
+                <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No events in this range.</div>
+              ) : (
+                <table style={{ borderCollapse: "collapse", minWidth: 360 }}>
+                  <thead>
+                    <tr><th style={th}>Event type</th><th style={{ ...th, textAlign: "right" }}>Count</th></tr>
+                  </thead>
+                  <tbody>
+                    {d.by_event_type.map((row) => (
+                      <tr key={row.event_type}>
+                        <td style={td}>{row.event_type}</td>
+                        <td style={tdNum}>{row.count}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </>
+          )}
+        </Panel>
+
+        <Panel title="Top users" query={byUser} testid="admin-analytics-users">
+          {(d) => (
+            <>
+              {d.truncated && <TruncatedBadge />}
+              {d.users.length === 0 ? (
+                <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No user activity in this range.</div>
+              ) : (
+                <table style={{ borderCollapse: "collapse", minWidth: 520 }}>
+                  <thead>
+                    <tr>
+                      <th style={th}>User</th>
+                      <th style={{ ...th, textAlign: "right" }}>Events</th>
+                      <th style={{ ...th, textAlign: "right" }}>LLM cost</th>
+                      <th style={{ ...th, textAlign: "right" }}>Tokens</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {d.users.map((u) => (
+                      <tr key={u.user_id}>
+                        <td style={{ ...td, fontFamily: "var(--font-mono, monospace)", fontSize: 12 }}>{u.user_id}</td>
+                        <td style={tdNum}>{u.event_count}</td>
+                        <td style={tdNum}>${u.llm_cost_usd.toFixed(4)}</td>
+                        <td style={tdNum}>{u.total_tokens}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </>
+          )}
+        </Panel>
+
+        <Panel title="LLM cost" query={cost} testid="admin-analytics-cost">
+          {(d) => (
+            <>
+              <div style={{ display: "flex", gap: 6, alignItems: "center", marginBottom: 12 }}>
+                <span className="label-micro">Group by</span>
+                {GROUPS.map((g) => (
+                  <button
+                    key={g}
+                    data-testid={`admin-analytics-costgroup-${g}`}
+                    className="btn btn--sm"
+                    style={g === groupBy ? { fontWeight: 600, borderColor: "var(--accent)" } : undefined}
+                    onClick={() => setGroupBy(g)}
+                  >
+                    {g}
+                  </button>
+                ))}
+                {d.truncated && <TruncatedBadge />}
+              </div>
+              {d.rows.length === 0 ? (
+                <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No LLM calls in this range.</div>
+              ) : (
+                <table style={{ borderCollapse: "collapse", minWidth: 560 }}>
+                  <thead>
+                    <tr>
+                      <th style={th}>{d.group_by}</th>
+                      <th style={{ ...th, textAlign: "right" }}>Calls</th>
+                      <th style={{ ...th, textAlign: "right" }}>Prompt</th>
+                      <th style={{ ...th, textAlign: "right" }}>Completion</th>
+                      <th style={{ ...th, textAlign: "right" }}>Tokens</th>
+                      <th style={{ ...th, textAlign: "right" }}>Cost</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {d.rows.map((row) => (
+                      <tr key={row.key}>
+                        <td style={td}>{row.key || "(none)"}</td>
+                        <td style={tdNum}>{row.calls}</td>
+                        <td style={tdNum}>{row.prompt_tokens}</td>
+                        <td style={tdNum}>{row.completion_tokens}</td>
+                        <td style={tdNum}>{row.total_tokens}</td>
+                        <td style={tdNum}>${row.cost_usd.toFixed(4)}</td>
+                      </tr>
+                    ))}
+                    <tr>
+                      <td style={{ ...td, fontWeight: 600 }}>Total</td>
+                      <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.calls}</td>
+                      <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.prompt_tokens}</td>
+                      <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.completion_tokens}</td>
+                      <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.total_tokens}</td>
+                      <td style={{ ...tdNum, fontWeight: 600 }}>${d.totals.cost_usd.toFixed(4)}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              )}
+            </>
+          )}
+        </Panel>
+
+        <Panel title="Errors" query={errs} testid="admin-analytics-errors">
+          {(d) => (
+            <>
+              {d.truncated && <TruncatedBadge />}
+              {d.errors.length === 0 ? (
+                <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No errors in this range. 🎉</div>
+              ) : (
+                <table style={{ borderCollapse: "collapse", minWidth: 640 }}>
+                  <thead>
+                    <tr>
+                      <th style={th}>Time</th>
+                      <th style={th}>Type</th>
+                      <th style={th}>Method</th>
+                      <th style={th}>Path</th>
+                      <th style={{ ...th, textAlign: "right" }}>Status</th>
+                      <th style={{ ...th, textAlign: "right" }}>Duration</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {d.errors.map((e, i) => (
+                      <tr key={e.request_id ?? `${e.created_at}-${i}`}>
+                        <td style={{ ...td, whiteSpace: "nowrap" }}>{e.created_at ?? "—"}</td>
+                        <td style={td}>{e.event_type}</td>
+                        <td style={td}>{e.method ?? "—"}</td>
+                        <td style={{ ...td, fontFamily: "var(--font-mono, monospace)", fontSize: 12 }}>{e.path ?? "—"}</td>
+                        <td style={tdNum}>{e.status_code ?? "—"}</td>
+                        <td style={tdNum}>{e.duration_ms != null ? `${e.duration_ms.toFixed(1)}ms` : "—"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </>
+          )}
+        </Panel>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/adminAnalyticsApi.test.ts
+++ b/frontend/src/lib/adminAnalyticsApi.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { adminErrors, adminLlmCost, adminUsageByUser, adminUsageSummary } from './api';
+
+/** The #121 data layer's wrapper contract: each helper hits its
+ * /api/admin/analytics endpoint and forwards only the params the caller set,
+ * so the backend's defaults (last 30 days, group_by=feature, no bucket)
+ * stay server-owned. */
+
+const realFetch = globalThis.fetch;
+
+const okJson = () =>
+  new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn().mockResolvedValue(okJson()) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+function calledURL(): URL {
+  const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  return new URL(fetchMock.mock.calls[0][0] as string, 'http://test.local');
+}
+
+const FROM = '2026-07-01T00:00:00+00:00';
+const TO = '2026-08-01T00:00:00+00:00';
+
+describe('adminUsageSummary', () => {
+  it('hits the endpoint bare when no params are given', async () => {
+    await adminUsageSummary();
+    const url = calledURL();
+    expect(url.pathname).toBe('/api/admin/analytics/usage/summary');
+    expect(url.search).toBe('');
+  });
+
+  it('forwards from/to/bucket', async () => {
+    await adminUsageSummary({ from: FROM, to: TO, bucket: 'day' });
+    const url = calledURL();
+    expect(url.searchParams.get('from')).toBe(FROM);
+    expect(url.searchParams.get('to')).toBe(TO);
+    expect(url.searchParams.get('bucket')).toBe('day');
+  });
+});
+
+describe('adminUsageByUser', () => {
+  it('forwards range and pagination', async () => {
+    await adminUsageByUser({ from: FROM, to: TO, limit: 25, offset: 100 });
+    const url = calledURL();
+    expect(url.pathname).toBe('/api/admin/analytics/usage/by-user');
+    expect(url.searchParams.get('limit')).toBe('25');
+    expect(url.searchParams.get('offset')).toBe('100');
+  });
+});
+
+describe('adminLlmCost', () => {
+  it('forwards group_by and bucket', async () => {
+    await adminLlmCost({ from: FROM, to: TO, group_by: 'model', bucket: 'day' });
+    const url = calledURL();
+    expect(url.pathname).toBe('/api/admin/analytics/llm/cost');
+    expect(url.searchParams.get('group_by')).toBe('model');
+    expect(url.searchParams.get('bucket')).toBe('day');
+  });
+
+  it('omits group_by when unset so the server default (feature) applies', async () => {
+    await adminLlmCost({ from: FROM, to: TO });
+    expect(calledURL().searchParams.has('group_by')).toBe(false);
+  });
+});
+
+describe('adminErrors', () => {
+  it('forwards range, pagination, and bucket', async () => {
+    await adminErrors({ from: FROM, to: TO, limit: 10, offset: 20, bucket: 'day' });
+    const url = calledURL();
+    expect(url.pathname).toBe('/api/admin/analytics/errors');
+    expect(url.searchParams.get('limit')).toBe('10');
+    expect(url.searchParams.get('offset')).toBe('20');
+    expect(url.searchParams.get('bucket')).toBe('day');
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,6 +8,8 @@ import type {
   AllowlistEmail, AchievementTrigger, AdminAuditEntry, AnalyticsOverview, PaginatedUsers,
   Note, LinkedConcept,
   GraphUpdate, MasteryChange,
+  AnalyticsBucket, LlmCostGroupBy,
+  UsageSummaryData, UsageByUserData, LlmCostData, ErrorsPageData,
 } from '@/lib/types';
 import { statusOf } from '@/lib/errorMessage';
 
@@ -1133,6 +1135,34 @@ export const adminAuditLog = (params?: {
 // Admin — analytics
 export const adminAnalyticsOverview = () =>
   fetchJSON<AnalyticsOverview>('/api/admin/analytics/overview');
+
+// Admin — analytics rollups (#121, over the #120 API). Params the caller
+// leaves unset are omitted so the backend defaults stay server-owned
+// (last 30 days, group_by=feature, no series).
+const analyticsQuery = (params?: Record<string, string | number | undefined>) => {
+  const qp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params ?? {})) {
+    if (v !== undefined && v !== '') qp.set(k, String(v));
+  }
+  const s = qp.toString();
+  return s ? `?${s}` : '';
+};
+
+export const adminUsageSummary = (params?: { from?: string; to?: string; bucket?: AnalyticsBucket }) =>
+  fetchJSON<UsageSummaryData>(`/api/admin/analytics/usage/summary${analyticsQuery(params)}`);
+
+export const adminUsageByUser = (params?: { from?: string; to?: string; limit?: number; offset?: number }) =>
+  fetchJSON<UsageByUserData>(`/api/admin/analytics/usage/by-user${analyticsQuery(params)}`);
+
+export const adminLlmCost = (params?: {
+  from?: string; to?: string; group_by?: LlmCostGroupBy; bucket?: AnalyticsBucket;
+}) =>
+  fetchJSON<LlmCostData>(`/api/admin/analytics/llm/cost${analyticsQuery(params)}`);
+
+export const adminErrors = (params?: {
+  from?: string; to?: string; limit?: number; offset?: number; bucket?: AnalyticsBucket;
+}) =>
+  fetchJSON<ErrorsPageData>(`/api/admin/analytics/errors${analyticsQuery(params)}`);
 
 // Careers
 export const submitJobApplication = async (data: {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -448,3 +448,110 @@ export interface Note {
   created_at: string;
   updated_at: string;
 }
+
+// ── Admin analytics (#121) ───────────────────────────────────────────────────
+// Mirrors backend/routes/admin_analytics.py's response models (issue #120 plus
+// the #121 bucket/series addition). Distinct names from the legacy
+// AnalyticsOverview family above, which belongs to /admin/analytics/overview.
+// `range` uses the wire key "from" (the backend serializes its `from_` field
+// with an alias); `series` is present only when the request set `bucket=day`
+// and is sparse — days with no rows are omitted, the client zero-fills.
+
+export type LlmCostGroupBy = 'user' | 'feature' | 'model';
+export type AnalyticsBucket = 'day';
+
+export interface AnalyticsRange {
+  from: string;
+  to: string;
+}
+
+export interface UsageDayPoint {
+  date: string; // YYYY-MM-DD, UTC
+  count: number;
+}
+
+export interface CostDayPoint {
+  date: string; // YYYY-MM-DD, UTC
+  calls: number;
+  total_tokens: number;
+  cost_usd: number;
+}
+
+export interface EventTypeCount {
+  event_type: string;
+  count: number;
+}
+
+export interface UsageSummaryData {
+  range: AnalyticsRange;
+  total_events: number;
+  distinct_active_users: number;
+  by_event_type: EventTypeCount[];
+  truncated: boolean;
+  series: UsageDayPoint[] | null;
+}
+
+export interface UserUsageRow {
+  user_id: string;
+  event_count: number;
+  by_category: Record<string, number>;
+  llm_cost_usd: number;
+  total_tokens: number;
+}
+
+export interface UsageByUserData {
+  range: AnalyticsRange;
+  total_users: number;
+  limit: number;
+  offset: number;
+  users: UserUsageRow[];
+  truncated: boolean;
+}
+
+export interface LlmCostRow {
+  key: string;
+  calls: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  cost_usd: number;
+}
+
+export interface LlmCostTotals {
+  calls: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  cost_usd: number;
+}
+
+export interface LlmCostData {
+  range: AnalyticsRange;
+  group_by: LlmCostGroupBy;
+  rows: LlmCostRow[];
+  totals: LlmCostTotals;
+  truncated: boolean;
+  series: CostDayPoint[] | null;
+}
+
+export interface ErrorEventRow {
+  created_at: string | null;
+  event_type: string;
+  request_id: string | null;
+  user_id: string | null;
+  path: string | null;
+  method: string | null;
+  status_code: number | null;
+  duration_ms: number | null;
+}
+
+export interface ErrorsPageData {
+  range: AnalyticsRange;
+  total: number;
+  limit: number;
+  offset: number;
+  errors: ErrorEventRow[];
+  // Refers to the bucket series' scan (the feed itself is paginated).
+  truncated: boolean;
+  series: UsageDayPoint[] | null;
+}

--- a/frontend/src/lib/useAdminAnalytics.test.ts
+++ b/frontend/src/lib/useAdminAnalytics.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { presetRange } from './useAdminAnalytics';
+
+// Pure date math for the dashboard's range presets. The default clock is
+// lib/testMode's now() (frozen under NEXT_PUBLIC_TEST_MODE) — these tests pin
+// the math itself with an explicit nowMs.
+
+const NOW = Date.UTC(2026, 6, 30, 12, 0, 0); // 2026-07-30T12:00:00Z
+
+describe('presetRange', () => {
+  it('builds a last-N-days window ending now, in ISO UTC', () => {
+    expect(presetRange(30, NOW)).toEqual({
+      from: '2026-06-30T12:00:00.000Z',
+      to: '2026-07-30T12:00:00.000Z',
+    });
+  });
+
+  it('supports the 7-day preset', () => {
+    expect(presetRange(7, NOW)).toEqual({
+      from: '2026-07-23T12:00:00.000Z',
+      to: '2026-07-30T12:00:00.000Z',
+    });
+  });
+});

--- a/frontend/src/lib/useAdminAnalytics.ts
+++ b/frontend/src/lib/useAdminAnalytics.ts
@@ -50,20 +50,40 @@ export interface AnalyticsQuery<T> {
   reload: () => void;
 }
 
-function useAnalyticsQuery<T>(fetcher: () => Promise<T>): AnalyticsQuery<T> {
+function useAnalyticsQuery<T>(
+  fetcher: () => Promise<T>,
+  onBackgroundError?: (message: string) => void,
+): AnalyticsQuery<T> {
   const [data, setData] = React.useState<T | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  // Monotonic sequence: only the newest in-flight request may commit state,
+  // so an out-of-order response (7d resolving after 30d) can't overwrite
+  // newer data (PR #478 review).
+  const seqRef = React.useRef(0);
+  const hasDataRef = React.useRef(false);
+  // Read through a ref so an unstable callback can't retrigger the effect.
+  const bgErrorRef = React.useRef(onBackgroundError);
+  bgErrorRef.current = onBackgroundError;
 
   const load = React.useCallback(async () => {
+    const seq = ++seqRef.current;
     setLoading(true);
     try {
-      setData(await fetcher());
+      const result = await fetcher();
+      if (seq !== seqRef.current) return;
+      hasDataRef.current = true;
+      setData(result);
       setError(null);
     } catch (err) {
-      setError(humanizeError(err, "Couldn't load analytics."));
+      if (seq !== seqRef.current) return;
+      const message = humanizeError(err, "Couldn't load analytics.");
+      setError(message);
+      // #463 convention: initial failure renders the banner (no data yet);
+      // a failed BACKGROUND reload keeps the loaded view and toasts instead.
+      if (hasDataRef.current) bgErrorRef.current?.(message);
     } finally {
-      setLoading(false);
+      if (seq === seqRef.current) setLoading(false);
     }
   }, [fetcher]);
 
@@ -74,54 +94,63 @@ function useAnalyticsQuery<T>(fetcher: () => Promise<T>): AnalyticsQuery<T> {
   return { data, loading, error, reload: load };
 }
 
+export interface AnalyticsHookOptions {
+  bucket?: AnalyticsBucket;
+  limit?: number;
+  offset?: number;
+  groupBy?: LlmCostGroupBy;
+  /** Called instead of the banner when a reload fails AFTER data has loaded. */
+  onBackgroundError?: (message: string) => void;
+}
+
 export function useUsageSummary(
   range: AnalyticsRangeValue,
-  bucket?: AnalyticsBucket,
+  opts?: AnalyticsHookOptions,
 ): AnalyticsQuery<UsageSummaryData> {
   const { from, to } = range;
+  const { bucket, onBackgroundError } = opts ?? {};
   const fetcher = React.useCallback(
     () => adminUsageSummary({ from, to, bucket }),
     [from, to, bucket],
   );
-  return useAnalyticsQuery(fetcher);
+  return useAnalyticsQuery(fetcher, onBackgroundError);
 }
 
 export function useUsageByUser(
   range: AnalyticsRangeValue,
-  limit?: number,
-  offset?: number,
+  opts?: AnalyticsHookOptions,
 ): AnalyticsQuery<UsageByUserData> {
   const { from, to } = range;
+  const { limit, offset, onBackgroundError } = opts ?? {};
   const fetcher = React.useCallback(
     () => adminUsageByUser({ from, to, limit, offset }),
     [from, to, limit, offset],
   );
-  return useAnalyticsQuery(fetcher);
+  return useAnalyticsQuery(fetcher, onBackgroundError);
 }
 
 export function useLlmCost(
   range: AnalyticsRangeValue,
-  groupBy?: LlmCostGroupBy,
-  bucket?: AnalyticsBucket,
+  opts?: AnalyticsHookOptions,
 ): AnalyticsQuery<LlmCostData> {
   const { from, to } = range;
+  const { groupBy, bucket, onBackgroundError } = opts ?? {};
   const fetcher = React.useCallback(
     () => adminLlmCost({ from, to, group_by: groupBy, bucket }),
     [from, to, groupBy, bucket],
   );
-  return useAnalyticsQuery(fetcher);
+  return useAnalyticsQuery(fetcher, onBackgroundError);
 }
 
 export function useErrorsFeed(
   range: AnalyticsRangeValue,
-  limit?: number,
-  offset?: number,
-  bucket?: AnalyticsBucket,
+  opts?: AnalyticsHookOptions,
 ): AnalyticsQuery<ErrorsPageData> {
   const { from, to } = range;
+  const { limit, offset, bucket, onBackgroundError } = opts ?? {};
   const fetcher = React.useCallback(
     () => adminErrors({ from, to, limit, offset, bucket }),
     [from, to, limit, offset, bucket],
   );
-  return useAnalyticsQuery(fetcher);
+  return useAnalyticsQuery(fetcher, onBackgroundError);
 }

--- a/frontend/src/lib/useAdminAnalytics.ts
+++ b/frontend/src/lib/useAdminAnalytics.ts
@@ -1,0 +1,127 @@
+"use client";
+
+/**
+ * Data hooks for the admin analytics dashboard (#121), over the
+ * /api/admin/analytics rollup API (#120).
+ *
+ * House data-fetching pattern (no SWR/React Query in this repo): a stable
+ * useCallback fetcher + a useEffect that re-runs when it changes, exposing
+ * { data, loading, error, reload }. Errors are humanized once here so every
+ * panel renders the same message shape. The default range clock routes
+ * through lib/testMode's now() so the E2E stack sees a frozen window.
+ */
+
+import React from "react";
+import {
+  adminErrors,
+  adminLlmCost,
+  adminUsageByUser,
+  adminUsageSummary,
+} from "./api";
+import { humanizeError } from "./errorMessage";
+import { now } from "./testMode";
+import type {
+  AnalyticsBucket,
+  ErrorsPageData,
+  LlmCostData,
+  LlmCostGroupBy,
+  UsageByUserData,
+  UsageSummaryData,
+} from "./types";
+
+export interface AnalyticsRangeValue {
+  from: string;
+  to: string;
+}
+
+/** Last-`days` window ending at `nowMs` (defaults to the testMode-aware
+ * clock), as the ISO strings the analytics endpoints take. */
+export function presetRange(days: number, nowMs: number = now()): AnalyticsRangeValue {
+  return {
+    from: new Date(nowMs - days * 86_400_000).toISOString(),
+    to: new Date(nowMs).toISOString(),
+  };
+}
+
+export interface AnalyticsQuery<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => void;
+}
+
+function useAnalyticsQuery<T>(fetcher: () => Promise<T>): AnalyticsQuery<T> {
+  const [data, setData] = React.useState<T | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const load = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      setData(await fetcher());
+      setError(null);
+    } catch (err) {
+      setError(humanizeError(err, "Couldn't load analytics."));
+    } finally {
+      setLoading(false);
+    }
+  }, [fetcher]);
+
+  React.useEffect(() => {
+    load();
+  }, [load]);
+
+  return { data, loading, error, reload: load };
+}
+
+export function useUsageSummary(
+  range: AnalyticsRangeValue,
+  bucket?: AnalyticsBucket,
+): AnalyticsQuery<UsageSummaryData> {
+  const { from, to } = range;
+  const fetcher = React.useCallback(
+    () => adminUsageSummary({ from, to, bucket }),
+    [from, to, bucket],
+  );
+  return useAnalyticsQuery(fetcher);
+}
+
+export function useUsageByUser(
+  range: AnalyticsRangeValue,
+  limit?: number,
+  offset?: number,
+): AnalyticsQuery<UsageByUserData> {
+  const { from, to } = range;
+  const fetcher = React.useCallback(
+    () => adminUsageByUser({ from, to, limit, offset }),
+    [from, to, limit, offset],
+  );
+  return useAnalyticsQuery(fetcher);
+}
+
+export function useLlmCost(
+  range: AnalyticsRangeValue,
+  groupBy?: LlmCostGroupBy,
+  bucket?: AnalyticsBucket,
+): AnalyticsQuery<LlmCostData> {
+  const { from, to } = range;
+  const fetcher = React.useCallback(
+    () => adminLlmCost({ from, to, group_by: groupBy, bucket }),
+    [from, to, groupBy, bucket],
+  );
+  return useAnalyticsQuery(fetcher);
+}
+
+export function useErrorsFeed(
+  range: AnalyticsRangeValue,
+  limit?: number,
+  offset?: number,
+  bucket?: AnalyticsBucket,
+): AnalyticsQuery<ErrorsPageData> {
+  const { from, to } = range;
+  const fetcher = React.useCallback(
+    () => adminErrors({ from, to, limit, offset, bucket }),
+    [from, to, limit, offset, bucket],
+  );
+  return useAnalyticsQuery(fetcher);
+}


### PR DESCRIPTION
Part of #121 (left open per closure policy — Andres verifies the UI surface and closes).

## Backend (small, approved addition to the #120 API)
- Optional `?bucket=day` on `/usage/summary`, `/llm/cost`, `/errors` adds a sparse UTC-day `series` (client zero-fills from `range`). The errors series runs its own capped scan and surfaces `truncated` — never silent partial data.
- `Range` now serializes `{"from", "to"}` (was the accidental Python field name `from_`) — fixed before any TS client froze on it.

## Frontend
- Typed wrappers + response types (distinct from the legacy `AnalyticsOverview` family) + thin data hooks on the house `useCallback`+`useEffect` pattern; `presetRange` uses `lib/testMode`'s clock.
- Admin-gated `/admin/analytics` rendering live data as raw tables (per #121 — charts are #122): usage summary, top users, LLM cost with group-by toggle, errors. Shared range selector (7d/30d/90d presets + custom dates) drives every panel; per-panel `error && !data` banner + retry; truncation badges.
- Admin gate outside the hook-owning body — a non-admin visit fires zero requests (was: four 403s each minting an `auth.permission_denied` audit event).
- Testids registered in BOTH `docs/frontend-testids.md` and the eslint `no-restricted-syntax` files array.

## Tests
- Backend: 7 new route tests (bucket series ×3 endpoints, wire-format, invalid bucket 422, series-scan truncation) — TDD red-first; suite 1509 passed.
- Frontend: 13 new (wrapper URL contracts, presetRange math, screen gate/panels/retry/range/truncation) — 369 passed, tsc clean, lint 0 errors.

The promoted UI journey lands with #122 (same surface, final UI) — API-level e2e coverage already exists in `events.spec.ts`. Full local e2e cycle runs before merge regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only analytics dashboard with date presets and custom date ranges.
  * Added usage, user activity, LLM cost, and error reporting panels.
  * Added daily analytics series for usage, costs, and errors.
  * Added independent loading, empty, error, retry, and truncation states for each panel.

* **Bug Fixes**
  * Corrected analytics range serialization to use the expected `from` and `to` parameters.

* **Documentation**
  * Documented analytics dashboard test identifiers.

* **Tests**
  * Added coverage for dashboard access, filtering, retries, validation, daily series, and truncation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->