### PR TITLE
perf(frontend): cut per-frame work in the hero canvas, backdrop and graph (#111)

### DIFF
--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -55,7 +55,7 @@
       "count": 1
     },
     "react-hooks/refs": {
-      "count": 13
+      "count": 14
     }
   },
   "src/components/KnowledgeGraph3D.test.tsx": {

--- a/frontend/src/app/(public)/about/page.tsx
+++ b/frontend/src/app/(public)/about/page.tsx
@@ -73,7 +73,7 @@ export default function AboutPage() {
           >
             <img
               src="/sapling-icon.svg"
-              alt="Sapling"
+              alt="Sapling" width={26} height={26}
               style={{ width: 26, height: 26, flexShrink: 0, position: "relative", top: -2 }}
             />
             <span
@@ -281,7 +281,7 @@ export default function AboutPage() {
           }}
         >
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <img src="/sapling-icon.svg" alt="Sapling" style={{ width: 20, height: 20 }} />
+            <img src="/sapling-icon.svg" alt="Sapling" width={20} height={20} style={{ width: 20, height: 20 }} />
             <span style={{ fontSize: 14, color: "var(--text-muted)" }}>Sapling · © 2026</span>
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 24 }}>

--- a/frontend/src/app/(public)/careers/CareersList.tsx
+++ b/frontend/src/app/(public)/careers/CareersList.tsx
@@ -50,7 +50,7 @@ export default function CareersList() {
           >
             <img
               src="/sapling-icon.svg"
-              alt="Sapling"
+              alt="Sapling" width={26} height={26}
               style={{ width: 26, height: 26, flexShrink: 0, position: 'relative', top: -2 }}
             />
             <span
@@ -363,7 +363,7 @@ export default function CareersList() {
           }}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <img src="/sapling-icon.svg" alt="Sapling" style={{ width: 20, height: 20 }} />
+            <img src="/sapling-icon.svg" alt="Sapling" width={20} height={20} style={{ width: 20, height: 20 }} />
             <span style={{ fontSize: 14, color: 'var(--text-muted)' }}>Sapling · © 2026</span>
           </div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 24 }}>

--- a/frontend/src/app/(public)/careers/[slug]/ApplyForm.tsx
+++ b/frontend/src/app/(public)/careers/[slug]/ApplyForm.tsx
@@ -144,7 +144,7 @@ export default function ApplyForm({ job }: { job: Job | null }) {
           >
             <img
               src="/sapling-icon.svg"
-              alt="Sapling"
+              alt="Sapling" width={24} height={24}
               style={{ width: 24, height: 24, position: 'relative', top: -1 }}
             />
             <span className="h-serif" style={{ fontSize: 20, color: 'var(--text)' }}>
@@ -533,7 +533,7 @@ export default function ApplyForm({ job }: { job: Job | null }) {
           }}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <img src="/sapling-icon.svg" alt="Sapling" style={{ width: 20, height: 20 }} />
+            <img src="/sapling-icon.svg" alt="Sapling" width={20} height={20} style={{ width: 20, height: 20 }} />
             <span style={{ fontSize: 14, color: 'var(--text-muted)' }}>Sapling · © 2026</span>
           </div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 24 }}>

--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -1,18 +1,29 @@
 'use client';
 
 import { useEffect, useState, useRef, useCallback } from 'react';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useUser } from '@/context/UserContext';
 import { useScrollLock } from '@/lib/useScrollLock';
 import { Network, Sparkles, FilePlus2, Brain, CalendarClock, Users, PenSquare } from 'lucide-react';
-import HowItWorks from '@/components/HowItWorks';
 import SignInModal from '@/components/SignInModal';
 import { HeroCard } from '@/components/HeroCard';
+import { linkPairs } from '@/lib/linkPairs';
 import { BRAND_FOREST } from '@/lib/brand';
 import { Button } from "@/components/ui";
 import { IS_TEST_MODE, random, now } from '@/lib/testMode';
 
+// Code-split: HowItWorks is ~54 motion.* elements and the landing page's only
+// framer-motion consumer, so importing it eagerly put the whole library on the
+// critical path for a section that lives well below the fold.
+// Deliberately NOT `ssr: false` — the markup still server-renders, so the
+// section stays in the HTML for crawlers; only its JS moves to its own chunk.
+const HowItWorks = dynamic(() => import('@/components/HowItWorks'));
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5000';
+
+/** Hero canvas: a node links to another within this many px, scaled by depth. */
+const LINK_REACH = 70;
 
 const SCRAMBLE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!<>-_\\/[]{}=+*^?#_";
 
@@ -219,17 +230,19 @@ export default function LandingPage() {
 
       ctx.globalCompositeOperation = 'source-over';
       ctx.lineWidth = 0.5;
-      for (let i = 0; i < proj.length; i++) {
-        for (let j = i + 1; j < proj.length; j++) {
-          const p1 = proj[i], p2 = proj[j];
-          const d = Math.hypot(p1.x - p2.x, p1.y - p2.y);
-          if (d < 70 * p1.sc) {
-            const a = (1 - d / (70 * p1.sc)) * 0.15 * Math.min(1, p1.sc);
-            if (a > 0.002) {
-              ctx.strokeStyle = `rgba(156,163,175,${a})`;
-              ctx.beginPath(); ctx.moveTo(p1.x, p1.y); ctx.lineTo(p2.x, p2.y); ctx.stroke();
-            }
-          }
+
+      // Link pass. This was an uncapped double loop measuring all ~25k pairs
+      // of the 226 projected nodes every frame, to draw the few dozen that
+      // actually qualify. `linkPairs` bins them spatially and emits exactly
+      // the same pairs in the same order — proved against the all-pairs
+      // version in linkPairs.test.ts, order included, because these strokes
+      // are translucent and overlapping.
+      for (const { i, j, d } of linkPairs(proj, LINK_REACH)) {
+        const p1 = proj[i], p2 = proj[j];
+        const a = (1 - d / (LINK_REACH * p1.sc)) * 0.15 * Math.min(1, p1.sc);
+        if (a > 0.002) {
+          ctx.strokeStyle = `rgba(156,163,175,${a})`;
+          ctx.beginPath(); ctx.moveTo(p1.x, p1.y); ctx.lineTo(p2.x, p2.y); ctx.stroke();
         }
       }
 
@@ -510,7 +523,7 @@ export default function LandingPage() {
       >
         <div className="max-w-[88%] mx-auto flex items-center justify-between w-full">
           <button type="button" aria-label="Sapling — scroll to top" className="flex items-center cursor-pointer group" style={{ gap: '4px' }} onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>
-            <img src="/sapling-icon.svg" alt="" style={{ width: '26px', height: '26px', flexShrink: 0, position: 'relative', top: '-2px' }} />
+            <img src="/sapling-icon.svg" alt="" width={26} height={26} style={{ width: '26px', height: '26px', flexShrink: 0, position: 'relative', top: '-2px' }} />
             <span style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: '20px', color: 'var(--brand-forest)', letterSpacing: '-0.02em', lineHeight: 1.1 }}>Sapling</span>
           </button>
           <div className="flex items-center">
@@ -726,7 +739,7 @@ export default function LandingPage() {
         <footer className="landing-section border-t border-white/35 py-12 px-8 relative z-10">
           <div className="max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between gap-6">
             <div className="flex items-center gap-2">
-              <img src="/sapling-icon.svg" alt="Sapling" style={{ width: '20px', height: '20px' }} />
+              <img src="/sapling-icon.svg" alt="Sapling" width={20} height={20} style={{ width: '20px', height: '20px' }} />
               <span className="text-sm font-light tracking-wide text-[var(--text-dim)]">Sapling · © 2026</span>
             </div>
             <div className="flex flex-wrap justify-center gap-6">
@@ -809,7 +822,7 @@ export default function LandingPage() {
               display: 'flex', flexDirection: 'column', gap: 22,
             }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                <img src="/sapling-icon.svg" alt="Sapling" style={{ width: 22, height: 22 }} />
+                <img src="/sapling-icon.svg" alt="Sapling" width={22} height={22} style={{ width: 22, height: 22 }} />
                 <span style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: 17, color: 'var(--brand-forest)', letterSpacing: '-0.02em' }}>Sapling</span>
               </div>
               <div>

--- a/frontend/src/app/(public)/privacy/page.tsx
+++ b/frontend/src/app/(public)/privacy/page.tsx
@@ -145,7 +145,7 @@ export default function PrivacyPage() {
           >
             <img
               src="/sapling-icon.svg"
-              alt="Sapling"
+              alt="Sapling" width={26} height={26}
               style={{ width: 26, height: 26, flexShrink: 0, position: "relative", top: -2 }}
             />
             <span
@@ -377,7 +377,7 @@ export default function PrivacyPage() {
           }}
         >
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <img src="/sapling-icon.svg" alt="Sapling" style={{ width: 20, height: 20 }} />
+            <img src="/sapling-icon.svg" alt="Sapling" width={20} height={20} style={{ width: 20, height: 20 }} />
             <span style={{ fontSize: 14, color: "var(--text-muted)" }}>Sapling · © 2026</span>
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 24 }}>

--- a/frontend/src/app/(public)/terms/page.tsx
+++ b/frontend/src/app/(public)/terms/page.tsx
@@ -111,7 +111,7 @@ export default function TermsPage() {
           >
             <img
               src="/sapling-icon.svg"
-              alt="Sapling"
+              alt="Sapling" width={26} height={26}
               style={{ width: 26, height: 26, flexShrink: 0, position: "relative", top: -2 }}
             />
             <span
@@ -252,7 +252,7 @@ export default function TermsPage() {
           }}
         >
           <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-            <img src="/sapling-icon.svg" alt="Sapling" style={{ width: 20, height: 20 }} />
+            <img src="/sapling-icon.svg" alt="Sapling" width={20} height={20} style={{ width: 20, height: 20 }} />
             <span style={{ fontSize: 14, color: "var(--text-muted)" }}>Sapling · © 2026</span>
           </div>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 24 }}>

--- a/frontend/src/components/AtmosphericBackdrop.tsx
+++ b/frontend/src/components/AtmosphericBackdrop.tsx
@@ -47,6 +47,8 @@ function orbRadius(orb: Orb) {
 
 /** ~30fps. Ambient drift does not need a frame the eye can't distinguish. */
 const FRAME_MS = 1000 / 30;
+/** The cadence the drift constants were tuned at; used to keep speed identical. */
+const BASE_FRAME_MS = 1000 / 60;
 
 /**
  * Pre-render one orb's radial gradient into its own offscreen canvas.
@@ -152,6 +154,13 @@ export function AtmosphericBackdrop() {
         rafRef.current = requestAnimationFrame(paint);
         return;
       }
+      // Drift is advanced ONCE per painted frame, so halving the frame rate
+      // would otherwise halve the apparent speed — a visible change, which
+      // this is not allowed to be. Scale each step by how many 60fps frames
+      // actually elapsed. Clamped so a backgrounded tab (or the very first
+      // frame, when lastPaint is still 0) can't teleport the field on resume.
+      const elapsed = lastPaintRef.current ? t - lastPaintRef.current : BASE_FRAME_MS;
+      const step = Math.min(Math.max(elapsed / BASE_FRAME_MS, 0), 4);
       lastPaintRef.current = t;
 
       const { w, h } = sizeRef.current;
@@ -174,9 +183,9 @@ export function AtmosphericBackdrop() {
       // Slow drift. Wrap orbs that float past the edges (with a soft margin
       // so they don't pop in — the gradient tail handles the fade).
       for (const orb of orbsRef.current) {
-        orb.phase += 0.0008;
-        orb.x += orb.vx + Math.cos(orb.phase) * 0.04;
-        orb.y += orb.vy + Math.sin(orb.phase * 0.8) * 0.03;
+        orb.phase += 0.0008 * step;
+        orb.x += (orb.vx + Math.cos(orb.phase) * 0.04) * step;
+        orb.y += (orb.vy + Math.sin(orb.phase * 0.8) * 0.03) * step;
         const m = orb.r;
         if (orb.x < -m) orb.x = w + m;
         else if (orb.x > w + m) orb.x = -m;

--- a/frontend/src/components/AtmosphericBackdrop.tsx
+++ b/frontend/src/components/AtmosphericBackdrop.tsx
@@ -40,6 +40,45 @@ const PALETTE = [
   "#b8c9a6", // pale sage-adjacent (barely, for continuity)
 ];
 
+/** The painted radius of an orb — fixed for its lifetime (r and z never change). */
+function orbRadius(orb: Orb) {
+  return orb.r * (0.7 + orb.z * 0.6);
+}
+
+/** ~30fps. Ambient drift does not need a frame the eye can't distinguish. */
+const FRAME_MS = 1000 / 30;
+
+/**
+ * Pre-render one orb's radial gradient into its own offscreen canvas.
+ *
+ * Everything the gradient depends on — colour, radius, depth-derived alpha —
+ * is fixed when the orb is created; only x/y move. Baking once turns the
+ * per-frame cost from "build 14 gradients and fill 14 arcs" into "blit 14
+ * bitmaps", which is the whole point: this backdrop is mounted app-wide, in
+ * both ShellFrame layouts, behind every screen.
+ */
+function bakeOrb(orb: Orb, dpr: number): HTMLCanvasElement {
+  const rad = orbRadius(orb);
+  const alpha = 0.035 + orb.z * 0.07;
+  const size = Math.max(1, Math.ceil(rad * 2 * dpr));
+  const c = document.createElement("canvas");
+  c.width = size;
+  c.height = size;
+  const cx = c.getContext("2d");
+  if (cx) {
+    cx.scale(dpr, dpr);
+    const grad = cx.createRadialGradient(rad, rad, 0, rad, rad, rad);
+    grad.addColorStop(0, hexToRgba(orb.color, alpha));
+    grad.addColorStop(0.55, hexToRgba(orb.color, alpha * 0.45));
+    grad.addColorStop(1, hexToRgba(orb.color, 0));
+    cx.fillStyle = grad;
+    cx.beginPath();
+    cx.arc(rad, rad, rad, 0, Math.PI * 2);
+    cx.fill();
+  }
+  return c;
+}
+
 function makeOrbs(width: number, height: number): Orb[] {
   const count = 14;
   const orbs: Orb[] = [];
@@ -64,6 +103,10 @@ export function AtmosphericBackdrop() {
   const orbsRef = React.useRef<Orb[]>([]);
   const sizeRef = React.useRef<{ w: number; h: number; dpr: number }>({ w: 0, h: 0, dpr: 1 });
   const reducedMotionRef = React.useRef<boolean>(false);
+  /** One pre-rendered gradient bitmap per orb; see bakeOrb. */
+  const spritesRef = React.useRef<HTMLCanvasElement[]>([]);
+  const spriteDprRef = React.useRef<number>(0);
+  const lastPaintRef = React.useRef<number>(0);
 
   React.useEffect(() => {
     const canvas = canvasRef.current;
@@ -89,33 +132,42 @@ export function AtmosphericBackdrop() {
       canvas.style.height = `${h}px`;
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
       if (orbsRef.current.length === 0) orbsRef.current = makeOrbs(w, h);
+      // Bake once, and again only if the device pixel ratio actually changes
+      // (dragging the window to a different-density display). Orb radii do
+      // not depend on viewport size, so a plain resize reuses the sprites.
+      if (spritesRef.current.length !== orbsRef.current.length || spriteDprRef.current !== dpr) {
+        spritesRef.current = orbsRef.current.map((orb) => bakeOrb(orb, dpr));
+        spriteDprRef.current = dpr;
+      }
     };
     resize();
     window.addEventListener("resize", resize);
 
     const paint = (t: number) => {
+      // Ambient drift at 60fps buys nothing — these orbs move well under a
+      // pixel per frame. Halving the rate halves the whole cost of the
+      // backdrop, app-wide. `t === 0` is the reduced-motion still frame,
+      // which must always paint.
+      if (t && t - lastPaintRef.current < FRAME_MS) {
+        rafRef.current = requestAnimationFrame(paint);
+        return;
+      }
+      lastPaintRef.current = t;
+
       const { w, h } = sizeRef.current;
       ctx.clearRect(0, 0, w, h);
 
       // The pale-green background tint preserved — the backdrop must NOT
       // paint a big opaque fill; the page's own --bg shows through.
-      for (const orb of orbsRef.current) {
-        const x = orb.x;
-        const y = orb.y;
-        const rad = orb.r * (0.7 + orb.z * 0.6);
-        // Peak opacity 0.10 on the closest orbs; falls off with depth.
-        const alpha = 0.035 + orb.z * 0.07;
-
-        const grad = ctx.createRadialGradient(x, y, 0, x, y, rad);
-        grad.addColorStop(0, hexToRgba(orb.color, alpha));
-        grad.addColorStop(0.55, hexToRgba(orb.color, alpha * 0.45));
-        grad.addColorStop(1, hexToRgba(orb.color, 0));
-
-        ctx.fillStyle = grad;
-        ctx.beginPath();
-        ctx.arc(x, y, rad, 0, Math.PI * 2);
-        ctx.fill();
-      }
+      const sprites = spritesRef.current;
+      orbsRef.current.forEach((orb, i) => {
+        const sprite = sprites[i];
+        if (!sprite) return;
+        const rad = orbRadius(orb);
+        // Peak opacity 0.10 on the closest orbs; falls off with depth — both
+        // already baked into the sprite.
+        ctx.drawImage(sprite, orb.x - rad, orb.y - rad, rad * 2, rad * 2);
+      });
 
       if (reducedMotionRef.current) return;
 

--- a/frontend/src/components/KnowledgeGraph2D.tsx
+++ b/frontend/src/components/KnowledgeGraph2D.tsx
@@ -444,12 +444,14 @@ function KnowledgeGraph2DImpl({
   // link endpoints from ids into node references once the simulation runs,
   // so this only gets consulted before that swap — but that is exactly the
   // first, busiest frames.
-  // One O(N) pass per render, shared by every edge below — versus the O(E x N)
-  // the per-edge `.find()` cost. Deliberately NOT memoised: `simNodes` is a
-  // ref's array, and feeding a ref-derived value into a hook's dependency list
-  // is exactly what the "no refs during render" rule forbids. The build is
-  // cheap enough that caching it would trade a real lint violation for a
-  // saving nobody can measure.
+  // One O(N) pass per render, shared by every edge below, replacing the
+  // per-edge `.find()` that made edge rendering O(E x N) every frame.
+  //
+  // Not memoised, but not because memoising would cost anything at lint level
+  // — measured, `useMemo` here reports the same react-hooks/refs count. It is
+  // simply that `simNodes` is a ref's array mutated in place, so it is not a
+  // sound useMemo dependency: its identity would not change when its contents
+  // do. An unconditional 226-entry rebuild is both correct and cheap.
   const nodeById = new Map<string, SimNode>();
   for (const n of simNodes) nodeById.set(n.id, n);
 

--- a/frontend/src/components/KnowledgeGraph2D.tsx
+++ b/frontend/src/components/KnowledgeGraph2D.tsx
@@ -137,6 +137,8 @@ function KnowledgeGraph2DImpl({
   const simLinksRef = React.useRef<SimLink[]>([]);
 
   const [, forceRerender] = React.useReducer((x) => x + 1, 0);
+  /** Pending coalesced tick render (see the simulation's "tick" handler). */
+  const tickRafRef = React.useRef<number | null>(null);
   const [hovered, setHovered] = React.useState<GraphNode | null>(null);
   const [tooltipPos, setTooltipPos] = React.useState({ x: 0, y: 0 });
   const [view, setView] = React.useState({ tx: 0, ty: 0, scale: 1 });
@@ -173,8 +175,11 @@ function KnowledgeGraph2DImpl({
       } as SimNode;
     });
 
+    // Set membership rather than two linear scans per edge — same O(E x N)
+    // shape as the render-time lookup below, just on the data-prep side.
+    const nextNodeIds = new Set(nextNodes.map((n) => n.id));
     const nextLinks: SimLink[] = edges
-      .filter((e) => nextNodes.some((n) => n.id === e.source) && nextNodes.some((n) => n.id === e.target))
+      .filter((e) => nextNodeIds.has(e.source) && nextNodeIds.has(e.target))
       .map((e) => ({ source: e.source, target: e.target, strength: e.strength }));
 
     simNodesRef.current = nextNodes;
@@ -182,7 +187,21 @@ function KnowledgeGraph2DImpl({
 
     if (!simRef.current) {
       simRef.current = forceSimulation<SimNode>(nextNodes).on("tick", () => {
-        forceRerender();
+        // Coalesce ticks into at most ONE React render per animation frame.
+        // d3's internal timer can fire more than once per frame under load,
+        // and each render reconciles the whole SVG — every node group, every
+        // edge line. Extra renders inside one frame are invisible by
+        // definition: the browser only paints once.
+        //
+        // This deliberately does not touch the reduced-motion / test-mode
+        // path below: `simulation.tick()` does not dispatch "tick" events
+        // (only the internal timer does), so the synchronous settle still
+        // renders exactly once, synchronously, and stays deterministic.
+        if (tickRafRef.current != null) return;
+        tickRafRef.current = requestAnimationFrame(() => {
+          tickRafRef.current = null;
+          forceRerender();
+        });
       });
     } else {
       simRef.current.nodes(nextNodes);
@@ -229,6 +248,12 @@ function KnowledgeGraph2DImpl({
     return () => {
       simRef.current?.stop();
       simRef.current = null;
+      // Drop any tick render still queued for the next frame, so it can't
+      // fire against an unmounted tree.
+      if (tickRafRef.current != null) {
+        cancelAnimationFrame(tickRafRef.current);
+        tickRafRef.current = null;
+      }
     };
   }, []);
 
@@ -344,7 +369,12 @@ function KnowledgeGraph2DImpl({
   };
 
   const onPointerMove = (e: React.PointerEvent) => {
-    setTooltipPos({ x: e.clientX, y: e.clientY });
+    // Only while a tooltip is actually showing. This used to run
+    // unconditionally on every pointer move across the whole SVG, so simply
+    // moving the mouse over empty canvas re-rendered the entire graph — for a
+    // value nothing reads unless `hovered` is set (see the tooltip below).
+    // Entering a node seeds the position, so the first frame is placed right.
+    if (hovered) setTooltipPos({ x: e.clientX, y: e.clientY });
     const drag = dragRef.current;
     if (!drag || e.pointerId !== drag.pointerId) return;
     movedRef.current = true;
@@ -410,6 +440,18 @@ function KnowledgeGraph2DImpl({
 
   const simNodes = simNodesRef.current;
   const simLinks = simLinksRef.current;
+  // Built once per render and shared by every edge below. d3-force mutates
+  // link endpoints from ids into node references once the simulation runs,
+  // so this only gets consulted before that swap — but that is exactly the
+  // first, busiest frames.
+  // One O(N) pass per render, shared by every edge below — versus the O(E x N)
+  // the per-edge `.find()` cost. Deliberately NOT memoised: `simNodes` is a
+  // ref's array, and feeding a ref-derived value into a hook's dependency list
+  // is exactly what the "no refs during render" rule forbids. The build is
+  // cheap enough that caching it would trade a real lint violation for a
+  // saving nobody can measure.
+  const nodeById = new Map<string, SimNode>();
+  for (const n of simNodes) nodeById.set(n.id, n);
 
   return (
     <div style={{ position: "relative", width, height, overflow: "hidden", background: "transparent" }}>
@@ -440,8 +482,12 @@ function KnowledgeGraph2DImpl({
           {/* Edges */}
           <g>
             {simLinks.map((l, i) => {
-              const s = typeof l.source === "object" ? (l.source as SimNode) : simNodes.find((n) => n.id === l.source);
-              const t = typeof l.target === "object" ? (l.target as SimNode) : simNodes.find((n) => n.id === l.target);
+              // Map lookup, not a linear scan: this runs for every edge on
+              // every render, and the render happens on every settled frame
+              // of the simulation — so a `.find()` here was O(edges x nodes)
+              // per frame.
+              const s = typeof l.source === "object" ? (l.source as SimNode) : nodeById.get(l.source as string);
+              const t = typeof l.target === "object" ? (l.target as SimNode) : nodeById.get(l.target as string);
               if (!s || !t || s.x == null || t.x == null) return null;
               const op = variant === "constellation" ? 0.35 : 0.2;
               return (
@@ -478,7 +524,13 @@ function KnowledgeGraph2DImpl({
                   data-node-id={n.id}
                   style={{ cursor: "grab" }}
                   onPointerDown={(ev) => onNodePointerDown(ev, n)}
-                  onPointerEnter={() => setHovered(n)}
+                  onPointerEnter={(ev) => {
+                    setHovered(n);
+                    // Seed the position here: onPointerMove only tracks while
+                    // something is hovered, so without this the tooltip would
+                    // show at the previous hover's coordinates for one frame.
+                    setTooltipPos({ x: ev.clientX, y: ev.clientY });
+                  }}
                   onPointerLeave={() => setHovered((h) => (h?.id === n.id ? null : h))}
                   onClick={(ev) => {
                     ev.stopPropagation();

--- a/frontend/src/components/MarkdownChat.tsx
+++ b/frontend/src/components/MarkdownChat.tsx
@@ -199,7 +199,7 @@ const COMPONENTS: Components = {
     <img
       src={typeof src === "string" ? src : undefined}
       alt={alt || ""}
-      loading="lazy"
+      loading="lazy" decoding="async"
       style={{
         maxWidth: "100%",
         height: "auto",

--- a/frontend/src/components/ReportIssueFlow.tsx
+++ b/frontend/src/components/ReportIssueFlow.tsx
@@ -195,7 +195,7 @@ export function ReportIssueFlow({ open, onClose }: ReportIssueFlowProps) {
                 border: "1px solid var(--border)",
               }}
             >
-              <img src={s.preview} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+              <img src={s.preview} alt="" decoding="async" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
               <button
                 onClick={() => removeScreenshot(i)}
                 aria-label="Remove screenshot"

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -110,7 +110,7 @@ export function SideNav() {
       >
         <img
           src="/sapling-icon.svg"
-          alt="Sapling"
+          alt="Sapling" width={32} height={32}
           style={{
             width: 32,
             height: 32,

--- a/frontend/src/components/SignInModal.tsx
+++ b/frontend/src/components/SignInModal.tsx
@@ -249,7 +249,7 @@ export default function SignInModal({ open, onClose, errorCode }: SignInModalPro
         >×</button>
 
         <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 24 }}>
-          <img src="/sapling-icon.svg" alt="Sapling" style={{ width: 22, height: 22 }} />
+          <img src="/sapling-icon.svg" alt="Sapling" width={22} height={22} style={{ width: 22, height: 22 }} />
           <span style={{ fontFamily: "var(--font-spectral), 'Spectral', Georgia, serif", fontWeight: 700, fontSize: 17, color: "var(--brand-forest)", letterSpacing: "-0.02em" }}>Sapling</span>
         </div>
 

--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -168,7 +168,7 @@ export function TopNav() {
       <Link href="/dashboard" style={{ display: "flex", alignItems: "center", gap: "2px", textDecoration: "none" }}>
         <img
           src="/sapling-icon.svg"
-          alt="Sapling"
+          alt="Sapling" width={32} height={32}
           style={{
             width: "32px",
             height: "32px",

--- a/frontend/src/components/screens/Admin.tsx
+++ b/frontend/src/components/screens/Admin.tsx
@@ -936,7 +936,7 @@ function CosmeticsTab() {
               />
             </div>
             {form.asset_url && (
-              <img src={form.asset_url} alt="" loading="lazy" style={{ maxHeight: 56, marginTop: 6, borderRadius: "var(--r-sm)", border: "1px solid var(--border)" }} />
+              <img src={form.asset_url} alt="" loading="lazy" decoding="async" style={{ maxHeight: 56, marginTop: 6, borderRadius: "var(--r-sm)", border: "1px solid var(--border)" }} />
             )}
           </LabeledField>
         )}
@@ -983,7 +983,7 @@ function CosmeticsTab() {
               <CatalogRow
                 key={c.id}
                 left={c.asset_url ? (
-                  <img src={c.asset_url} alt="" width={28} height={28} loading="lazy" style={{ width: 28, height: 28, borderRadius: "var(--r-sm)", objectFit: "cover", border: "1px solid var(--border)" }} />
+                  <img src={c.asset_url} alt="" width={28} height={28} loading="lazy" decoding="async" style={{ width: 28, height: 28, borderRadius: "var(--r-sm)", objectFit: "cover", border: "1px solid var(--border)" }} />
                 ) : c.css_value ? (
                   <span style={{ padding: "2px 6px", fontSize: 10, borderRadius: "var(--r-sm)", background: c.css_value, color: "#fff", border: "1px solid var(--border)" }}>
                     sample

--- a/frontend/src/components/screens/Settings.tsx
+++ b/frontend/src/components/screens/Settings.tsx
@@ -890,7 +890,7 @@ function CosmeticPreview({
           <img
             src={cosmetic.asset_url}
             alt=""
-            loading="lazy"
+            loading="lazy" decoding="async"
             style={{ position: "absolute", inset: 0, width: "100%", height: "100%", pointerEvents: "none", objectFit: "contain" }}
           />
         )}
@@ -900,7 +900,7 @@ function CosmeticPreview({
   if (cosmetic.type === "banner" && cosmetic.asset_url) {
     return (
       <div style={{ width: "100%", height: 48, borderRadius: "var(--r-sm)", overflow: "hidden", border: "1px solid var(--border)" }}>
-        <img src={cosmetic.asset_url} alt="" loading="lazy" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+        <img src={cosmetic.asset_url} alt="" loading="lazy" decoding="async" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
       </div>
     );
   }

--- a/frontend/src/components/screens/Social.tsx
+++ b/frontend/src/components/screens/Social.tsx
@@ -624,7 +624,7 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
                     }}
                   >
                     {m.image_url && (
-                      <img src={m.image_url} alt="attachment" loading="lazy" style={{ maxWidth: 260, borderRadius: "var(--r-sm)", marginBottom: m.text ? 6 : 0 }} />
+                      <img src={m.image_url} alt="attachment" loading="lazy" decoding="async" style={{ maxWidth: 260, borderRadius: "var(--r-sm)", marginBottom: m.text ? 6 : 0 }} />
                     )}
                     {renderText(m.text)}
                     {m.edited_at && <span style={{ fontSize: 10, opacity: 0.6, marginLeft: 6 }}>(edited)</span>}

--- a/frontend/src/lib/linkPairs.test.ts
+++ b/frontend/src/lib/linkPairs.test.ts
@@ -66,6 +66,25 @@ describe('linkPairs', () => {
     expect(linkPairs([points[1], points[0]], REACH)).toEqual([{ i: 0, j: 1, d: 50 }]);
   });
 
+  it('does not duplicate pairs when the grid spans a wide coordinate range', () => {
+    // Regression: the grid used to pack (gx, gy) into one integer assuming
+    // both stayed inside a bound. A small `reach` makes cells small, so the
+    // grid coordinates blow past it, two different cells collide, the same
+    // bucket gets visited twice in one 3x3 scan — and the pair is emitted
+    // TWICE. Found in review; this is the exact repro.
+    const points: ProjectedPoint[] = [
+      { x: 0, y: 0, sc: 1 },
+      { x: 0, y: 5000, sc: 1 },
+      { x: 0.5, y: 5000.4, sc: 1 },
+    ];
+    expect(linkPairs(points, 1)).toEqual(linkPairsNaive(points, 1));
+    expect(linkPairs(points, 1)).toHaveLength(1);
+
+    // And at a range no packed key could have survived at all.
+    const far = cloud(31, 120, 4_000_000).map((p) => ({ ...p, sc: 0.02 }));
+    expect(linkPairs(far, REACH)).toEqual(linkPairsNaive(far, REACH));
+  });
+
   it('degenerates safely', () => {
     expect(linkPairs([], REACH)).toEqual([]);
     expect(linkPairs([{ x: 0, y: 0, sc: 1 }], REACH)).toEqual([]);

--- a/frontend/src/lib/linkPairs.test.ts
+++ b/frontend/src/lib/linkPairs.test.ts
@@ -1,0 +1,94 @@
+/**
+ * #111 — the binned link pass must be a drop-in for the all-pairs one.
+ *
+ * The perf PR claims "no visual change". For this optimisation that claim is
+ * checkable rather than aspirational: the fast version has to emit the same
+ * pairs, in the same order, with the same distances. Order is part of it —
+ * the caller strokes translucent overlapping lines, so a different sequence
+ * composites to a different image.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { linkPairs, linkPairsNaive, type ProjectedPoint } from './linkPairs';
+
+const REACH = 70;
+
+/** Deterministic PRNG, so a failure is reproducible. */
+function makeRng(seed: number) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+/** A cloud shaped like the real one: 226 nodes, scales spanning the projection. */
+function cloud(seed: number, count: number, spread: number): ProjectedPoint[] {
+  const rnd = makeRng(seed);
+  return Array.from({ length: count }, () => ({
+    x: (rnd() - 0.5) * spread,
+    y: (rnd() - 0.5) * spread,
+    sc: 0.7 + rnd() * 1.0,
+  }));
+}
+
+describe('linkPairs', () => {
+  it('matches the all-pairs reference exactly, across many random clouds', () => {
+    for (let seed = 1; seed <= 40; seed++) {
+      const points = cloud(seed, 226, 1600);
+      expect(linkPairs(points, REACH), `seed ${seed}`).toEqual(linkPairsNaive(points, REACH));
+    }
+  });
+
+  it('matches at densities that stress the binning', () => {
+    // Tight cloud: nearly everything is within reach, so buckets are huge.
+    const dense = cloud(7, 200, 120);
+    expect(linkPairs(dense, REACH)).toEqual(linkPairsNaive(dense, REACH));
+    // Sparse cloud: almost nothing links, so most buckets are empty.
+    const sparse = cloud(8, 200, 20000);
+    expect(linkPairs(sparse, REACH)).toEqual(linkPairsNaive(sparse, REACH));
+  });
+
+  it('handles negative coordinates, which the parallax offset produces', () => {
+    const shifted = cloud(11, 150, 1200).map((p) => ({ ...p, x: p.x - 3000, y: p.y - 2000 }));
+    expect(linkPairs(shifted, REACH)).toEqual(linkPairsNaive(shifted, REACH));
+  });
+
+  it('is asymmetric in the same way the original was', () => {
+    // The threshold comes from the FIRST point, so a small-scale point can
+    // fail to reach a partner that would have reached it. Order must not be
+    // silently normalised away.
+    const points: ProjectedPoint[] = [
+      { x: 0, y: 0, sc: 0.1 }, // reach 7
+      { x: 50, y: 0, sc: 2.0 }, // reach 140
+    ];
+    expect(linkPairs(points, REACH)).toEqual([]);
+    expect(linkPairs([points[1], points[0]], REACH)).toEqual([{ i: 0, j: 1, d: 50 }]);
+  });
+
+  it('degenerates safely', () => {
+    expect(linkPairs([], REACH)).toEqual([]);
+    expect(linkPairs([{ x: 0, y: 0, sc: 1 }], REACH)).toEqual([]);
+    // A zero reach links nothing and must not divide by a zero cell size.
+    expect(linkPairs(cloud(3, 20, 500), 0)).toEqual([]);
+    // Coincident points are at distance 0, which is inside any positive reach.
+    const stacked = Array.from({ length: 4 }, () => ({ x: 5, y: 5, sc: 1 }));
+    expect(linkPairs(stacked, REACH)).toEqual(linkPairsNaive(stacked, REACH));
+  });
+
+  it('actually avoids the all-pairs work', () => {
+    // Guard against a future "simplification" that quietly restores the
+    // double loop: on a sparse cloud the binned version must measure far
+    // fewer distances than the naive one would.
+    const points = cloud(21, 400, 9000);
+    let measured = 0;
+    const counting = points.map((p) => ({
+      get x() { measured++; return p.x; },
+      get y() { return p.y; },
+      get sc() { return p.sc; },
+    })) as unknown as ProjectedPoint[];
+    linkPairs(counting, REACH);
+    const allPairs = (points.length * (points.length - 1)) / 2;
+    expect(measured).toBeLessThan(allPairs / 4);
+  });
+});

--- a/frontend/src/lib/linkPairs.ts
+++ b/frontend/src/lib/linkPairs.ts
@@ -1,0 +1,93 @@
+/**
+ * Which projected nodes the landing hero canvas draws a link between (#111).
+ *
+ * The rule: for an ordered pair i < j, link them when their 2D distance is
+ * under `reach * points[i].sc`. The threshold comes from the FIRST point's
+ * scale, so the relation is not symmetric and the ordering matters.
+ *
+ * This ran as an uncapped double loop on every frame — ~25k distance checks
+ * for 226 nodes, to draw the few dozen pairs that actually qualify. Since a
+ * point can only reach `reach * sc` pixels, binning into a grid whose cell is
+ * the largest such radius means every possible partner lies in the 3x3 block
+ * around it, and nothing else is ever measured.
+ *
+ * Extracted from the canvas so the fast version can be proved equivalent to
+ * the obvious one (see linkPairs.test.ts) rather than merely believed to be.
+ */
+export type ProjectedPoint = { x: number; y: number; sc: number };
+export type LinkPair = { i: number; j: number; d: number };
+
+/**
+ * The obvious all-pairs implementation. Kept as the executable definition of
+ * correctness for the binned version below — not used to render.
+ */
+export function linkPairsNaive(points: ProjectedPoint[], reach: number): LinkPair[] {
+  const out: LinkPair[] = [];
+  for (let i = 0; i < points.length; i++) {
+    const p1 = points[i];
+    const threshold = reach * p1.sc;
+    for (let j = i + 1; j < points.length; j++) {
+      const p2 = points[j];
+      const d = Math.hypot(p1.x - p2.x, p1.y - p2.y);
+      if (d < threshold) out.push({ i, j, d });
+    }
+  }
+  return out;
+}
+
+/**
+ * Spatially binned equivalent. Emits pairs in the same order as
+ * `linkPairsNaive` — ascending i, then ascending j — which matters because
+ * the caller strokes translucent overlapping lines, and draw order decides
+ * the composited result.
+ */
+export function linkPairs(points: ProjectedPoint[], reach: number): LinkPair[] {
+  const out: LinkPair[] = [];
+  if (points.length === 0) return out;
+
+  let maxR = 0;
+  for (const p of points) {
+    const r = reach * p.sc;
+    if (r > maxR) maxR = r;
+  }
+  // A non-positive reach links nothing; guard before it becomes a zero cell.
+  if (maxR <= 0) return out;
+  const cell = maxR;
+
+  // Grid coords stay far inside +/-1024 for any plausible viewport, so they
+  // pack into a single integer key with no collisions.
+  const key = (gx: number, gy: number) => ((gx + 1024) << 12) | (gy + 1024);
+
+  const grid = new Map<number, number[]>();
+  for (let i = 0; i < points.length; i++) {
+    const k = key(Math.floor(points[i].x / cell), Math.floor(points[i].y / cell));
+    const bucket = grid.get(k);
+    if (bucket) bucket.push(i);
+    else grid.set(k, [i]);
+  }
+
+  const candidates: number[] = [];
+  for (let i = 0; i < points.length; i++) {
+    const p1 = points[i];
+    const threshold = reach * p1.sc;
+    const gx = Math.floor(p1.x / cell);
+    const gy = Math.floor(p1.y / cell);
+
+    candidates.length = 0;
+    for (let ox = -1; ox <= 1; ox++) {
+      for (let oy = -1; oy <= 1; oy++) {
+        const bucket = grid.get(key(gx + ox, gy + oy));
+        if (!bucket) continue;
+        for (const j of bucket) if (j > i) candidates.push(j);
+      }
+    }
+    candidates.sort((a, b) => a - b);
+
+    for (const j of candidates) {
+      const p2 = points[j];
+      const d = Math.hypot(p1.x - p2.x, p1.y - p2.y);
+      if (d < threshold) out.push({ i, j, d });
+    }
+  }
+  return out;
+}

--- a/frontend/src/lib/linkPairs.ts
+++ b/frontend/src/lib/linkPairs.ts
@@ -54,16 +54,24 @@ export function linkPairs(points: ProjectedPoint[], reach: number): LinkPair[] {
   if (maxR <= 0) return out;
   const cell = maxR;
 
-  // Grid coords stay far inside +/-1024 for any plausible viewport, so they
-  // pack into a single integer key with no collisions.
-  const key = (gx: number, gy: number) => ((gx + 1024) << 12) | (gy + 1024);
-
-  const grid = new Map<number, number[]>();
+  // Column-of-rows rather than one packed integer key. A packed key needs a
+  // bound on the grid coordinates to stay collision-free, and this is an
+  // exported general-purpose helper — a caller with a small `reach` or a wide
+  // coordinate space would silently blow that bound and get two different
+  // cells hashing together, which shows up as DUPLICATED pairs (the same
+  // bucket visited twice in one 3x3 scan). Nesting has no such precondition.
+  const grid = new Map<number, Map<number, number[]>>();
   for (let i = 0; i < points.length; i++) {
-    const k = key(Math.floor(points[i].x / cell), Math.floor(points[i].y / cell));
-    const bucket = grid.get(k);
+    const gx = Math.floor(points[i].x / cell);
+    const gy = Math.floor(points[i].y / cell);
+    let column = grid.get(gx);
+    if (!column) {
+      column = new Map<number, number[]>();
+      grid.set(gx, column);
+    }
+    const bucket = column.get(gy);
     if (bucket) bucket.push(i);
-    else grid.set(k, [i]);
+    else column.set(gy, [i]);
   }
 
   const candidates: number[] = [];
@@ -75,8 +83,10 @@ export function linkPairs(points: ProjectedPoint[], reach: number): LinkPair[] {
 
     candidates.length = 0;
     for (let ox = -1; ox <= 1; ox++) {
+      const column = grid.get(gx + ox);
+      if (!column) continue;
       for (let oy = -1; oy <= 1; oy++) {
-        const bucket = grid.get(key(gx + ox, gy + oy));
+        const bucket = column.get(gy + oy);
         if (!bucket) continue;
         for (const j of bucket) if (j > i) candidates.push(j);
       }


### PR DESCRIPTION
Four hot spots, no visual change. **Half of #111 was already fixed on main** and is untouched here — the landing canvas already respects reduced-motion, per-node `shadowBlur` is gone (0 hits repo-wide), the floating-cards RAF already resolves its NodeList once, and the spotlight rect is already cached. Those claims in the issue body are stale; this PR is only the genuinely remaining work.

## 1. Hero canvas link pass — measured 0.353ms → 0.097ms per frame (3.6×)

An uncapped double loop measured all **25,425** pairs of the 226 projected nodes every frame, to draw the ~**213** that actually qualify. 99.2% of the distance checks were wasted.

A node can only link within `70 * sc` px, so binning into a grid whose cell is the *largest* such radius means every possible partner sits in the 3×3 block around it and nothing else is ever measured.

Extracted to `lib/linkPairs.ts` so "identical output" is **provable rather than asserted**: `linkPairs.test.ts` compares it to the all-pairs reference across 40 random clouds plus dense, sparse, negative-coordinate, asymmetric and degenerate cases — and checks the emission **order** matches, because these are translucent overlapping strokes and order decides the composited image. One test also guards against a future "simplification" quietly restoring the double loop.

## 2. AtmosphericBackdrop — 14 gradients per frame → 14 blits, at half the rate

It rebuilt 14 full-viewport radial gradients *every frame at 60fps*, app-wide, mounted twice by `ShellFrame`. Everything a gradient depends on — colour, radius, depth-derived alpha — is fixed when the orb is created; only x/y move.

Each orb is baked once into an offscreen canvas and blitted; the loop is capped at ~30fps (ambient drift moves well under a pixel per frame). Re-bakes only when the device pixel ratio actually changes.

The reduced-motion still-frame path is preserved exactly, **including** the existing behaviour that switching reduced-motion on mid-session stops the loop.

## 3. KnowledgeGraph2D — three problems

- **Tick storm.** `.on("tick", forceRerender)` reconciled the whole SVG per physics tick. Ticks now coalesce into at most one render per animation frame. This does **not** touch the deterministic settle: `simulation.tick()` does not dispatch tick events (only the internal timer does), so the reduced-motion/test-mode path still renders once, synchronously, and stays deterministic.
- **Tooltip churn.** `setTooltipPos` was the unconditional first statement of `onPointerMove` — moving the mouse over empty canvas re-rendered the entire graph to update a value nothing reads unless `hovered` is set. Now gated, with the position seeded on pointer-enter so the first frame still lands correctly.
- **O(E·N) lookups.** Edge rendering used `.find()` per endpoint per edge per frame; the link filter did two `.some()` scans per edge. Both now use a Map/Set.

The offscreen `IntersectionObserver` pause and unmount cleanup are preserved, and the queued tick render is cancelled on unmount so it can't fire against a dead tree.

## 4. Images and framer-motion

Intrinsic `width`/`height` on the **19** brand-icon sites (a fixed-size asset whose box was only pinned in inline CSS, so nothing reserved it before styles resolved), and `decoding="async"` on the lazily-loaded ones. `next/image` deliberately not adopted, per your call.

`HowItWorks` (~54 `motion.*`, the landing page's only framer-motion consumer) is now `next/dynamic`, so the library leaves the critical path for a section below the fold. **Not** `ssr: false` — the markup still server-renders.

**`Study.tsx` and `Calendar.tsx` are deliberately left alone.** The brief listed them, but both wrap their screen's *primary content* in the motion element — deferring it would defer the content itself, which is worse than the bundle cost it saves. `Calendar.test.tsx`'s framer-motion mock stays green either way.

## One suppression count moves

`KnowledgeGraph2D` `react-hooks/refs` 13 → 14. Building the id→node Map is one more use of a ref-derived value during render, in a file where that pattern is already baselined 13 times. I verified in isolation that the Map is the sole cause (restoring `.find()` returns it to 13), and tried three formulations — all cost the same. The trade is one more instance of an existing suppressed pattern in exchange for deleting a per-frame O(E·N) scan.

## Gates

- `tsc --noEmit` clean · `npm run lint` 0 errors (35 warnings, one fewer than before) · `npx vitest run` 59 files, 415 tests
- Full local e2e cycle — recorded in a comment below

part of #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved responsiveness of the interactive knowledge graph and animated background effects.
  * Optimized homepage canvas link rendering for smoother visual performance.
  * Improved image loading and decoding across chat, reports, settings, and other screens.
  * Added image dimensions to logos to reduce layout shifts during page loading.

* **Tests**
  * Added comprehensive coverage for visual link-generation behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->