### PR TITLE
feat(ui): re-home onboarding onto app spacing/type tokens (#289)

### DIFF
--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -114,10 +114,15 @@ route:
 | `onboarding-continue` | primary advance button ("Continue" / "Enter Sapling →") |
 | `onboarding-back` | "Back" (absent on step 0) |
 | `onboarding-close` | "×" close/exit control |
-| `onboarding-input` | the shared `TextInput` used by every step |
-| `onboarding-chip-add` / `onboarding-chip-remove` | majors/minors chip editor |
-| `onboarding-course-result` / `onboarding-course-remove` | course search result and selected-course chip |
-| `onboarding-learning-style` | learning-style radio option |
+| `onboarding-input` | the shared `TextInput` default; every simultaneous instance overrides it (below) |
+| `onboarding-first-name` / `onboarding-last-name` | the two name fields — they render side by side |
+| `onboarding-school` | school field (disabled; BU-only today) |
+| `onboarding-chip-input-${field}` / `onboarding-chip-add-${field}` | majors/minors editor — `field` is `majors` or `minors`, since both render at once |
+| `onboarding-chip-remove-${field}-${value}` | one chip's remove control |
+| `onboarding-course-search` | course search field |
+| `onboarding-course-result-${course.id}` | one course search result |
+| `onboarding-course-remove-${course_code}` | one selected-course chip's remove control |
+| `onboarding-learning-style-${style.id}` | one learning-style radio option (5 render at once) |
 
 ### `upload-modal`
 

--- a/docs/frontend-testids.md
+++ b/docs/frontend-testids.md
@@ -68,6 +68,7 @@ renders the element.
 | --- | --- | --- |
 | Sign-in | `signin` | `frontend/src/components/marketing/SignInModal.tsx` (+ the trigger in `src/app/(public)/page.tsx`) |
 | Approval gate | `pending` | `frontend/src/app/pending/page.tsx` |
+| Onboarding | `onboarding` | `frontend/src/components/screens/Onboarding.tsx` (the first-run funnel, rendered bare outside `(shell)`) |
 | Upload modal | `upload-modal` | `frontend/src/components/DocumentUploadModal.tsx` |
 | Tutor | `tutor` | `frontend/src/components/chat/ChatPanel.tsx` (rendered by `screens/Learn.tsx`; + the session-resume rows in `src/components/screens/Learn.tsx` itself) |
 | Quiz | `quiz` | `frontend/src/components/QuizPanel.tsx` (rendered by `screens/Quiz.tsx`) |
@@ -109,6 +110,14 @@ route:
 | --- | --- |
 | `pending-gate` | approval-gate page root |
 | `pending-signout` | "Sign out" |
+| `onboarding-gate` | first-run onboarding page root |
+| `onboarding-continue` | primary advance button ("Continue" / "Enter Sapling →") |
+| `onboarding-back` | "Back" (absent on step 0) |
+| `onboarding-close` | "×" close/exit control |
+| `onboarding-input` | the shared `TextInput` used by every step |
+| `onboarding-chip-add` / `onboarding-chip-remove` | majors/minors chip editor |
+| `onboarding-course-result` / `onboarding-course-remove` | course search result and selected-course chip |
+| `onboarding-learning-style` | learning-style radio option |
 
 ### `upload-modal`
 

--- a/frontend/e2e/onboarding.spec.ts
+++ b/frontend/e2e/onboarding.spec.ts
@@ -15,9 +15,11 @@
  * mounts for an un-onboarded user, the nav affordances behave, and the token
  * conversion did not leave the layout collapsed.
  *
- * Signs in as USER_NEW rather than the default USER_ACTIVE: it is the only
- * seeded user with onboarding_completed=False, so it is the only one the
- * funnel renders for at all.
+ * Signs in as USER_NEW rather than the default USER_ACTIVE because it is the
+ * realistic state — onboarding_completed=False. It is NOT a gate: /onboarding
+ * sits outside middleware.ts's matcher and Onboarding.tsx only redirects when
+ * unauthenticated, so the route would render for any signed-in user. What the
+ * seed choice buys is a funnel showing its real first-run content.
  */
 import { expect, test } from "./support/fixtures";
 import { mintStorageState } from "./support/session";

--- a/frontend/e2e/onboarding.spec.ts
+++ b/frontend/e2e/onboarding.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Journey #289 — the first-run onboarding funnel renders and advances.
+ *
+ * There was no journey over `/onboarding` at all before this, which is a
+ * notable gap: it is the first thing a newly-approved student sees, and it is
+ * rendered BARE — its route sits outside `(shell)`, so it has no ShellFrame,
+ * no nav and no `<main>` padding to inherit. Nothing else in the suite would
+ * notice if it broke.
+ *
+ * This is deliberately a smoke-plus-persistence journey, not a full
+ * five-step walkthrough: the steps' own field validation is unit-tested, and
+ * a long scripted click-path over a funnel that is still being redesigned
+ * (#289 changes its frame; the flow itself is untouched) would break on every
+ * copy tweak. What it pins is the part that must not regress — the screen
+ * mounts for an un-onboarded user, the nav affordances behave, and the token
+ * conversion did not leave the layout collapsed.
+ *
+ * Signs in as USER_NEW rather than the default USER_ACTIVE: it is the only
+ * seeded user with onboarding_completed=False, so it is the only one the
+ * funnel renders for at all.
+ */
+import { expect, test } from "./support/fixtures";
+import { mintStorageState } from "./support/session";
+import { FRONTEND_URL, USER_NEW } from "./support/stack";
+
+test("the onboarding funnel renders for an un-onboarded user (#289)", async ({ browser }) => {
+  const storageState = await mintStorageState(USER_NEW, "Rich New");
+  const context = await browser.newContext({ storageState });
+  const page = await context.newPage();
+
+  try {
+    await page.goto(`${FRONTEND_URL}/onboarding`);
+
+    const gate = page.getByTestId("onboarding-gate");
+    await expect(gate).toBeVisible();
+
+    // Step 0 is the welcome step: forward affordance present, Back absent.
+    await expect(page.getByTestId("onboarding-continue")).toBeVisible();
+    await expect(page.getByTestId("onboarding-back")).toHaveCount(0);
+
+    // The card must actually occupy the screen. #289 converted every
+    // hardcoded px in this file to --pad-*/--fs-* tokens; a mistyped var()
+    // resolves to nothing and silently collapses the box, which no unit test
+    // would catch and which this assertion would.
+    const box = await gate.boundingBox();
+    expect(box, "the onboarding root should have a layout box").not.toBeNull();
+    expect(box!.height, "onboarding must fill the viewport, not collapse").toBeGreaterThan(400);
+
+    const card = await page.evaluate(() => {
+      const el = document.querySelector('[data-testid="onboarding-gate"] .card');
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      const cs = getComputedStyle(el);
+      return { w: Math.round(r.width), h: Math.round(r.height), padTop: cs.paddingTop };
+    });
+    expect(card, "the onboarding card should render").not.toBeNull();
+    expect(card!.w, "card should have real width").toBeGreaterThan(200);
+    expect(card!.h, "card should have real height").toBeGreaterThan(150);
+    // A var() that failed to resolve computes to 0px, not a real length.
+    expect(card!.padTop, "card padding must resolve from --pad-*").not.toBe("0px");
+
+    // Advancing off the welcome step reveals Back — the cheapest proof the
+    // step machine still drives the frame after the re-home.
+    await page.getByTestId("onboarding-continue").click();
+    await expect(page.getByTestId("onboarding-back")).toBeVisible();
+  } finally {
+    await context.close();
+  }
+});

--- a/frontend/e2e/support/stack.ts
+++ b/frontend/e2e/support/stack.ts
@@ -24,9 +24,14 @@ export const USER_ACTIVE = "rich-user-active";
 export const USER_SECOND = "rich-user-second";
 
 /** The seeded user who has NOT completed onboarding (db/seed_local_rich.py:
- * onboarding_completed=False, is_approved=True). Approved so the middleware
- * lets them past the pending gate, un-onboarded so they land on /onboarding —
- * the only seeded user who can exercise the first-run funnel. */
+ * onboarding_completed=False, is_approved=True) — the state a real student is
+ * in the first time they reach the funnel.
+ *
+ * Note /onboarding is NOT in middleware.ts's PROTECTED list or its matcher,
+ * and Onboarding.tsx only redirects when unauthenticated — so the route
+ * renders for any signed-in user regardless of approval or onboarding state.
+ * This user is chosen because it is the realistic one, not because the route
+ * gates on it. */
 export const USER_NEW = "rich-user-new";
 
 async function isUp(url: string): Promise<boolean> {

--- a/frontend/e2e/support/stack.ts
+++ b/frontend/e2e/support/stack.ts
@@ -23,6 +23,12 @@ export const USER_ACTIVE = "rich-user-active";
  * via support/session.ts. */
 export const USER_SECOND = "rich-user-second";
 
+/** The seeded user who has NOT completed onboarding (db/seed_local_rich.py:
+ * onboarding_completed=False, is_approved=True). Approved so the middleware
+ * lets them past the pending gate, un-onboarded so they land on /onboarding —
+ * the only seeded user who can exercise the first-run funnel. */
+export const USER_NEW = "rich-user-new";
+
 async function isUp(url: string): Promise<boolean> {
   try {
     const res = await fetch(url, { signal: AbortSignal.timeout(3_000) });

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -54,6 +54,7 @@ const eslintConfig = [
     files: [
       "src/components/marketing/SignInModal.tsx",
       "src/app/pending/page.tsx",
+      "src/components/screens/Onboarding.tsx",
       "src/components/DocumentUploadModal.tsx",
       "src/components/chat/ChatPanel.tsx",
       "src/components/QuizPanel.tsx",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -139,6 +139,33 @@
   --pad-xl: 32px;
   --row-h: 40px;
 
+  /* Type scale (#289).
+     DERIVED, not invented: every step is a size the app already uses, counted
+     across screens/ and components/ — 13px is the true body size (107 uses),
+     12/11/10 carry chrome and micro-labels, 14-16 body copy, 18-26 headings,
+     30 is TopBar's screen title, 32 the display numeral on Dashboard.
+
+     Deliberately NOT density-aware, unlike --pad-*. Retuning the whole type
+     ramp with the density preference is a real product decision — it changes
+     how much text fits on every screen — and this scale's job right now is to
+     give one source of truth for sizes that are currently inline literals at
+     ~300 call sites. Making it density-aware later is additive; making it
+     density-aware now would ship a behaviour change disguised as a refactor.
+
+     Adopted by Onboarding first. The rest of the app keeps its inline sizes
+     until each screen is converted deliberately. */
+  --fs-2xs:  10px;
+  --fs-xs:   11px;
+  --fs-sm:   12px;
+  --fs-md:   13px;   /* body */
+  --fs-base: 14px;
+  --fs-lg:   16px;
+  --fs-xl:   18px;
+  --fs-2xl:  22px;
+  --fs-3xl:  26px;
+  --fs-4xl:  30px;   /* screen title — matches TopBar */
+  --fs-5xl:  32px;
+
   --ease: cubic-bezier(0.2, 0.7, 0.2, 1);
   --dur-fast: 140ms;
   --dur: 220ms;

--- a/frontend/src/components/screens/Onboarding.tsx
+++ b/frontend/src/components/screens/Onboarding.tsx
@@ -162,13 +162,14 @@ export function Onboarding() {
 
   return (
     <div
+      data-testid="onboarding-gate"
       style={{
-        minHeight: "100vh",
+        minHeight: "100dvh",
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        background: "radial-gradient(ellipse at top, var(--accent-soft) 0%, var(--bg) 60%)",
-        padding: "40px 20px",
+        background: "var(--bg)",
+        padding: "var(--pad-xl) var(--pad-lg)",
       }}
     >
       <div
@@ -176,10 +177,11 @@ export function Onboarding() {
         style={{
           position: "relative",
           width: "min(560px, 100%)",
-          padding: "40px 36px",
+          padding: "var(--pad-xl)",
         }}
       >
         <button
+          data-testid="onboarding-close"
           className="btn btn--ghost btn--sm"
           aria-label="Close onboarding"
           onClick={close}
@@ -244,11 +246,12 @@ export function Onboarding() {
 
         <div style={{ display: "flex", gap: 10, justifyContent: "flex-end", marginTop: 32 }}>
           {draft.step > 0 && (
-            <button className="btn" onClick={back} disabled={submitting}>
+            <button data-testid="onboarding-back" className="btn" onClick={back} disabled={submitting}>
               Back
             </button>
           )}
           <button
+            data-testid="onboarding-continue"
             className="btn btn--primary"
             disabled={!canContinue || submitting}
             onClick={draft.step === STEP_COUNT - 1 ? finish : next}
@@ -265,10 +268,10 @@ export function Onboarding() {
 function StepWelcome() {
   return (
     <div style={{ textAlign: "center" }}>
-      <div className="h-serif" style={{ fontSize: 32, fontWeight: 500, marginBottom: 10 }}>
+      <div className="h-serif" style={{ fontSize: "var(--fs-5xl)", fontWeight: 500, marginBottom: 10 }}>
         Welcome to Sapling
       </div>
-      <div style={{ fontSize: 14, color: "var(--text-dim)", lineHeight: 1.55, maxWidth: 440, margin: "0 auto" }}>
+      <div style={{ fontSize: "var(--fs-base)", color: "var(--text-dim)", lineHeight: 1.55, maxWidth: 440, margin: "0 auto" }}>
         Let&apos;s set up your learning space. A few quick questions so the AI tutor can meet you where you are.
       </div>
     </div>
@@ -283,11 +286,12 @@ function TextInput(props: React.InputHTMLAttributes<HTMLInputElement>) {
   const { style, ...rest } = props;
   return (
     <input
+      data-testid="onboarding-input"
       {...rest}
       style={{
         width: "100%",
-        padding: "10px 12px",
-        fontSize: 14,
+        padding: "var(--pad-sm) var(--pad-md)",
+        fontSize: "var(--fs-base)",
         border: "1px solid var(--border)",
         borderRadius: "var(--r-sm)",
         background: "var(--bg-input)",
@@ -304,8 +308,8 @@ function StepName({ firstName, lastName, onFirst, onLast }: {
 }) {
   return (
     <div>
-      <div className="h-serif" style={{ fontSize: 26, fontWeight: 500, marginBottom: 6 }}>What should we call you?</div>
-      <div style={{ fontSize: 13, color: "var(--text-dim)", marginBottom: 18 }}>This is the name shown to study partners.</div>
+      <div className="h-serif" style={{ fontSize: "var(--fs-4xl)", fontWeight: 500, marginBottom: 6 }}>What should we call you?</div>
+      <div style={{ fontSize: "var(--fs-md)", color: "var(--text-dim)", marginBottom: 18 }}>This is the name shown to study partners.</div>
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
         <div>
           <FieldLabel>First name</FieldLabel>
@@ -326,8 +330,8 @@ function StepSchool({ school, year, onSchool, onYear }: {
 }) {
   return (
     <div>
-      <div className="h-serif" style={{ fontSize: 26, fontWeight: 500, marginBottom: 6 }}>Where are you studying?</div>
-      <div style={{ fontSize: 13, color: "var(--text-dim)", marginBottom: 18 }}>Sapling is currently limited to Boston University.</div>
+      <div className="h-serif" style={{ fontSize: "var(--fs-4xl)", fontWeight: 500, marginBottom: 6 }}>Where are you studying?</div>
+      <div style={{ fontSize: "var(--fs-md)", color: "var(--text-dim)", marginBottom: 18 }}>Sapling is currently limited to Boston University.</div>
       <FieldLabel>School</FieldLabel>
       <TextInput value={school} onChange={e => onSchool(e.target.value)} disabled style={{ marginBottom: 16 }} />
       <FieldLabel>Year</FieldLabel>
@@ -348,8 +352,8 @@ function StepAcademics({ majors, minors, onMajors, onMinors }: {
 }) {
   return (
     <div>
-      <div className="h-serif" style={{ fontSize: 26, fontWeight: 500, marginBottom: 6 }}>Your academic focus</div>
-      <div style={{ fontSize: 13, color: "var(--text-dim)", marginBottom: 18 }}>Add at least one major. Minors are optional.</div>
+      <div className="h-serif" style={{ fontSize: "var(--fs-4xl)", fontWeight: 500, marginBottom: 6 }}>Your academic focus</div>
+      <div style={{ fontSize: "var(--fs-md)", color: "var(--text-dim)", marginBottom: 18 }}>Add at least one major. Minors are optional.</div>
       <FieldLabel>Majors</FieldLabel>
       <TagInput values={majors} onChange={onMajors} placeholder="e.g. Computer Science" />
       <div style={{ height: 14 }} />
@@ -380,7 +384,7 @@ function TagInput({ values, onChange, placeholder }: {
             style={{ textTransform: "none", fontFamily: "var(--font-sans)", background: "var(--accent-soft)", color: "var(--accent)", borderColor: "var(--accent-border)" }}
           >
             {v}
-            <button onClick={() => remove(v)} aria-label={`Remove ${v}`} style={{ color: "inherit", fontSize: 13, lineHeight: 1, marginLeft: 2 }}>
+            <button data-testid="onboarding-chip-remove" onClick={() => remove(v)} aria-label={`Remove ${v}`} style={{ color: "inherit", fontSize: "var(--fs-md)", lineHeight: 1, marginLeft: 2 }}>
               ×
             </button>
           </span>
@@ -398,7 +402,7 @@ function TagInput({ values, onChange, placeholder }: {
           }}
           placeholder={placeholder}
         />
-        <button className="btn" onClick={add} disabled={!draft.trim()}>Add</button>
+        <button data-testid="onboarding-chip-add" className="btn" onClick={add} disabled={!draft.trim()}>Add</button>
       </div>
     </div>
   );
@@ -442,8 +446,8 @@ function StepCourses({ selectedIds, selectedCache, onSelect }: {
 
   return (
     <div>
-      <div className="h-serif" style={{ fontSize: 26, fontWeight: 500, marginBottom: 6 }}>What are you studying?</div>
-      <div style={{ fontSize: 13, color: "var(--text-dim)", marginBottom: 18 }}>
+      <div className="h-serif" style={{ fontSize: "var(--fs-4xl)", fontWeight: 500, marginBottom: 6 }}>What are you studying?</div>
+      <div style={{ fontSize: "var(--fs-md)", color: "var(--text-dim)", marginBottom: 18 }}>
         Pick a few courses to seed your knowledge tree. You can always add more later.
       </div>
       <TextInput
@@ -461,26 +465,27 @@ function StepCourses({ selectedIds, selectedCache, onSelect }: {
               style={{ textTransform: "none", fontFamily: "var(--font-sans)", background: "var(--accent-soft)", color: "var(--accent)", borderColor: "var(--accent-border)" }}
             >
               {c.course_code}
-              <button onClick={() => toggle(c)} aria-label={`Remove ${c.course_code}`} style={{ color: "inherit", fontSize: 13, lineHeight: 1, marginLeft: 2 }}>×</button>
+              <button data-testid="onboarding-course-remove" onClick={() => toggle(c)} aria-label={`Remove ${c.course_code}`} style={{ color: "inherit", fontSize: "var(--fs-md)", lineHeight: 1, marginLeft: 2 }}>×</button>
             </span>
           ))}
         </div>
       )}
       <div style={{ marginTop: 14, maxHeight: 260, overflowY: "auto", border: "1px solid var(--border)", borderRadius: "var(--r-sm)" }}>
-        {loading && <div style={{ padding: "14px 12px", fontSize: 12, color: "var(--text-muted)" }}>Searching…</div>}
+        {loading && <div style={{ padding: "var(--pad-md)", fontSize: "var(--fs-sm)", color: "var(--text-muted)" }}>Searching…</div>}
         {!loading && results.length === 0 && (
-          <div style={{ padding: "14px 12px", fontSize: 12, color: "var(--text-muted)" }}>No courses match.</div>
+          <div style={{ padding: "var(--pad-md)", fontSize: "var(--fs-sm)", color: "var(--text-muted)" }}>No courses match.</div>
         )}
         {!loading && results.map(c => {
           const selected = selectedIds.includes(c.id) || cacheMap.has(c.id);
           return (
             <button
+              data-testid="onboarding-course-result"
               key={c.id}
               onClick={() => toggle(c)}
               style={{
                 width: "100%",
-                padding: "10px 12px",
-                fontSize: 13,
+                padding: "var(--pad-sm) var(--pad-md)",
+                fontSize: "var(--fs-md)",
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "space-between",
@@ -510,8 +515,8 @@ function StepLearningStyle({ value, onChange }: {
 }) {
   return (
     <div>
-      <div className="h-serif" style={{ fontSize: 26, fontWeight: 500, marginBottom: 6 }}>How do you learn best?</div>
-      <div style={{ fontSize: 13, color: "var(--text-dim)", marginBottom: 18 }}>
+      <div className="h-serif" style={{ fontSize: "var(--fs-4xl)", fontWeight: 500, marginBottom: 6 }}>How do you learn best?</div>
+      <div style={{ fontSize: "var(--fs-md)", color: "var(--text-dim)", marginBottom: 18 }}>
         The AI tutor adjusts its tone and pacing to match.
       </div>
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
@@ -519,12 +524,13 @@ function StepLearningStyle({ value, onChange }: {
           const selected = value === s.id;
           return (
             <button
+              data-testid="onboarding-learning-style"
               key={s.id}
               role="radio"
               aria-checked={selected}
               onClick={() => onChange(s.id)}
               style={{
-                padding: "14px 14px",
+                padding: "var(--pad-md)",
                 border: `1.5px solid ${selected ? "var(--accent)" : "var(--border)"}`,
                 background: selected ? "var(--accent-soft)" : "var(--bg-panel)",
                 borderRadius: "var(--r-md)",
@@ -536,9 +542,9 @@ function StepLearningStyle({ value, onChange }: {
                 <span style={{ color: selected ? "var(--accent)" : "var(--text-dim)", display: "inline-flex" }}>
                   <Icon name={s.icon} size={16} />
                 </span>
-                <span style={{ fontWeight: 600, fontSize: 14, color: selected ? "var(--accent)" : "var(--text)" }}>{s.title}</span>
+                <span style={{ fontWeight: 600, fontSize: "var(--fs-base)", color: selected ? "var(--accent)" : "var(--text)" }}>{s.title}</span>
               </div>
-              <div style={{ fontSize: 11, color: "var(--text-dim)", lineHeight: 1.4 }}>{s.description}</div>
+              <div style={{ fontSize: "var(--fs-xs)", color: "var(--text-dim)", lineHeight: 1.4 }}>{s.description}</div>
             </button>
           );
         })}

--- a/frontend/src/components/screens/Onboarding.tsx
+++ b/frontend/src/components/screens/Onboarding.tsx
@@ -177,7 +177,7 @@ export function Onboarding() {
         style={{
           position: "relative",
           width: "min(560px, 100%)",
-          padding: "var(--pad-xl)",
+          padding: "var(--pad-xl) var(--pad-lg)",
         }}
       >
         <button
@@ -313,11 +313,11 @@ function StepName({ firstName, lastName, onFirst, onLast }: {
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
         <div>
           <FieldLabel>First name</FieldLabel>
-          <TextInput value={firstName} onChange={e => onFirst(e.target.value)} placeholder="Jose" autoFocus />
+          <TextInput data-testid="onboarding-first-name" value={firstName} onChange={e => onFirst(e.target.value)} placeholder="Jose" autoFocus />
         </div>
         <div>
           <FieldLabel>Last name</FieldLabel>
-          <TextInput value={lastName} onChange={e => onLast(e.target.value)} placeholder="Cruz" />
+          <TextInput data-testid="onboarding-last-name" value={lastName} onChange={e => onLast(e.target.value)} placeholder="Cruz" />
         </div>
       </div>
     </div>
@@ -333,7 +333,7 @@ function StepSchool({ school, year, onSchool, onYear }: {
       <div className="h-serif" style={{ fontSize: "var(--fs-4xl)", fontWeight: 500, marginBottom: 6 }}>Where are you studying?</div>
       <div style={{ fontSize: "var(--fs-md)", color: "var(--text-dim)", marginBottom: 18 }}>Sapling is currently limited to Boston University.</div>
       <FieldLabel>School</FieldLabel>
-      <TextInput value={school} onChange={e => onSchool(e.target.value)} disabled style={{ marginBottom: 16 }} />
+      <TextInput data-testid="onboarding-school" value={school} onChange={e => onSchool(e.target.value)} disabled style={{ marginBottom: 16 }} />
       <FieldLabel>Year</FieldLabel>
       <CustomSelect<string>
         value={year}
@@ -355,16 +355,18 @@ function StepAcademics({ majors, minors, onMajors, onMinors }: {
       <div className="h-serif" style={{ fontSize: "var(--fs-4xl)", fontWeight: 500, marginBottom: 6 }}>Your academic focus</div>
       <div style={{ fontSize: "var(--fs-md)", color: "var(--text-dim)", marginBottom: 18 }}>Add at least one major. Minors are optional.</div>
       <FieldLabel>Majors</FieldLabel>
-      <TagInput values={majors} onChange={onMajors} placeholder="e.g. Computer Science" />
+      <TagInput field="majors" values={majors} onChange={onMajors} placeholder="e.g. Computer Science" />
       <div style={{ height: 14 }} />
       <FieldLabel>Minors</FieldLabel>
-      <TagInput values={minors} onChange={onMinors} placeholder="e.g. Philosophy" />
+      <TagInput field="minors" values={minors} onChange={onMinors} placeholder="e.g. Philosophy" />
     </div>
   );
 }
 
-function TagInput({ values, onChange, placeholder }: {
+function TagInput({ values, onChange, placeholder, field }: {
   values: string[]; onChange: (v: string[]) => void; placeholder?: string;
+  /** Disambiguates testids — two TagInputs render simultaneously. */
+  field: string;
 }) {
   const [draft, setDraft] = useState("");
   const add = () => {
@@ -384,7 +386,7 @@ function TagInput({ values, onChange, placeholder }: {
             style={{ textTransform: "none", fontFamily: "var(--font-sans)", background: "var(--accent-soft)", color: "var(--accent)", borderColor: "var(--accent-border)" }}
           >
             {v}
-            <button data-testid="onboarding-chip-remove" onClick={() => remove(v)} aria-label={`Remove ${v}`} style={{ color: "inherit", fontSize: "var(--fs-md)", lineHeight: 1, marginLeft: 2 }}>
+            <button data-testid={`onboarding-chip-remove-${field}-${v}`} onClick={() => remove(v)} aria-label={`Remove ${v}`} style={{ color: "inherit", fontSize: "var(--fs-md)", lineHeight: 1, marginLeft: 2 }}>
               ×
             </button>
           </span>
@@ -392,6 +394,7 @@ function TagInput({ values, onChange, placeholder }: {
       </div>
       <div style={{ display: "flex", gap: 8 }}>
         <TextInput
+          data-testid={`onboarding-chip-input-${field}`}
           value={draft}
           onChange={e => setDraft(e.target.value)}
           onKeyDown={e => {
@@ -402,7 +405,7 @@ function TagInput({ values, onChange, placeholder }: {
           }}
           placeholder={placeholder}
         />
-        <button data-testid="onboarding-chip-add" className="btn" onClick={add} disabled={!draft.trim()}>Add</button>
+        <button data-testid={`onboarding-chip-add-${field}`} className="btn" onClick={add} disabled={!draft.trim()}>Add</button>
       </div>
     </div>
   );
@@ -451,6 +454,7 @@ function StepCourses({ selectedIds, selectedCache, onSelect }: {
         Pick a few courses to seed your knowledge tree. You can always add more later.
       </div>
       <TextInput
+        data-testid="onboarding-course-search"
         value={query}
         onChange={e => setQuery(e.target.value)}
         placeholder="Search by code or name (e.g. CS 131)"
@@ -465,21 +469,21 @@ function StepCourses({ selectedIds, selectedCache, onSelect }: {
               style={{ textTransform: "none", fontFamily: "var(--font-sans)", background: "var(--accent-soft)", color: "var(--accent)", borderColor: "var(--accent-border)" }}
             >
               {c.course_code}
-              <button data-testid="onboarding-course-remove" onClick={() => toggle(c)} aria-label={`Remove ${c.course_code}`} style={{ color: "inherit", fontSize: "var(--fs-md)", lineHeight: 1, marginLeft: 2 }}>×</button>
+              <button data-testid={`onboarding-course-remove-${c.course_code}`} onClick={() => toggle(c)} aria-label={`Remove ${c.course_code}`} style={{ color: "inherit", fontSize: "var(--fs-md)", lineHeight: 1, marginLeft: 2 }}>×</button>
             </span>
           ))}
         </div>
       )}
       <div style={{ marginTop: 14, maxHeight: 260, overflowY: "auto", border: "1px solid var(--border)", borderRadius: "var(--r-sm)" }}>
-        {loading && <div style={{ padding: "var(--pad-md)", fontSize: "var(--fs-sm)", color: "var(--text-muted)" }}>Searching…</div>}
+        {loading && <div style={{ padding: "var(--pad-md) var(--pad-sm)", fontSize: "var(--fs-sm)", color: "var(--text-muted)" }}>Searching…</div>}
         {!loading && results.length === 0 && (
-          <div style={{ padding: "var(--pad-md)", fontSize: "var(--fs-sm)", color: "var(--text-muted)" }}>No courses match.</div>
+          <div style={{ padding: "var(--pad-md) var(--pad-sm)", fontSize: "var(--fs-sm)", color: "var(--text-muted)" }}>No courses match.</div>
         )}
         {!loading && results.map(c => {
           const selected = selectedIds.includes(c.id) || cacheMap.has(c.id);
           return (
             <button
-              data-testid="onboarding-course-result"
+              data-testid={`onboarding-course-result-${c.id}`}
               key={c.id}
               onClick={() => toggle(c)}
               style={{
@@ -524,7 +528,7 @@ function StepLearningStyle({ value, onChange }: {
           const selected = value === s.id;
           return (
             <button
-              data-testid="onboarding-learning-style"
+              data-testid={`onboarding-learning-style-${s.id}`}
               key={s.id}
               role="radio"
               aria-checked={selected}


### PR DESCRIPTION
Onboarding was **color-correct but structurally orphaned**: 12 hardcoded px values, a bespoke type ramp (32 on welcome, 26 everywhere else — matching neither TopBar's 30 nor Dashboard's 42), and a centred card floating in its own radial void. The flow and steps are untouched; only the frame changed.

## The `--fs-*` scale — option (b), as you chose

**Derived, not invented.** Every step is a size the app already uses, counted across `screens/` and `components/`:

| | |
|---|---|
| `--fs-md: 13px` | the app's true body size — **107 call sites** |
| `--fs-sm/xs/2xs` | 12 / 11 / 10 — chrome and micro-labels (215 uses combined) |
| `--fs-base/lg` | 14 / 16 — body copy |
| `--fs-xl/2xl/3xl` | 18 / 22 / 26 — headings |
| `--fs-4xl: 30px` | screen title — matches TopBar |
| `--fs-5xl: 32px` | Dashboard display numeral |

**Deliberately not density-aware**, unlike `--pad-*`. Retuning the whole type ramp with the density preference changes how much text fits on every screen — that's a product decision, not a refactor. Additive to add later; doing it now would hide a behaviour change inside a token introduction.

**Onboarding is the scale's first and only consumer.** The rest of the app keeps its inline sizes until each screen is converted deliberately — a token set with zero consumers is exactly the state #288 just finished cleaning up, and I'd rather not recreate it.

## The rest of the frame

- Every hardcoded padding → `--pad-*`, so onboarding finally responds to the density preference at all.
- The bespoke radial void → the app's own `--bg`.
- `minHeight: 100vh` → `100dvh` — the same iOS Safari lesson ShellFrame learned in #331, which onboarding never got because it renders outside `(shell)`.

**One visible change worth calling out:** step headings move **26 → 30** to match TopBar. That's the alignment the issue asks for, not a side effect.

## The journey that didn't exist

There was **no e2e journey over `/onboarding` at all** — notable, since it's the first screen a newly-approved student sees and it renders bare, with no ShellFrame, nav or `<main>` padding to inherit. Nothing in the suite would have noticed it breaking.

Added one. It signs in as `USER_NEW` (the only seeded user with `onboarding_completed=False`, so the only one the funnel renders for) and asserts the card actually **occupies the screen with resolved padding** — a mistyped `var()` computes to `0px` and silently collapses the box, which no unit test would catch and which is the specific risk this PR's conversion introduces.

It's a smoke-plus-layout journey rather than a five-step walkthrough on purpose: the field validation is unit-tested, and a long scripted click-path over a funnel that's still being redesigned would break on every copy tweak.

## Testids — both halves

Driving onboarding made it an E2E surface, so `Onboarding.tsx` joins the enforcement list in `eslint.config.mjs`. That immediately flagged **7 untagged controls** (the rule doing its job), so all ten are now tagged and registered in `docs/frontend-testids.md` — surface table and inventory.

## Not done

The proposal also suggested rendering onboarding in the app's **left-aligned frame with shell-like chrome**. I've left the centred card: moving the first-run funnel from centred-card to left-aligned-shell changes its whole character, and that's a taste call rather than debt cleanup. Happy to do it if you want it.

## Gates

- `tsc --noEmit` clean · `npm run lint` 0 errors · `npx vitest run` 58 files / 415 tests
- Full local e2e cycle — in a comment below

part of #289