### PR TITLE
feat(social): reserve space for chat image attachments (#315)

### DIFF
--- a/backend/db/migrations/0040_room_message_image_dimensions.sql
+++ b/backend/db/migrations/0040_room_message_image_dimensions.sql
@@ -1,0 +1,22 @@
+-- 0040: store intrinsic dimensions for room-chat image attachments (#315).
+--
+-- `room_messages` carries only `image_url`, so the client has nothing to
+-- reserve space with and renders attachments into a zero-height box until the
+-- image loads. With `loading="lazy"` (added by #312) that means scrolling UP
+-- through history expands each image as it nears the viewport and shifts the
+-- transcript mid-scroll. Chrome and Firefox mostly absorb it via scroll
+-- anchoring; Safari has none, so the viewport visibly jumps on every load.
+--
+-- It also breaks the `loadEarlier` scrollTop compensation, which measures
+-- scrollHeight before the prepended images have loaded.
+--
+-- Nullable and unpopulated by design: every message written before this
+-- migration keeps NULL, and the client falls back to its current behaviour
+-- for those rows. Backfilling would mean fetching every historical image to
+-- measure it, which is not worth it for a layout hint.
+--
+-- IF NOT EXISTS so this is a no-op wherever the columns already exist.
+
+ALTER TABLE room_messages
+    ADD COLUMN IF NOT EXISTS image_width  INTEGER,
+    ADD COLUMN IF NOT EXISTS image_height INTEGER;

--- a/backend/db/migrations/0040_room_message_image_dimensions.sql
+++ b/backend/db/migrations/0040_room_message_image_dimensions.sql
@@ -20,3 +20,25 @@
 ALTER TABLE room_messages
     ADD COLUMN IF NOT EXISTS image_width  INTEGER,
     ADD COLUMN IF NOT EXISTS image_height INTEGER;
+
+-- Bounds at the database too, not only in the request model. These values are
+-- client-supplied and the client renders them as an aspect-ratio, so an
+-- absurd pair is a layout weapon against every member of the room rather than
+-- a bad row for its author. Matches the CHECK convention 0021 established for
+-- client-supplied numerics.
+--
+-- NOT VALID so the constraint applies to new writes without scanning existing
+-- rows: every pre-existing row has NULL in both columns anyway, and NULL
+-- passes a CHECK regardless.
+DO $$
+BEGIN
+    ALTER TABLE room_messages
+        ADD CONSTRAINT room_messages_image_dims_sane
+        CHECK (
+            (image_width  IS NULL OR (image_width  > 0 AND image_width  <= 20000))
+            AND
+            (image_height IS NULL OR (image_height > 0 AND image_height <= 20000))
+        ) NOT VALID;
+EXCEPTION
+    WHEN duplicate_object THEN NULL;  -- already present; nothing to do
+END $$;

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -154,8 +154,15 @@ class SendMessageBody(BaseModel):
     # Intrinsic pixel size of image_url, measured client-side at upload (#315).
     # Optional: older clients omit them and the UI falls back to unreserved
     # layout, exactly as before.
-    image_width: Optional[int] = None
-    image_height: Optional[int] = None
+    #
+    # BOUNDED, because these are client-supplied and the transcript renders
+    # them as an aspect-ratio directly. Unbounded, any room member could post
+    # width=1/height=2000000000 — inside Postgres INTEGER range, so it inserts
+    # cleanly — and blow out that room's transcript for everyone, with no edit
+    # path to recover. 20000 is comfortably past any real image (8K is 7680)
+    # while keeping the ratio sane.
+    image_width: Optional[int] = Field(default=None, gt=0, le=20000)
+    image_height: Optional[int] = Field(default=None, gt=0, le=20000)
     reply_to_id: Optional[str] = None
 
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -151,6 +151,11 @@ class SendMessageBody(BaseModel):
     user_name: str
     text: Optional[str] = None
     image_url: Optional[str] = None
+    # Intrinsic pixel size of image_url, measured client-side at upload (#315).
+    # Optional: older clients omit them and the UI falls back to unreserved
+    # layout, exactly as before.
+    image_width: Optional[int] = None
+    image_height: Optional[int] = None
     reply_to_id: Optional[str] = None
 
 

--- a/backend/routes/social.py
+++ b/backend/routes/social.py
@@ -387,7 +387,7 @@ def get_room_messages(room_id: str, request: Request, before: str | None = None,
     # `limit`, an extra page exists. (Using `len(rows) == limit` reports a
     # phantom "load more" at exact page boundaries — issue #131.)
     rows = table("room_messages").select(
-        "id,room_id,user_id,user_name,text,image_url,reply_to_id,is_deleted,edited_at,created_at",
+        "id,room_id,user_id,user_name,text,image_url,image_width,image_height,reply_to_id,is_deleted,edited_at,created_at",
         filters=filters,
         order="created_at.desc",
         limit=limit + 1,
@@ -456,6 +456,8 @@ def send_room_message(room_id: str, body: SendMessageBody, request: Request):
         "user_name": body.user_name,
         "text": encrypt_if_present(body.text or None),
         "image_url": body.image_url or None,
+        "image_width": body.image_width or None,
+        "image_height": body.image_height or None,
         "reply_to_id": body.reply_to_id or None,
     })
 

--- a/backend/tests/test_social_messages.py
+++ b/backend/tests/test_social_messages.py
@@ -192,3 +192,31 @@ class TestGetRoomMessages:
 
         assert r.status_code == 200
         assert captured["limit"] == 2  # floored to 1, +1 probe row
+
+
+class TestImageDimensionBounds:
+    """#315: image_width/image_height are client-supplied and the transcript
+    renders them straight into an aspect-ratio, so an absurd pair is a layout
+    weapon against every member of the room — not just a bad row for its
+    author. The request model must reject them before they reach the DB.
+    """
+
+    def _post(self, **extra):
+        body = {"user_id": "u1", "user_name": "Alice", "image_url": "https://x/i.png"}
+        body.update(extra)
+        return client.post(f"/api/social/rooms/{ROOM_ID}/messages", json=body)
+
+    def test_rejects_absurd_height(self):
+        # Inside Postgres INTEGER range, so nothing downstream would object:
+        # a 1x2000000000 ratio renders a ~2-billion-pixel-tall bubble.
+        assert self._post(image_width=1, image_height=2_000_000_000).status_code == 422
+
+    def test_rejects_non_positive(self):
+        assert self._post(image_width=0, image_height=100).status_code == 422
+        assert self._post(image_width=-5, image_height=100).status_code == 422
+
+    def test_accepts_omitted_dimensions(self):
+        # Older clients send neither; the UI falls back to unreserved layout.
+        # 422 would mean the optionality regressed. Anything else (including
+        # auth/membership rejections) means validation let it through.
+        assert self._post().status_code != 422

--- a/frontend/src/components/screens/Social.tsx
+++ b/frontend/src/components/screens/Social.tsx
@@ -270,6 +270,36 @@ function PublicRoomsList({ excludeIds, onJoined }: { excludeIds: string[]; onJoi
   );
 }
 
+/**
+ * Intrinsic pixel size of a picked image file, or null if it can't be read
+ * (#315).
+ *
+ * Measured from an object URL rather than after upload, so the dimensions
+ * travel with the message that creates it and history renders reserved from
+ * the first paint. Resolving null on error is deliberate: a message that
+ * cannot be measured should still send, it just renders unreserved like it
+ * did before.
+ */
+async function readImageSize(file: File): Promise<{ width: number; height: number } | undefined> {
+  if (typeof window === "undefined" || !file.type.startsWith("image/")) return undefined;
+  const url = URL.createObjectURL(file);
+  try {
+    return await new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () =>
+        resolve(
+          img.naturalWidth && img.naturalHeight
+            ? { width: img.naturalWidth, height: img.naturalHeight }
+            : undefined,
+        );
+      img.onerror = () => resolve(undefined);
+      img.src = url;
+    });
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
 function RoomChat({ roomId, members }: { roomId: string; members: { user_id: string; name: string }[] }) {
   const { userId, userName } = useUser();
   const toast = useToast();
@@ -499,12 +529,16 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
       return;
     }
     try {
+      // Measure before upload so the transcript can reserve the exact box.
+      // Failure is non-fatal: without dimensions the attachment just renders
+      // unreserved, which is the pre-#315 behaviour.
+      const imageSize = await readImageSize(file);
       const path = `${roomId}/${userId}-${Date.now()}-${file.name}`;
       const up = await supa.storage.from("chat-images").upload(path, file);
       if (up.error) throw up.error;
       const pub = supa.storage.from("chat-images").getPublicUrl(path);
       const url: string = pub.data.publicUrl;
-      const res = await sendRoomMessage(roomId, userId, userName || "Me", "", url);
+      const res = await sendRoomMessage(roomId, userId, userName || "Me", "", url, undefined, imageSize);
       // Append from the POST response (own realtime echoes are skipped to avoid
       // duplicates), deduping by id in case the echo already landed.
       const saved = res?.message as RoomMessageRow | undefined;
@@ -624,7 +658,28 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
                     }}
                   >
                     {m.image_url && (
-                      <img src={m.image_url} alt="attachment" loading="lazy" decoding="async" style={{ maxWidth: 260, borderRadius: "var(--r-sm)", marginBottom: m.text ? 6 : 0 }} />
+                      <img
+                        src={m.image_url}
+                        alt="attachment"
+                        loading="lazy"
+                        decoding="async"
+                        {...(m.image_width && m.image_height
+                          ? { width: m.image_width, height: m.image_height }
+                          : {})}
+                        style={{
+                          maxWidth: 260,
+                          borderRadius: "var(--r-sm)",
+                          marginBottom: m.text ? 6 : 0,
+                          // With intrinsic dimensions the browser reserves the
+                          // box from the aspect ratio before the lazily-loaded
+                          // bytes arrive, so scrolling back through history
+                          // does not shift the transcript. Safari has no scroll
+                          // anchoring to hide it, which is why this matters.
+                          ...(m.image_width && m.image_height
+                            ? { aspectRatio: `${m.image_width} / ${m.image_height}`, height: "auto" }
+                            : {}),
+                        }}
+                      />
                     )}
                     {renderText(m.text)}
                     {m.edited_at && <span style={{ fontSize: 10, opacity: 0.6, marginLeft: 6 }}>(edited)</span>}

--- a/frontend/src/components/screens/Social.tsx
+++ b/frontend/src/components/screens/Social.tsx
@@ -676,7 +676,18 @@ function RoomChat({ roomId, members }: { roomId: string; members: { user_id: str
                           // does not shift the transcript. Safari has no scroll
                           // anchoring to hide it, which is why this matters.
                           ...(m.image_width && m.image_height
-                            ? { aspectRatio: `${m.image_width} / ${m.image_height}`, height: "auto" }
+                            ? {
+                                aspectRatio: `${m.image_width} / ${m.image_height}`,
+                                height: "auto",
+                                // Belt and braces against dimensions that do
+                                // not match the bytes: the server bounds them,
+                                // but a merely WRONG pair would otherwise
+                                // stretch the image instead of letterboxing.
+                                objectFit: "contain" as const,
+                                // maxWidth alone cannot cap a very tall image
+                                // once the ratio drives the height.
+                                maxHeight: 320,
+                              }
                             : {}),
                         }}
                       />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -580,10 +580,22 @@ export const getRoomMessages = (roomId: string, opts?: { before?: string; limit?
   );
 };
 
-export const sendRoomMessage = (roomId: string, userId: string, userName: string, text: string, imageUrl?: string, replyToId?: string) =>
+export const sendRoomMessage = (
+  roomId: string, userId: string, userName: string, text: string,
+  imageUrl?: string, replyToId?: string,
+  /** Intrinsic pixel size of imageUrl, so the transcript can reserve the box
+   *  before the lazily-loaded image arrives (#315). */
+  imageSize?: { width: number; height: number },
+) =>
   fetchJSON<{ message: any }>(`/api/social/rooms/${roomId}/messages`, {
     method: 'POST',
-    body: JSON.stringify({ user_id: userId, user_name: userName, text: text || null, image_url: imageUrl || null, reply_to_id: replyToId || null }),
+    body: JSON.stringify({
+      user_id: userId, user_name: userName, text: text || null,
+      image_url: imageUrl || null,
+      image_width: imageSize?.width ?? null,
+      image_height: imageSize?.height ?? null,
+      reply_to_id: replyToId || null,
+    }),
   });
 
 export const toggleRoomReaction = (roomId: string, messageId: string, userId: string, emoji: string) =>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -132,6 +132,9 @@ export interface RoomMessageRow {
   user_name: string;
   text: string | null;
   image_url: string | null;
+  /** Intrinsic size of image_url; null on messages sent before #315. */
+  image_width?: number | null;
+  image_height?: number | null;
   created_at: string;
   reply_to_id: string | null;
   is_deleted: boolean;


### PR DESCRIPTION
Room-chat attachments rendered into a **zero-height box** until the image loaded. Combined with the `loading="lazy"` #312 added, scrolling *up* through history expanded each image as it neared the viewport and shifted the transcript mid-scroll.

- Chrome/Firefox: mostly absorbed by native scroll anchoring
- **Safari (desktop + iOS): no scroll anchoring — the viewport visibly jumps on every image load**

It also invalidated the `loadEarlier` scrollTop compensation, which measures `scrollHeight` before the prepended images have loaded.

This is also the gap **#111 deliberately left open** — that PR added `decoding="async"` to these images but declined to invent dimensions for natural-aspect user uploads, precisely because there were none stored. Now there are.

## Why it needed the backend

`room_messages` stored only `image_url`. Nothing to reserve a box with, so it couldn't be fixed in the frontend alone.

| layer | change |
|---|---|
| `0040` | `image_width` / `image_height` on `room_messages`, nullable |
| `models` | same two fields on `SendMessageBody`, optional |
| `social.py` | both columns in the select list **and** the insert |
| `api.ts` | `sendRoomMessage` takes an optional `imageSize` |
| `Social.tsx` | measures the file before upload; renders into an aspect-ratio box |

The measurement runs on the picked `File` via an object URL **before** upload, so the dimensions travel with the message that creates it — history then renders reserved from the first paint rather than after a round trip.

## Degrades quietly at every layer

That's deliberate, because this is a layout hint and must never be able to block a message:

- columns are **nullable and unbackfilled** — every pre-existing message keeps `NULL`
- `readImageSize` resolves `undefined` on a non-image or a decode failure rather than throwing
- the renderer applies `width`/`height`/`aspect-ratio` **only when both values are present**

Anything without dimensions renders exactly as it does today. Backfilling would mean fetching every historical image to measure it — not worth it for a layout hint.

## Gates

- `tsc --noEmit` clean · `npm run lint` 0 errors · `npx vitest run` 58 files / 415 tests
- backend `pytest` 1526 passed, 32 skipped · `ruff check` clean
- **From-empty replay** (not just a normal cycle — this adds a migration, and `e2e-up` runs against a DB that already has the schema): in a comment below

part of #315