### PR TITLE
feat(analytics): #122 dashboard UI — charts, sortable users, promoted journey

### DIFF
--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -283,6 +283,7 @@ entered the lint block new, so there is no baselined backlog.
 | `admin-analytics-range-from` / `-to` | the custom date inputs (UTC day start/end) |
 | `admin-analytics-cost-group-feature` / `-user` / `-model` | the LLM-cost group-by toggle (drives the `group_by` query) |
 | `admin-analytics-usage-retry` / `-users-retry` / `-cost-retry` / `-errors-retry` | per-panel "Try again" after a failed load (`error && !data` gate) |
+| `admin-analytics-users-sort-events` / `-cost` / `-tokens` | Top-users table column-sort headers (#122) — first click sorts desc, second flips |
 
 ### `library`
 

--- a/frontend/e2e/admin-analytics.spec.ts
+++ b/frontend/e2e/admin-analytics.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Admin analytics dashboard journey (#122, over the #121 data layer).
+ *
+ * The journey: as the seeded student, fire one 404 (→ error.4xx) and create
+ * one note (→ note.created) — the same two cheap real actions events.spec.ts
+ * uses, FIFO-ordered so the error lands with/before the note. Then, as the
+ * seeded admin (rich-user-admin via mintStorageState), poll the rollup API
+ * until the queue worker flushes (never a bare sleep), open /admin/analytics
+ * in a real browser context, and assert the DASHBOARD renders the data: the
+ * events-per-day and errors-per-day charts, the top-event-types entry, the
+ * error-feed row for the bogus path, the cost group-by toggle driving its
+ * heading, and the range presets re-running the panels. A student visiting
+ * the route gets the refusal screen.
+ *
+ * Isolation: `events` is not in TRUNCATE_DENYLIST, so this test starts from
+ * an empty events table; causal assertions key on values unique to this test
+ * (the bogus path, the created note's id via queryRaw), not bare counts.
+ */
+import { expect, test } from "./support/fixtures";
+import { queryRaw } from "./support/db";
+import { mintStorageState } from "./support/session";
+import { FRONTEND_URL, USER_ACTIVE } from "./support/stack";
+
+const USER_ADMIN = "rich-user-admin"; // seeded with the admin role
+const BOGUS_PATH = "/api/e2e-analytics-dashboard-no-such-route";
+
+test("admin analytics dashboard renders live usage, errors, and controls (#122)", async ({
+  request,
+  playwright,
+  browser,
+  page,
+}) => {
+  // Sanity: the default storageState authenticates as the student.
+  const me = await request.get("/api/auth/me");
+  expect(me.status(), await me.text()).toBe(200);
+
+  // 1) Generate rows: a 404 first (FIFO), then one real note create.
+  expect((await request.get(BOGUS_PATH)).status()).toBe(404);
+  const noteRes = await request.post("/api/notes", {
+    data: {
+      user_id: USER_ACTIVE,
+      course_id: "rich-course-math210", // seeded enrollment of rich-user-active
+      title: "E2E dashboard note",
+      body: "Body so has_body is true.",
+    },
+  });
+  expect(noteRes.status(), await noteRes.text()).toBe(200);
+  const noteId = ((await noteRes.json()) as { id: string }).id;
+  expect(noteId).toBeTruthy();
+
+  // 2) Non-admin gate: the student sees the refusal screen, not the panels.
+  await page.goto(`${FRONTEND_URL}/admin/analytics`);
+  await expect(page.getByText(/don't have admin access/i)).toBeVisible();
+
+  // 3) As the admin, poll the API until the flush lands, then drive the UI.
+  const adminState = await mintStorageState(USER_ADMIN, "Ada Admin");
+  const adminReq = await playwright.request.newContext({
+    baseURL: FRONTEND_URL,
+    storageState: adminState,
+  });
+  const adminCtx = await browser.newContext({ storageState: adminState });
+  try {
+    await expect
+      .poll(
+        async () => {
+          const res = await adminReq.get("/api/admin/analytics/usage/summary");
+          if (!res.ok()) return -1;
+          const body = (await res.json()) as {
+            by_event_type: Array<{ event_type: string; count: number }>;
+          };
+          return body.by_event_type.find((r) => r.event_type === "note.created")?.count ?? 0;
+        },
+        {
+          timeout: 5_000,
+          message: "note.created should appear in /usage/summary (worker flushes ≤1s)",
+        },
+      )
+      .toBeGreaterThan(0);
+
+    const adminPage = await adminCtx.newPage();
+    await adminPage.goto(`${FRONTEND_URL}/admin/analytics`);
+
+    // Charts render from the day series (lazy-loaded components).
+    await expect(adminPage.getByRole("img", { name: "Events per day" })).toBeVisible();
+    await expect(adminPage.getByRole("img", { name: "Errors per day" })).toBeVisible();
+    // The generated rows surface: top-event-types entry + the error-feed row.
+    await expect(adminPage.getByText("note.created").first()).toBeVisible();
+    await expect(adminPage.getByText(BOGUS_PATH).first()).toBeVisible();
+
+    // The cost group-by toggle drives its heading (and the group_by query).
+    await adminPage.getByTestId("admin-analytics-cost-group-model").click();
+    await expect(adminPage.getByText("Cost by model")).toBeVisible();
+
+    // A range preset re-runs every panel without breaking the page.
+    await adminPage.getByTestId("admin-analytics-range-7d").click();
+    await expect(adminPage.getByRole("img", { name: "Events per day" })).toBeVisible();
+
+    // 4) DB causality: THIS test's note produced THIS event row.
+    const rows = await queryRaw(
+      "SELECT payload FROM events WHERE event_type = 'note.created' AND user_id = $1",
+      [USER_ACTIVE],
+    );
+    const mine = rows.find((r) => (r.payload as { note_id?: string }).note_id === noteId);
+    expect(mine, `no note.created event for note ${noteId}`).toBeTruthy();
+  } finally {
+    await adminCtx.close();
+    await adminReq.dispose();
+  }
+});

--- a/frontend/src/components/AnalyticsCharts.test.tsx
+++ b/frontend/src/components/AnalyticsCharts.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+/**
+ * Chart primitives for the admin analytics dashboard (#122): pure scale/path
+ * math plus render contracts for the two hand-rolled SVG forms (day line/area,
+ * horizontal category bars). No chart library — these are the tests that keep
+ * the math honest.
+ */
+
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import {
+  CategoryBars,
+  DayLineChart,
+  linePoints,
+  niceTicks,
+  zeroFillDays,
+} from "./AnalyticsCharts";
+
+afterEach(cleanup);
+
+describe("zeroFillDays", () => {
+  it("fills every UTC day in the range, zeroing the gaps", () => {
+    const out = zeroFillDays(
+      [
+        { date: "2026-07-10", value: 1 },
+        { date: "2026-07-12", value: 3 },
+      ],
+      "2026-07-09T00:00:00.000Z",
+      "2026-07-13T23:59:59.999Z",
+    );
+    expect(out.map((p) => p.date)).toEqual([
+      "2026-07-09", "2026-07-10", "2026-07-11", "2026-07-12", "2026-07-13",
+    ]);
+    expect(out.map((p) => p.value)).toEqual([0, 1, 0, 3, 0]);
+  });
+
+  it("returns the sparse input unchanged when the range exceeds the cap", () => {
+    const sparse = [{ date: "2020-01-01", value: 2 }];
+    const out = zeroFillDays(sparse, "2020-01-01T00:00:00.000Z", "2026-01-01T00:00:00.000Z");
+    expect(out).toEqual(sparse);
+  });
+});
+
+describe("niceTicks", () => {
+  it("produces uniform rounded steps from zero covering the max", () => {
+    const ticks = niceTicks(97);
+    expect(ticks[0]).toBe(0);
+    expect(ticks.at(-1)!).toBeGreaterThanOrEqual(97);
+    const step = ticks[1] - ticks[0];
+    for (let i = 1; i < ticks.length; i++) expect(ticks[i] - ticks[i - 1]).toBe(step);
+  });
+
+  it("handles an all-zero series without collapsing", () => {
+    const ticks = niceTicks(0);
+    expect(ticks.length).toBeGreaterThanOrEqual(2);
+    expect(ticks.at(-1)!).toBeGreaterThan(0);
+  });
+});
+
+describe("linePoints", () => {
+  it("maps values to inverted y (bigger value = smaller y) across the width", () => {
+    const pts = linePoints(
+      [
+        { date: "2026-07-01", value: 0 },
+        { date: "2026-07-02", value: 10 },
+      ],
+      { width: 100, height: 50, max: 10 },
+    );
+    expect(pts).toHaveLength(2);
+    expect(pts[0].x).toBe(0);
+    expect(pts[1].x).toBe(100);
+    expect(pts[0].y).toBe(50); // value 0 sits on the baseline
+    expect(pts[1].y).toBe(0);  // max value sits at the top
+  });
+});
+
+describe("DayLineChart", () => {
+  const series = [
+    { date: "2026-07-10", value: 1 },
+    { date: "2026-07-11", value: 4 },
+    { date: "2026-07-12", value: 2 },
+  ];
+
+  it("renders an svg with a line path and an accessible label", () => {
+    render(<DayLineChart points={series} color="#1B6C42" ariaLabel="Events per day" />);
+    const svg = screen.getByRole("img", { name: "Events per day" });
+    expect(svg.querySelector("path[data-part='line']")).toBeTruthy();
+  });
+
+  it("renders the empty state when there are no points", () => {
+    render(<DayLineChart points={[]} color="#1B6C42" ariaLabel="Events per day" />);
+    expect(screen.getByText(/no data/i)).toBeTruthy();
+  });
+});
+
+describe("CategoryBars", () => {
+  it("renders one bar per row with direct value labels", () => {
+    const { container } = render(
+      <CategoryBars
+        rows={[
+          { label: "note.created", value: 20 },
+          { label: "error.4xx", value: 3 },
+        ]}
+        ariaLabel="Top event types"
+      />,
+    );
+    expect(container.querySelectorAll("rect[data-part='bar']")).toHaveLength(2);
+    expect(screen.getByText("note.created")).toBeTruthy();
+    expect(screen.getByText("20")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/AnalyticsCharts.test.tsx
+++ b/frontend/src/components/AnalyticsCharts.test.tsx
@@ -14,6 +14,7 @@ import {
   DayLineChart,
   linePoints,
   niceTicks,
+  tooltipLeftPct,
   zeroFillDays,
 } from "./AnalyticsCharts";
 
@@ -72,6 +73,20 @@ describe("linePoints", () => {
     expect(pts[1].x).toBe(100);
     expect(pts[0].y).toBe(50); // value 0 sits on the baseline
     expect(pts[1].y).toBe(0);  // max value sits at the top
+  });
+});
+
+describe("tooltipLeftPct", () => {
+  // The tooltip is an HTML sibling of a scaled SVG (viewBox width ≠ rendered
+  // CSS width when the container is narrow), so its position must be a
+  // PERCENTAGE of the wrapper, never viewBox pixels (PR #479 review).
+  it("maps the hovered x to a wrapper percentage", () => {
+    expect(tooltipLeftPct(264, 36, 600)).toBe(50); // (264+36)/600
+  });
+
+  it("clamps to the 8–92% band so the box never clips the edges", () => {
+    expect(tooltipLeftPct(0, 0, 600)).toBe(8);
+    expect(tooltipLeftPct(600, 36, 600)).toBe(92);
   });
 });
 

--- a/frontend/src/components/AnalyticsCharts.tsx
+++ b/frontend/src/components/AnalyticsCharts.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+/**
+ * Hand-rolled SVG chart primitives for the admin analytics dashboard (#122).
+ * No chart library (bundle discipline) — two forms cover every panel:
+ *
+ *   - DayLineChart: single-series change-over-time (events/day, cost/day,
+ *     errors/day). 2px line + soft area fill, recessive grid, crosshair +
+ *     tooltip hover layer, ≥8px hover marker.
+ *   - CategoryBars: magnitude across a short category list (top event types,
+ *     cost by group). Thin horizontal bars, one hue, 4px rounded DATA end
+ *     (baseline end stays square), direct value labels.
+ *
+ * Color notes (dataviz skill, validated via validate_palette.js): every chart
+ * here is single-series, so hues encode panel identity, not categories — the
+ * forest green (#1B6C42) and the status red (--err) never share a plot, and
+ * the errors panel carries its title + labels so identity is never
+ * color-alone. Text always wears text tokens, never the series color.
+ */
+
+import React from "react";
+
+export interface DayPointValue {
+  date: string; // YYYY-MM-DD (UTC)
+  value: number;
+}
+
+const DAY_MS = 86_400_000;
+const ZERO_FILL_CAP_DAYS = 400;
+
+/** Zero-fill the sparse server series to one point per UTC day across the
+ * range. Ranges longer than the cap return the sparse input unchanged (the
+ * line still renders; zero-filling years of days helps nobody). */
+export function zeroFillDays(
+  points: DayPointValue[],
+  fromIso: string,
+  toIso: string,
+  capDays: number = ZERO_FILL_CAP_DAYS,
+): DayPointValue[] {
+  const start = Date.parse(fromIso.slice(0, 10) + "T00:00:00.000Z");
+  const end = Date.parse(toIso.slice(0, 10) + "T00:00:00.000Z");
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return points;
+  const days = Math.round((end - start) / DAY_MS) + 1;
+  if (days > capDays) return points;
+  const byDate = new Map(points.map((p) => [p.date, p.value]));
+  const out: DayPointValue[] = [];
+  for (let i = 0; i < days; i++) {
+    const date = new Date(start + i * DAY_MS).toISOString().slice(0, 10);
+    out.push({ date, value: byDate.get(date) ?? 0 });
+  }
+  return out;
+}
+
+/** Uniform "nice"-stepped ticks from 0 covering max (used for the y grid). */
+export function niceTicks(max: number, count = 4): number[] {
+  const target = max > 0 ? max : 1;
+  const rawStep = target / count;
+  const mag = 10 ** Math.floor(Math.log10(rawStep));
+  const nice = [1, 2, 2.5, 5, 10].find((m) => m * mag >= rawStep) ?? 10;
+  const step = nice * mag;
+  const ticks: number[] = [];
+  for (let v = 0; v < target + step; v += step) ticks.push(Number(v.toFixed(6)));
+  return ticks;
+}
+
+/** Map day points onto plot coordinates; y is inverted (SVG grows downward). */
+export function linePoints(
+  points: DayPointValue[],
+  plot: { width: number; height: number; max: number },
+): { x: number; y: number; point: DayPointValue }[] {
+  const { width, height, max } = plot;
+  const denom = Math.max(points.length - 1, 1);
+  const safeMax = max > 0 ? max : 1;
+  return points.map((point, i) => ({
+    x: points.length === 1 ? width / 2 : (i / denom) * width,
+    y: height - (point.value / safeMax) * height,
+    point,
+  }));
+}
+
+/** Container-width measurement; falls back to the default width when
+ * ResizeObserver is unavailable (jsdom). */
+function useMeasuredWidth(fallback: number): [React.RefObject<HTMLDivElement | null>, number] {
+  const ref = React.useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = React.useState(fallback);
+  React.useEffect(() => {
+    if (typeof ResizeObserver === "undefined" || !ref.current) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (w) setWidth(Math.max(240, Math.floor(w)));
+    });
+    ro.observe(ref.current);
+    return () => ro.disconnect();
+  }, []);
+  return [ref, width];
+}
+
+function EmptyNote() {
+  return <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No data in this range.</div>;
+}
+
+const AXIS_TEXT: React.CSSProperties = {
+  fontSize: 10,
+  fill: "var(--text-muted)",
+  fontVariantNumeric: "tabular-nums",
+};
+
+export function DayLineChart({
+  points,
+  color,
+  fillColor,
+  ariaLabel,
+  format = (v: number) => String(v),
+  height = 150,
+}: {
+  points: DayPointValue[];
+  color: string;
+  fillColor?: string;
+  ariaLabel: string;
+  format?: (v: number) => string;
+  height?: number;
+}) {
+  const [wrapRef, width] = useMeasuredWidth(600);
+  const [hover, setHover] = React.useState<number | null>(null);
+  if (points.length === 0) return <EmptyNote />;
+
+  const PAD_L = 36;
+  const PAD_B = 18;
+  const PAD_T = 8;
+  const plotW = Math.max(width - PAD_L - 8, 40);
+  const plotH = height - PAD_T - PAD_B;
+  const max = Math.max(...points.map((p) => p.value));
+  const ticks = niceTicks(max);
+  const top = ticks.at(-1)!;
+  const pts = linePoints(points, { width: plotW, height: plotH, max: top });
+  const line = pts.map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(" ");
+  const area = `${line} L${pts.at(-1)!.x.toFixed(1)},${plotH} L${pts[0].x.toFixed(1)},${plotH} Z`;
+  const hovered = hover != null ? pts[hover] : null;
+
+  const onMove = (e: React.PointerEvent<SVGRectElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = ((e.clientX - rect.left) / rect.width) * plotW;
+    let best = 0;
+    for (let i = 1; i < pts.length; i++) if (Math.abs(pts[i].x - x) < Math.abs(pts[best].x - x)) best = i;
+    setHover(best);
+  };
+
+  return (
+    <div ref={wrapRef} style={{ position: "relative" }}>
+      <svg role="img" aria-label={ariaLabel} width="100%" height={height} viewBox={`0 0 ${width} ${height}`}>
+        <g transform={`translate(${PAD_L},${PAD_T})`}>
+          {ticks.map((t) => {
+            const y = plotH - (t / top) * plotH;
+            return (
+              <g key={t}>
+                <line x1={0} x2={plotW} y1={y} y2={y} stroke="var(--border)" strokeWidth={1} />
+                <text x={-6} y={y + 3} textAnchor="end" style={AXIS_TEXT}>{format(t)}</text>
+              </g>
+            );
+          })}
+          {fillColor && <path d={area} fill={fillColor} opacity={0.6} />}
+          <path d={line} data-part="line" fill="none" stroke={color} strokeWidth={2} strokeLinejoin="round" />
+          {hovered && (
+            <>
+              <line x1={hovered.x} x2={hovered.x} y1={0} y2={plotH} stroke="var(--text-muted)" strokeWidth={1} strokeDasharray="3 3" />
+              <circle cx={hovered.x} cy={hovered.y} r={4.5} fill={color} stroke="var(--bg-panel)" strokeWidth={2} />
+            </>
+          )}
+          <text x={0} y={plotH + 13} style={AXIS_TEXT}>{points[0].date}</text>
+          <text x={plotW} y={plotH + 13} textAnchor="end" style={AXIS_TEXT}>{points.at(-1)!.date}</text>
+          <rect
+            x={0} y={0} width={plotW} height={plotH} fill="transparent"
+            onPointerMove={onMove} onPointerLeave={() => setHover(null)}
+          />
+        </g>
+      </svg>
+      {hovered && (
+        <div
+          role="status"
+          style={{
+            position: "absolute",
+            left: Math.min(Math.max(hovered.x + PAD_L - 40, 0), width - 120),
+            top: 0,
+            background: "var(--bg-panel)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--r-sm)",
+            boxShadow: "var(--shadow-sm)",
+            padding: "4px 8px",
+            fontSize: 12,
+            pointerEvents: "none",
+            whiteSpace: "nowrap",
+          }}
+        >
+          <span style={{ color: "var(--text-muted)" }}>{hovered.point.date}</span>{" "}
+          <strong style={{ fontVariantNumeric: "tabular-nums" }}>{format(hovered.point.value)}</strong>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Horizontal bar with the DATA end rounded (4px) and the baseline end square. */
+function barPath(w: number, h: number): string {
+  const r = Math.min(4, w, h / 2);
+  return `M0,0 H${w - r} A${r},${r} 0 0 1 ${w},${r} V${h - r} A${r},${r} 0 0 1 ${w - r},${h} H0 Z`;
+}
+
+export function CategoryBars({
+  rows,
+  ariaLabel,
+  color = "var(--brand-forest, #1B6C42)",
+  format = (v: number) => String(v),
+}: {
+  rows: { label: string; value: number }[];
+  ariaLabel: string;
+  color?: string;
+  format?: (v: number) => string;
+}) {
+  if (rows.length === 0) return <EmptyNote />;
+  const max = Math.max(...rows.map((r) => r.value), 1);
+  return (
+    <div role="img" aria-label={ariaLabel} style={{ display: "grid", gap: 6 }}>
+      {rows.map((row) => {
+        const pct = Math.max((row.value / max) * 100, 0.5);
+        return (
+          <div
+            key={row.label}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "minmax(120px, 220px) 1fr 64px",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <span style={{ fontSize: 12, color: "var(--text-dim)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {row.label}
+            </span>
+            <svg width={`${pct}%`} height={14} viewBox="0 0 100 14" preserveAspectRatio="none" style={{ minWidth: 3 }}>
+              <path d={barPath(100, 14)} data-part="bar-shape" fill={color} />
+              <rect data-part="bar" x={0} y={0} width={100} height={14} fill="transparent">
+                <title>{`${row.label}: ${format(row.value)}`}</title>
+              </rect>
+            </svg>
+            <span style={{ fontSize: 12, textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
+              {format(row.value)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/AnalyticsCharts.tsx
+++ b/frontend/src/components/AnalyticsCharts.tsx
@@ -19,37 +19,11 @@
  */
 
 import React from "react";
+import { type DayPointValue, zeroFillDays } from "@/lib/daySeries";
 
-export interface DayPointValue {
-  date: string; // YYYY-MM-DD (UTC)
-  value: number;
-}
-
-const DAY_MS = 86_400_000;
-const ZERO_FILL_CAP_DAYS = 400;
-
-/** Zero-fill the sparse server series to one point per UTC day across the
- * range. Ranges longer than the cap return the sparse input unchanged (the
- * line still renders; zero-filling years of days helps nobody). */
-export function zeroFillDays(
-  points: DayPointValue[],
-  fromIso: string,
-  toIso: string,
-  capDays: number = ZERO_FILL_CAP_DAYS,
-): DayPointValue[] {
-  const start = Date.parse(fromIso.slice(0, 10) + "T00:00:00.000Z");
-  const end = Date.parse(toIso.slice(0, 10) + "T00:00:00.000Z");
-  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return points;
-  const days = Math.round((end - start) / DAY_MS) + 1;
-  if (days > capDays) return points;
-  const byDate = new Map(points.map((p) => [p.date, p.value]));
-  const out: DayPointValue[] = [];
-  for (let i = 0; i < days; i++) {
-    const date = new Date(start + i * DAY_MS).toISOString().slice(0, 10);
-    out.push({ date, value: byDate.get(date) ?? 0 });
-  }
-  return out;
-}
+// Re-exported so chart consumers/tests can keep a single import site; the
+// canonical home is lib/daySeries.ts (JSX-free — see its header for why).
+export { zeroFillDays, type DayPointValue };
 
 /** Uniform "nice"-stepped ticks from 0 covering max (used for the y grid). */
 export function niceTicks(max: number, count = 4): number[] {
@@ -61,6 +35,16 @@ export function niceTicks(max: number, count = 4): number[] {
   const ticks: number[] = [];
   for (let v = 0; v < target + step; v += step) ticks.push(Number(v.toFixed(6)));
   return ticks;
+}
+
+/** Tooltip x-position as a PERCENTAGE of the chart wrapper. The tooltip is
+ * an HTML sibling of a scaled SVG (viewBox width ≠ rendered CSS width when
+ * the container is narrower than the measurement floor), so viewBox pixels
+ * would drift; a wrapper percentage tracks the rendered scale exactly.
+ * Clamped to 8–92% so the box never clips the panel edges. */
+export function tooltipLeftPct(x: number, padL: number, width: number): number {
+  const pct = ((x + padL) / Math.max(width, 1)) * 100;
+  return Math.round(Math.min(Math.max(pct, 8), 92) * 100) / 100;
 }
 
 /** Map day points onto plot coordinates; y is inverted (SVG grows downward). */
@@ -179,7 +163,8 @@ export function DayLineChart({
           role="status"
           style={{
             position: "absolute",
-            left: Math.min(Math.max(hovered.x + PAD_L - 40, 0), width - 120),
+            left: `${tooltipLeftPct(hovered.x, PAD_L, width)}%`,
+            transform: "translateX(-50%)",
             top: 0,
             background: "var(--bg-panel)",
             border: "1px solid var(--border)",

--- a/frontend/src/components/screens/AdminAnalytics.test.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.test.tsx
@@ -48,6 +48,21 @@ const api = vi.hoisted(() => ({
 }));
 vi.mock("@/lib/api", () => api);
 
+// Charts are lazy-loaded via next/dynamic in the screen; render them
+// synchronously in tests (house passthrough precedent).
+vi.mock("next/dynamic", () => ({
+  default: (loader: () => Promise<unknown>) => {
+    let Comp: React.ComponentType<Record<string, unknown>> | null = null;
+    loader().then((m) => { Comp = (m as { default?: never } & Record<string, never>) as never; });
+    return function DynamicPassthrough(props: Record<string, unknown>) {
+      const [, force] = React.useReducer((x: number) => x + 1, 0);
+      React.useEffect(() => { if (!Comp) { loader().then((m) => { Comp = m as never; force(); }); } }, []);
+      const C = Comp as React.ComponentType<Record<string, unknown>> | null;
+      return C ? <C {...props} /> : null;
+    };
+  },
+}));
+
 import { AdminAnalytics } from "./AdminAnalytics";
 
 const RANGE = { from: "2026-06-30T12:00:00.000Z", to: "2026-07-30T12:00:00.000Z" };
@@ -58,14 +73,20 @@ const summaryFixture = {
   distinct_active_users: 7,
   by_event_type: [{ event_type: "note.created", count: 20 }],
   truncated: false,
-  series: null,
+  series: [
+    { date: "2026-07-10", count: 12 },
+    { date: "2026-07-12", count: 30 },
+  ],
 };
 const byUserFixture = {
   range: RANGE,
-  total_users: 1,
+  total_users: 2,
   limit: 50,
   offset: 0,
-  users: [{ user_id: "u-alpha", event_count: 5, by_category: { usage: 5 }, llm_cost_usd: 1.23, total_tokens: 456 }],
+  users: [
+    { user_id: "u-alpha", event_count: 5, by_category: { usage: 5 }, llm_cost_usd: 1.23, total_tokens: 456 },
+    { user_id: "u-beta", event_count: 9, by_category: { usage: 9 }, llm_cost_usd: 0.5, total_tokens: 100 },
+  ],
   truncated: false,
 };
 const costFixture = {
@@ -74,7 +95,7 @@ const costFixture = {
   rows: [{ key: "quiz", calls: 3, prompt_tokens: 10, completion_tokens: 5, total_tokens: 15, cost_usd: 0.5 }],
   totals: { calls: 3, prompt_tokens: 10, completion_tokens: 5, total_tokens: 15, cost_usd: 0.5 },
   truncated: true,
-  series: null,
+  series: [{ date: "2026-07-10", calls: 3, total_tokens: 15, cost_usd: 0.5 }],
 };
 const errorsFixture = {
   range: RANGE,
@@ -86,7 +107,7 @@ const errorsFixture = {
     user_id: "u-alpha", path: "/api/quiz", method: "POST", status_code: 500, duration_ms: 12.3,
   }],
   truncated: false,
-  series: null,
+  series: [{ date: "2026-07-15", count: 1 }],
 };
 
 function primeHappyPath() {
@@ -115,10 +136,11 @@ describe("AdminAnalytics", () => {
     primeHappyPath();
     render(<AdminAnalytics />);
     await waitFor(() => {
-      expect(screen.getByText("42")).toBeTruthy(); // total events
-      expect(screen.getByText("note.created")).toBeTruthy();
+      expect(screen.getByText("42")).toBeTruthy(); // total events stat
+      // Chart labels + table fallbacks both carry these — multiple matches are expected.
+      expect(screen.getAllByText("note.created").length).toBeGreaterThanOrEqual(1);
       expect(screen.getByText("u-alpha")).toBeTruthy();
-      expect(screen.getByText("quiz")).toBeTruthy();
+      expect(screen.getAllByText("quiz").length).toBeGreaterThanOrEqual(1);
       expect(screen.getByText("error.5xx")).toBeTruthy();
     });
   });
@@ -152,7 +174,7 @@ describe("AdminAnalytics", () => {
   it("surfaces the truncation badge when an aggregation was capped", async () => {
     primeHappyPath();
     render(<AdminAnalytics />);
-    await screen.findByText("quiz");
+    await screen.findAllByText("quiz");
     expect(screen.getByText(/truncated/i)).toBeTruthy();
   });
 
@@ -197,5 +219,46 @@ describe("AdminAnalytics", () => {
       expect(last.from).toBe("2099-09-01T00:00:00.000Z");
       expect(last.to >= last.from).toBe(true);
     });
+  });
+
+  it("requests day bucketing for the trend panels (#122)", async () => {
+    primeHappyPath();
+    render(<AdminAnalytics />);
+    await screen.findByText("42");
+    expect(api.adminUsageSummary.mock.calls.at(-1)![0].bucket).toBe("day");
+    expect(api.adminLlmCost.mock.calls.at(-1)![0].bucket).toBe("day");
+    expect(api.adminErrors.mock.calls.at(-1)![0].bucket).toBe("day");
+    expect(api.adminUsageByUser.mock.calls.at(-1)![0].bucket).toBeUndefined();
+  });
+
+  it("renders the trend charts and the event-type bars from the series (#122)", async () => {
+    primeHappyPath();
+    render(<AdminAnalytics />);
+    await screen.findByText("42");
+    expect(await screen.findByRole("img", { name: "Events per day" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Cost per day" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Errors per day" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Top event types" })).toBeTruthy();
+  });
+
+  it("keeps a table fallback behind each chart panel (#122 a11y)", async () => {
+    primeHappyPath();
+    render(<AdminAnalytics />);
+    await screen.findByText("42");
+    // The raw tables from #121 survive as expandable data views.
+    expect(screen.getAllByText("View data").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("sorts the users table by a clicked column (#122)", async () => {
+    primeHappyPath();
+    render(<AdminAnalytics />);
+    await screen.findByText("u-alpha");
+    const order = () => {
+      const cells = screen.getAllByText(/^u-(alpha|beta)$/).map((el) => el.textContent);
+      return cells;
+    };
+    expect(order()).toEqual(["u-alpha", "u-beta"]); // server order (cost desc)
+    fireEvent.click(screen.getByTestId("admin-analytics-users-sort-events"));
+    await waitFor(() => expect(order()).toEqual(["u-beta", "u-alpha"])); // events desc
   });
 });

--- a/frontend/src/components/screens/AdminAnalytics.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.tsx
@@ -9,9 +9,22 @@
  */
 
 import React from "react";
+import dynamic from "next/dynamic";
 import { TopBar } from "../TopBar";
 import { useToast } from "../ToastProvider";
 import { useUser } from "@/context/UserContext";
+import { zeroFillDays, type DayPointValue } from "../AnalyticsCharts";
+
+// Chart components load lazily (the #122 bundle-discipline checkbox); the
+// pure helpers above are a few hundred bytes and import statically.
+const DayLineChart = dynamic(() => import("../AnalyticsCharts").then((m) => m.DayLineChart), {
+  ssr: false,
+  loading: () => null,
+});
+const CategoryBars = dynamic(() => import("../AnalyticsCharts").then((m) => m.CategoryBars), {
+  ssr: false,
+  loading: () => null,
+});
 import {
   presetRange,
   useErrorsFeed,
@@ -113,10 +126,18 @@ function AnalyticsBody() {
     [toast],
   );
 
-  const summary = useUsageSummary(range, { onBackgroundError });
+  const summary = useUsageSummary(range, { bucket: "day", onBackgroundError });
   const byUser = useUsageByUser(range, { onBackgroundError });
-  const cost = useLlmCost(range, { groupBy, onBackgroundError });
-  const errs = useErrorsFeed(range, { onBackgroundError });
+  const cost = useLlmCost(range, { groupBy, bucket: "day", onBackgroundError });
+  const errs = useErrorsFeed(range, { bucket: "day", onBackgroundError });
+
+  // Users-table sort: null = keep the server order (cost desc, then events).
+  const [userSort, setUserSort] = React.useState<{
+    key: "events" | "cost" | "tokens" | null;
+    desc: boolean;
+  }>({ key: null, desc: true });
+  const toggleUserSort = (key: "events" | "cost" | "tokens") =>
+    setUserSort((s) => (s.key === key ? { key, desc: !s.desc } : { key, desc: true }));
 
   const setCustom = (edge: "from" | "to", day: string) => {
     if (!day) return;
@@ -180,18 +201,34 @@ function AnalyticsBody() {
       </div>
 
       <div style={{ padding: "24px 32px", display: "grid", gap: 16 }}>
+        {/* Headline stats — type carries the hierarchy, no card chrome. */}
+        <div style={{ display: "flex", gap: 40, flexWrap: "wrap", padding: "4px 2px" }}>
+          <Stat label="Total events" value={summary.data ? summary.data.total_events : "—"} />
+          <Stat label="Active users" value={summary.data ? summary.data.distinct_active_users : "—"} />
+          <Stat label="LLM cost" value={cost.data ? `$${cost.data.totals.cost_usd.toFixed(2)}` : "—"} />
+          <Stat label="LLM calls" value={cost.data ? cost.data.totals.calls : "—"} />
+        </div>
+
         <Panel title="Usage" query={summary} testid="admin-analytics-usage">
           {(d) => (
             <>
               {d.truncated && <TruncatedBadge />}
-              <div style={{ display: "flex", gap: 32, margin: "8px 0 16px" }}>
-                <Stat label="Total events" value={d.total_events} />
-                <Stat label="Active users" value={d.distinct_active_users} />
-              </div>
-              {d.by_event_type.length === 0 ? (
-                <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No events in this range.</div>
-              ) : (
-                <table style={{ borderCollapse: "collapse", minWidth: 360 }}>
+              <DayLineChart
+                points={d.series?.length
+                  ? zeroFillDays(d.series.map((p) => ({ date: p.date, value: p.count })), d.range.from, d.range.to)
+                  : []}
+                color="var(--brand-forest, #1B6C42)"
+                fillColor="var(--sap-100, #e0ecd8)"
+                ariaLabel="Events per day"
+              />
+              <h3 className="label-micro" style={{ margin: "16px 0 8px" }}>Top event types</h3>
+              <CategoryBars
+                rows={d.by_event_type.slice(0, 8).map((r) => ({ label: r.event_type, value: r.count }))}
+                ariaLabel="Top event types"
+              />
+              <details style={{ marginTop: 12 }}>
+                <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data</summary>
+                <table style={{ borderCollapse: "collapse", minWidth: 360, marginTop: 8 }}>
                   <thead>
                     <tr><th style={th}>Event type</th><th style={{ ...th, textAlign: "right" }}>Count</th></tr>
                   </thead>
@@ -204,41 +241,66 @@ function AnalyticsBody() {
                     ))}
                   </tbody>
                 </table>
-              )}
+              </details>
             </>
           )}
         </Panel>
 
         <Panel title="Top users" query={byUser} testid="admin-analytics-users">
-          {(d) => (
-            <>
-              {d.truncated && <TruncatedBadge />}
-              {d.users.length === 0 ? (
-                <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No user activity in this range.</div>
-              ) : (
-                <table style={{ borderCollapse: "collapse", minWidth: 520 }}>
-                  <thead>
-                    <tr>
-                      <th style={th}>User</th>
-                      <th style={{ ...th, textAlign: "right" }}>Events</th>
-                      <th style={{ ...th, textAlign: "right" }}>LLM cost</th>
-                      <th style={{ ...th, textAlign: "right" }}>Tokens</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {d.users.map((u) => (
-                      <tr key={u.user_id}>
-                        <td style={{ ...td, fontFamily: "var(--font-mono, monospace)", fontSize: 12 }}>{u.user_id}</td>
-                        <td style={tdNum}>{u.event_count}</td>
-                        <td style={tdNum}>${u.llm_cost_usd.toFixed(4)}</td>
-                        <td style={tdNum}>{u.total_tokens}</td>
+          {(d) => {
+            const selectors = {
+              events: (u: (typeof d.users)[number]) => u.event_count,
+              cost: (u: (typeof d.users)[number]) => u.llm_cost_usd,
+              tokens: (u: (typeof d.users)[number]) => u.total_tokens,
+            } as const;
+            const users = userSort.key
+              ? [...d.users].sort((a, b) => {
+                  const sel = selectors[userSort.key!];
+                  return userSort.desc ? sel(b) - sel(a) : sel(a) - sel(b);
+                })
+              : d.users;
+            const sortBtn = (key: keyof typeof selectors, label: string) => (
+              <button
+                data-testid={`admin-analytics-users-sort-${key}`}
+                onClick={() => toggleUserSort(key)}
+                style={{
+                  font: "inherit", color: "inherit", textTransform: "inherit", letterSpacing: "inherit",
+                  fontWeight: userSort.key === key ? 700 : "inherit",
+                }}
+              >
+                {label}{userSort.key === key ? (userSort.desc ? " ↓" : " ↑") : ""}
+              </button>
+            );
+            return (
+              <>
+                {d.truncated && <TruncatedBadge />}
+                {d.users.length === 0 ? (
+                  <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No user activity in this range.</div>
+                ) : (
+                  <table style={{ borderCollapse: "collapse", minWidth: 520 }}>
+                    <thead>
+                      <tr>
+                        <th style={th}>User</th>
+                        <th style={{ ...th, textAlign: "right" }}>{sortBtn("events", "Events")}</th>
+                        <th style={{ ...th, textAlign: "right" }}>{sortBtn("cost", "LLM cost")}</th>
+                        <th style={{ ...th, textAlign: "right" }}>{sortBtn("tokens", "Tokens")}</th>
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
-              )}
-            </>
-          )}
+                    </thead>
+                    <tbody>
+                      {users.map((u) => (
+                        <tr key={u.user_id}>
+                          <td style={{ ...td, fontFamily: "var(--font-mono, monospace)", fontSize: 12 }}>{u.user_id}</td>
+                          <td style={tdNum}>{u.event_count}</td>
+                          <td style={tdNum}>${u.llm_cost_usd.toFixed(4)}</td>
+                          <td style={tdNum}>{u.total_tokens}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </>
+            );
+          }}
         </Panel>
 
         <Panel title="LLM cost" query={cost} testid="admin-analytics-cost">
@@ -259,10 +321,24 @@ function AnalyticsBody() {
                 ))}
                 {d.truncated && <TruncatedBadge />}
               </div>
-              {d.rows.length === 0 ? (
-                <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No LLM calls in this range.</div>
-              ) : (
-                <table style={{ borderCollapse: "collapse", minWidth: 560 }}>
+              <DayLineChart
+                points={d.series?.length
+                  ? zeroFillDays(d.series.map((p) => ({ date: p.date, value: p.cost_usd })), d.range.from, d.range.to)
+                  : []}
+                color="var(--brand-forest, #1B6C42)"
+                fillColor="var(--sap-100, #e0ecd8)"
+                ariaLabel="Cost per day"
+                format={(v) => `$${v.toFixed(2)}`}
+              />
+              <h3 className="label-micro" style={{ margin: "16px 0 8px" }}>Cost by {d.group_by}</h3>
+              <CategoryBars
+                rows={d.rows.slice(0, 8).map((r) => ({ label: r.key || "(none)", value: r.cost_usd }))}
+                ariaLabel={`Cost by ${d.group_by}`}
+                format={(v) => `$${v.toFixed(4)}`}
+              />
+              <details style={{ marginTop: 12 }}>
+                <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data</summary>
+                <table style={{ borderCollapse: "collapse", minWidth: 560, marginTop: 8 }}>
                   <thead>
                     <tr>
                       <th style={th}>{d.group_by}</th>
@@ -294,7 +370,7 @@ function AnalyticsBody() {
                     </tr>
                   </tbody>
                 </table>
-              )}
+              </details>
             </>
           )}
         </Panel>
@@ -303,6 +379,14 @@ function AnalyticsBody() {
           {(d) => (
             <>
               {d.truncated && <TruncatedBadge />}
+              <DayLineChart
+                points={d.series?.length
+                  ? zeroFillDays(d.series.map((p) => ({ date: p.date, value: p.count })), d.range.from, d.range.to)
+                  : []}
+                color="var(--err, #a83a3a)"
+                ariaLabel="Errors per day"
+              />
+              <div style={{ height: 12 }} />
               {d.errors.length === 0 ? (
                 <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No errors in this range. 🎉</div>
               ) : (

--- a/frontend/src/components/screens/AdminAnalytics.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 /**
- * Admin analytics screen (#121): typed data layer + raw tables over
+ * Admin analytics dashboard (#121 data layer + #122 charts) over
  * /api/admin/analytics (usage summary, per-user rollup, LLM cost, errors).
  * One date range drives every panel; each panel owns its loading/error/empty
- * state so a single failed query never blanks the page. Charts and visual
- * polish are #122 — this screen deliberately renders plain numbers/tables.
+ * state so a single failed query never blanks the page. Charts render from
+ * the ?bucket=day series via the lazy-loaded AnalyticsCharts primitives,
+ * with the #121 raw tables kept as per-panel "View data" fallbacks.
  */
 
 import React from "react";
@@ -13,10 +14,13 @@ import dynamic from "next/dynamic";
 import { TopBar } from "../TopBar";
 import { useToast } from "../ToastProvider";
 import { useUser } from "@/context/UserContext";
-import { zeroFillDays, type DayPointValue } from "../AnalyticsCharts";
+import { zeroFillDays } from "@/lib/daySeries";
 
-// Chart components load lazily (the #122 bundle-discipline checkbox); the
-// pure helpers above are a few hundred bytes and import statically.
+// Chart components load lazily (the #122 bundle-discipline checkbox). The
+// pure helper imports statically from lib/daySeries — its own JSX-free
+// module, so no synchronous edge pulls AnalyticsCharts into the main chunk
+// (a static import from the SAME module would defeat dynamic(); PR #479
+// review).
 const DayLineChart = dynamic(() => import("../AnalyticsCharts").then((m) => m.DayLineChart), {
   ssr: false,
   loading: () => null,

--- a/frontend/src/lib/daySeries.ts
+++ b/frontend/src/lib/daySeries.ts
@@ -1,0 +1,38 @@
+/**
+ * Day-series helpers shared by the analytics screen and the lazy-loaded
+ * chart components. This module deliberately contains NO React/JSX: the
+ * screen imports it statically, and a static import pulls its whole module
+ * into the eager chunk — keeping it tiny is what lets AnalyticsCharts.tsx
+ * stay behind next/dynamic (PR #479 review).
+ */
+
+export interface DayPointValue {
+  date: string; // YYYY-MM-DD (UTC)
+  value: number;
+}
+
+const DAY_MS = 86_400_000;
+const ZERO_FILL_CAP_DAYS = 400;
+
+/** Zero-fill the sparse server series to one point per UTC day across the
+ * range. Ranges longer than the cap return the sparse input unchanged (the
+ * line still renders; zero-filling years of days helps nobody). */
+export function zeroFillDays(
+  points: DayPointValue[],
+  fromIso: string,
+  toIso: string,
+  capDays: number = ZERO_FILL_CAP_DAYS,
+): DayPointValue[] {
+  const start = Date.parse(fromIso.slice(0, 10) + "T00:00:00.000Z");
+  const end = Date.parse(toIso.slice(0, 10) + "T00:00:00.000Z");
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return points;
+  const days = Math.round((end - start) / DAY_MS) + 1;
+  if (days > capDays) return points;
+  const byDate = new Map(points.map((p) => [p.date, p.value]));
+  const out: DayPointValue[] = [];
+  for (let i = 0; i < days; i++) {
+    const date = new Date(start + i * DAY_MS).toISOString().slice(0, 10);
+    out.push({ date, value: byDate.get(date) ?? 0 });
+  }
+  return out;
+}

--- a/frontend/src/lib/useAdminAnalytics.testmode.test.ts
+++ b/frontend/src/lib/useAdminAnalytics.testmode.test.ts
@@ -1,0 +1,35 @@
+/**
+ * NEXT_PUBLIC_TEST_MODE behavior for the analytics range presets.
+ *
+ * presetRange builds QUERY BOUNDS over `events`/`llm_usage` rows that the
+ * backend stamps with its REAL clock — so unlike rendered relative dates
+ * (#426), the default must NOT come from testMode's frozen clock. Under the
+ * e2e stack the frozen default pointed the dashboard at an empty March 2026
+ * window while the journey's events landed in real-clock July, rendering
+ * every panel permanently empty (caught by admin-analytics.spec.ts).
+ * A #426-family skip-list entry: query bounds stay real.
+ *
+ * Module-loading strategy mirrors page.testmode.test.tsx: the flag is
+ * captured when @/lib/testMode first evaluates, so stub the env at file
+ * scope and import lazily.
+ */
+
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.stubEnv("NEXT_PUBLIC_TEST_MODE", "1");
+
+let presetRange: typeof import("./useAdminAnalytics").presetRange;
+let TEST_NOW_MS: number;
+
+beforeAll(async () => {
+  ({ presetRange } = await import("./useAdminAnalytics"));
+  ({ TEST_NOW_MS } = await import("./testMode"));
+});
+
+describe("presetRange under NEXT_PUBLIC_TEST_MODE", () => {
+  it("defaults to the REAL clock, not the frozen testMode instant", () => {
+    const to = Date.parse(presetRange(30).to);
+    expect(Math.abs(to - Date.now())).toBeLessThan(60_000);
+    expect(Math.abs(to - TEST_NOW_MS)).toBeGreaterThan(86_400_000);
+  });
+});

--- a/frontend/src/lib/useAdminAnalytics.ts
+++ b/frontend/src/lib/useAdminAnalytics.ts
@@ -7,8 +7,8 @@
  * House data-fetching pattern (no SWR/React Query in this repo): a stable
  * useCallback fetcher + a useEffect that re-runs when it changes, exposing
  * { data, loading, error, reload }. Errors are humanized once here so every
- * panel renders the same message shape. The default range clock routes
- * through lib/testMode's now() so the E2E stack sees a frozen window.
+ * panel renders the same message shape. The default range clock is the REAL
+ * clock (see presetRange's docstring for why it skips testMode's now()).
  */
 
 import React from "react";
@@ -19,7 +19,6 @@ import {
   adminUsageSummary,
 } from "./api";
 import { humanizeError } from "./errorMessage";
-import { now } from "./testMode";
 import type {
   AnalyticsBucket,
   ErrorsPageData,
@@ -34,9 +33,13 @@ export interface AnalyticsRangeValue {
   to: string;
 }
 
-/** Last-`days` window ending at `nowMs` (defaults to the testMode-aware
- * clock), as the ISO strings the analytics endpoints take. */
-export function presetRange(days: number, nowMs: number = now()): AnalyticsRangeValue {
+/** Last-`days` window ending at `nowMs`, as the ISO strings the analytics
+ * endpoints take. Defaults to the REAL clock even under
+ * NEXT_PUBLIC_TEST_MODE — a #426-family skip-list entry: these are QUERY
+ * BOUNDS over rows the backend stamps with its real clock, and the frozen
+ * testMode instant pointed the e2e dashboard at an empty March window
+ * (admin-analytics.spec.ts). Deterministic tests pass nowMs explicitly. */
+export function presetRange(days: number, nowMs: number = Date.now()): AnalyticsRangeValue {
   return {
     from: new Date(nowMs - days * 86_400_000).toISOString(),
     to: new Date(nowMs).toISOString(),


### PR DESCRIPTION
Part of #122 (left open per closure policy — Andres verifies the UI and closes). Builds on the #121 data layer (PR #478).

## What
- **Chart primitives** (`AnalyticsCharts.tsx`, no new dependency): hand-rolled SVG day line/area with a crosshair+tooltip hover layer, and horizontal category bars with 4px rounded data-ends + direct value labels. Pure math helpers (`zeroFillDays`/`niceTicks`/`linePoints`) are unit-tested; components lazy-load via `next/dynamic` (ssr:false).
- **Dashboard** on `/admin/analytics`: headline stat strip (total events, active users, LLM cost, calls — type hierarchy, no card chrome), events-per-day + top event types, cost-per-day + cost-by-group with the `group_by` toggle, a sortable top-users table, and an errors-per-day trend above the feed. Every chart panel keeps a **'View data' table fallback**; truncation badges stay.
- **Color discipline** (dataviz skill): every chart is single-series — forest `#1B6C42` for usage/cost, the status red only on the errors trend (title+labels carry identity, never color alone). Palette checked with the skill's validator; text wears text tokens.
- **Journey**: `e2e/admin-analytics.spec.ts` — real student actions generate events → poll the rollup → drive the dashboard as the seeded admin (charts render, feed row for the bogus path, group-by toggle, range preset, student refusal), DB causality via `queryRaw`.

## Notes
- "Error-rate trend" shipped as errors-per-day (an honest count trend; a true rate would couple two panels' scans — happy to follow up if you want rate).
- One axis per chart everywhere; tokens stay in tables/tooltips rather than a second y-scale.

## Tests
Frontend 384 passed (12 screen tests incl. bucket wiring, chart render, sort, table fallback; 8 chart-primitive tests), tsc clean, lint 0 errors. Full local e2e cycle (now 31 journeys) runs before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)