### PR TITLE
docs: tick [P0-B] in the token-unification follow-ups (verified done)

### DIFF
--- a/docs/superpowers/followups/2026-06-30-token-unification-followups.md
+++ b/docs/superpowers/followups/2026-06-30-token-unification-followups.md
@@ -12,10 +12,16 @@ Each is its own plan / PR. Severity tags map to `docs/frontend-rhythm-audit.md`.
 
 ## Component re-skins (the visible "feels different" fixes)
 
-- [ ] **[P0-B] Beta CTA button species.** Replace the rounded-full pill + infinite `beta-glow`
+- [x] **[P0-B] Beta CTA button species.** Replace the rounded-full pill + infinite `beta-glow`
       animation with the app button language (rectangular, `--r-sm`, solid `--brand-forest`).
       Convert the perpetual glow into a single finite entrance using `--brand-glow`.
       Files: `app/(public)/page.tsx`, `globals.css` (`.beta-glow-btn`).
+      ✅ **Done (verified 2026-07-30):** landed with the #291 motion work and the beta-pill
+      removal (#287). `beta-glow` / `.beta-glow-btn` no longer exist anywhere in `frontend/src`,
+      and the landing CTAs are the shared `<Button variant="primary" size="xl">`
+      (`.btn .btn--primary .btn--xl`) — app button language, no motion. The glow was **deleted
+      outright rather than converted** to a `--brand-glow` entrance, which satisfies the intent
+      (no perpetual motion, one button species); `--brand-glow` consequently has no consumers.
 - [ ] **[P1-E] Extract one hero-card primitive from `--surface-hero`.** Replace the duplicated
       inline 24px warm-gradient box in the beta modal (`app/(public)/page.tsx`) and
       `components/SignInModal.tsx` with a single shared component backed by `--surface-hero` /


### PR DESCRIPTION
Docs-only, one checkbox.

While verifying the design-debt pool I found `[P0-B]` still unticked although it is verifiably done: `beta-glow` / `.beta-glow-btn` no longer exist anywhere in `frontend/src`, and the landing CTAs are the shared `<Button variant="primary" size="xl">` (`.btn .btn--primary .btn--xl`) — app button language, no motion. It landed with the #291 motion work and the #287 beta-pill removal and was simply never ticked, so anyone trusting the doc would have re-done it.

The note also records that the glow was **deleted outright** rather than converted into a `--brand-glow` finite entrance. That satisfies the item's intent (no perpetual motion, one button species) and explains why `--brand-glow` has no consumers today.

No code paths touched, so no e2e cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the beta call-to-action to use the standard primary button appearance.
  - Removed the pill-shaped styling and persistent glow effect for a cleaner, more consistent presentation.
- **Documentation**
  - Marked the related beta call-to-action follow-up as completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->