### PR TITLE
fix(ci): prune stale eslint suppressions unblocking the frontend lane

### DIFF
--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -124,7 +124,7 @@
       "count": 2
     },
     "no-restricted-syntax": {
-      "count": 20
+      "count": 17
     }
   },
   "src/components/screens/Library.tsx": {


### PR DESCRIPTION
## Summary
- Every `CI` workflow run (PRs and main pushes) has been red since the #471 merge at 12:17: the lint step exits 2 with `There are suppressions left that do not occur anymore`.
- Root cause: retiring the legacy chat paths removed three suppressed `no-restricted-syntax` occurrences from `src/components/screens/Learn.tsx`; eslint (bulk-suppressions baseline) exits 2 when `eslint-suppressions.json` entries no longer match any violation, even with 0 errors.
- Fix: `npx eslint . --prune-suppressions` — a one-line count update (20 → 17). No rule or code changes.

## Verification
- `npx eslint . --max-warnings=-1` → exit 0 (was 2) on a worktree of origin/main + this change
- `npx tsc --noEmit` → exit 0
- `npm test` → 372/372 passing
(tsc/vitest were being skipped behind the lint failure in CI, so they were re-verified explicitly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)