### PR TITLE
feat(analytics): #122 gaps — tokens/day chart, error-rate trend, day-series table fallbacks

### DIFF
--- a/frontend/src/components/AnalyticsCharts.test.tsx
+++ b/frontend/src/components/AnalyticsCharts.test.tsx
@@ -12,6 +12,8 @@ import { cleanup, render, screen } from "@testing-library/react";
 import {
   CategoryBars,
   DayLineChart,
+  errorRateSeries,
+  formatCompactCount,
   linePoints,
   niceTicks,
   tooltipLeftPct,
@@ -40,6 +42,41 @@ describe("zeroFillDays", () => {
     const sparse = [{ date: "2020-01-01", value: 2 }];
     const out = zeroFillDays(sparse, "2020-01-01T00:00:00.000Z", "2026-01-01T00:00:00.000Z");
     expect(out).toEqual(sparse);
+  });
+});
+
+describe("errorRateSeries", () => {
+  it("joins by date over the events domain and reports a percentage", () => {
+    const out = errorRateSeries(
+      [{ date: "2026-07-10", value: 1 }],
+      [
+        { date: "2026-07-10", value: 4 },
+        { date: "2026-07-11", value: 8 },
+      ],
+    );
+    expect(out).toEqual([
+      { date: "2026-07-10", value: 25 }, // 1 error / 4 events
+      { date: "2026-07-11", value: 0 },  // no errors that day
+    ]);
+  });
+
+  it("reports 0 for zero-event days — never NaN/Infinity", () => {
+    const out = errorRateSeries(
+      [{ date: "2026-07-10", value: 3 }],
+      [{ date: "2026-07-10", value: 0 }],
+    );
+    expect(out).toEqual([{ date: "2026-07-10", value: 0 }]);
+    expect(out.every((p) => Number.isFinite(p.value))).toBe(true);
+  });
+});
+
+describe("formatCompactCount", () => {
+  it("keeps small counts exact and compacts thousands/millions", () => {
+    expect(formatCompactCount(0)).toBe("0");
+    expect(formatCompactCount(950)).toBe("950");
+    expect(formatCompactCount(1500)).toBe("1.5k");
+    expect(formatCompactCount(20_000)).toBe("20k");
+    expect(formatCompactCount(2_500_000)).toBe("2.5M");
   });
 });
 

--- a/frontend/src/components/AnalyticsCharts.test.tsx
+++ b/frontend/src/components/AnalyticsCharts.test.tsx
@@ -68,6 +68,17 @@ describe("errorRateSeries", () => {
     expect(out).toEqual([{ date: "2026-07-10", value: 0 }]);
     expect(out.every((p) => Number.isFinite(p.value))).toBe(true);
   });
+
+  it("drops error dates absent from the events domain (documented contract)", () => {
+    // The events series drives the output domain; an error day outside it is
+    // silently dropped. Unreachable via the screen (both series zero-fill over
+    // the same range), but the helper is exported — pin the contract.
+    const out = errorRateSeries(
+      [{ date: "2026-07-09", value: 5 }],
+      [{ date: "2026-07-10", value: 10 }],
+    );
+    expect(out).toEqual([{ date: "2026-07-10", value: 0 }]);
+  });
 });
 
 describe("formatCompactCount", () => {
@@ -77,6 +88,14 @@ describe("formatCompactCount", () => {
     expect(formatCompactCount(1500)).toBe("1.5k");
     expect(formatCompactCount(20_000)).toBe("20k");
     expect(formatCompactCount(2_500_000)).toBe("2.5M");
+  });
+
+  it("handles unit boundaries — never emits '1000k'", () => {
+    expect(formatCompactCount(999)).toBe("999");
+    expect(formatCompactCount(1000)).toBe("1k");
+    expect(formatCompactCount(999_949)).toBe("999.9k");
+    expect(formatCompactCount(999_950)).toBe("1M"); // rounds to 1000.0k → promoted
+    expect(formatCompactCount(1_000_000)).toBe("1M");
   });
 });
 

--- a/frontend/src/components/AnalyticsCharts.tsx
+++ b/frontend/src/components/AnalyticsCharts.tsx
@@ -19,11 +19,11 @@
  */
 
 import React from "react";
-import { type DayPointValue, zeroFillDays } from "@/lib/daySeries";
+import { type DayPointValue, errorRateSeries, formatCompactCount, zeroFillDays } from "@/lib/daySeries";
 
 // Re-exported so chart consumers/tests can keep a single import site; the
 // canonical home is lib/daySeries.ts (JSX-free — see its header for why).
-export { zeroFillDays, type DayPointValue };
+export { errorRateSeries, formatCompactCount, zeroFillDays, type DayPointValue };
 
 /** Uniform "nice"-stepped ticks from 0 covering max (used for the y grid). */
 export function niceTicks(max: number, count = 4): number[] {

--- a/frontend/src/components/screens/AdminAnalytics.test.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.test.tsx
@@ -251,7 +251,18 @@ describe("AdminAnalytics", () => {
     await screen.findByText("42");
     // The #121 category tables survive, and each day-series chart cluster now
     // has a "View data" table twin (the hover tooltip has no keyboard path).
-    expect(screen.getAllByText("View data").length).toBeGreaterThanOrEqual(5);
+    // Summaries carry per-chart labels so screen-reader users can tell the
+    // five disclosures apart.
+    expect(screen.getAllByText(/^View data: /).length).toBeGreaterThanOrEqual(5);
+    for (const label of [
+      "View data: events per day",
+      "View data: event types",
+      "View data: cost per day",
+      "View data: cost breakdown",
+      "View data: errors per day",
+    ]) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
     const panel = (name: string) =>
       within(screen.getByRole("heading", { name }).closest("section") as HTMLElement);
     // Usage day table: the plotted 2026-07-10 value plus an explicit

--- a/frontend/src/components/screens/AdminAnalytics.test.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.test.tsx
@@ -283,6 +283,30 @@ describe("AdminAnalytics", () => {
     expect(within(errRow).getByText("25%")).toBeTruthy();
   });
 
+  it("withholds the error rate when the summary payload belongs to a different range", async () => {
+    // The hooks keep their last payload during a range-change reload, so the
+    // errors panel can briefly see a summary from the OLD range. The rate
+    // must show its waiting state, not an all-0% line fabricated from
+    // zero-filled stale days (#491 review).
+    primeHappyPath();
+    api.adminUsageSummary.mockResolvedValue({
+      ...summaryFixture,
+      range: { from: "2026-05-01T00:00:00.000Z", to: "2026-05-31T00:00:00.000Z" },
+    });
+    render(<AdminAnalytics />);
+    await screen.findByText("error.5xx");
+    expect(screen.getByText(/appears once the usage events-per-day series loads/i)).toBeTruthy();
+    expect(screen.queryByRole("img", { name: "Error rate per day" })).toBeNull();
+    // The errors day table shows the absolute count but no fabricated 0% rate.
+    const errPanel = within(
+      screen.getByRole("heading", { name: "Errors" }).closest("section") as HTMLElement,
+    );
+    for (const cell of errPanel.getAllByText("2026-07-15")) {
+      const row = cell.closest("tr");
+      if (row) expect(within(row).queryByText("0%")).toBeNull();
+    }
+  });
+
   it("sorts the users table by a clicked column (#122)", async () => {
     primeHappyPath();
     render(<AdminAnalytics />);

--- a/frontend/src/components/screens/AdminAnalytics.test.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.test.tsx
@@ -14,7 +14,7 @@
 
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 const userState = vi.hoisted(() => ({ isAdmin: true, userReady: true, userId: "admin-1" }));
 vi.mock("@/context/UserContext", () => ({
@@ -76,6 +76,7 @@ const summaryFixture = {
   series: [
     { date: "2026-07-10", count: 12 },
     { date: "2026-07-12", count: 30 },
+    { date: "2026-07-15", count: 4 }, // rate denominator for the errors-panel day
   ],
 };
 const byUserFixture = {
@@ -237,16 +238,38 @@ describe("AdminAnalytics", () => {
     await screen.findByText("42");
     expect(await screen.findByRole("img", { name: "Events per day" })).toBeTruthy();
     expect(screen.getByRole("img", { name: "Cost per day" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Tokens per day" })).toBeTruthy();
     expect(screen.getByRole("img", { name: "Errors per day" })).toBeTruthy();
+    // Labeled as a RATE — errors ÷ events joined across panels.
+    expect(screen.getByRole("img", { name: "Error rate per day" })).toBeTruthy();
     expect(screen.getByRole("img", { name: "Top event types" })).toBeTruthy();
   });
 
-  it("keeps a table fallback behind each chart panel (#122 a11y)", async () => {
+  it("keeps table fallbacks behind every chart, day series included (#122 a11y)", async () => {
     primeHappyPath();
     render(<AdminAnalytics />);
     await screen.findByText("42");
-    // The raw tables from #121 survive as expandable data views.
-    expect(screen.getAllByText("View data").length).toBeGreaterThanOrEqual(2);
+    // The #121 category tables survive, and each day-series chart cluster now
+    // has a "View data" table twin (the hover tooltip has no keyboard path).
+    expect(screen.getAllByText("View data").length).toBeGreaterThanOrEqual(5);
+    const panel = (name: string) =>
+      within(screen.getByRole("heading", { name }).closest("section") as HTMLElement);
+    // Usage day table: the plotted 2026-07-10 value plus an explicit
+    // zero-filled gap day (2026-07-11 is absent from the sparse series).
+    const usageRow = panel("Usage").getByText("2026-07-10").closest("tr")!;
+    expect(within(usageRow).getByText("12")).toBeTruthy();
+    const gapRow = panel("Usage").getByText("2026-07-11").closest("tr")!;
+    expect(within(gapRow).getByText("0")).toBeTruthy();
+    // Cost day table mirrors CostDayPoint: calls, tokens, and formatted cost.
+    const costRow = panel("LLM cost").getByText("2026-07-10").closest("tr")!;
+    expect(within(costRow).getByText("3")).toBeTruthy();
+    expect(within(costRow).getByText("15")).toBeTruthy();
+    expect(within(costRow).getByText("$0.50")).toBeTruthy();
+    // Errors day table: the absolute count and the cross-panel rate
+    // (1 error ÷ 4 events on 2026-07-15).
+    const errRow = panel("Errors").getByText("2026-07-15").closest("tr")!;
+    expect(within(errRow).getByText("1")).toBeTruthy();
+    expect(within(errRow).getByText("25%")).toBeTruthy();
   });
 
   it("sorts the users table by a clicked column (#122)", async () => {

--- a/frontend/src/components/screens/AdminAnalytics.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.tsx
@@ -5,8 +5,11 @@
  * /api/admin/analytics (usage summary, per-user rollup, LLM cost, errors).
  * One date range drives every panel; each panel owns its loading/error/empty
  * state so a single failed query never blanks the page. Charts render from
- * the ?bucket=day series via the lazy-loaded AnalyticsCharts primitives,
- * with the #121 raw tables kept as per-panel "View data" fallbacks.
+ * the ?bucket=day series via the lazy-loaded AnalyticsCharts primitives —
+ * cost AND tokens over time, absolute errors plus the error RATE (errors ÷
+ * events, joined across panels) — with the #121 raw tables kept as per-panel
+ * "View data" fallbacks and every day-series chart mirrored by its own
+ * "View data" table (the hover tooltip alone has no keyboard path).
  */
 
 import React from "react";
@@ -14,7 +17,7 @@ import dynamic from "next/dynamic";
 import { TopBar } from "../TopBar";
 import { useToast } from "../ToastProvider";
 import { useUser } from "@/context/UserContext";
-import { zeroFillDays } from "@/lib/daySeries";
+import { errorRateSeries, formatCompactCount, zeroFillDays, type DayPointValue } from "@/lib/daySeries";
 
 // Chart components load lazily (the #122 bundle-discipline checkbox). The
 // pure helper imports statically from lib/daySeries — its own JSX-free
@@ -38,7 +41,7 @@ import {
   type AnalyticsQuery,
   type AnalyticsRangeValue,
 } from "@/lib/useAdminAnalytics";
-import type { LlmCostGroupBy } from "@/lib/types";
+import type { CostDayPoint, LlmCostGroupBy } from "@/lib/types";
 
 const PRESETS = [
   { days: 7, label: "7d" },
@@ -56,6 +59,10 @@ const td: React.CSSProperties = {
   fontSize: 13, padding: "6px 8px", borderTop: "1px solid var(--border)",
 };
 const tdNum: React.CSSProperties = { ...td, textAlign: "right", fontVariantNumeric: "tabular-nums" };
+// Panel tables keep a minWidth so columns stay readable; this wrapper lets
+// narrow viewports scroll the table instead of overflowing the page.
+const scrollX: React.CSSProperties = { overflowX: "auto" };
+const formatPct = (v: number) => `${Number(v.toFixed(1))}%`;
 
 function TruncatedBadge() {
   // Copy stays meaning-neutral: on the aggregation panels `truncated` means
@@ -74,6 +81,51 @@ function Stat({ label, value }: { label: string; value: React.ReactNode }) {
       <div className="label-micro">{label}</div>
       <div style={{ fontSize: 24, fontWeight: 600 }}>{value}</div>
     </div>
+  );
+}
+
+/** "View data" table twin for the day-series charts (#122 a11y): the chart
+ * tooltip is pointer-hover only, so every plotted day/value pair also needs a
+ * keyboard/screen-reader path. Rows follow the first non-empty series' dates
+ * (callers zero-fill every series over the same range, so domains align);
+ * a column with no value for a date renders an em dash. */
+function DaySeriesTable({ columns }: {
+  columns: { label: string; points: DayPointValue[]; format?: (v: number) => string }[];
+}) {
+  const dates = columns.find((c) => c.points.length)?.points.map((p) => p.date) ?? [];
+  if (dates.length === 0) return null;
+  const byDate = columns.map((c) => new Map(c.points.map((p) => [p.date, p.value])));
+  return (
+    <details style={{ marginTop: 12 }}>
+      <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data</summary>
+      <div style={scrollX}>
+        <table style={{ borderCollapse: "collapse", minWidth: 280, marginTop: 8 }}>
+          <thead>
+            <tr>
+              <th style={th}>Date</th>
+              {columns.map((c) => (
+                <th key={c.label} style={{ ...th, textAlign: "right" }}>{c.label}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {dates.map((date) => (
+              <tr key={date}>
+                <td style={td}>{date}</td>
+                {columns.map((c, i) => {
+                  const value = byDate[i].get(date);
+                  return (
+                    <td key={c.label} style={tdNum}>
+                      {value == null ? "—" : (c.format ?? String)(value)}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
   );
 }
 
@@ -214,40 +266,46 @@ function AnalyticsBody() {
         </div>
 
         <Panel title="Usage" query={summary} testid="admin-analytics-usage">
-          {(d) => (
-            <>
-              {d.truncated && <TruncatedBadge />}
-              <DayLineChart
-                points={d.series?.length
-                  ? zeroFillDays(d.series.map((p) => ({ date: p.date, value: p.count })), d.range.from, d.range.to)
-                  : []}
-                color="var(--brand-forest, #1B6C42)"
-                fillColor="var(--sap-100, #e0ecd8)"
-                ariaLabel="Events per day"
-              />
-              <h3 className="label-micro" style={{ margin: "16px 0 8px" }}>Top event types</h3>
-              <CategoryBars
-                rows={d.by_event_type.slice(0, 8).map((r) => ({ label: r.event_type, value: r.count }))}
-                ariaLabel="Top event types"
-              />
-              <details style={{ marginTop: 12 }}>
-                <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data</summary>
-                <table style={{ borderCollapse: "collapse", minWidth: 360, marginTop: 8 }}>
-                  <thead>
-                    <tr><th style={th}>Event type</th><th style={{ ...th, textAlign: "right" }}>Count</th></tr>
-                  </thead>
-                  <tbody>
-                    {d.by_event_type.map((row) => (
-                      <tr key={row.event_type}>
-                        <td style={td}>{row.event_type}</td>
-                        <td style={tdNum}>{row.count}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </details>
-            </>
-          )}
+          {(d) => {
+            const eventPoints = d.series?.length
+              ? zeroFillDays(d.series.map((p) => ({ date: p.date, value: p.count })), d.range.from, d.range.to)
+              : [];
+            return (
+              <>
+                {d.truncated && <TruncatedBadge />}
+                <DayLineChart
+                  points={eventPoints}
+                  color="var(--brand-forest, #1B6C42)"
+                  fillColor="var(--sap-100, #e0ecd8)"
+                  ariaLabel="Events per day"
+                />
+                <DaySeriesTable columns={[{ label: "Events", points: eventPoints }]} />
+                <h3 className="label-micro" style={{ margin: "16px 0 8px" }}>Top event types</h3>
+                <CategoryBars
+                  rows={d.by_event_type.slice(0, 8).map((r) => ({ label: r.event_type, value: r.count }))}
+                  ariaLabel="Top event types"
+                />
+                <details style={{ marginTop: 12 }}>
+                  <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data</summary>
+                  <div style={scrollX}>
+                    <table style={{ borderCollapse: "collapse", minWidth: 360, marginTop: 8 }}>
+                      <thead>
+                        <tr><th style={th}>Event type</th><th style={{ ...th, textAlign: "right" }}>Count</th></tr>
+                      </thead>
+                      <tbody>
+                        {d.by_event_type.map((row) => (
+                          <tr key={row.event_type}>
+                            <td style={td}>{row.event_type}</td>
+                            <td style={tdNum}>{row.count}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </details>
+              </>
+            );
+          }}
         </Panel>
 
         <Panel title="Top users" query={byUser} testid="admin-analytics-users">
@@ -281,26 +339,28 @@ function AnalyticsBody() {
                 {d.users.length === 0 ? (
                   <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No user activity in this range.</div>
                 ) : (
-                  <table style={{ borderCollapse: "collapse", minWidth: 520 }}>
-                    <thead>
-                      <tr>
-                        <th style={th}>User</th>
-                        <th style={{ ...th, textAlign: "right" }}>{sortBtn("events", "Events")}</th>
-                        <th style={{ ...th, textAlign: "right" }}>{sortBtn("cost", "LLM cost")}</th>
-                        <th style={{ ...th, textAlign: "right" }}>{sortBtn("tokens", "Tokens")}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {users.map((u) => (
-                        <tr key={u.user_id}>
-                          <td style={{ ...td, fontFamily: "var(--font-mono, monospace)", fontSize: 12 }}>{u.user_id}</td>
-                          <td style={tdNum}>{u.event_count}</td>
-                          <td style={tdNum}>${u.llm_cost_usd.toFixed(4)}</td>
-                          <td style={tdNum}>{u.total_tokens}</td>
+                  <div style={scrollX}>
+                    <table style={{ borderCollapse: "collapse", minWidth: 520 }}>
+                      <thead>
+                        <tr>
+                          <th style={th}>User</th>
+                          <th style={{ ...th, textAlign: "right" }}>{sortBtn("events", "Events")}</th>
+                          <th style={{ ...th, textAlign: "right" }}>{sortBtn("cost", "LLM cost")}</th>
+                          <th style={{ ...th, textAlign: "right" }}>{sortBtn("tokens", "Tokens")}</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                      </thead>
+                      <tbody>
+                        {users.map((u) => (
+                          <tr key={u.user_id}>
+                            <td style={{ ...td, fontFamily: "var(--font-mono, monospace)", fontSize: 12 }}>{u.user_id}</td>
+                            <td style={tdNum}>{u.event_count}</td>
+                            <td style={tdNum}>${u.llm_cost_usd.toFixed(4)}</td>
+                            <td style={tdNum}>{u.total_tokens}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
                 )}
               </>
             );
@@ -308,7 +368,18 @@ function AnalyticsBody() {
         </Panel>
 
         <Panel title="LLM cost" query={cost} testid="admin-analytics-cost">
-          {(d) => (
+          {(d) => {
+            // One CostDayPoint series carries all three per-day metrics;
+            // zero-fill each projection over the same range so the cost and
+            // tokens charts (and the day table) share one date domain.
+            const dayMetric = (pick: (p: CostDayPoint) => number) =>
+              d.series?.length
+                ? zeroFillDays(d.series.map((p) => ({ date: p.date, value: pick(p) })), d.range.from, d.range.to)
+                : [];
+            const costPoints = dayMetric((p) => p.cost_usd);
+            const tokenPoints = dayMetric((p) => p.total_tokens);
+            const callPoints = dayMetric((p) => p.calls);
+            return (
             <>
               <div style={{ display: "flex", gap: 6, alignItems: "center", marginBottom: 12 }}>
                 <span className="label-micro">Group by</span>
@@ -326,13 +397,26 @@ function AnalyticsBody() {
                 {d.truncated && <TruncatedBadge />}
               </div>
               <DayLineChart
-                points={d.series?.length
-                  ? zeroFillDays(d.series.map((p) => ({ date: p.date, value: p.cost_usd })), d.range.from, d.range.to)
-                  : []}
+                points={costPoints}
                 color="var(--brand-forest, #1B6C42)"
                 fillColor="var(--sap-100, #e0ecd8)"
                 ariaLabel="Cost per day"
                 format={(v) => `$${v.toFixed(2)}`}
+              />
+              <h3 className="label-micro" style={{ margin: "16px 0 8px" }}>Tokens per day</h3>
+              <DayLineChart
+                points={tokenPoints}
+                color="var(--brand-forest, #1B6C42)"
+                fillColor="var(--sap-100, #e0ecd8)"
+                ariaLabel="Tokens per day"
+                format={formatCompactCount}
+              />
+              <DaySeriesTable
+                columns={[
+                  { label: "Calls", points: callPoints },
+                  { label: "Tokens", points: tokenPoints },
+                  { label: "Cost", points: costPoints, format: (v) => `$${v.toFixed(2)}` },
+                ]}
               />
               <h3 className="label-micro" style={{ margin: "16px 0 8px" }}>Cost by {d.group_by}</h3>
               <CategoryBars
@@ -342,85 +426,124 @@ function AnalyticsBody() {
               />
               <details style={{ marginTop: 12 }}>
                 <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data</summary>
-                <table style={{ borderCollapse: "collapse", minWidth: 560, marginTop: 8 }}>
-                  <thead>
-                    <tr>
-                      <th style={th}>{d.group_by}</th>
-                      <th style={{ ...th, textAlign: "right" }}>Calls</th>
-                      <th style={{ ...th, textAlign: "right" }}>Prompt</th>
-                      <th style={{ ...th, textAlign: "right" }}>Completion</th>
-                      <th style={{ ...th, textAlign: "right" }}>Tokens</th>
-                      <th style={{ ...th, textAlign: "right" }}>Cost</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {d.rows.map((row) => (
-                      <tr key={row.key}>
-                        <td style={td}>{row.key || "(none)"}</td>
-                        <td style={tdNum}>{row.calls}</td>
-                        <td style={tdNum}>{row.prompt_tokens}</td>
-                        <td style={tdNum}>{row.completion_tokens}</td>
-                        <td style={tdNum}>{row.total_tokens}</td>
-                        <td style={tdNum}>${row.cost_usd.toFixed(4)}</td>
+                <div style={scrollX}>
+                  <table style={{ borderCollapse: "collapse", minWidth: 560, marginTop: 8 }}>
+                    <thead>
+                      <tr>
+                        <th style={th}>{d.group_by}</th>
+                        <th style={{ ...th, textAlign: "right" }}>Calls</th>
+                        <th style={{ ...th, textAlign: "right" }}>Prompt</th>
+                        <th style={{ ...th, textAlign: "right" }}>Completion</th>
+                        <th style={{ ...th, textAlign: "right" }}>Tokens</th>
+                        <th style={{ ...th, textAlign: "right" }}>Cost</th>
                       </tr>
-                    ))}
-                    <tr>
-                      <td style={{ ...td, fontWeight: 600 }}>Total</td>
-                      <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.calls}</td>
-                      <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.prompt_tokens}</td>
-                      <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.completion_tokens}</td>
-                      <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.total_tokens}</td>
-                      <td style={{ ...tdNum, fontWeight: 600 }}>${d.totals.cost_usd.toFixed(4)}</td>
-                    </tr>
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody>
+                      {d.rows.map((row) => (
+                        <tr key={row.key}>
+                          <td style={td}>{row.key || "(none)"}</td>
+                          <td style={tdNum}>{row.calls}</td>
+                          <td style={tdNum}>{row.prompt_tokens}</td>
+                          <td style={tdNum}>{row.completion_tokens}</td>
+                          <td style={tdNum}>{row.total_tokens}</td>
+                          <td style={tdNum}>${row.cost_usd.toFixed(4)}</td>
+                        </tr>
+                      ))}
+                      <tr>
+                        <td style={{ ...td, fontWeight: 600 }}>Total</td>
+                        <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.calls}</td>
+                        <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.prompt_tokens}</td>
+                        <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.completion_tokens}</td>
+                        <td style={{ ...tdNum, fontWeight: 600 }}>{d.totals.total_tokens}</td>
+                        <td style={{ ...tdNum, fontWeight: 600 }}>${d.totals.cost_usd.toFixed(4)}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </details>
             </>
-          )}
+            );
+          }}
         </Panel>
 
         <Panel title="Errors" query={errs} testid="admin-analytics-errors">
-          {(d) => (
+          {(d) => {
+            const errorPoints = d.series?.length
+              ? zeroFillDays(d.series.map((p) => ({ date: p.date, value: p.count })), d.range.from, d.range.to)
+              : [];
+            // The rate denominator joins ACROSS panels: the usage summary's
+            // events/day series. Both series zero-fill over THIS panel's
+            // range so errorRateSeries joins on an aligned date domain (days
+            // with zero events report 0%, never NaN/Infinity).
+            const eventPoints = summary.data?.series?.length
+              ? zeroFillDays(
+                  summary.data.series.map((p) => ({ date: p.date, value: p.count })),
+                  d.range.from,
+                  d.range.to,
+                )
+              : [];
+            const ratePoints = errorRateSeries(errorPoints, eventPoints);
+            return (
             <>
               {d.truncated && <TruncatedBadge />}
               <DayLineChart
-                points={d.series?.length
-                  ? zeroFillDays(d.series.map((p) => ({ date: p.date, value: p.count })), d.range.from, d.range.to)
-                  : []}
+                points={errorPoints}
                 color="var(--err, #a83a3a)"
                 ariaLabel="Errors per day"
+              />
+              <h3 className="label-micro" style={{ margin: "16px 0 8px" }}>Error rate</h3>
+              {ratePoints.length ? (
+                <DayLineChart
+                  points={ratePoints}
+                  color="var(--err, #a83a3a)"
+                  ariaLabel="Error rate per day"
+                  format={formatPct}
+                />
+              ) : (
+                <div style={{ color: "var(--text-muted)", fontSize: 13 }}>
+                  Error rate appears once the usage events-per-day series loads.
+                </div>
+              )}
+              <DaySeriesTable
+                columns={[
+                  { label: "Errors", points: errorPoints },
+                  { label: "Error rate", points: ratePoints, format: formatPct },
+                ]}
               />
               <div style={{ height: 12 }} />
               {d.errors.length === 0 ? (
                 <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No errors in this range. 🎉</div>
               ) : (
-                <table style={{ borderCollapse: "collapse", minWidth: 640 }}>
-                  <thead>
-                    <tr>
-                      <th style={th}>Time</th>
-                      <th style={th}>Type</th>
-                      <th style={th}>Method</th>
-                      <th style={th}>Path</th>
-                      <th style={{ ...th, textAlign: "right" }}>Status</th>
-                      <th style={{ ...th, textAlign: "right" }}>Duration</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {d.errors.map((e, i) => (
-                      <tr key={e.request_id ?? `${e.created_at}-${i}`}>
-                        <td style={{ ...td, whiteSpace: "nowrap" }}>{e.created_at ?? "—"}</td>
-                        <td style={td}>{e.event_type}</td>
-                        <td style={td}>{e.method ?? "—"}</td>
-                        <td style={{ ...td, fontFamily: "var(--font-mono, monospace)", fontSize: 12 }}>{e.path ?? "—"}</td>
-                        <td style={tdNum}>{e.status_code ?? "—"}</td>
-                        <td style={tdNum}>{e.duration_ms != null ? `${e.duration_ms.toFixed(1)}ms` : "—"}</td>
+                <div style={scrollX}>
+                  <table style={{ borderCollapse: "collapse", minWidth: 640 }}>
+                    <thead>
+                      <tr>
+                        <th style={th}>Time</th>
+                        <th style={th}>Type</th>
+                        <th style={th}>Method</th>
+                        <th style={th}>Path</th>
+                        <th style={{ ...th, textAlign: "right" }}>Status</th>
+                        <th style={{ ...th, textAlign: "right" }}>Duration</th>
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody>
+                      {d.errors.map((e, i) => (
+                        <tr key={e.request_id ?? `${e.created_at}-${i}`}>
+                          <td style={{ ...td, whiteSpace: "nowrap" }}>{e.created_at ?? "—"}</td>
+                          <td style={td}>{e.event_type}</td>
+                          <td style={td}>{e.method ?? "—"}</td>
+                          <td style={{ ...td, fontFamily: "var(--font-mono, monospace)", fontSize: 12 }}>{e.path ?? "—"}</td>
+                          <td style={tdNum}>{e.status_code ?? "—"}</td>
+                          <td style={tdNum}>{e.duration_ms != null ? `${e.duration_ms.toFixed(1)}ms` : "—"}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
               )}
             </>
-          )}
+            );
+          }}
         </Panel>
       </div>
     </div>

--- a/frontend/src/components/screens/AdminAnalytics.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.tsx
@@ -89,7 +89,8 @@ function Stat({ label, value }: { label: string; value: React.ReactNode }) {
  * keyboard/screen-reader path. Rows follow the first non-empty series' dates
  * (callers zero-fill every series over the same range, so domains align);
  * a column with no value for a date renders an em dash. */
-function DaySeriesTable({ columns }: {
+function DaySeriesTable({ label, columns }: {
+  label: string;
   columns: { label: string; points: DayPointValue[]; format?: (v: number) => string }[];
 }) {
   const dates = columns.find((c) => c.points.length)?.points.map((p) => p.date) ?? [];
@@ -97,7 +98,7 @@ function DaySeriesTable({ columns }: {
   const byDate = columns.map((c) => new Map(c.points.map((p) => [p.date, p.value])));
   return (
     <details style={{ marginTop: 12 }}>
-      <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data</summary>
+      <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data: {label}</summary>
       <div style={scrollX}>
         <table style={{ borderCollapse: "collapse", minWidth: 280, marginTop: 8 }}>
           <thead>
@@ -279,14 +280,14 @@ function AnalyticsBody() {
                   fillColor="var(--sap-100, #e0ecd8)"
                   ariaLabel="Events per day"
                 />
-                <DaySeriesTable columns={[{ label: "Events", points: eventPoints }]} />
+                <DaySeriesTable label="events per day" columns={[{ label: "Events", points: eventPoints }]} />
                 <h3 className="label-micro" style={{ margin: "16px 0 8px" }}>Top event types</h3>
                 <CategoryBars
                   rows={d.by_event_type.slice(0, 8).map((r) => ({ label: r.event_type, value: r.count }))}
                   ariaLabel="Top event types"
                 />
                 <details style={{ marginTop: 12 }}>
-                  <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data</summary>
+                  <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data: event types</summary>
                   <div style={scrollX}>
                     <table style={{ borderCollapse: "collapse", minWidth: 360, marginTop: 8 }}>
                       <thead>
@@ -412,6 +413,7 @@ function AnalyticsBody() {
                 format={formatCompactCount}
               />
               <DaySeriesTable
+                label="cost per day"
                 columns={[
                   { label: "Calls", points: callPoints },
                   { label: "Tokens", points: tokenPoints },
@@ -425,7 +427,7 @@ function AnalyticsBody() {
                 format={(v) => `$${v.toFixed(4)}`}
               />
               <details style={{ marginTop: 12 }}>
-                <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data</summary>
+                <summary style={{ fontSize: 12, color: "var(--text-muted)", cursor: "pointer" }}>View data: cost breakdown</summary>
                 <div style={scrollX}>
                   <table style={{ borderCollapse: "collapse", minWidth: 560, marginTop: 8 }}>
                     <thead>
@@ -468,9 +470,13 @@ function AnalyticsBody() {
 
         <Panel title="Errors" query={errs} testid="admin-analytics-errors">
           {(d) => {
-            const errorPoints = d.series?.length
-              ? zeroFillDays(d.series.map((p) => ({ date: p.date, value: p.count })), d.range.from, d.range.to)
-              : [];
+            // Zero-fill even when the series is empty: a no-error range is a
+            // flat zero line and real 0s in the table, not "unknown" dashes.
+            const errorPoints = zeroFillDays(
+              (d.series ?? []).map((p) => ({ date: p.date, value: p.count })),
+              d.range.from,
+              d.range.to,
+            );
             // The rate denominator joins ACROSS panels: the usage summary's
             // events/day series. Both series zero-fill over THIS panel's
             // range so errorRateSeries joins on an aligned date domain (days
@@ -501,10 +507,15 @@ function AnalyticsBody() {
                 />
               ) : (
                 <div style={{ color: "var(--text-muted)", fontSize: 13 }}>
-                  Error rate appears once the usage events-per-day series loads.
+                  {summary.error
+                    ? "Couldn't load the events-per-day series, so the error rate can't be computed."
+                    : summary.data
+                      ? "No events in this range."
+                      : "Error rate appears once the usage events-per-day series loads."}
                 </div>
               )}
               <DaySeriesTable
+                label="errors per day"
                 columns={[
                   { label: "Errors", points: errorPoints },
                   { label: "Error rate", points: ratePoints, format: formatPct },

--- a/frontend/src/components/screens/AdminAnalytics.tsx
+++ b/frontend/src/components/screens/AdminAnalytics.tsx
@@ -62,7 +62,9 @@ const tdNum: React.CSSProperties = { ...td, textAlign: "right", fontVariantNumer
 // Panel tables keep a minWidth so columns stay readable; this wrapper lets
 // narrow viewports scroll the table instead of overflowing the page.
 const scrollX: React.CSSProperties = { overflowX: "auto" };
-const formatPct = (v: number) => `${Number(v.toFixed(1))}%`;
+// Tiny nonzero rates floor at "<0.1%" so the tooltip/table never reads as
+// "no errors" when errors exist.
+const formatPct = (v: number) => (v > 0 && v < 0.1 ? "<0.1%" : `${Number(v.toFixed(1))}%`);
 
 function TruncatedBadge() {
   // Copy stays meaning-neutral: on the aggregation panels `truncated` means
@@ -480,14 +482,23 @@ function AnalyticsBody() {
             // The rate denominator joins ACROSS panels: the usage summary's
             // events/day series. Both series zero-fill over THIS panel's
             // range so errorRateSeries joins on an aligned date domain (days
-            // with zero events report 0%, never NaN/Infinity).
-            const eventPoints = summary.data?.series?.length
-              ? zeroFillDays(
-                  summary.data.series.map((p) => ({ date: p.date, value: p.count })),
-                  d.range.from,
-                  d.range.to,
-                )
-              : [];
+            // with zero events report 0%, never NaN/Infinity). The summary
+            // hook keeps its LAST payload while a range change reloads, so
+            // guard on day-key range agreement — a stale series zero-filled
+            // against the new range would fabricate an all-0% rate line.
+            const summaryRange = summary.data?.range;
+            const rangesAgree =
+              !!summaryRange &&
+              summaryRange.from.slice(0, 10) === d.range.from.slice(0, 10) &&
+              summaryRange.to.slice(0, 10) === d.range.to.slice(0, 10);
+            const eventPoints =
+              rangesAgree && summary.data?.series?.length
+                ? zeroFillDays(
+                    summary.data.series.map((p) => ({ date: p.date, value: p.count })),
+                    d.range.from,
+                    d.range.to,
+                  )
+                : [];
             const ratePoints = errorRateSeries(errorPoints, eventPoints);
             return (
             <>
@@ -499,17 +510,22 @@ function AnalyticsBody() {
               />
               <h3 className="label-micro" style={{ margin: "16px 0 8px" }}>Error rate</h3>
               {ratePoints.length ? (
-                <DayLineChart
-                  points={ratePoints}
-                  color="var(--err, #a83a3a)"
-                  ariaLabel="Error rate per day"
-                  format={formatPct}
-                />
+                <>
+                  {/* A truncated summary scan undercounts the denominator, so
+                      the rate can overshoot — surface it on THIS chart. */}
+                  {summary.data?.truncated && <TruncatedBadge />}
+                  <DayLineChart
+                    points={ratePoints}
+                    color="var(--err, #a83a3a)"
+                    ariaLabel="Error rate per day"
+                    format={formatPct}
+                  />
+                </>
               ) : (
                 <div style={{ color: "var(--text-muted)", fontSize: 13 }}>
                   {summary.error
                     ? "Couldn't load the events-per-day series, so the error rate can't be computed."
-                    : summary.data
+                    : summary.data && rangesAgree
                       ? "No events in this range."
                       : "Error rate appears once the usage events-per-day series loads."}
                 </div>

--- a/frontend/src/lib/daySeries.ts
+++ b/frontend/src/lib/daySeries.ts
@@ -36,3 +36,26 @@ export function zeroFillDays(
   }
   return out;
 }
+
+/** Per-day error rate as a PERCENTAGE (0–100): error count ÷ total events,
+ * joined by date over the events (denominator) series. Days with zero events
+ * report 0 — never NaN/Infinity. Feed both series through zeroFillDays over
+ * the SAME range first so the date domains line up. */
+export function errorRateSeries(
+  errorPoints: DayPointValue[],
+  eventPoints: DayPointValue[],
+): DayPointValue[] {
+  const errByDate = new Map(errorPoints.map((p) => [p.date, p.value]));
+  return eventPoints.map((p) => ({
+    date: p.date,
+    value: p.value > 0 ? ((errByDate.get(p.date) ?? 0) / p.value) * 100 : 0,
+  }));
+}
+
+/** Compact count for chart axes ("950", "1.5k", "2.5M") — the narrow y-axis
+ * gutter can't fit raw token totals; table fallbacks keep the exact values. */
+export function formatCompactCount(v: number): string {
+  if (v >= 1_000_000) return `${Number((v / 1_000_000).toFixed(1))}M`;
+  if (v >= 1_000) return `${Number((v / 1_000).toFixed(1))}k`;
+  return String(v);
+}

--- a/frontend/src/lib/daySeries.ts
+++ b/frontend/src/lib/daySeries.ts
@@ -56,6 +56,10 @@ export function errorRateSeries(
  * gutter can't fit raw token totals; table fallbacks keep the exact values. */
 export function formatCompactCount(v: number): string {
   if (v >= 1_000_000) return `${Number((v / 1_000_000).toFixed(1))}M`;
-  if (v >= 1_000) return `${Number((v / 1_000).toFixed(1))}k`;
+  if (v >= 1_000) {
+    // Rounding can carry 999_950+ up to "1000k" — promote to the next unit.
+    const k = Number((v / 1_000).toFixed(1));
+    return k >= 1_000 ? `${Number((k / 1_000).toFixed(1))}M` : `${k}k`;
+  }
   return String(v);
 }


### PR DESCRIPTION
## Summary

PR #479 shipped the #122 dashboard, but a criterion-by-criterion audit against the issue spec found three concrete gaps. This PR closes them:

1. **"Cost & tokens over time" — tokens were never charted.** The LLM cost panel now projects the `CostDayPoint` series into zero-filled day series and renders a second lazy `DayLineChart` ("Tokens per day"), with a compact-count axis formatter (`formatCompactCount` in `daySeries.ts`) so token magnitudes fit the y-gutter. No backend work — the API already returned `calls`/`total_tokens` per day.
2. **"Error-rate trend" was an error-count trend.** New JSX-free `errorRateSeries` joins the errors/day series with the usage summary's events/day series by date (both zero-filled over the panel range): rate = errors ÷ events as a percentage; zero-event days report 0, never NaN/Infinity. The absolute errors/day chart stays; the rate chart renders alongside it (muted note if the usage series hasn't loaded).
3. **The three line charts had no table fallback** — day values were reachable only by pointer hover. New `DaySeriesTable` mirrors the existing "View data" `<details>` pattern for every day-series chart (usage events/day; cost calls/tokens/cost; errors count/rate). Also wraps all `minWidth` tables in an `overflowX: auto` container so narrow viewports scroll the table, not the page.

Constraints preserved: hand-rolled SVG only (no chart lib), `next/dynamic` + `ssr:false` lazy-loading and the JSX-free `daySeries.ts` split untouched, `role="img"` + aria-labels on new charts, brand tokens, no glass/gradient-text, and every name/testid asserted by `e2e/admin-analytics.spec.ts` unchanged.

## Verification

- vitest on touched files: **25 tests pass** — the old `View data ≥ 2` smoke assert is replaced with panel-scoped assertions of specific day values (incl. a 25% rate = 1 error ÷ 4 events fixture)
- `tsc --noEmit` clean; eslint exit 0 on all touched files
- ⚠️ Local E2E lane not runnable on this machine (unprovisioned stack — details in PR #490); `e2e.yml` runs the admin-analytics journey on push to main. All names/testids that journey asserts are unchanged.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added accessible data tables and “View data” fallbacks for analytics charts.
  - Added daily error-rate reporting based on usage events.
  - Added daily usage event charts and expanded LLM cost reporting for tokens, calls, and cost.
  - Added compact formatting for large counts.

- **Improvements**
  - Improved responsive display of analytics tables.
  - Missing daily usage and error values are now shown as zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->