### PR TITLE
refactor(landing): delete unreachable effects and orphaned CSS (#344 phase 1)

### DIFF
--- a/frontend/eslint-suppressions.json
+++ b/frontend/eslint-suppressions.json
@@ -6,7 +6,7 @@
     "prefer-const": {
       "count": 2
     },
-    "react-hooks/immutability": {
+    "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },

--- a/frontend/src/app/(public)/page.tsx
+++ b/frontend/src/app/(public)/page.tsx
@@ -404,77 +404,16 @@ export default function LandingPage() {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
           entry.target.classList.remove('opacity-0', 'translate-y-[30px]');
-          if (entry.target.classList.contains('landing-stat-fade-up')) startCounters(entry.target as HTMLElement);
           obs.unobserve(entry.target);
         }
       });
     }, { threshold: 0.2 });
-    document.querySelectorAll('.landing-fade-up, .landing-stat-fade-up').forEach(el => {
+    document.querySelectorAll('.landing-fade-up').forEach(el => {
       el.classList.add('opacity-0', 'translate-y-[30px]', 'transition-all', 'duration-700', 'ease-out');
       obs.observe(el);
     });
     return () => obs.disconnect();
   }, []);
-
-  // Spotlight card mouse-follow
-  useEffect(() => {
-    const cards = Array.from(document.querySelectorAll<HTMLElement>('.landing-spotlight-card'));
-    if (cards.length === 0) return;
-
-    // `getBoundingClientRect` per mousemove forces a layout flush on every
-    // pointer sample. Measure on enter instead and hold the rect until
-    // something can actually have moved the card.
-    const rects = new WeakMap<HTMLElement, DOMRect>();
-
-    const measure = (card: HTMLElement) => {
-      const r = card.getBoundingClientRect();
-      rects.set(card, r);
-      return r;
-    };
-    const onEnter = (e: Event) => { measure(e.currentTarget as HTMLElement); };
-    const onMove = (e: MouseEvent) => {
-      const card = e.currentTarget as HTMLElement;
-      const r = rects.get(card) ?? measure(card);
-      card.style.setProperty('--mouse-x', `${e.clientX - r.left}px`);
-      card.style.setProperty('--mouse-y', `${e.clientY - r.top}px`);
-    };
-    // Rects are viewport-relative, so scrolling invalidates them even though
-    // the card hasn't moved in the document. Drop them and re-measure lazily.
-    const invalidate = () => { for (const c of cards) rects.delete(c); };
-
-    cards.forEach(c => {
-      c.addEventListener('mouseenter', onEnter);
-      c.addEventListener('mousemove', onMove);
-    });
-    window.addEventListener('scroll', invalidate, { passive: true });
-    window.addEventListener('resize', invalidate);
-    return () => {
-      cards.forEach(c => {
-        c.removeEventListener('mouseenter', onEnter);
-        c.removeEventListener('mousemove', onMove);
-      });
-      window.removeEventListener('scroll', invalidate);
-      window.removeEventListener('resize', invalidate);
-    };
-  }, []);
-
-  function startCounters(container: HTMLElement) {
-    container.querySelectorAll<HTMLElement>('.counter, .counter-float').forEach(el => {
-      if (el.classList.contains('counted')) return;
-      el.classList.add('counted');
-      const target = parseFloat(el.dataset.target || '0');
-      const isFloat = el.classList.contains('counter-float');
-      const dur = 1500, startT = performance.now();
-      function update(now: number) {
-        const p = Math.min((now - startT) / dur, 1);
-        const ease = 1 - Math.pow(1 - p, 4);
-        el.textContent = isFloat ? (target * ease).toFixed(1) : Math.floor(target * ease).toLocaleString();
-        if (p < 1) requestAnimationFrame(update);
-        else el.textContent = isFloat ? target.toFixed(1) : target.toLocaleString();
-      }
-      requestAnimationFrame(update);
-    });
-  }
 
   // ── Onboarding entry ──────────────────────────────────────────────
   // The signup flow lives at /onboarding (screens/Onboarding). Unauthenticated

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -390,7 +390,6 @@ body { font-size: 14px; line-height: 1.5; }
   .assignment-row:hover { background: var(--accent-soft); }
 }
 
-
 /* Course-detail two-column shell: assignment list (primary action surface)
  * on the left, sticky projection sidebar on the right. Collapses to a
  * single column below 1100px so the sidebar stacks above the list. */
@@ -683,44 +682,10 @@ body { font-size: 14px; line-height: 1.5; }
 .landing-intro-orbit-node--purple { background: #8A63D2;  left: -3px; top: 30%; transform: translateY(-50%); }
 
 /* ── Button shimmer ────────────────────────────────────────────── */
-.landing-btn-shimmer { position: relative; overflow: hidden; }
-.landing-btn-shimmer::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(to right, transparent, rgba(255,255,255,0.3), transparent);
-  transform: translateX(-200%);
-  transition: transform 0.7s ease;
-  border-radius: 9999px;
-  pointer-events: none;
-}
-.landing-btn-shimmer:hover::before { transform: translateX(200%); }
 
 /* ── Spotlight card (mouse-follow glow) ────────────────────────── */
-.landing-spotlight-card {
-  position: relative;
-  overflow: hidden;
-}
-.landing-spotlight-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 1rem;
-  background: radial-gradient(250px circle at var(--mouse-x, 0) var(--mouse-y, 0), rgba(27,108,66,0.04) 0%, transparent 70%);
-  opacity: 0;
-  transition: opacity 0.5s ease;
-  pointer-events: none;
-  z-index: 0;
-}
-.landing-spotlight-card:hover::before { opacity: 1; }
 
 /* ── Feature card icon hover ───────────────────────────────────── */
-.landing-icon-container {
-  transition: transform 0.4s var(--ease);
-}
-.landing-spotlight-card:hover .landing-icon-container {
-  transform: scale(1.1) rotate(5deg);
-}
 
 /* ── Landing scrollbar ─────────────────────────────────────────── */
 .landing-page ::-webkit-scrollbar       { width: 6px; }
@@ -821,7 +786,6 @@ input[type="reset"]:disabled {
 .cosmetic-equipped {
   transition: box-shadow 150ms ease, border-color 150ms ease;
 }
-
 
 /* ══════════════════════════════════════════════════════════════════
    PRE-AUTH (sign-in / landing) THEME — scoped to .landing-page only.
@@ -955,26 +919,7 @@ input[type="reset"]:disabled {
 .landing-page .landing-intro-orbit-node--blue   { background: var(--info);  bottom: -3px; left: 35%; transform: translateX(-50%); }
 .landing-page .landing-intro-orbit-node--purple { background: #8A63D2;  left: -3px; top: 30%; transform: translateY(-50%); }
 
-/* Button shimmer. */
-.landing-page .landing-btn-shimmer { position: relative; overflow: hidden; }
-.landing-page .landing-btn-shimmer::before {
-  content: ''; position: absolute; inset: 0;
-  background: linear-gradient(to right, transparent, rgba(255,255,255,0.3), transparent);
-  transform: translateX(-200%); transition: transform 0.7s ease;
-  border-radius: 9999px; pointer-events: none;
-}
-.landing-page .landing-btn-shimmer:hover::before { transform: translateX(200%); }
-
 /* Spotlight card hover glow. */
-.landing-page .landing-spotlight-card { position: relative; overflow: hidden; }
-.landing-page .landing-spotlight-card::before {
-  content: ""; position: absolute; inset: 0; border-radius: 1rem;
-  background: radial-gradient(250px circle at var(--mouse-x, 0) var(--mouse-y, 0), rgba(27,108,66,0.04) 0%, transparent 70%);
-  opacity: 0; transition: opacity 0.5s ease; pointer-events: none; z-index: 0;
-}
-.landing-page .landing-spotlight-card:hover::before { opacity: 1; }
-.landing-page .landing-icon-container { transition: transform 0.4s var(--ease); }
-.landing-page .landing-spotlight-card:hover .landing-icon-container { transform: scale(1.1) rotate(5deg); }
 
 /* Landing scrollbar. */
 .landing-page ::-webkit-scrollbar       { width: 6px; }


### PR DESCRIPTION
Phase 1 of the landing redesign: **dead-code removal only, no visual change.** Phases 2–4 need your and Jack's taste input and aren't touched.

## Removed — each verified unreachable, not assumed

| what | why it was dead |
|---|---|
| `startCounters` (18 lines) | its only caller was the `landing-stat-fade-up` branch of the fade-up observer, and that class appears in **no markup anywhere** |
| the spotlight mouse-follow effect (42 lines) | opens with `if (cards.length === 0) return`, and `.landing-spotlight-card` is applied in no markup — it early-returned on every mount |
| 16 orphaned CSS rules | `.landing-btn-shimmer`, `.landing-spotlight-card`, `.landing-icon-container` — zero consumers outside `globals.css`, in **both** the unscoped and scoped copies |

The observer itself stays: `.landing-fade-up` is live at three call sites, so only the stat branch and the dead selector go.

**Net: 117 deleted, 1 added.**

## One thing in the diff that looks alarming and isn't

The suppressions baseline swaps `react-hooks/immutability` → `react-hooks/set-state-in-effect` on `(public)/page.tsx`. **That is not a new violation.**

The deleted code mutated DOM styles and drove `requestAnimationFrame` loops, which made React Compiler bail out on the whole component — masking a pre-existing `setState` inside the mount-time URL-error effect at `:110`. Removing the dead code made the file analyzable again, and the latent violation surfaced.

Verified by swapping main's `page.tsx` into this branch: with main's file the full lint is **0 errors**, with mine it's **1**. Same suppressions file both times.

The pattern itself predates this PR and can't move to lazy state init — the initializer would also run during SSR, where `window` is undefined. Suppression count for the file is unchanged: one out, one in.

## Deliberately not done

The wider de-dup of the unscoped vs `.landing-page`-scoped rule blocks. I verified it's safe *in principle*:

- all 21 unscoped `landing-*` selectors have scoped twins
- the two apparent "properties only the unscoped rule defines" are comment-parsing artifacts — the scoped rules do define them, identically
- no `.public-surface` content page (about/careers/privacy/terms) uses a `landing-*` class

But the two blocks are **interleaved with 11 unrelated rules** (`.glass-panel`, `.liquid-glass-*`, `.glass-input`, `:root`, toast keyframes…), so it can't be a range delete — and this phase's own gate is *"screenshot diff shows no change"*, which I can't run here: Turbopack refuses the symlinked `node_modules` in a worktree. Left for a follow-up that can actually be screenshotted, rather than shipping ~200 lines of CSS deletion on the acquisition surface unverified.

Also untouched: the hint text (`"SEE WHAT'S INSIDE"`, `"Scroll the catalog"`, `"— end of catalog"`) and the page indicator. Both are **visible** changes, so they belong with your phase-2 sign-off, not in a zero-visual-change cleanup.

## Gates

- `tsc --noEmit` clean · `npm run lint` 0 errors · `npx vitest run` 58 files / 415 tests
- Full local e2e cycle — in a comment below

part of #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refinements**
  * Simplified landing-page scroll animations to focus on supported fade-up elements.
  * Removed animated statistic counters from the landing page.
  * Streamlined landing-page visual effects, including button shimmer, card glow, and feature-icon hover styling.
* **Maintenance**
  * Updated linting configuration to reflect the current React hook usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->