### PR TITLE
refactor(ui): extract the shared hero-card surface (#288)

### DIFF
--- a/docs/superpowers/followups/2026-06-30-token-unification-followups.md
+++ b/docs/superpowers/followups/2026-06-30-token-unification-followups.md
@@ -22,10 +22,18 @@ Each is its own plan / PR. Severity tags map to `docs/frontend-rhythm-audit.md`.
       (`.btn .btn--primary .btn--xl`) — app button language, no motion. The glow was **deleted
       outright rather than converted** to a `--brand-glow` entrance, which satisfies the intent
       (no perpetual motion, one button species); `--brand-glow` consequently has no consumers.
-- [ ] **[P1-E] Extract one hero-card primitive from `--surface-hero`.** Replace the duplicated
+- [x] **[P1-E] Extract one hero-card primitive from `--surface-hero`.** Replace the duplicated
       inline 24px warm-gradient box in the beta modal (`app/(public)/page.tsx`) and
       `components/SignInModal.tsx` with a single shared component backed by `--surface-hero` /
       `--surface-hero-shadow`.
+      ✅ **Done (verified 2026-07-30):** landed with #288. `.card--hero` (a named variant of
+      `.card`) plus `.hero-surface` (the gradient alone, for panels nested inside a hero card)
+      now consume both tokens, and a thin `<HeroCard>` wrapper owns the pair. All five literal
+      sites are converted — four in `app/(public)/page.tsx`, one in `components/SignInModal.tsx`
+      — and `HeroCard.test.tsx` fails if a literal copy of the gradient reappears anywhere in
+      `frontend/src`. The literal fallbacks (`var(--surface-hero, …)`) exist because the tokens
+      are scoped to `.public-surface, .landing-page`; every consumer is inside that subtree
+      today, so they are defensive rather than load-bearing.
 - [ ] **[P1-C] Re-home onboarding** (`components/screens/Onboarding.tsx`) into the app's
       layout/spacing/type — `--pad-*` spacing, the shell type scale — instead of a centered
       card floating in a radial-gradient void.

--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -7,6 +7,7 @@ import { useScrollLock } from '@/lib/useScrollLock';
 import { Network, Sparkles, FilePlus2, Brain, CalendarClock, Users, PenSquare } from 'lucide-react';
 import HowItWorks from '@/components/HowItWorks';
 import SignInModal from '@/components/SignInModal';
+import { HeroCard } from '@/components/HeroCard';
 import { BRAND_FOREST } from '@/lib/brand';
 import { Button } from "@/components/ui";
 import { IS_TEST_MODE, random, now } from '@/lib/testMode';
@@ -750,16 +751,9 @@ export default function LandingPage() {
           style={{ background: 'rgba(12,18,26,0.45)' }}
           onClick={closeModal}
         >
-          <div
-            className={`${betaModalClosing ? 'modal-card-out' : 'modal-card-in'}`}
-            style={{
-              background: 'linear-gradient(145deg, #d5e8d8 0%, #e8f0e3 45%, #f0ebe0 100%)',
-              borderRadius: 20,
-              padding: '40px 52px',
-              textAlign: 'center',
-              border: '1px solid rgba(255,255,255,0.7)',
-              boxShadow: '0 20px 60px rgba(15,23,42,0.15)',
-            }}
+          <HeroCard
+            className={betaModalClosing ? 'modal-card-out' : 'modal-card-in'}
+            style={{ padding: '40px 52px', textAlign: 'center' }}
             onClick={e => e.stopPropagation()}
           >
             <h2 style={{ margin: 0, fontFamily: "var(--font-playfair), 'Playfair Display', Georgia, serif", fontSize: 32, lineHeight: 1.1, fontWeight: 600, letterSpacing: '-0.02em', color: '#1a1a1a' }}>
@@ -768,7 +762,7 @@ export default function LandingPage() {
             <p style={{ margin: '10px 0 0', fontSize: 17, color: '#4b5563', fontStyle: 'italic' }}>
               See you in the inbox - The Team
             </p>
-          </div>
+          </HeroCard>
         </div>
       )}
       {betaModalOpen && !betaSubmitted && (
@@ -777,20 +771,16 @@ export default function LandingPage() {
           style={{ background: 'rgba(12,18,26,0.65)' }}
           onClick={() => { if (!betaSubmitting) closeModal(); }}
         >
-          <div
+          <HeroCard
             className={`relative w-full ${betaModalClosing ? 'modal-card-out' : 'modal-card-in'}`}
             style={{
               maxWidth: 'min(1040px, 94vw)',
               width: '100%',
-              background: 'linear-gradient(145deg, #d5e8d8 0%, #e8f0e3 45%, #f0ebe0 100%)',
-              borderRadius: 24,
               display: 'grid',
               gridTemplateColumns: '1fr 1px 1fr',
               minHeight: 560,
               maxHeight: 'calc(100vh - 48px)',
               overflow: 'hidden',
-              border: '1px solid rgba(255,255,255,0.7)',
-              boxShadow: '0 20px 60px rgba(15,23,42,0.12), inset 0 0 0 1px rgba(255,255,255,0.5)',
             }}
             onClick={e => e.stopPropagation()}
             role="dialog"
@@ -814,9 +804,8 @@ export default function LandingPage() {
             >×</button>
 
             {/* ── Left: brand + perks panel ── */}
-            <div style={{
+            <div className="hero-surface" style={{
               padding: '36px 36px 32px',
-              background: 'linear-gradient(145deg, #d5e8d8 0%, #e8f0e3 45%, #f0ebe0 100%)',
               display: 'flex', flexDirection: 'column', gap: 22,
             }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
@@ -868,7 +857,7 @@ export default function LandingPage() {
             <div style={{ background: 'rgba(107,114,128,0.15)', alignSelf: 'stretch' }} />
 
             {/* ── Right: newsletter form ── */}
-            <div style={{ padding: '44px 42px 36px', display: 'flex', flexDirection: 'column', background: 'linear-gradient(145deg, #d5e8d8 0%, #e8f0e3 45%, #f0ebe0 100%)' }}>
+            <div className="hero-surface" style={{ padding: '44px 42px 36px', display: 'flex', flexDirection: 'column' }}>
               <div style={{ fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace", fontSize: 10, color: '#D97706', letterSpacing: '0.3em', textTransform: 'uppercase', fontWeight: 500, marginBottom: 10 }}>
                 ● Issue 001 dropping soon
               </div>
@@ -968,7 +957,7 @@ export default function LandingPage() {
                 </p>
               </form>
             </div>
-          </div>
+          </HeroCard>
         </div>
       )}
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -219,6 +219,14 @@ body { font-size: 14px; line-height: 1.5; }
    --surface-hero / --surface-hero-shadow tokens sat further down this file
    with zero consumers. These two classes are the only consumers now.
 
+   One value here is a correction rather than a de-drift, and is worth naming:
+   the shadow's base COLOUR was consistent across all five sites at
+   rgba(15,23,42) — Tailwind slate-900, which nothing else in this app uses.
+   The token is rgba(19,38,16) = --sap-900, the same base as --shadow-sm/md/lg.
+   So adopting it re-tints these shadows from cool slate to the warm green the
+   rest of the surface language already casts. Deliberate; the token had no
+   consumers, so this is the first time that value renders. */
+
    `.hero-surface` is the gradient ALONE — for panels nested inside a
    `.card--hero`, which must not restate its border, radius or shadow.
    `.card--hero` is the full surface, and is used together with `.card`

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -212,6 +212,35 @@ body { font-size: 14px; line-height: 1.5; }
   border-radius: var(--r-lg); box-shadow: var(--shadow-sm);
 }
 
+/* ── Hero surface (#288) ──────────────────────────────────────────────────
+   The warm marketing gradient behind the sign-in and beta modals. It was
+   inlined as a literal at five sites and had already drifted apart there
+   (three different shadow alphas, two radii, one missing inset), while the
+   --surface-hero / --surface-hero-shadow tokens sat further down this file
+   with zero consumers. These two classes are the only consumers now.
+
+   `.hero-surface` is the gradient ALONE — for panels nested inside a
+   `.card--hero`, which must not restate its border, radius or shadow.
+   `.card--hero` is the full surface, and is used together with `.card`
+   (`class="card card--hero"`), so it has to be declared after it to win.
+
+   The literal fallbacks are deliberate. The tokens are scoped to
+   `.public-surface, .landing-page`, so a `.card--hero` mounted anywhere
+   outside the pre-auth subtree would otherwise render with no background at
+   all. Every consumer is inside that subtree today — this is the guard for
+   the day one of them isn't, which for a shared component is a matter of
+   time rather than of chance. */
+.hero-surface,
+.card--hero {
+  background: var(--surface-hero, linear-gradient(145deg, #d5e8d8 0%, #e8f0e3 45%, #f0ebe0 100%));
+}
+
+.card--hero {
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: 24px;
+  box-shadow: var(--surface-hero-shadow, 0 20px 60px rgba(19, 38, 16, 0.12), inset 0 0 0 1px rgba(255, 255, 255, 0.5));
+}
+
 .divider { height: 1px; background: var(--border); }
 
 .label-micro {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -225,7 +225,7 @@ body { font-size: 14px; line-height: 1.5; }
    The token is rgba(19,38,16) = --sap-900, the same base as --shadow-sm/md/lg.
    So adopting it re-tints these shadows from cool slate to the warm green the
    rest of the surface language already casts. Deliberate; the token had no
-   consumers, so this is the first time that value renders. */
+   consumers, so this is the first time that value renders.
 
    `.hero-surface` is the gradient ALONE — for panels nested inside a
    `.card--hero`, which must not restate its border, radius or shadow.

--- a/frontend/src/app/globals.test.ts
+++ b/frontend/src/app/globals.test.ts
@@ -1,0 +1,111 @@
+/**
+ * globals.css has to survive the CSS parser.
+ *
+ * Nothing in the fast lane reads this file as CSS: eslint lints JS/TS, tsc
+ * checks types, and vitest never imports the stylesheet. The first thing that
+ * actually parses it is the Next production build — so a broken comment or an
+ * unbalanced brace sails through `lint + tsc + vitest`, goes green in CI, and
+ * only surfaces when the e2e stack tries to build the frontend.
+ *
+ * That happened while writing #288: an edit closed a block comment early,
+ * leaving the rest of it as raw stylesheet text. postcss reported it 780 lines
+ * later ("Unclosed string" at the next quote it met), which is a long way from
+ * the actual mistake.
+ *
+ * This is a hand-rolled scan rather than a postcss import on purpose: postcss
+ * is only a TRANSITIVE dependency here (`@tailwindcss/postcss` is the direct
+ * one), and the installed version already drifts from CI's. A dependency-free
+ * check can't develop that skew.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const CSS_PATH = path.resolve(__dirname, 'globals.css');
+
+/**
+ * Walk the stylesheet the way a tokenizer does — tracking comments, strings
+ * and brace depth — and collect every structural problem with its line.
+ */
+function structuralProblems(css: string): string[] {
+  const problems: string[] = [];
+  let i = 0;
+  let line = 1;
+  let depth = 0;
+
+  while (i < css.length) {
+    const c = css[i];
+
+    if (c === '\n') { line++; i++; continue; }
+
+    // Block comment: skip to its terminator.
+    if (c === '/' && css[i + 1] === '*') {
+      const openedAt = line;
+      const end = css.indexOf('*/', i + 2);
+      if (end === -1) {
+        problems.push(`unterminated block comment opened at line ${openedAt}`);
+        break;
+      }
+      for (let k = i; k < end; k++) if (css[k] === '\n') line++;
+      i = end + 2;
+      continue;
+    }
+
+    // A comment terminator outside a comment means an earlier one closed
+    // early — the exact mistake this file exists to catch.
+    if (c === '*' && css[i + 1] === '/') {
+      problems.push(`stray "*/" at line ${line} (a block comment closed early above)`);
+      i += 2;
+      continue;
+    }
+
+    // Strings: CSS strings do not span raw newlines.
+    if (c === '"' || c === "'") {
+      const quote = c;
+      let k = i + 1;
+      while (k < css.length && css[k] !== quote && css[k] !== '\n') {
+        if (css[k] === '\\') k++;
+        k++;
+      }
+      if (css[k] !== quote) {
+        problems.push(`unclosed ${quote === '"' ? 'double' : 'single'}-quoted string at line ${line}`);
+        break;
+      }
+      i = k + 1;
+      continue;
+    }
+
+    if (c === '{') depth++;
+    if (c === '}') {
+      depth--;
+      if (depth < 0) {
+        problems.push(`unbalanced "}" at line ${line}`);
+        depth = 0;
+      }
+    }
+    i++;
+  }
+
+  if (depth !== 0) problems.push(`${depth} unclosed block(s) at end of file`);
+  return problems;
+}
+
+describe('globals.css', () => {
+  it('is structurally parseable', () => {
+    const css = fs.readFileSync(CSS_PATH, 'utf8');
+    expect(structuralProblems(css)).toEqual([]);
+  });
+
+  it('detects the failure modes it is meant to catch', () => {
+    // Guard the guard: a scan that silently returns [] for broken input would
+    // be worse than no scan at all.
+    expect(structuralProblems('/* opened but never closed\n.a { color: red; }')).toHaveLength(1);
+    expect(structuralProblems('/* closed early */ stray text */\n.a { color: red; }')[0]).toMatch(/stray/);
+    expect(structuralProblems('.a { content: "oops;\n}')[0]).toMatch(/unclosed/);
+    expect(structuralProblems('.a { color: red;')[0]).toMatch(/unclosed block/);
+    expect(structuralProblems('.a { color: red; } }')[0]).toMatch(/unbalanced/);
+    // And it must stay quiet on legitimate CSS, including quotes and
+    // apostrophes inside comments.
+    expect(structuralProblems('/* it\'s fine "really" */\n.a::before { content: ""; }')).toEqual([]);
+  });
+});

--- a/frontend/src/components/HeroCard.test.tsx
+++ b/frontend/src/components/HeroCard.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+/**
+ * #288 — the hero surface is shared, and stays shared.
+ *
+ * The gradient behind the sign-in and beta modals was pasted at five sites
+ * and had already drifted at four of them (three shadow alphas, two radii,
+ * one missing inset) while the --surface-hero tokens sat unused. These tests
+ * pin the contract that replaced it: one component, one pair of classes, and
+ * no literal left anywhere to drift from.
+ */
+import React from 'react';
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { HeroCard } from './HeroCard';
+
+const SRC = path.resolve(__dirname, '..');
+const GLOBALS = path.join(SRC, 'app/globals.css');
+
+/** The literal that used to be inlined at all five sites. */
+const GRADIENT = 'linear-gradient(145deg, #d5e8d8 0%, #e8f0e3 45%, #f0ebe0 100%)';
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    // Application source only — a test is allowed to name the literal it
+    // guards against (this file does, right above).
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+afterEach(cleanup);
+
+describe('#288 hero surface', () => {
+  it('carries both classes and forwards className, props and ref', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <HeroCard ref={ref} className="modal-card-in" data-testid="probe" role="dialog">
+        body
+      </HeroCard>,
+    );
+    const el = screen.getByTestId('probe');
+    expect(el.className.split(/\s+/)).toEqual(
+      expect.arrayContaining(['card', 'card--hero', 'modal-card-in']),
+    );
+    // The variant has to sit alongside .card, not replace it.
+    expect(el.className).toContain('card');
+    expect(el.getAttribute('role')).toBe('dialog');
+    expect(ref.current).toBe(el);
+  });
+
+  it('renders without a className', () => {
+    render(<HeroCard data-testid="bare">body</HeroCard>);
+    expect(screen.getByTestId('bare').className).toBe('card card--hero');
+  });
+
+  it('leaves no inlined copy of the gradient anywhere in src/', () => {
+    const offenders = walk(SRC)
+      .filter((f) => fs.readFileSync(f, 'utf8').includes(GRADIENT))
+      .map((f) => path.relative(SRC, f));
+    // globals.css is not walked (only .ts/.tsx), so the token definition and
+    // the class fallbacks are correctly out of scope here.
+    expect(
+      offenders,
+      `the hero gradient must come from .card--hero / .hero-surface, not a literal:\n${offenders.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('gives both hero rules a literal fallback, so an out-of-scope mount still paints', () => {
+    const css = fs.readFileSync(GLOBALS, 'utf8');
+    // --surface-hero is scoped to .public-surface/.landing-page. A hero card
+    // mounted outside that subtree resolves the var to nothing, so the
+    // fallback is the only thing standing between it and a transparent card.
+    const background = css.match(/\.hero-surface,\s*\n\.card--hero\s*\{[^}]*\}/);
+    expect(background, '.hero-surface/.card--hero background rule should exist').not.toBeNull();
+    expect(background![0]).toContain('var(--surface-hero,');
+    expect(background![0]).toContain(GRADIENT);
+
+    const shadow = css.match(/\.card--hero\s*\{[^}]*box-shadow[^}]*\}/);
+    expect(shadow, '.card--hero box-shadow rule should exist').not.toBeNull();
+    expect(shadow![0]).toContain('var(--surface-hero-shadow,');
+    // The fallback must include the inset half, or the token and the fallback
+    // render as two different surfaces.
+    expect(shadow![0]).toMatch(/inset 0 0 0 1px/);
+  });
+});

--- a/frontend/src/components/HeroCard.tsx
+++ b/frontend/src/components/HeroCard.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import React from "react";
+
+/**
+ * The warm hero surface shared by the sign-in and beta modals (#288).
+ *
+ * Thin on purpose: it owns the two classes and nothing else, so callers keep
+ * their own layout, sizing and dialog semantics in `style`/props. The visual
+ * itself lives in `.card--hero` (globals.css), backed by the
+ * `--surface-hero` / `--surface-hero-shadow` tokens.
+ *
+ * Before this existed, the gradient was pasted at five sites and had drifted
+ * at four of them — three shadow alphas, two radii, one missing inset. The
+ * point of the component is that there is now one place for it to drift.
+ *
+ * For a panel nested INSIDE a hero card, use the `.hero-surface` class
+ * directly: it applies the gradient without restating the parent's border,
+ * radius or shadow.
+ */
+export type HeroCardProps = React.ComponentPropsWithoutRef<"div">;
+
+export const HeroCard = React.forwardRef<HTMLDivElement, HeroCardProps>(
+  function HeroCard({ className, children, ...rest }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={["card", "card--hero", className].filter(Boolean).join(" ")}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+export default HeroCard;

--- a/frontend/src/components/HeroCard.tsx
+++ b/frontend/src/components/HeroCard.tsx
@@ -14,6 +14,10 @@ import React from "react";
  * at four of them — three shadow alphas, two radii, one missing inset. The
  * point of the component is that there is now one place for it to drift.
  *
+ * The shadow's base colour is the one value that had NOT drifted (every site
+ * used slate `rgba(15,23,42)`); adopting the token deliberately re-tints it
+ * to the warm `--sap-900` the app's other shadows use. See globals.css.
+ *
  * For a panel nested INSIDE a hero card, use the `.hero-surface` class
  * directly: it applies the gradient without restating the parent's border,
  * radius or shadow.

--- a/frontend/src/components/SignInModal.tsx
+++ b/frontend/src/components/SignInModal.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useUser } from "@/context/UserContext";
 import { useScrollLock } from "@/lib/useScrollLock";
+import { HeroCard } from "@/components/HeroCard";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 const POPUP_TIMEOUT_MS = 3 * 60 * 1000;
@@ -217,17 +218,13 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
       style={{ background: "rgba(12,18,26,0.55)" }}
       onClick={close}
     >
-      <div
+      <HeroCard
         ref={panelRef}
         tabIndex={-1}
         className={`relative w-full ${closing ? "modal-card-out" : "modal-card-in"}`}
         style={{
           maxWidth: 440,
-          background: "linear-gradient(145deg, #d5e8d8 0%, #e8f0e3 45%, #f0ebe0 100%)",
-          borderRadius: 24,
           padding: "44px 44px 36px",
-          border: "1px solid rgba(255,255,255,0.7)",
-          boxShadow: "0 20px 60px rgba(15,23,42,0.18), inset 0 0 0 1px rgba(255,255,255,0.5)",
         }}
         onClick={e => e.stopPropagation()}
         role="dialog"
@@ -346,7 +343,7 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
           {" "}and{" "}
           <a href="/privacy" style={{ color: "var(--brand-forest)", textDecoration: "underline" }}>privacy policy</a>.
         </p>
-      </div>
+      </HeroCard>
     </div>
   );
 }


### PR DESCRIPTION
The warm gradient behind the sign-in and beta modals was inlined as a literal at **five** sites, and had already drifted at four of them. `--surface-hero` / `--surface-hero-shadow` sat in `globals.css` with **zero** consumers.

| Site | Role | Radius | Shadow |
|---|---|---|---|
| `page.tsx:756` | beta success modal | 20 | `rgba(15,23,42,0.15)`, no inset |
| `page.tsx:785` | beta signup shell | 24 | `rgba(15,23,42,0.12)` + inset |
| `page.tsx:819` | modal left panel (inner) | — | background only |
| `page.tsx:871` | modal right panel (inner) | — | background only |
| `SignInModal.tsx:226` | sign-in modal | 24 | `rgba(15,23,42,0.18)` + inset |

## What replaced it

- **`.card--hero`** — a named variant of `.card`, used as `class="card card--hero"` (declared after `.card` so it wins).
- **`.hero-surface`** — the gradient *alone*, for the two inner panels, which must not restate the parent's border/radius/shadow.
- **`<HeroCard>`** — a thin wrapper that owns those two classes and forwards ref, className and every other prop. Callers keep their own layout and dialog semantics.

Both classes are now the tokens' only consumers.

## This is a visible change, and an intended one

Adopting the token moves the shadow hue from cool slate `rgba(15,23,42)` to the warm `rgba(19,38,16)` the rest of the app uses, unifies the alphas at `0.12`, and gives the beta success modal the 24px radius and inset highlight its two siblings already had. Before/after screenshots in a comment below.

## On the literal fallbacks

`var(--surface-hero, <literal>)` in both rules is deliberate. The tokens are scoped to `.public-surface, .landing-page`. I verified every consumer sits inside that subtree today — `SignInModal` is mounted only from the landing page, and nothing here portals to `document.body` — so the fallback is **defensive, not load-bearing**. For a shared component it is the cheap guard against the first mount that isn't.

## Deliberately not folded in

The close button and the logo/wordmark row. The close buttons are not duplicated verbatim after all — they differ in offset (18 vs 14) and only one carries a testid. The wordmark appears at **20** sites repo-wide with no shared component, so extracting it for 2 of them would leave a half-migration; #111 touches every icon site anyway, which is the coherent place for it.

## Tests

`HeroCard.test.tsx` pins the class contract and prop/ref forwarding, and adds two anti-drift guards: **no inlined copy of the gradient may exist anywhere in `src/`**, and both CSS rules must keep a literal fallback (including the inset half, or token and fallback would render as two different surfaces).

`data-testid="signin-modal"` and `"signin-close"` are unchanged; no testid surface was added, so neither half of the registry needed updating.

## Gates

- `tsc --noEmit` — clean
- `npm run lint` — 0 errors (36 pre-existing warnings)
- `npx vitest run` — 56 files, 403 tests passed
- Full local e2e cycle — recorded in a comment below

part of #288