### PR TITLE
feat: B10 stragglers — manual add-concept (#330) + rooms semantics (#405)

### DIFF
--- a/backend/db/migrations/0038_rooms_semantics.sql
+++ b/backend/db/migrations/0038_rooms_semantics.sql
@@ -1,0 +1,26 @@
+-- 0038: give the #405 rooms columns real semantics ("real ownership +
+-- public rooms").
+--
+-- 0032 added topic/course/owner_id/updated_at/is_public nullable and
+-- unpopulated (its header deliberately deferred the semantics to #405).
+-- This migration backfills and constrains them:
+--   * owner_id := created_by for existing rows — ownership starts with the
+--     creator and is TRANSFERABLE later; created_by stays the immutable
+--     creator record. Authorization (kick, future transfer/delete) keys on
+--     owner_id from here on.
+--   * is_public: DEFAULT false + NOT NULL (NULL was neither public nor
+--     private). false = invite-only; true = joinable without an invite via
+--     POST /api/social/public-rooms/{id}/join and listed by
+--     GET /api/social/public-rooms.
+--   * updated_at: DEFAULT now() + backfill from created_at; membership
+--     changes touch it in code (routes/social.py::_touch_room).
+
+UPDATE rooms SET owner_id = created_by WHERE owner_id IS NULL;
+ALTER TABLE rooms ALTER COLUMN owner_id SET NOT NULL;
+
+UPDATE rooms SET is_public = FALSE WHERE is_public IS NULL;
+ALTER TABLE rooms ALTER COLUMN is_public SET DEFAULT FALSE;
+ALTER TABLE rooms ALTER COLUMN is_public SET NOT NULL;
+
+UPDATE rooms SET updated_at = created_at WHERE updated_at IS NULL;
+ALTER TABLE rooms ALTER COLUMN updated_at SET DEFAULT now();

--- a/backend/db/seed_local_rich.py
+++ b/backend/db/seed_local_rich.py
@@ -450,7 +450,12 @@ def seed_rooms() -> None:
     for room_id, name, invite_code, created_by in _ROOMS:
         h.upsert(
             "rooms",
-            {"id": room_id, "name": name, "invite_code": invite_code, "created_by": created_by},
+            # owner_id mirrors create_room's semantics (#405): ownership starts
+            # with the creator. 0038 makes it NOT NULL and SQL has no
+            # cross-column default, so the seed must set it explicitly or a
+            # from-empty replay fails on the INSERT.
+            {"id": room_id, "name": name, "invite_code": invite_code,
+             "created_by": created_by, "owner_id": created_by},
             on_conflict="invite_code",
         )
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -122,6 +122,15 @@ class UpdateCourseColorBody(BaseModel):
 class CreateRoomBody(BaseModel):
     user_id: str = "user_andres"
     room_name: str = "Study Room"
+    # #405 semantics: optional labeling + the public flag (false = invite-only).
+    topic: str | None = None
+    course: str | None = None
+    is_public: bool = False
+
+
+class PublicJoinBody(BaseModel):
+    """Body for the invite-less join of a public room (#405)."""
+    user_id: str
 
 
 class JoinRoomBody(BaseModel):

--- a/backend/routes/graph.py
+++ b/backend/routes/graph.py
@@ -91,10 +91,13 @@ def remove_course(user_id: str, course_id: str, request: Request):
 class AddNodeBody(BaseModel):
     """Body for manually adding a single concept node (#330).
 
-    ``course_id`` is required: the UNIQUE (user_id, course_id, concept_name)
-    dedup treats NULL course as always-distinct, so courseless manual nodes
-    would duplicate freely. ``anchor_node_id`` optionally links the new node
-    to an existing one (the client defaults it to the focused concept/root).
+    ``course_id`` is required as a PRODUCT rule, not a storage one: a manual
+    concept always belongs to a course, and the graph is course-scoped
+    everywhere else. (The 0023 constraint is UNIQUE NULLS NOT DISTINCT, so a
+    courseless node would in fact collide with any other courseless node of
+    the same name rather than duplicate — a confusing merge either way.)
+    ``anchor_node_id`` optionally links the new node to an existing one (the
+    client defaults it to the focused concept/root).
     """
     concept_name: str
     course_id: str

--- a/backend/routes/graph.py
+++ b/backend/routes/graph.py
@@ -10,7 +10,7 @@ from services.auth_guard import require_self
 from services.graph_service import (
     get_graph, get_recommendations,
     get_courses, add_course, delete_course, update_course_color,
-    delete_node, update_node_color,
+    add_node, delete_node, update_node_color,
 )
 from services.request_context import current_request_id
 from agents import WORKER_LIMITS
@@ -87,6 +87,31 @@ def remove_course(user_id: str, course_id: str, request: Request):
 
 
 # ── Node endpoints ───────────────────────────────────────────────────────────
+
+class AddNodeBody(BaseModel):
+    """Body for manually adding a single concept node (#330).
+
+    ``course_id`` is required: the UNIQUE (user_id, course_id, concept_name)
+    dedup treats NULL course as always-distinct, so courseless manual nodes
+    would duplicate freely. ``anchor_node_id`` optionally links the new node
+    to an existing one (the client defaults it to the focused concept/root).
+    """
+    concept_name: str
+    course_id: str
+    anchor_node_id: Optional[str] = None
+
+
+@router.post("/{user_id}/nodes")
+def create_node(user_id: str, body: AddNodeBody, request: Request):
+    require_self(user_id, request)
+    if not body.concept_name.strip():
+        raise HTTPException(status_code=422, detail="concept_name must be non-empty")
+    if not body.course_id.strip():
+        raise HTTPException(status_code=422, detail="course_id is required")
+    return add_node(
+        user_id, body.concept_name, body.course_id, anchor_node_id=body.anchor_node_id,
+    )
+
 
 @router.delete("/{user_id}/nodes/{node_id}")
 def remove_node(user_id: str, node_id: str, request: Request):

--- a/backend/routes/social.py
+++ b/backend/routes/social.py
@@ -100,7 +100,13 @@ def join_public_room(room_id: str, body: PublicJoinBody, request: Request):
         "room_id", filters={"room_id": f"eq.{room_id}", "user_id": f"eq.{body.user_id}"},
     )
     if not existing:
-        table("room_members").insert({"room_id": room_id, "user_id": body.user_id})
+        # UPSERT, not insert: the pre-read is only a "did we actually add"
+        # signal, so a double-click racing itself must no-op on the
+        # room_members PK rather than surface a raw 500 (PR #485 review;
+        # same shape as #464's check-then-act finding).
+        table("room_members").upsert(
+            {"room_id": room_id, "user_id": body.user_id}, on_conflict="room_id,user_id",
+        )
         _touch_room(room_id)
         invalidate_summary(room_id)
     return {"joined": True, "room_id": room_id}
@@ -122,7 +128,10 @@ def join_room(body: JoinRoomBody, request: Request):
         filters={"room_id": f"eq.{room['id']}", "user_id": f"eq.{body.user_id}"},
     )
     if not existing:
-        table("room_members").insert({"room_id": room["id"], "user_id": body.user_id})
+        table("room_members").upsert(
+            {"room_id": room["id"], "user_id": body.user_id}, on_conflict="room_id,user_id",
+        )
+        _touch_room(room["id"])
         invalidate_summary(room["id"])
 
     members = table("room_members").select("user_id", filters={"room_id": f"eq.{room['id']}"})

--- a/backend/routes/social.py
+++ b/backend/routes/social.py
@@ -1,6 +1,7 @@
 import uuid
 import random
 import string
+from datetime import datetime, timezone
 from collections import defaultdict
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -10,7 +11,7 @@ from agents.deps import SaplingDeps
 from agents.social_summary import social_summary_agent
 from agents.usage import record_agent_usage
 from db.connection import table
-from models import CreateRoomBody, JoinRoomBody, MatchBody, SendMessageBody, EditMessageBody, ToggleReactionBody, LeaveRoomBody
+from models import CreateRoomBody, JoinRoomBody, MatchBody, PublicJoinBody, SendMessageBody, EditMessageBody, ToggleReactionBody, LeaveRoomBody
 from services.auth_guard import require_self, get_session_user_id
 from services.encryption import encrypt_if_present, decrypt_if_present
 from services.profiles import get_display_name, get_display_names
@@ -23,6 +24,16 @@ from services.social_cache_service import get_cached_summary, save_summary, inva
 router = APIRouter()
 
 
+def _touch_room(room_id: str) -> None:
+    """Bump rooms.updated_at on membership changes (#405 gave it a writer;
+    message traffic is deliberately left alone — the 0033 realtime publication
+    owns that flow)."""
+    table("rooms").update(
+        {"updated_at": datetime.now(timezone.utc).isoformat()},
+        {"id": f"eq.{room_id}"},
+    )
+
+
 @router.post("/rooms/create")
 def create_room(body: CreateRoomBody, request: Request):
     require_self(body.user_id, request)
@@ -33,10 +44,66 @@ def create_room(body: CreateRoomBody, request: Request):
         "name": body.room_name,
         "invite_code": invite_code,
         "created_by": body.user_id,
+        # #405 semantics: owner_id is REAL ownership (transferable later),
+        # seeded to the creator; is_public gates the invite-less public join.
+        "owner_id": body.user_id,
+        "topic": body.topic,
+        "course": body.course,
+        "is_public": body.is_public,
     })
     table("room_members").insert({"room_id": room_id, "user_id": body.user_id})
     invalidate_summary(room_id)
     return {"room_id": room_id, "invite_code": invite_code}
+
+
+@router.get("/public-rooms")
+def list_public_rooms(request: Request, user_id: str = Query(...)):
+    """Public rooms (#405): is_public=true rooms, joinable without an invite.
+    The select never includes invite_code, so the public listing cannot leak
+    the private join path."""
+    require_self(user_id, request)
+    rooms = table("rooms").select(
+        "id,name,topic,course,owner_id,created_by,created_at,updated_at,is_public",
+        filters={"is_public": "eq.true"},
+    ) or []
+    out = []
+    for room in rooms:
+        members = table("room_members").select(
+            "user_id", filters={"room_id": f"eq.{room['id']}"},
+        ) or []
+        # Explicit projection (never a row spread): the public payload cannot
+        # leak invite_code even if the row carries it.
+        out.append({
+            "id": room["id"],
+            "name": room.get("name"),
+            "topic": room.get("topic"),
+            "course": room.get("course"),
+            "owner_id": room.get("owner_id"),
+            "created_by": room.get("created_by"),
+            "created_at": room.get("created_at"),
+            "updated_at": room.get("updated_at"),
+            "is_public": True,
+            "member_count": len(members),
+        })
+    return {"rooms": out}
+
+
+@router.post("/public-rooms/{room_id}/join")
+def join_public_room(room_id: str, body: PublicJoinBody, request: Request):
+    require_self(body.user_id, request)
+    rooms = table("rooms").select("id,is_public", filters={"id": f"eq.{room_id}"})
+    if not rooms:
+        raise HTTPException(status_code=404, detail="Room not found")
+    if not rooms[0].get("is_public"):
+        raise HTTPException(status_code=403, detail="This room is invite-only")
+    existing = table("room_members").select(
+        "room_id", filters={"room_id": f"eq.{room_id}", "user_id": f"eq.{body.user_id}"},
+    )
+    if not existing:
+        table("room_members").insert({"room_id": room_id, "user_id": body.user_id})
+        _touch_room(room_id)
+        invalidate_summary(room_id)
+    return {"joined": True, "room_id": room_id}
 
 
 @router.post("/rooms/join")
@@ -262,6 +329,7 @@ def school_match(body: MatchBody, request: Request):
 def leave_room(room_id: str, body: LeaveRoomBody, request: Request):
     require_self(body.user_id, request)
     table("room_members").delete({"room_id": f"eq.{room_id}", "user_id": f"eq.{body.user_id}"})
+    _touch_room(room_id)
     invalidate_summary(room_id)
     return {"left": True}
 
@@ -275,9 +343,12 @@ def kick_member(room_id: str, member_id: str, request: Request, requester_id: st
     )
     if not room_rows:
         raise HTTPException(status_code=404, detail="Room not found")
-    if room_rows[0]["created_by"] != requester_id:
-        raise HTTPException(status_code=403, detail="Only the room leader can kick members")
+    # #405: authorization keys on owner_id (real, transferable ownership) —
+    # created_by stays the immutable creator record and no longer gates.
+    if room_rows[0]["owner_id"] != requester_id:
+        raise HTTPException(status_code=403, detail="Only the room owner can kick members")
     table("room_members").delete({"room_id": f"eq.{room_id}", "user_id": f"eq.{member_id}"})
+    _touch_room(room_id)
     invalidate_summary(room_id)
     return {"kicked": True}
 

--- a/backend/services/graph_service.py
+++ b/backend/services/graph_service.py
@@ -576,6 +576,66 @@ def _coerce_unit(value, default: float = 0.0) -> float:
     return max(0.0, min(1.0, f))
 
 
+def add_node(
+    user_id: str,
+    concept_name: str,
+    course_id: str,
+    anchor_node_id: str | None = None,
+    initial_mastery: float = 0.0,
+) -> dict:
+    """Create-or-merge one manually named concept (#330).
+
+    A thin wrapper over apply_graph_update so the UNIQUE-backed dedup, edge
+    machinery, and offering-analytics refresh stay in one place (routes never
+    write graph_nodes/graph_edges directly). The anchor id resolves to its
+    concept NAME because apply_graph_update's edge _lookup is name-keyed; a
+    stale anchor (deleted mid-flight) silently drops the edge, never the node.
+    Returns {"node": <canonical row>, "already_existed": bool} so the UI can
+    toast merge-vs-create and reconcile its optimistic id.
+    """
+    name = " ".join((concept_name or "").split())
+    if not name:
+        raise ValueError("concept_name must be non-empty")
+    if not course_id:
+        raise ValueError("course_id is required")
+    norm = _normalize_concept(name)
+    scope = {"user_id": f"eq.{user_id}", "course_id": f"eq.{course_id}"}
+
+    pre = table("graph_nodes").select("id,concept_name", filters=scope) or []
+    already_existed = any(
+        _normalize_concept(r.get("concept_name") or "") == norm for r in pre
+    )
+
+    update: dict = {
+        "new_nodes": [
+            {"concept_name": name, "course_id": course_id, "initial_mastery": initial_mastery},
+        ],
+    }
+    if anchor_node_id:
+        anchor_rows = table("graph_nodes").select(
+            "id,concept_name",
+            filters={"id": f"eq.{anchor_node_id}", "user_id": f"eq.{user_id}"},
+        ) or []
+        anchor_name = (anchor_rows[0].get("concept_name") if anchor_rows else "") or ""
+        if anchor_name and _normalize_concept(anchor_name) != norm:
+            update["new_edges"] = [
+                {"source": anchor_name, "target": name, "relationship_type": "related", "strength": 0.5},
+            ]
+
+    apply_graph_update(user_id, update, course_id=course_id)
+
+    rows = table("graph_nodes").select(
+        "id,concept_name,course_id,mastery_score,mastery_tier", filters=scope,
+    ) or []
+    node = next(
+        (r for r in rows if _normalize_concept(r.get("concept_name") or "") == norm),
+        None,
+    )
+    if node is None:
+        raise RuntimeError(f"add_node: {name!r} missing after apply_graph_update")
+    return {"node": node, "already_existed": already_existed}
+
+
 def apply_graph_update(user_id: str, graph_update: dict, course_id: str | None = None) -> list:
     """
     Apply a graph_update dict to the DB. Returns mastery_changes list.

--- a/backend/services/graph_service.py
+++ b/backend/services/graph_service.py
@@ -585,13 +585,21 @@ def add_node(
 ) -> dict:
     """Create-or-merge one manually named concept (#330).
 
-    A thin wrapper over apply_graph_update so the UNIQUE-backed dedup, edge
-    machinery, and offering-analytics refresh stay in one place (routes never
-    write graph_nodes/graph_edges directly). The anchor id resolves to its
-    concept NAME because apply_graph_update's edge _lookup is name-keyed; a
-    stale anchor (deleted mid-flight) silently drops the edge, never the node.
-    Returns {"node": <canonical row>, "already_existed": bool} so the UI can
-    toast merge-vs-create and reconcile its optimistic id.
+    A thin wrapper over apply_graph_update so the dedup, edge machinery, and
+    offering-analytics refresh stay in one place (routes never write
+    graph_nodes/graph_edges directly). The anchor id resolves to its concept
+    NAME because apply_graph_update's edge _lookup is name-keyed; a stale or
+    out-of-course anchor silently drops the edge, never the node. Returns
+    {"node": <canonical row>, "already_existed": bool} so the UI can toast
+    merge-vs-create and reconcile its optimistic id.
+
+    Dedup caveat (pre-existing, inherited from apply_graph_update): the
+    case/whitespace folding is Python-side, while the 0023 constraint is a
+    case-SENSITIVE UNIQUE. Two concurrent adds differing only in case can
+    therefore both land, and `already_existed` is computed from a pre-read
+    that can go stale under the same race. Sequential use — every path the
+    UI offers — dedups correctly. Tracked separately for a citext/functional
+    index rather than widened here.
     """
     name = " ".join((concept_name or "").split())
     if not name:
@@ -612,9 +620,17 @@ def add_node(
         ],
     }
     if anchor_node_id:
+        # Scoped to the target course as well as the user: apply_graph_update
+        # resolves edge endpoints by NAME *within* the course, so an anchor
+        # from another course could silently wire to a same-named node here
+        # instead of being dropped as stale (PR #485 review).
         anchor_rows = table("graph_nodes").select(
             "id,concept_name",
-            filters={"id": f"eq.{anchor_node_id}", "user_id": f"eq.{user_id}"},
+            filters={
+                "id": f"eq.{anchor_node_id}",
+                "user_id": f"eq.{user_id}",
+                "course_id": f"eq.{course_id}",
+            },
         ) or []
         anchor_name = (anchor_rows[0].get("concept_name") if anchor_rows else "") or ""
         if anchor_name and _normalize_concept(anchor_name) != norm:

--- a/backend/tests/test_graph_add_node.py
+++ b/backend/tests/test_graph_add_node.py
@@ -1,0 +1,122 @@
+"""Tests for the manual add-concept path (#330): graph_service.add_node and
+POST /api/graph/{user_id}/nodes.
+
+add_node is a thin wrapper over apply_graph_update — the dedup/merge and
+analytics-refresh machinery stays in one place (routes never write
+graph_nodes/graph_edges directly), so these tests pin the ORCHESTRATION:
+the pre-check that reports merge-vs-create, the anchor-id → name resolution
+that feeds the edge (apply_graph_update resolves edges by name), and the
+canonical read-back. Supabase is mocked per tests/test_graph_service.py's
+idiom; apply_graph_update itself is patched (its behavior has its own suite).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+import routes.graph as graph_routes
+import services.graph_service as gs
+
+client = TestClient(app)
+
+ANCHOR = {"id": "n-root", "concept_name": "Math 210", "course_id": "c1"}
+CREATED = {
+    "id": "n-new", "concept_name": "Recursion", "course_id": "c1",
+    "mastery_score": 0.0, "mastery_tier": "unexplored",
+}
+
+
+def _graph_nodes_mock(select_side_effect):
+    """One cached graph_nodes mock whose .select returns follow the given
+    sequence; other tables return empty lists."""
+    nodes = MagicMock()
+    nodes.select.side_effect = select_side_effect
+
+    def factory(name):
+        if name == "graph_nodes":
+            return nodes
+        other = MagicMock()
+        other.select.return_value = []
+        return other
+    return factory, nodes
+
+
+class TestAddNodeService:
+    def test_creates_via_apply_graph_update_with_anchor_edge(self):
+        # selects: pre-check (no match) → anchor lookup → canonical read-back
+        factory, _ = _graph_nodes_mock([[], [ANCHOR], [CREATED]])
+        with patch.object(gs, "table", side_effect=factory), \
+             patch.object(gs, "apply_graph_update", return_value=[]) as agu:
+            out = gs.add_node("u1", "  Recursion ", "c1", anchor_node_id="n-root")
+
+        assert out["already_existed"] is False
+        assert out["node"]["id"] == "n-new"
+        agu.assert_called_once()
+        update = agu.call_args.args[1]
+        assert update["new_nodes"] == [
+            {"concept_name": "Recursion", "course_id": "c1", "initial_mastery": 0.0},
+        ]
+        # The edge feeds apply_graph_update by NAME (its _lookup is name-keyed).
+        assert update["new_edges"][0]["source"] == "Math 210"
+        assert update["new_edges"][0]["target"] == "Recursion"
+        assert agu.call_args.kwargs.get("course_id") == "c1"
+
+    def test_merge_reports_already_existed(self):
+        existing = {**CREATED, "id": "n-1", "mastery_score": 0.4, "mastery_tier": "learning"}
+        # pre-check finds the (case-insensitively) matching row; no anchor;
+        # read-back returns the surviving row.
+        factory, _ = _graph_nodes_mock([[existing], [existing]])
+        with patch.object(gs, "table", side_effect=factory), \
+             patch.object(gs, "apply_graph_update", return_value=[]):
+            out = gs.add_node("u1", "recursion", "c1")
+
+        assert out["already_existed"] is True
+        assert out["node"]["id"] == "n-1"
+
+    def test_missing_anchor_creates_node_without_edge(self):
+        # anchor id resolves to nothing (deleted mid-flight) — node still lands.
+        factory, _ = _graph_nodes_mock([[], [], [CREATED]])
+        with patch.object(gs, "table", side_effect=factory), \
+             patch.object(gs, "apply_graph_update", return_value=[]) as agu:
+            out = gs.add_node("u1", "Recursion", "c1", anchor_node_id="n-gone")
+
+        assert out["already_existed"] is False
+        assert "new_edges" not in agu.call_args.args[1]
+
+    def test_blank_name_raises(self):
+        with pytest.raises(ValueError):
+            gs.add_node("u1", "   ", "c1")
+
+
+class TestAddNodeRoute:
+    def test_post_returns_node_and_flag(self, monkeypatch):
+        monkeypatch.setattr(
+            graph_routes, "add_node",
+            lambda user_id, concept_name, course_id, anchor_node_id=None: {
+                "node": CREATED, "already_existed": False,
+            },
+        )
+        r = client.post("/api/graph/u1/nodes", json={"concept_name": "Recursion", "course_id": "c1"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["node"]["id"] == "n-new"
+        assert body["already_existed"] is False
+
+    def test_post_whitespace_name_is_422(self):
+        r = client.post("/api/graph/u1/nodes", json={"concept_name": "   ", "course_id": "c1"})
+        assert r.status_code == 422
+
+    def test_post_missing_course_is_422(self):
+        r = client.post("/api/graph/u1/nodes", json={"concept_name": "Recursion"})
+        assert r.status_code == 422
+
+    def test_post_requires_self(self, monkeypatch):
+        from fastapi import HTTPException
+
+        def _deny(user_id, request):
+            raise HTTPException(status_code=403, detail="Forbidden")
+
+        monkeypatch.setattr(graph_routes, "require_self", _deny)
+        r = client.post("/api/graph/u1/nodes", json={"concept_name": "Recursion", "course_id": "c1"})
+        assert r.status_code == 403

--- a/backend/tests/test_social_rooms.py
+++ b/backend/tests/test_social_rooms.py
@@ -1,0 +1,123 @@
+"""Tests for the rooms semantics (#405, "real ownership + public rooms").
+
+Pins: create_room populates the 0032 columns (owner_id = creator, is_public
+defaulting false, topic/course from the body); the kick gate keys on
+OWNER_ID (ownership is transferable later — created_by stays the immutable
+creator record); membership changes touch rooms.updated_at; and the minimal
+public surface (GET /public-rooms + invite-less join) never leaks the
+invite_code and 403s private rooms. Supabase mocked per
+tests/test_social_messages.py's idiom.
+"""
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def _room(id="r1", owner="u-owner", creator="u-creator", is_public=False, **kw):
+    return {
+        "id": id, "name": "Room", "topic": None, "course": None,
+        "owner_id": owner, "created_by": creator, "invite_code": "ABC123",
+        "created_at": "2026-07-01T00:00:00Z", "updated_at": None,
+        "is_public": is_public, **kw,
+    }
+
+
+def _tables(data=None):
+    cache: dict = {}
+
+    def factory(name):
+        if name not in cache:
+            m = MagicMock()
+            m.select.return_value = (data or {}).get(name, [])
+            m.insert.return_value = []
+            m.update.return_value = []
+            m.delete.return_value = []
+            cache[name] = m
+        return cache[name]
+    return factory, cache
+
+
+class TestCreateRoomPopulates:
+    def test_defaults(self):
+        factory, mocks = _tables()
+        with patch("routes.social.table", side_effect=factory):
+            r = client.post("/api/social/rooms/create",
+                            json={"user_id": "u1", "room_name": "Algebra crew"})
+        assert r.status_code == 200
+        row = mocks["rooms"].insert.call_args.args[0]
+        assert row["owner_id"] == "u1"    # real ownership column, populated
+        assert row["created_by"] == "u1"  # immutable creator record
+        assert row["is_public"] is False
+        assert row["topic"] is None
+        assert row["course"] is None
+
+    def test_optional_fields(self):
+        factory, mocks = _tables()
+        with patch("routes.social.table", side_effect=factory):
+            r = client.post("/api/social/rooms/create", json={
+                "user_id": "u1", "room_name": "Algebra crew",
+                "topic": "Midterm prep", "course": "MATH210", "is_public": True,
+            })
+        assert r.status_code == 200
+        row = mocks["rooms"].insert.call_args.args[0]
+        assert row["topic"] == "Midterm prep"
+        assert row["course"] == "MATH210"
+        assert row["is_public"] is True
+
+
+class TestKickAuthKeysOnOwner:
+    def test_creator_who_is_not_owner_cannot_kick(self):
+        factory, _ = _tables({"rooms": [_room()]})
+        with patch("routes.social.table", side_effect=factory):
+            r = client.delete("/api/social/rooms/r1/members/u2?requester_id=u-creator")
+        assert r.status_code == 403
+
+    def test_owner_kicks_and_touches_updated_at(self):
+        factory, mocks = _tables({"rooms": [_room()]})
+        with patch("routes.social.table", side_effect=factory):
+            r = client.delete("/api/social/rooms/r1/members/u2?requester_id=u-owner")
+        assert r.status_code == 200
+        mocks["room_members"].delete.assert_called_once()
+        assert "updated_at" in mocks["rooms"].update.call_args.args[0]
+
+
+class TestPublicRooms:
+    def test_list_filters_public_and_never_leaks_the_invite_code(self):
+        factory, mocks = _tables({
+            "rooms": [_room(id="r-pub", is_public=True)],
+            "room_members": [{"room_id": "r-pub", "user_id": "u9"}],
+        })
+        with patch("routes.social.table", side_effect=factory):
+            r = client.get("/api/social/public-rooms?user_id=u9")
+        assert r.status_code == 200
+        rooms = r.json()["rooms"]
+        assert rooms[0]["id"] == "r-pub"
+        assert rooms[0]["member_count"] == 1
+        assert "invite_code" not in rooms[0]
+        filters = mocks["rooms"].select.call_args.kwargs.get("filters") or {}
+        assert filters.get("is_public") == "eq.true"
+
+    def test_join_public_room_inserts_membership(self):
+        factory, mocks = _tables({"rooms": [_room(id="r-pub", is_public=True)]})
+        with patch("routes.social.table", side_effect=factory):
+            r = client.post("/api/social/public-rooms/r-pub/join", json={"user_id": "u2"})
+        assert r.status_code == 200
+        member = mocks["room_members"].insert.call_args.args[0]
+        assert member == {"room_id": "r-pub", "user_id": "u2"}
+        assert "updated_at" in mocks["rooms"].update.call_args.args[0]
+
+    def test_join_private_room_is_403(self):
+        factory, _ = _tables({"rooms": [_room(id="r-priv", is_public=False)]})
+        with patch("routes.social.table", side_effect=factory):
+            r = client.post("/api/social/public-rooms/r-priv/join", json={"user_id": "u2"})
+        assert r.status_code == 403
+
+    def test_join_unknown_room_is_404(self):
+        factory, _ = _tables()
+        with patch("routes.social.table", side_effect=factory):
+            r = client.post("/api/social/public-rooms/r-nope/join", json={"user_id": "u2"})
+        assert r.status_code == 404

--- a/backend/tests/test_social_rooms.py
+++ b/backend/tests/test_social_rooms.py
@@ -34,6 +34,7 @@ def _tables(data=None):
             m = MagicMock()
             m.select.return_value = (data or {}).get(name, [])
             m.insert.return_value = []
+            m.upsert.return_value = []
             m.update.return_value = []
             m.delete.return_value = []
             cache[name] = m
@@ -106,8 +107,11 @@ class TestPublicRooms:
         with patch("routes.social.table", side_effect=factory):
             r = client.post("/api/social/public-rooms/r-pub/join", json={"user_id": "u2"})
         assert r.status_code == 200
-        member = mocks["room_members"].insert.call_args.args[0]
+        # UPSERT, not insert: a double-click racing itself must no-op on the
+        # room_members PK rather than 500 (PR #485 review).
+        member = mocks["room_members"].upsert.call_args.args[0]
         assert member == {"room_id": "r-pub", "user_id": "u2"}
+        assert mocks["room_members"].upsert.call_args.kwargs["on_conflict"] == "room_id,user_id"
         assert "updated_at" in mocks["rooms"].update.call_args.args[0]
 
     def test_join_private_room_is_403(self):

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -183,6 +183,9 @@ route:
 | `graph-node-circle` | the main circle inside a 2D node group — the mark that encodes the mastery tier as `opacity` |
 | `graph-edge` | one 2D SVG edge `<line>` |
 | `graph-zoom-in` / `graph-zoom-out` / `graph-zoom-reset` | 2D zoom controls |
+| `graph-add-concept` | Tree toolbar: "＋ Add concept" opener (#330) — rendered only when a single course pill is selected (the "all" filter gives no course to attribute the node to) |
+| `graph-add-concept-input` | the concept-name `<input>` (Enter submits, Escape cancels) |
+| `graph-add-concept-submit` | the "Add" button — POSTs create-or-merge, toasts, reloads the graph |
 
 `graph-node-item` / `graph-node` carry the node id as a separate
 `data-node-id` attribute instead of a testid suffix (the repeated-items rule

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -209,6 +209,9 @@ never collide in the DOM.
 | `social-join-room` | sidebar "Join" (opens the invite-code input) |
 | `social-create-join-input` | shared create/join text input |
 | `social-create-join-submit` | "Go" |
+| `social-create-topic` / `social-create-course` | create-mode optional labeling inputs (#405) |
+| `social-create-public` | create-mode "Public" checkbox (#405) — public rooms are joinable without an invite |
+| `social-public-join-{roomId}` | "Join" on a discovered public room (stable domain id, #405) |
 | `social-room-item-{roomId}` | a room in the sidebar list (stable seeded/domain id) |
 | `social-room-name` | active room title in the header |
 | `social-invite-copy` | invite-code copy chip in the header |
@@ -353,6 +356,11 @@ coverage and regenerate with `npm run lint:baseline`.
 `src/components/screens/Learn.tsx` (the session-resume rows, #392) is in the
 `files` list with the same treatment: its 21 pre-existing untagged elements are
 baselined, so only NEW interactive elements there must carry a testid.
+
+`screens/Tree.tsx` (#330) gets the same treatment: its 8 pre-existing
+untagged buttons/inputs (search, zoom, detail-panel actions) are baselined
+in `eslint-suppressions.json`; only NEW interactive elements there must
+carry a testid (the `graph-add-concept*` trio entered tagged).
 
 The `gradebook` surface files (#139/#468) get the same treatment:
 `screens/Gradebook/Course.tsx`, `Landing.tsx`, `Gradebook/AssignmentList.tsx`

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -358,9 +358,11 @@ coverage and regenerate with `npm run lint:baseline`.
 baselined, so only NEW interactive elements there must carry a testid.
 
 `screens/Tree.tsx` (#330) gets the same treatment: its 8 pre-existing
-untagged buttons/inputs (search, zoom, detail-panel actions) are baselined
-in `eslint-suppressions.json`; only NEW interactive elements there must
-carry a testid (the `graph-add-concept*` trio entered tagged).
+untagged elements — the search input, the five detail-panel actions
+(close / learn / quiz / delete / resume), and the two fullscreen toggles —
+are baselined in `eslint-suppressions.json`; only NEW interactive elements
+there must carry a testid (the `graph-add-concept*` trio entered tagged).
+Note the `graph-zoom-*` controls live in `KnowledgeGraph2D.tsx`, not here.
 
 The `gradebook` surface files (#139/#468) get the same treatment:
 `screens/Gradebook/Course.tsx`, `Landing.tsx`, `Gradebook/AssignmentList.tsx`

--- a/frontend/e2e/room-public.spec.ts
+++ b/frontend/e2e/room-public.spec.ts
@@ -52,7 +52,7 @@ test("a public room is created with real semantics and joined invite-less (#405)
 
   // Second user discovers and joins WITHOUT an invite.
   const ctx2 = await browser.newContext({
-    storageState: await mintStorageState(USER_SECOND, "Casey Second"),
+    storageState: await mintStorageState(USER_SECOND, "Sam Second"),
   });
   try {
     const page2 = await ctx2.newPage();

--- a/frontend/e2e/room-public.spec.ts
+++ b/frontend/e2e/room-public.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Public-rooms journey (#405, "real ownership + public rooms").
+ *
+ * As the seeded student: create a room through the UI with a topic and the
+ * Public flag. Assert the DB semantics the 0038 migration + populate-on-create
+ * established: owner_id = creator (real, transferable ownership — created_by
+ * stays the immutable creator record), is_public true, topic stored. Then, as
+ * the SECOND seeded user in a separate browser context, discover the room in
+ * the "Public rooms" list and join it WITHOUT an invite code — the whole point
+ * of is_public — and assert the membership row. The public listing payload
+ * never carries invite_code (pinned by backend tests; the UI never sees it).
+ */
+import { expect, test } from "./support/fixtures";
+import { queryRaw } from "./support/db";
+import { mintStorageState } from "./support/session";
+import { FRONTEND_URL, USER_ACTIVE, USER_SECOND } from "./support/stack";
+
+const ROOM_NAME = "E2E Public Room";
+
+test("a public room is created with real semantics and joined invite-less (#405)", async ({
+  page,
+  browser,
+}) => {
+  await page.goto(`${FRONTEND_URL}/social`);
+  await page.getByTestId("social-create-room").click();
+  await page.getByTestId("social-create-join-input").fill(ROOM_NAME);
+  await page.getByTestId("social-create-topic").fill("Midterm prep");
+  await page.getByTestId("social-create-public").check();
+  await page.getByTestId("social-create-join-submit").click();
+
+  // DB semantics (never a bare sleep): owner seeded to the creator, flag real.
+  await expect
+    .poll(
+      async () => {
+        const rows = await queryRaw(
+          "SELECT id, owner_id, created_by, topic, is_public FROM rooms WHERE name = $1",
+          [ROOM_NAME],
+        );
+        return rows.length;
+      },
+      { timeout: 5_000, message: "the room row should land with the #405 columns" },
+    )
+    .toBe(1);
+  const [room] = await queryRaw(
+    "SELECT id, owner_id, created_by, topic, is_public FROM rooms WHERE name = $1",
+    [ROOM_NAME],
+  );
+  expect(room.owner_id).toBe(USER_ACTIVE);
+  expect(room.created_by).toBe(USER_ACTIVE);
+  expect(room.topic).toBe("Midterm prep");
+  expect(room.is_public).toBe(true);
+
+  // Second user discovers and joins WITHOUT an invite.
+  const ctx2 = await browser.newContext({
+    storageState: await mintStorageState(USER_SECOND, "Casey Second"),
+  });
+  try {
+    const page2 = await ctx2.newPage();
+    await page2.goto(`${FRONTEND_URL}/social`);
+    await page2.getByTestId(`social-public-join-${room.id}`).click();
+    await expect(page2.getByTestId(`social-room-item-${room.id}`)).toBeVisible();
+
+    const members = await queryRaw(
+      "SELECT user_id FROM room_members WHERE room_id = $1 AND user_id = $2",
+      [room.id, USER_SECOND],
+    );
+    expect(members).toHaveLength(1);
+  } finally {
+    await ctx2.close();
+  }
+});

--- a/frontend/e2e/tree-add-concept.spec.ts
+++ b/frontend/e2e/tree-add-concept.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Manual add-concept journey (#330).
+ *
+ * As the seeded student on /tree: select the MATH210 course pill (the
+ * composer only renders for a single-course filter — "all" gives no course
+ * to attribute the node to), add a uniquely named concept, and assert the
+ * DB truth (exactly one graph_nodes row for user+course+name) plus the
+ * reloaded graph rendering it via the a11y node list. Then re-add the same
+ * name CASE-DRIFTED and assert the backend's UNIQUE-backed dedup merged it
+ * (merge toast; still one row) instead of duplicating.
+ *
+ * No DB edge is asserted: with no node selected the composer sends no
+ * anchor, so the node lands edge-less by design and the renderer's per-node
+ * hub spoke keeps it visually attached (see graph.spec.ts's invariants).
+ */
+import { expect, test } from "./support/fixtures";
+import { queryRaw } from "./support/db";
+import { FRONTEND_URL, USER_ACTIVE } from "./support/stack";
+
+const COURSE_ID = "rich-course-math210";
+const CONCEPT = "E2E Manual Concept";
+
+test("Tree add-concept persists, renders, and dedups on re-add (#330)", async ({ page }) => {
+  await page.goto(`${FRONTEND_URL}/tree`);
+  await page.getByRole("button", { name: /MATH210/ }).click();
+
+  await page.getByTestId("graph-add-concept").click();
+  await page.getByTestId("graph-add-concept-input").fill(CONCEPT);
+  await page.getByTestId("graph-add-concept-submit").click();
+
+  // DB truth first (never a bare sleep): exactly one row lands.
+  await expect
+    .poll(
+      async () => {
+        const rows = await queryRaw(
+          "SELECT id FROM graph_nodes WHERE user_id = $1 AND course_id = $2 AND concept_name = $3",
+          [USER_ACTIVE, COURSE_ID, CONCEPT],
+        );
+        return rows.length;
+      },
+      { timeout: 5_000, message: "the concept should persist to graph_nodes" },
+    )
+    .toBe(1);
+
+  const rows = await queryRaw(
+    "SELECT id FROM graph_nodes WHERE user_id = $1 AND course_id = $2 AND concept_name = $3",
+    [USER_ACTIVE, COURSE_ID, CONCEPT],
+  );
+  const nodeId = rows[0].id as string;
+
+  // The post-save reload renders the canonical node (a11y list, by id —
+  // concept names are only unique per course).
+  await expect(
+    page.locator(`[data-testid="graph-node-item"][data-node-id="${nodeId}"]`),
+  ).toBeAttached();
+
+  // Re-add case-drifted → merge, not duplicate.
+  await page.getByTestId("graph-add-concept").click();
+  await page.getByTestId("graph-add-concept-input").fill(CONCEPT.toUpperCase());
+  await page.getByTestId("graph-add-concept-submit").click();
+  await expect(page.getByText(/merged into your existing/i)).toBeVisible();
+
+  const after = await queryRaw(
+    "SELECT id FROM graph_nodes WHERE user_id = $1 AND course_id = $2 AND LOWER(concept_name) = LOWER($3)",
+    [USER_ACTIVE, COURSE_ID, CONCEPT],
+  );
+  expect(after).toHaveLength(1);
+  expect(after[0].id).toBe(nodeId); // the original row survived the merge
+});

--- a/frontend/e2e/tree-add-concept.spec.ts
+++ b/frontend/e2e/tree-add-concept.spec.ts
@@ -22,7 +22,10 @@ const CONCEPT = "E2E Manual Concept";
 
 test("Tree add-concept persists, renders, and dedups on re-add (#330)", async ({ page }) => {
   await page.goto(`${FRONTEND_URL}/tree`);
-  await page.getByRole("button", { name: /MATH210/ }).click();
+  // `exact` matters: the course pill's label is a prefix of the graph node's
+  // a11y activate button ("MATH210 - Linear Algebra"), so a loose match is a
+  // strict-mode violation once the graph renders.
+  await page.getByRole("button", { name: "MATH210", exact: true }).click();
 
   await page.getByTestId("graph-add-concept").click();
   await page.getByTestId("graph-add-concept-input").fill(CONCEPT);

--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -140,6 +140,9 @@
   "src/components/screens/Tree.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
+    },
+    "no-restricted-syntax": {
+      "count": 8
     }
   },
   "src/lib/api.test.ts": {

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -73,6 +73,7 @@ const eslintConfig = [
       "src/components/Gradebook/AssignmentList.tsx",
       "src/components/Gradebook/AssignmentModal.tsx",
       "src/components/screens/AdminAnalytics.tsx",
+      "src/components/screens/Tree.tsx",
     ],
     rules: {
       "no-restricted-syntax": [

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -34,6 +34,7 @@ import {
   learnAction,
   getCourses,
   getGraph,
+  addGraphNode,
   deleteGraphNode,
   describeConcept,
   shouldFallBackToJson,
@@ -43,6 +44,7 @@ import {
   type ChatResult,
   type GraphDelta,
 } from "@/lib/api";
+import { reconcileNodes, retargetEdges } from "@/lib/graphOptimistic";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
 import { apiToGraphNode, type GraphNode, type GraphEdge } from "@/lib/data";
 
@@ -1150,8 +1152,10 @@ function LearnInner() {
 
   // Manually add a concept to the current course. The new node links to the
   // focused concept (or the course root) so it joins the tree, starts as
-  // "unexplored", and becomes the focus. State-first; real-backend
-  // persistence for add would need a dedicated endpoint.
+  // "unexplored", and becomes the focus. Optimistic-first, then persisted
+  // via POST /api/graph/{user}/nodes (#330): the temp id is swapped for the
+  // canonical row (which may be a dedup MERGE into an existing node), or
+  // rolled back with a toast when the write fails.
   const addConcept = (name: string) => {
     const label = name.trim();
     if (!label || !cardCourseId) return;
@@ -1172,6 +1176,24 @@ function LearnInner() {
     setFocusedNodeId(id);
     setNewConceptName("");
     setAddingConcept(false);
+    if (!userId) return;
+    addGraphNode(userId, {
+      concept_name: label,
+      course_id: cardCourseId,
+      anchor_node_id: anchorId || undefined,
+    })
+      .then((res) => {
+        setGraphNodes(prev => reconcileNodes(prev, id, res.node));
+        setGraphEdges(prev => retargetEdges(prev, id, res.node.id));
+        setFocusedNodeId(cur => (cur === id ? res.node.id : cur));
+        if (res.already_existed) toast.success(`Merged into your existing “${label}” node.`);
+      })
+      .catch(() => {
+        setGraphNodes(prev => prev.filter(n => n.id !== id));
+        setGraphEdges(prev => prev.filter(e => e.source !== id && e.target !== id));
+        setFocusedNodeId(cur => (cur === id ? null : cur));
+        toast.error("Couldn't save the concept — it was removed.");
+      });
   };
 
   // Remove a concept: drop the node + its edges and clear focus if it was

--- a/frontend/src/components/screens/Learn.tsx
+++ b/frontend/src/components/screens/Learn.tsx
@@ -44,7 +44,7 @@ import {
   type ChatResult,
   type GraphDelta,
 } from "@/lib/api";
-import { reconcileNodes, retargetEdges } from "@/lib/graphOptimistic";
+import { dropOptimisticConcept, reconcileNodes, retargetEdges } from "@/lib/graphOptimistic";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
 import { apiToGraphNode, type GraphNode, type GraphEdge } from "@/lib/data";
 
@@ -449,6 +449,7 @@ function LearnInner() {
   // Inline "add concept" composer state for the knowledge-map rail.
   const [addingConcept, setAddingConcept] = useState(false);
   const [newConceptName, setNewConceptName] = useState("");
+  const optimisticSeq = useRef(0);
   // AI-generated concept descriptions, fetched lazily for the focused concept
   // when it has no stored description (keyed by node id). `descInflightRef`
   // dedupes concurrent fetches for the same node.
@@ -1161,7 +1162,11 @@ function LearnInner() {
     if (!label || !cardCourseId) return;
     const root = graphNodes.find(n => n.is_subject_root && n.course_id === cardCourseId);
     const anchorId = focusConcept?.id ?? root?.id;
-    const id = `node-new-${Date.now()}`;
+    // Monotonic suffix: Date.now() alone is ms-resolution, and this path has
+    // no in-flight guard (Enter key-repeat can fire twice before the composer
+    // unmounts), so two adds could share a temp id and desync reconcile
+    // (PR #485 review).
+    const id = `node-new-${Date.now()}-${++optimisticSeq.current}`;
     const newNode: GraphNode = {
       id,
       name: label,
@@ -1183,14 +1188,19 @@ function LearnInner() {
       anchor_node_id: anchorId || undefined,
     })
       .then((res) => {
+        // A live tutor turn may already have rendered this concept as a
+        // `stream-<name>` placeholder; the backend merged by name, so absorb
+        // that node and its edges too (PR #485 review).
+        const streamId = `stream-${normalizeConceptName(label)}`;
         setGraphNodes(prev => reconcileNodes(prev, id, res.node));
-        setGraphEdges(prev => retargetEdges(prev, id, res.node.id));
-        setFocusedNodeId(cur => (cur === id ? res.node.id : cur));
+        setGraphEdges(prev =>
+          retargetEdges(retargetEdges(prev, id, res.node.id), streamId, res.node.id));
+        setFocusedNodeId(cur => (cur === id || cur === streamId ? res.node.id : cur));
         if (res.already_existed) toast.success(`Merged into your existing “${label}” node.`);
       })
       .catch(() => {
-        setGraphNodes(prev => prev.filter(n => n.id !== id));
-        setGraphEdges(prev => prev.filter(e => e.source !== id && e.target !== id));
+        setGraphNodes(prev => dropOptimisticConcept(prev, [], id).nodes);
+        setGraphEdges(prev => dropOptimisticConcept([], prev, id).edges);
         setFocusedNodeId(cur => (cur === id ? null : cur));
         toast.error("Couldn't save the concept — it was removed.");
       });

--- a/frontend/src/components/screens/Social.tsx
+++ b/frontend/src/components/screens/Social.tsx
@@ -15,6 +15,8 @@ import {
   getUserRooms,
   createRoom,
   joinRoom,
+  listPublicRooms,
+  joinPublicRoom,
   getRoomMessages,
   sendRoomMessage,
   toggleRoomReaction,
@@ -28,10 +30,15 @@ import {
   getStudents,
   type StudentRow,
 } from "@/lib/api";
-import type { RoomMessageRow, RoomOverviewData } from "@/lib/types";
+import type { PublicRoom, RoomMessageRow, RoomOverviewData } from "@/lib/types";
 
 type Tab = "overview" | "chat" | "match" | "activity" | "directory";
-type Room = { id: string; name: string; invite_code: string; member_count: number; created_by?: string };
+type Room = {
+  id: string; name: string; invite_code: string; member_count: number;
+  created_by?: string;
+  // #405 columns (populated on create; older rows may carry nulls)
+  topic?: string | null; course?: string | null; is_public?: boolean | null;
+};
 
 const EMOJI_50 = [
   "👍","🎉","❤️","🔥","🙌","💯","😂","😊","🤔","😮",
@@ -97,15 +104,32 @@ function CreateJoinBar({ onDone }: { onDone: () => void }) {
   const toast = useToast();
   const [mode, setMode] = React.useState<"idle" | "create" | "join">("idle");
   const [value, setValue] = React.useState("");
+  // #405 create-form fields: optional labeling + the public flag
+  // (false = invite-only; true = listed and joinable without an invite).
+  const [topic, setTopic] = React.useState("");
+  const [course, setCourse] = React.useState("");
+  const [isPublic, setIsPublic] = React.useState(false);
+
+  const reset = () => {
+    setMode("idle");
+    setValue("");
+    setTopic("");
+    setCourse("");
+    setIsPublic(false);
+  };
 
   const submit = async () => {
     if (!value.trim() || !userId) return;
     try {
-      if (mode === "create") await createRoom(userId, value.trim());
-      else if (mode === "join") await joinRoom(userId, value.trim());
+      if (mode === "create") {
+        await createRoom(userId, value.trim(), {
+          topic: topic.trim() || undefined,
+          course: course.trim() || undefined,
+          is_public: isPublic,
+        });
+      } else if (mode === "join") await joinRoom(userId, value.trim());
       toast.success(mode === "create" ? "Room created" : "Joined room");
-      setMode("idle");
-      setValue("");
+      reset();
       onDone();
     } catch (err) {
       toast.error(String(err));
@@ -123,22 +147,114 @@ function CreateJoinBar({ onDone }: { onDone: () => void }) {
     );
   }
 
+  const inputStyle: React.CSSProperties = {
+    flex: 1, padding: "6px 10px",
+    border: "1px solid var(--border)", borderRadius: "var(--r-sm)",
+    fontSize: 12, background: "var(--bg-panel)",
+  };
+
   return (
-    <div style={{ display: "flex", gap: 6, marginTop: 10 }}>
-      <input
-        data-testid="social-create-join-input"
-        autoFocus
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={(e) => { if (e.key === "Enter") submit(); if (e.key === "Escape") setMode("idle"); }}
-        placeholder={mode === "create" ? "Room name" : "Invite code"}
-        style={{
-          flex: 1, padding: "6px 10px",
-          border: "1px solid var(--border)", borderRadius: "var(--r-sm)",
-          fontSize: 12, background: "var(--bg-panel)",
-        }}
-      />
-      <button data-testid="social-create-join-submit" className="btn btn--sm btn--primary" onClick={submit}>Go</button>
+    <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 10 }}>
+      <div style={{ display: "flex", gap: 6 }}>
+        <input
+          data-testid="social-create-join-input"
+          autoFocus
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") submit(); if (e.key === "Escape") reset(); }}
+          placeholder={mode === "create" ? "Room name" : "Invite code"}
+          style={inputStyle}
+        />
+        <button data-testid="social-create-join-submit" className="btn btn--sm btn--primary" onClick={submit}>Go</button>
+      </div>
+      {mode === "create" && (
+        <>
+          <input
+            data-testid="social-create-topic"
+            value={topic}
+            onChange={(e) => setTopic(e.target.value)}
+            placeholder="Topic (optional)"
+            style={inputStyle}
+          />
+          <input
+            data-testid="social-create-course"
+            value={course}
+            onChange={(e) => setCourse(e.target.value)}
+            placeholder="Course (optional)"
+            style={inputStyle}
+          />
+          <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, color: "var(--text-dim)" }}>
+            <input
+              data-testid="social-create-public"
+              type="checkbox"
+              checked={isPublic}
+              onChange={(e) => setIsPublic(e.target.checked)}
+            />
+            Public — anyone can find and join without an invite
+          </label>
+        </>
+      )}
+    </div>
+  );
+}
+
+function PublicRoomsList({ excludeIds, onJoined }: { excludeIds: string[]; onJoined: () => void }) {
+  const { userId } = useUser();
+  const toast = useToast();
+  const [rooms, setRooms] = React.useState<PublicRoom[]>([]);
+
+  const refresh = React.useCallback(async () => {
+    if (!userId) return;
+    try {
+      setRooms((await listPublicRooms(userId)).rooms);
+    } catch {
+      // Discovery is best-effort; the rooms list itself stays authoritative.
+    }
+  }, [userId]);
+
+  React.useEffect(() => { refresh(); }, [refresh]);
+
+  const discoverable = rooms.filter((r) => !excludeIds.includes(r.id));
+  if (discoverable.length === 0) return null;
+
+  const join = async (roomId: string) => {
+    if (!userId) return;
+    try {
+      await joinPublicRoom(userId, roomId);
+      toast.success("Joined room");
+      onJoined();
+    } catch (err) {
+      toast.error(String(err));
+    }
+  };
+
+  return (
+    <div style={{ marginTop: 14 }}>
+      <div className="label-micro" style={{ marginBottom: 6 }}>Public rooms</div>
+      {discoverable.map((r) => (
+        <div
+          key={r.id}
+          style={{
+            display: "flex", alignItems: "center", gap: 8,
+            padding: "8px 10px", marginBottom: 4,
+            border: "1px solid var(--border)", borderRadius: "var(--r-md)",
+          }}
+        >
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{r.name}</div>
+            <div style={{ fontSize: 11, color: "var(--text-muted)" }}>
+              {r.topic ? `${r.topic} · ` : ""}{r.member_count} member{r.member_count === 1 ? "" : "s"}
+            </div>
+          </div>
+          <button
+            data-testid={`social-public-join-${r.id}`}
+            className="btn btn--sm"
+            onClick={() => join(r.id)}
+          >
+            Join
+          </button>
+        </div>
+      ))}
     </div>
   );
 }
@@ -1116,10 +1232,16 @@ export function Social() {
                 marginBottom: 4, display: "flex", flexDirection: "column", gap: 2,
               }}
             >
-              <div style={{ fontSize: 13, fontWeight: 600 }}>{r.name}</div>
-              <div style={{ fontSize: 11, color: "var(--text-muted)" }}>{r.member_count} members</div>
+              <div style={{ fontSize: 13, fontWeight: 600, display: "flex", alignItems: "center", gap: 6 }}>
+                {r.name}
+                {r.is_public && <span className="chip" style={{ fontSize: 10 }}>Public</span>}
+              </div>
+              <div style={{ fontSize: 11, color: "var(--text-muted)" }}>
+                {r.topic ? `${r.topic} · ` : ""}{r.member_count} members
+              </div>
             </button>
           ))}
+          {!loading && <PublicRoomsList excludeIds={rooms.map((r) => r.id)} onJoined={load} />}
         </div>
       </aside>
     </FullHeightScreen>

--- a/frontend/src/components/screens/Social.tsx
+++ b/frontend/src/components/screens/Social.tsx
@@ -202,15 +202,19 @@ function PublicRoomsList({ excludeIds, onJoined }: { excludeIds: string[]; onJoi
   const { userId } = useUser();
   const toast = useToast();
   const [rooms, setRooms] = React.useState<PublicRoom[]>([]);
+  const [joining, setJoining] = React.useState<string | null>(null);
 
   const refresh = React.useCallback(async () => {
     if (!userId) return;
     try {
       setRooms((await listPublicRooms(userId)).rooms);
-    } catch {
-      // Discovery is best-effort; the rooms list itself stays authoritative.
+    } catch (err) {
+      // Never swallow: an empty list has to mean "no public rooms", not
+      // "the fetch broke" (#463/#185 convention). This is a secondary
+      // surface, so it toasts rather than taking over with a banner.
+      toast.error(`Couldn't load public rooms. ${String(err)}`);
     }
-  }, [userId]);
+  }, [userId, toast]);
 
   React.useEffect(() => { refresh(); }, [refresh]);
 
@@ -218,13 +222,19 @@ function PublicRoomsList({ excludeIds, onJoined }: { excludeIds: string[]; onJoi
   if (discoverable.length === 0) return null;
 
   const join = async (roomId: string) => {
-    if (!userId) return;
+    if (!userId || joining) return;
+    setJoining(roomId);
     try {
       await joinPublicRoom(userId, roomId);
       toast.success("Joined room");
       onJoined();
+      // onJoined reloads MY rooms; this list owns its own data, so refresh
+      // it too or the joined room lingers as "discoverable" (#485 review).
+      await refresh();
     } catch (err) {
       toast.error(String(err));
+    } finally {
+      setJoining(null);
     }
   };
 
@@ -249,9 +259,10 @@ function PublicRoomsList({ excludeIds, onJoined }: { excludeIds: string[]; onJoi
           <button
             data-testid={`social-public-join-${r.id}`}
             className="btn btn--sm"
+            disabled={joining !== null}
             onClick={() => join(r.id)}
           >
-            Join
+            {joining === r.id ? "Joining…" : "Join"}
           </button>
         </div>
       ))}
@@ -770,7 +781,11 @@ function RoomOverview({ roomId, onChange }: { roomId: string; onChange: () => vo
   }, [roomId]);
 
   const refresh = () => getRoomOverview(roomId).then(setData).catch(console.error);
-  const isLeader = data?.room?.created_by === userId;
+  // Ownership, not authorship: the backend's kick gate keys on owner_id
+  // (#405, transferable later). Fall back to created_by for rows predating
+  // the 0038 backfill.
+  const roomOwnerId = data?.room?.owner_id ?? data?.room?.created_by;
+  const isLeader = roomOwnerId === userId;
 
   const comparison = React.useMemo(() => {
     if (!data || !suggestedId || suggestedId === userId) return null;
@@ -854,7 +869,7 @@ function RoomOverview({ roomId, onChange }: { roomId: string; onChange: () => vo
           <MemberRow
             key={m.user_id}
             member={m}
-            isLeader={data.room.created_by === m.user_id}
+            isLeader={(data.room.owner_id ?? data.room.created_by) === m.user_id}
             canKick={isLeader && m.user_id !== userId}
             onKick={async () => {
               try {

--- a/frontend/src/components/screens/Tree.tsx
+++ b/frontend/src/components/screens/Tree.tsx
@@ -11,7 +11,7 @@ import { GraphPanelSkeleton } from "../Skeleton";
 import { useUser } from "@/context/UserContext";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { useActiveSemester, courseInTerm } from "@/lib/useActiveSemester";
-import { getGraph, getCourses, getSessions, deleteGraphNode, type EnrolledCourse, type Session } from "@/lib/api";
+import { getGraph, getCourses, getSessions, addGraphNode, deleteGraphNode, type EnrolledCourse, type Session } from "@/lib/api";
 import { useToast } from "../ToastProvider";
 import { useConfirm } from "@/lib/useConfirm";
 import type { GraphNode as ApiNode, GraphEdge as ApiEdge } from "@/lib/types";
@@ -49,6 +49,13 @@ export function Tree() {
   const [sessions, setSessions] = React.useState<Session[]>([]);
   const [loading, setLoading] = React.useState(true);
 
+  // Manual add-concept composer (#330) — only offered when a single course
+  // is selected: courseFilter is a FILTER whose "all" value gives no course
+  // to attribute the new node to.
+  const [addingConcept, setAddingConcept] = React.useState(false);
+  const [newConceptName, setNewConceptName] = React.useState("");
+  const [savingConcept, setSavingConcept] = React.useState(false);
+
   const toast = useToast();
 
   React.useEffect(() => {
@@ -82,6 +89,32 @@ export function Tree() {
       setLoading(false);
     }
   }, [userId, activeSemester]);
+
+  // Manual add-concept (#330): create-or-merge server-side (the backend
+  // dedups case/whitespace-insensitively), then reload so the canonical row
+  // and its anchor edge render from DB truth. The selected node anchors the
+  // edge when it belongs to the chosen course; otherwise the course root
+  // does, server-side.
+  const submitAddConcept = async () => {
+    const name = newConceptName.trim();
+    if (!name || courseFilter === "all" || !userId || savingConcept) return;
+    setSavingConcept(true);
+    try {
+      const res = await addGraphNode(userId, {
+        concept_name: name,
+        course_id: courseFilter,
+        anchor_node_id: selected && selected.course_id === courseFilter ? selected.id : undefined,
+      });
+      toast.success(res.already_existed ? `Merged into your existing “${name}” node.` : `Added “${name}”.`);
+      setNewConceptName("");
+      setAddingConcept(false);
+      await load();
+    } catch {
+      toast.error("Couldn't add the concept.");
+    } finally {
+      setSavingConcept(false);
+    }
+  };
 
   React.useEffect(() => {
     // Wait for the active-semester read from localStorage before the first load,
@@ -323,6 +356,44 @@ export function Tree() {
             {c.course_code || c.course_name}
           </Pill>
         ))}
+        {courseFilter !== "all" && (
+          addingConcept ? (
+            <span style={{ display: "inline-flex", gap: 6, alignItems: "center", marginLeft: "auto" }}>
+              <input
+                data-testid="graph-add-concept-input"
+                autoFocus
+                value={newConceptName}
+                placeholder="Concept name"
+                onChange={(e) => setNewConceptName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") submitAddConcept();
+                  if (e.key === "Escape") { setAddingConcept(false); setNewConceptName(""); }
+                }}
+                style={{
+                  fontSize: 13, padding: "5px 10px", border: "1px solid var(--border)",
+                  borderRadius: "var(--r-full)", background: "var(--bg-panel)", width: 180,
+                }}
+              />
+              <button
+                data-testid="graph-add-concept-submit"
+                className="btn btn--sm btn--primary"
+                disabled={!newConceptName.trim() || savingConcept}
+                onClick={submitAddConcept}
+              >
+                Add
+              </button>
+            </span>
+          ) : (
+            <button
+              data-testid="graph-add-concept"
+              className="btn btn--sm"
+              style={{ marginLeft: "auto" }}
+              onClick={() => setAddingConcept(true)}
+            >
+              ＋ Add concept
+            </button>
+          )
+        )}
       </div>
 
       <div style={{ display: "flex", height: "calc(100vh - 240px)" }}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -135,6 +135,21 @@ export const describeConcept = (userId: string, concept: string, courseLabel?: s
     { method: 'POST', body: JSON.stringify({ concept, course_label: courseLabel ?? null }) }
   );
 
+// Manual add-concept (#330). Returns the CANONICAL node — freshly created,
+// or the dedup survivor when the (case/whitespace-insensitive) name already
+// existed on this course — plus the merge flag the UI toasts on.
+export const addGraphNode = (
+  userId: string,
+  body: { concept_name: string; course_id: string; anchor_node_id?: string },
+) =>
+  fetchJSON<{
+    node: {
+      id: string; concept_name: string; course_id: string | null;
+      mastery_score: number; mastery_tier: string;
+    };
+    already_existed: boolean;
+  }>(`/api/graph/${userId}/nodes`, { method: 'POST', body: JSON.stringify(body) });
+
 export const deleteGraphNode = (userId: string, nodeId: string) =>
   fetchJSON<{ deleted: boolean }>(
     `/api/graph/${userId}/nodes/${encodeURIComponent(nodeId)}`,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   GraphUpdate, MasteryChange,
   AnalyticsBucket, LlmCostGroupBy,
   UsageSummaryData, UsageByUserData, LlmCostData, ErrorsPageData,
+  PublicRoom,
 } from '@/lib/types';
 import { statusOf } from '@/lib/errorMessage';
 
@@ -527,11 +528,26 @@ export const exportToGoogleCalendar = (userId: string, assignmentIds: string[]) 
   });
 
 // Social
-export const createRoom = (userId: string, roomName: string) =>
+export const createRoom = (
+  userId: string,
+  roomName: string,
+  opts?: { topic?: string; course?: string; is_public?: boolean },
+) =>
   fetchJSON<{ room_id: string; invite_code: string }>('/api/social/rooms/create', {
     method: 'POST',
-    body: JSON.stringify({ user_id: userId, room_name: roomName }),
+    body: JSON.stringify({ user_id: userId, room_name: roomName, ...opts }),
   });
+
+// #405 public rooms: is_public=true rooms are listed (no invite_code in the
+// payload, by construction) and joinable without an invite.
+export const listPublicRooms = (userId: string) =>
+  fetchJSON<{ rooms: PublicRoom[] }>(`/api/social/public-rooms?user_id=${encodeURIComponent(userId)}`);
+
+export const joinPublicRoom = (userId: string, roomId: string) =>
+  fetchJSON<{ joined: boolean; room_id: string }>(
+    `/api/social/public-rooms/${encodeURIComponent(roomId)}/join`,
+    { method: 'POST', body: JSON.stringify({ user_id: userId }) },
+  );
 
 export const joinRoom = (userId: string, inviteCode: string) =>
   fetchJSON<{ room: any }>('/api/social/rooms/join', {

--- a/frontend/src/lib/graphApi.test.ts
+++ b/frontend/src/lib/graphApi.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { addGraphNode } from './api';
+
+/** Wire contract for the manual add-concept endpoint (#330). */
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ node: { id: 'n1' }, already_existed: false }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    }),
+  ) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+describe('addGraphNode', () => {
+  it('POSTs the body to /api/graph/{userId}/nodes', async () => {
+    const res = await addGraphNode('u1', {
+      concept_name: 'Recursion', course_id: 'c1', anchor_node_id: 'n-root',
+    });
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('/api/graph/u1/nodes');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      concept_name: 'Recursion', course_id: 'c1', anchor_node_id: 'n-root',
+    });
+    expect(res.already_existed).toBe(false);
+  });
+});

--- a/frontend/src/lib/graphOptimistic.test.ts
+++ b/frontend/src/lib/graphOptimistic.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { dropOptimisticConcept, reconcileNodes, retargetEdges } from "./graphOptimistic";
+
+/** Pure state math for the manual add-concept flow (#330): the UI adds an
+ * optimistic `node-new-*` entry immediately, then swaps in the canonical row
+ * the backend returns — or drops the optimistic entry when the write fails. */
+
+const TEMP = "node-new-123";
+const CANON = { id: "n-canon", mastery_score: 0.4, mastery_tier: "learning" };
+
+const nodes = [
+  { id: "n-root", name: "Math 210", mastery_tier: "subject_root", mastery_score: 0 },
+  { id: TEMP, name: "Recursion", mastery_tier: "unexplored", mastery_score: 0 },
+];
+
+describe("reconcileNodes", () => {
+  it("replaces the optimistic id (and mastery fields) with the canonical row", () => {
+    const out = reconcileNodes(nodes, TEMP, CANON);
+    expect(out.map((n) => n.id)).toEqual(["n-root", "n-canon"]);
+    expect(out[1].mastery_tier).toBe("learning");
+    expect(out[1].mastery_score).toBe(0.4);
+  });
+
+  it("drops the optimistic node when the canonical row is already rendered (merge)", () => {
+    const withCanon = [...nodes, { id: "n-canon", name: "Recursion", mastery_tier: "learning", mastery_score: 0.4 }];
+    const out = reconcileNodes(withCanon, TEMP, CANON);
+    expect(out.map((n) => n.id)).toEqual(["n-root", "n-canon"]);
+  });
+});
+
+describe("retargetEdges", () => {
+  it("retargets optimistic edge endpoints to the canonical id", () => {
+    const out = retargetEdges([{ source: "n-root", target: TEMP, strength: 0.4 }], TEMP, "n-canon");
+    expect(out).toEqual([{ source: "n-root", target: "n-canon", strength: 0.4 }]);
+  });
+
+  it("drops self-loops and duplicates created by the merge", () => {
+    const out = retargetEdges(
+      [
+        { source: "n-root", target: TEMP },
+        { source: "n-root", target: "n-canon" }, // already present → the retargeted copy is a dupe
+        { source: TEMP, target: TEMP },
+      ],
+      TEMP,
+      "n-canon",
+    );
+    expect(out).toEqual([{ source: "n-root", target: "n-canon" }]);
+  });
+});
+
+describe("dropOptimisticConcept", () => {
+  it("removes the optimistic node and every edge touching it", () => {
+    const out = dropOptimisticConcept(nodes, [{ source: "n-root", target: TEMP }], TEMP);
+    expect(out.nodes.map((n) => n.id)).toEqual(["n-root"]);
+    expect(out.edges).toEqual([]);
+  });
+});

--- a/frontend/src/lib/graphOptimistic.test.ts
+++ b/frontend/src/lib/graphOptimistic.test.ts
@@ -26,6 +26,27 @@ describe("reconcileNodes", () => {
     const out = reconcileNodes(withCanon, TEMP, CANON);
     expect(out.map((n) => n.id)).toEqual(["n-root", "n-canon"]);
   });
+
+  it("absorbs a live stream-* placeholder for the same concept (PR #485 review)", () => {
+    // A tutor turn can introduce `stream-<normalized-name>` placeholders that
+    // haven't been swapped for real ids yet. Manually re-adding that concept
+    // merges server-side, so the client must not end up rendering both.
+    const withPlaceholder = [
+      ...nodes,
+      { id: "stream-recursion", name: "Recursion", mastery_tier: "unexplored", mastery_score: 0 },
+    ];
+    const out = reconcileNodes(withPlaceholder, TEMP, { ...CANON, concept_name: "  RECURSION " });
+    expect(out.map((n) => n.id)).toEqual(["n-root", "n-canon"]);
+  });
+
+  it("keeps a same-named node that is NOT a placeholder (distinct real rows)", () => {
+    const withReal = [
+      ...nodes,
+      { id: "n-other", name: "Recursion", mastery_tier: "learning", mastery_score: 0.4 },
+    ];
+    const out = reconcileNodes(withReal, TEMP, { ...CANON, concept_name: "Recursion" });
+    expect(out.map((n) => n.id)).toEqual(["n-root", "n-canon", "n-other"]);
+  });
 });
 
 describe("retargetEdges", () => {

--- a/frontend/src/lib/graphOptimistic.ts
+++ b/frontend/src/lib/graphOptimistic.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure state math for the manual add-concept flow (#330).
+ *
+ * The UI adds an optimistic `node-new-<ts>` entry (and its anchor edge)
+ * immediately, then POST /api/graph/{user}/nodes returns the CANONICAL row —
+ * either freshly created or the UNIQUE-dedup survivor of a case/whitespace
+ * merge. These helpers swap the optimistic id for the canonical one across
+ * the two state collections (nodes and edges live in separate useStates, so
+ * each helper touches exactly one and works inside a functional updater),
+ * and roll the optimistic entry back when the write fails.
+ */
+
+export interface OptimisticNode {
+  id: string;
+  mastery_score?: number;
+  mastery_tier?: string;
+  [key: string]: unknown;
+}
+
+export interface OptimisticEdge {
+  source: string;
+  target: string;
+  [key: string]: unknown;
+}
+
+export interface CanonicalNode {
+  id: string;
+  mastery_score?: number;
+  mastery_tier?: string;
+}
+
+/** Swap the optimistic node for the canonical row. When the canonical id is
+ * already rendered (the name merged into an existing node), the optimistic
+ * entry is simply dropped. */
+export function reconcileNodes<N extends OptimisticNode>(
+  nodes: N[],
+  tempId: string,
+  canonical: CanonicalNode,
+): N[] {
+  if (nodes.some((n) => n.id === canonical.id)) {
+    return nodes.filter((n) => n.id !== tempId);
+  }
+  return nodes.map((n) =>
+    n.id === tempId
+      ? {
+          ...n,
+          id: canonical.id,
+          mastery_score: canonical.mastery_score ?? n.mastery_score,
+          mastery_tier: canonical.mastery_tier ?? n.mastery_tier,
+        }
+      : n,
+  );
+}
+
+/** Retarget edges touching the optimistic id onto the canonical id, dropping
+ * the self-loops and duplicates a merge can create. */
+export function retargetEdges<E extends OptimisticEdge>(
+  edges: E[],
+  tempId: string,
+  canonicalId: string,
+): E[] {
+  const out: E[] = [];
+  const seen = new Set<string>();
+  for (const edge of edges) {
+    const source = edge.source === tempId ? canonicalId : edge.source;
+    const target = edge.target === tempId ? canonicalId : edge.target;
+    if (source === target) continue;
+    const key = `${source}→${target}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ ...edge, source, target });
+  }
+  return out;
+}
+
+/** Roll back a failed add: remove the optimistic node and every edge touching it. */
+export function dropOptimisticConcept<N extends OptimisticNode, E extends OptimisticEdge>(
+  nodes: N[],
+  edges: E[],
+  tempId: string,
+): { nodes: N[]; edges: E[] } {
+  return {
+    nodes: nodes.filter((n) => n.id !== tempId),
+    edges: edges.filter((e) => e.source !== tempId && e.target !== tempId),
+  };
+}

--- a/frontend/src/lib/graphOptimistic.ts
+++ b/frontend/src/lib/graphOptimistic.ts
@@ -25,22 +25,48 @@ export interface OptimisticEdge {
 
 export interface CanonicalNode {
   id: string;
+  concept_name?: string;
   mastery_score?: number;
   mastery_tier?: string;
 }
 
+/** Client-side placeholder ids: the optimistic add (`node-new-<ts>`) and the
+ * streamed-turn merge's unknown-concept entries (`stream-<normalized-name>`,
+ * see Learn.tsx's mergeGraphDelta). Both stand in for a row whose real id
+ * isn't known yet, so either may be absorbed by a canonical row. */
+const PLACEHOLDER_ID = /^(node-new-|stream-)/;
+
+const norm = (s: unknown) => String(s ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+
 /** Swap the optimistic node for the canonical row. When the canonical id is
  * already rendered (the name merged into an existing node), the optimistic
- * entry is simply dropped. */
+ * entry is simply dropped.
+ *
+ * Also absorbs any OTHER placeholder standing in for the same concept — a
+ * live tutor turn can have introduced a `stream-<name>` node that hasn't been
+ * swapped for its real id yet, and the backend merges by name, so without
+ * this the client renders two nodes for one row until the next full refetch
+ * (PR #485 review). Same-named nodes with REAL ids are left alone: they are
+ * distinct rows the server chose not to merge.
+ */
 export function reconcileNodes<N extends OptimisticNode>(
   nodes: N[],
   tempId: string,
   canonical: CanonicalNode,
 ): N[] {
-  if (nodes.some((n) => n.id === canonical.id)) {
-    return nodes.filter((n) => n.id !== tempId);
+  const canonName = norm(canonical.concept_name);
+  const absorbed = (n: N) =>
+    n.id !== canonical.id &&
+    n.id !== tempId &&
+    PLACEHOLDER_ID.test(n.id) &&
+    canonName !== "" &&
+    norm((n as { name?: unknown }).name) === canonName;
+
+  const kept = nodes.filter((n) => !absorbed(n));
+  if (kept.some((n) => n.id === canonical.id)) {
+    return kept.filter((n) => n.id !== tempId);
   }
-  return nodes.map((n) =>
+  return kept.map((n) =>
     n.id === tempId
       ? {
           ...n,

--- a/frontend/src/lib/socialApi.test.ts
+++ b/frontend/src/lib/socialApi.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoom, joinPublicRoom, listPublicRooms } from './api';
+
+/** Wire contracts for the #405 rooms semantics: create carries the new
+ * optional fields; the public surface lists and joins without an invite. */
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ room_id: 'r1', invite_code: 'ABC', rooms: [], joined: true }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    }),
+  ) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+const lastCall = () => {
+  const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+  return fetchMock.mock.calls.at(-1) as [string, RequestInit | undefined];
+};
+
+describe('createRoom', () => {
+  it('stays back-compatible without options', async () => {
+    await createRoom('u1', 'Algebra crew');
+    const [, init] = lastCall();
+    expect(JSON.parse(init!.body as string)).toEqual({ user_id: 'u1', room_name: 'Algebra crew' });
+  });
+
+  it('forwards topic/course/is_public when given', async () => {
+    await createRoom('u1', 'Algebra crew', { topic: 'Midterm prep', course: 'MATH210', is_public: true });
+    const [, init] = lastCall();
+    expect(JSON.parse(init!.body as string)).toEqual({
+      user_id: 'u1', room_name: 'Algebra crew',
+      topic: 'Midterm prep', course: 'MATH210', is_public: true,
+    });
+  });
+});
+
+describe('public rooms', () => {
+  it('listPublicRooms hits the public listing with the user id', async () => {
+    await listPublicRooms('u1');
+    const [url] = lastCall();
+    expect(url).toBe('/api/social/public-rooms?user_id=u1');
+  });
+
+  it('joinPublicRoom POSTs the invite-less join', async () => {
+    await joinPublicRoom('u2', 'r-pub');
+    const [url, init] = lastCall();
+    expect(url).toBe('/api/social/public-rooms/r-pub/join');
+    expect(JSON.parse(init!.body as string)).toEqual({ user_id: 'u2' });
+  });
+});

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -555,3 +555,18 @@ export interface ErrorsPageData {
   truncated: boolean;
   series: UsageDayPoint[] | null;
 }
+
+// ── Public rooms (#405) ──────────────────────────────────────────────────────
+// The invite-less discovery payload; deliberately carries NO invite_code.
+export interface PublicRoom {
+  id: string;
+  name: string;
+  topic: string | null;
+  course: string | null;
+  owner_id: string;
+  created_by: string;
+  created_at: string | null;
+  updated_at: string | null;
+  is_public: true;
+  member_count: number;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -116,7 +116,12 @@ export interface RoomMember {
 }
 
 export interface RoomOverviewData {
-  room: { id: string; name: string; invite_code: string; created_by: string };
+  room: {
+    id: string; name: string; invite_code: string; created_by: string;
+    // #405: real ownership, distinct from the immutable creator record.
+    // Optional so rows predating the 0038 backfill still typecheck.
+    owner_id?: string | null;
+  };
   members: RoomMember[];
   ai_summary: string;
 }


### PR DESCRIPTION
Part of #330 and part of #405 (both left open per closure policy — Andres verifies the UI surfaces and closes). Completes B10 alongside the #323 audit (closed with follow-ups #481–#484).

## #330 — manually add a concept
- `graph_service.add_node`: thin wrapper over `apply_graph_update` (dedup/edges/analytics-refresh stay in one place); resolves the anchor id to its NAME (the edge machinery is name-keyed); reports merge-vs-create; returns the canonical row. `POST /api/graph/{user_id}/nodes` (require_self, 422 on blank name; `course_id` required — NULL-course dedup is always-distinct).
- Learn's rail composer now actually PERSISTS (it was client-only — concepts vanished on refresh): optimistic node kept, canonical id swapped via pure unit-tested helpers, rollback + toast on failure, merge toast on dedup.
- Tree gains '+ Add concept' (single-course filter only; anchors to the selected node). Testids registered doc+eslint; Tree.tsx entered the lint enforcement list with its 8 pre-existing untagged elements baselined per the documented recipe.
- Journey `tree-add-concept.spec.ts`: persist → render (a11y list by node id) → case-drifted re-add merges, original row survives.

## #405 — rooms semantics (Andres's decision: real ownership + public rooms)
- **Migration 0038**: `owner_id := created_by` backfill + NOT NULL (ownership is real and transferable later; `created_by` stays the immutable creator record), `is_public` DEFAULT false NOT NULL, `updated_at` DEFAULT now() + backfill.
- `create_room` populates owner/topic/course/is_public; kick authorization keys on **owner_id**; membership changes touch `updated_at`.
- **Public surface**: `GET /api/social/public-rooms` (explicit projection — cannot leak `invite_code`) + invite-less `POST /api/social/public-rooms/{id}/join` (403 private, idempotent). Frontend: create form gains topic/course/Public, sidebar shows topic + Public badge, and a Public-rooms discovery list with one-click Join. A fuller discovery surface stays future work per the decision.
- Journey `room-public.spec.ts`: UI create with topic+public → DB semantics assert → second user joins invite-less → membership row.

## Tests
Backend: 17 new (add_node service/route ×8, rooms semantics ×9); suite 1525 passed; ruff clean. Frontend: 397 passed / tsc / lint 0 errors (rebased over #480's suppressions prune — converged). Two promoted journeys. Full local e2e cycle before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public study rooms with optional topics and courses.
  * Users can discover and join public rooms without invite codes.
  * Added manual concept creation for selected courses, including duplicate merging and optional relationships.
  * Added public-room labels, member counts, and discovery controls.

* **Bug Fixes**
  * Improved room ownership permissions and membership update tracking.
  * Added safer defaults and validation for room data.

* **Tests**
  * Added coverage for public rooms, concept creation, merging, and related user flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->