### PR TITLE
docs(frontend): correct the engine-strict guard — it blocks `npm ci` too

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -7,12 +7,28 @@
 #
 # What `engine-strict=true` actually does:
 #
-# It makes LOCAL `npm install` fail fast against the package.json
-# `engines` constraint when the running npm is out of range, stopping
-# the bad lockfile commit at its source. It does NOT change `npm ci`'s
-# behavior — `npm ci` ignores engine-strict in npm >=7. So this is a
-# guard on the WRITE path (regeneration), not the READ path
-# (consumption).
+# It makes npm fail fast against the package.json `engines` constraint
+# whenever the running npm is out of range. It blocks BOTH paths:
+#
+#   npm install — the WRITE path this guard exists for: it stops a
+#                 lockfile regenerated on the wrong npm at its source.
+#   npm ci      — the READ path, too. Verified 2026-07-31 on npm 12.0.1
+#                 against this `<11` pin: exit 1, code EBADENGINE.
+#
+# An earlier version of this comment claimed `npm ci` ignores
+# engine-strict in npm >=7. That is false for modern npm, and believing
+# it costs time: the #113 frontend audit (2026-07-03, npm 11.6.2) lost a
+# session to an empty node_modules and a silently disabled lint gate.
+#
+# So on npm 11+/12+ a plain `npm ci` fails. Either install the pinned
+# npm (`npm install -g npm@10.9.2` — what CI does), or unblock the READ
+# path only:
+#
+#     npm_config_engine_strict=false npm ci
+#
+# NEVER pair that bypass with `npm install`/`npm update` and commit the
+# result — an off-pin lockfile is precisely what breaks the Cloudflare
+# deploy described above.
 #
 # Pin: matches package.json engines — node >=20.9.0, npm 10.9.x.
 #

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,11 +8,27 @@ Visual system: warm paper neutrals, botanical forest-green accent, serif (Spectr
 
 ```bash
 cd frontend
-npm install          # Node >= 20.9, npm >= 10.9
+npm install          # Node >= 20.9, npm >= 10.9 <11 — enforced, see below
 npm run dev          # http://localhost:3000
 ```
 
 Backend `/api/*` calls are rewritten to `http://localhost:5000` by default (override via `BACKEND_URL`). For the real local backend stack, see `docs/local-supabase.md`.
+
+### If your npm is 11 or newer
+
+`.npmrc` sets `engine-strict=true` against a `npm >=10.9.0 <11` pin, and that blocks **`npm ci` as well as `npm install`** — verified on npm 12.0.1 (exit 1, `EBADENGINE`). The failure mode is quiet: `node_modules` stays empty, so `npm run lint` / `npm run typecheck` stop being a real gate rather than reporting an error. Either install the pinned npm:
+
+```bash
+npm install -g npm@10.9.2      # what CI does before `npm ci`
+```
+
+or unblock the read path only:
+
+```bash
+npm_config_engine_strict=false npm ci    # restores node_modules + the lint gate
+```
+
+**Never pair that bypass with `npm install` and commit the regenerated `package-lock.json`.** Cloudflare Workers Builds runs `npm ci` on npm 10.9.2 and rejects an off-pin lockfile with `Missing X from lock file`, breaking the deploy — that is the entire reason the pin exists. See `frontend/.npmrc` for the full rationale and the relax-plan for when CF upgrades its runner.
 
 ## Build & deploy
 


### PR DESCRIPTION
`frontend/.npmrc` told contributors that `engine-strict=true` was a **write-path-only** guard, because "`npm ci` ignores engine-strict in npm >=7". That is false for modern npm.

Probed against a minimal package carrying the same `>=10.9.0 <11` pin, on **npm 12.0.1 / node v26.4.0**:

| command | `engine-strict` | exit |
|---|---|---|
| `npm ci` | `true` | **1** — `EBADENGINE` |
| `npm install` | `true` | **1** — `EBADENGINE` |
| `npm_config_engine_strict=false npm ci` | bypassed | 0 |

It also explains a detail the old story never fit: the #113 frontend audit (2026-07-03, npm 11.6.2) had to run `npm_config_engine_strict=false npm **ci**`. If the guard were write-path-only, the bypass would not have been needed there at all. That session lost time to an empty `node_modules` — the failure is quiet, so `npm run lint` / `npm run typecheck` stop being a real gate instead of erroring.

## Changes

- **`frontend/.npmrc`** — replace the false mechanism block with what `engine-strict` actually does (both paths), the probe result and date, and the two real unblocks.
- **`frontend/README.md`** — new "If your npm is 11 or newer" section under Run, so a contributor hits the answer before the empty `node_modules`.

Both keep the never-commit-an-off-pin-lockfile rule prominent — an off-pin lockfile is what breaks the Cloudflare Workers deploy, and the whole reason the pin exists.

`.github/workflows/ci.yml`'s comment (":84 — `.npmrc` engine-strict=true enforces it during `npm ci`") was already correct and is unchanged.

Comments and docs only — no code, no lockfile, no dependency changes.

## Follow-up

The live Canopy doc `sapling-frontend-local-dev` carries the same false claim; a corrected **v2 is staged** and needs promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)