### PR TITLE
fix(study): keep the exam selected when opening a recent guide (#476)

### DIFF
--- a/backend/db/seed_local_rich.py
+++ b/backend/db/seed_local_rich.py
@@ -575,6 +575,51 @@ def seed_flashcards() -> None:
         )
 
 
+# (guide_id, user_id, offering_id, exam_id, generated_at, content)
+#
+# A CACHED guide, so /study's "Recent guides" rail has an entry to open without
+# any generation: the guide GET returns a cache hit on (user, offering, exam)
+# before it ever reaches the study_guide agent, which has no function-mode
+# handler. `exam_id` points at the real fall-2025 CS101 exam assignment so the
+# exam picker can resolve the same row the rail entry opens.
+_STUDY_GUIDES = [
+    ("rich-guide-cs-f25-mid", USER_ACTIVE, OFF_CS_F25, "rich-asg-cs-f25-mid",
+     "2026-03-01T12:00:00Z",
+     {
+         "exam": "Midterm Exam",
+         "due_date": "2025-10-15",
+         "overview": "Covers variables, control flow, and functions.",
+         "topics": [
+             {
+                 "name": "Variables",
+                 "importance": "Every later topic builds on binding names to values.",
+                 "concepts": ["Assignment", "Scope"],
+             },
+             {
+                 "name": "Recursion",
+                 "importance": "The midterm's hardest questions are recursive traces.",
+                 "concepts": ["Base case", "Call stack"],
+             },
+         ],
+     }),
+]
+
+
+def seed_study_guides() -> None:
+    for guide_id, user_id, off_id, exam_id, generated_at, content in _STUDY_GUIDES:
+        h.insert_if_absent(
+            "study_guides",
+            guide_id,
+            {
+                "user_id": user_id,
+                "offering_id": off_id,
+                "exam_id": exam_id,
+                "generated_at": generated_at,
+                "content": content,
+            },
+        )
+
+
 # (qa_id, concept_node_id, difficulty, score, total, questions_json, answers_json, completed_at)
 _QUIZ_ATTEMPTS = [
     ("rich-qa-cs-variables-1", "rich-node-cs-variables", "easy", 9, 10,
@@ -670,7 +715,8 @@ _SUMMARY_ORDER = [
     "schools", "courses", "course_offerings", "users", "user_profiles", "user_roles",
     "enrollments", "graph_nodes", "graph_edges", "node_mastery_events",
     "gradebook_categories", "assignments", "rooms", "room_members", "room_messages",
-    "notes", "documents", "flashcards", "quiz_attempts", "sessions", "messages",
+    "notes", "documents", "flashcards", "study_guides", "quiz_attempts", "sessions",
+    "messages",
 ]
 
 
@@ -687,6 +733,7 @@ def main() -> None:
     seed_rooms()
     seed_notes_documents()
     seed_flashcards()
+    seed_study_guides()
     seed_quiz()
     seed_sessions()
     h.print_summary(_SUMMARY_ORDER, "Seed summary (rich local dataset):")

--- a/frontend/e2e/study-recent-guides.spec.ts
+++ b/frontend/e2e/study-recent-guides.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression journey for #476 — opening a guide from the "Recent guides" rail
+ * must leave the exam SELECTED, so Regenerate is usable on that path.
+ *
+ * The bug: openRecent sets courseId AND examId together, but the courseId-keyed
+ * exams effect opened with an unconditional `setExamId("")`. Both effects ran in
+ * the same commit, so the guide still loaded and only the NEXT render lost the
+ * exam — leaving a guide on screen above a dead Regenerate button. It needs a
+ * COURSE CHANGE to reproduce, which a fresh /study load gives for free
+ * (courseId starts ""); a rail entry for the already-selected course never
+ * tripped it.
+ *
+ * Seeded (db/seed_local_rich.py): rich-guide-cs-f25-mid, a CACHED guide for
+ * rich-user-active on the fall-2025 CS101 offering, keyed to the real
+ * "Midterm Exam" assignment. Cached matters — the guide GET returns the row
+ * before reaching the study_guide agent, which has NO function-mode handler.
+ * For the same reason this journey must never CLICK Regenerate: asserting the
+ * button is enabled is the fix; pressing it would generate.
+ */
+import { expect, test } from "./support/fixtures";
+
+// The course and exam pickers are the only listbox triggers on the guide pane,
+// in that DOM order. Once both hold a value their accessible names no longer
+// distinguish them from the rail entry, which repeats the exam title.
+const examPicker = (page: import("@playwright/test").Page) =>
+  page.locator('button[aria-haspopup="listbox"]').nth(1);
+
+test("opening a recent guide keeps the exam selected, so Regenerate is usable", async ({
+  page,
+}) => {
+  await page.goto("/study");
+
+  // Before any selection the exam picker reads "Select a course first", so the
+  // rail entry is the only thing named for the exam.
+  const railEntry = page.getByRole("button", { name: /Midterm Exam/ });
+  await expect(railEntry).toBeVisible();
+  await expect(examPicker(page)).toHaveText(/Select a course first/);
+
+  await railEntry.click();
+
+  // The guide loads — that was never the broken half.
+  await expect(page.getByText("Covers variables, control flow, and functions.")).toBeVisible();
+
+  // #476: the selection openRecent made survives the course change it caused.
+  await expect(examPicker(page)).toHaveText(/Midterm Exam/);
+  await expect(page.getByRole("button", { name: /Regenerate/ })).toBeEnabled();
+});

--- a/frontend/src/components/screens/Study.recentGuides.test.tsx
+++ b/frontend/src/components/screens/Study.recentGuides.test.tsx
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+/**
+ * Study — opening a guide from the "Recent guides" rail (#476).
+ *
+ * The defect is NOT that the open path forgets to select the exam: openRecent
+ * sets courseId AND examId together. It's that the courseId-keyed exams effect
+ * opens with an unconditional `setExamId("")` — a scope reset that can't tell
+ * "the user switched course" (selection now invalid) from "we just opened a
+ * specific guide" (selection deliberate and valid). Both effects run in the
+ * same commit, so the guide still loads, and the NEXT render has examId "" —
+ * which is why the symptom is "guide on screen, Regenerate permanently
+ * disabled" rather than "nothing opens".
+ *
+ * The discriminator that proves the mechanism is the same-course case: a rail
+ * entry for the ALREADY-selected course never trips the effect, so it works
+ * today. It's pinned below as a control.
+ *
+ * Regenerate's term is part of this fix, not a separate concern: the button is
+ * unreachable on the rail path today, so nothing could regenerate a rail-opened
+ * guide under the wrong term. Making it reachable exposes that hazard — the
+ * #475 F1 mismatch (a Spring guide regenerated as Fall silently persists a row
+ * against the wrong offering) — so regenerate has to replay the term the
+ * displayed guide was actually loaded with.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/context/UserContext", () => ({
+  useUser: () => ({ userId: "u1", userReady: true }),
+}));
+
+vi.mock("@/lib/useIsMobile", () => ({
+  useIsMobile: () => false,
+}));
+
+// Pulls in the whole import-tab tree (and more @/lib/api names) — out of scope.
+vi.mock("@/components/flashcards/FlashcardImportModal", () => ({
+  FlashcardImportModal: () => null,
+}));
+
+vi.mock("@/lib/api", () => ({
+  getCourses: vi.fn(async () => ({ courses: [] })),
+  getStudyGuideExams: vi.fn(async () => ({ exams: [] })),
+  getStudyGuide: vi.fn(async () => ({
+    guide: { exam: "Midterm 1", topics: [] },
+    generated_at: "2026-04-01T00:00:00Z",
+    cached: true,
+  })),
+  regenerateStudyGuide: vi.fn(async () => ({
+    success: true,
+    guide: { exam: "Midterm 1", topics: [] },
+    generated_at: "2026-04-02T00:00:00Z",
+  })),
+  getCachedStudyGuides: vi.fn(async () => ({ guides: [] })),
+  getFlashcards: vi.fn(async () => ({ flashcards: [] })),
+  generateFlashcards: vi.fn(),
+  rateFlashcard: vi.fn(),
+  deleteFlashcard: vi.fn(),
+  getDocuments: vi.fn(async () => ({ documents: [] })),
+}));
+
+import { Study } from "./Study";
+import { ToastProvider } from "../ToastProvider";
+import { ACTIVE_SEMESTER_STORAGE_KEY } from "@/lib/useActiveSemester";
+import {
+  getCachedStudyGuides,
+  getCourses,
+  getStudyGuide,
+  getStudyGuideExams,
+  regenerateStudyGuide,
+  type EnrolledCourse,
+} from "@/lib/api";
+
+const mockedCached = vi.mocked(getCachedStudyGuides);
+const mockedCourses = vi.mocked(getCourses);
+const mockedExams = vi.mocked(getStudyGuideExams);
+const mockedGuide = vi.mocked(getStudyGuide);
+const mockedRegenerate = vi.mocked(regenerateStudyGuide);
+
+/** The rail entry under test: course c1 / exam e1, generated under Fall 2025. */
+const RECENT = {
+  id: "g1",
+  course_id: "c1",
+  exam_id: "e1",
+  course_name: "Intro to CS",
+  exam_title: "Midterm 1",
+  overview: "",
+  generated_at: "2026-04-01T00:00:00Z",
+  semester: "Fall 2025",
+};
+
+function course(id: string, code: string, name: string, term: string): EnrolledCourse {
+  return {
+    enrollment_id: `enr-${id}`,
+    course_id: id,
+    course_code: code,
+    course_name: name,
+    school: "BU",
+    department: "CS",
+    color: null,
+    nickname: null,
+    node_count: 0,
+    enrolled_at: "2025-09-01",
+    term,
+  };
+}
+
+const COURSE_C1 = course("c1", "CS101", "Intro to CS", "Fall 2025");
+const COURSE_C2 = course("c2", "CS201", "Data Structures", "Fall 2025");
+
+/** The two CustomSelect triggers in DOM order: [course, exam]. They're the only
+ *  listbox triggers on the guide pane, and querying by accessible name can't
+ *  distinguish them once both hold a value. */
+function selectTriggers() {
+  return Array.from(
+    document.querySelectorAll<HTMLButtonElement>('button[aria-haspopup="listbox"]'),
+  );
+}
+
+const examTrigger = () => selectTriggers()[1];
+
+function renderStudy() {
+  return render(
+    <ToastProvider>
+      <Study />
+    </ToastProvider>,
+  );
+}
+
+/** Opens the rail entry titled "Midterm 1" (the aside is the only place that
+ *  title renders as a clickable button before an exam is selected). */
+async function openRecentGuide() {
+  await userEvent.click(await screen.findByText("Midterm 1"));
+}
+
+beforeEach(() => {
+  mockedCached.mockResolvedValue({ guides: [RECENT] });
+  mockedCourses.mockResolvedValue({ courses: [COURSE_C1, COURSE_C2] });
+  mockedExams.mockResolvedValue({
+    exams: [{ id: "e1", title: "Midterm 1", due_date: "2026-04-01" }],
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.removeItem(ACTIVE_SEMESTER_STORAGE_KEY);
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("Study — opening a guide from the Recent guides rail (#476)", () => {
+  it("keeps the exam selected, so Regenerate is usable", async () => {
+    renderStudy();
+    await openRecentGuide();
+
+    // The guide is on screen — the load was never the broken part.
+    await screen.findByRole("button", { name: /regenerate/i });
+    expect(screen.getByRole("button", { name: /regenerate/i })).toBeEnabled();
+  });
+
+  it("regenerates the exam that was opened", async () => {
+    renderStudy();
+    await openRecentGuide();
+
+    await userEvent.click(await screen.findByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => expect(mockedRegenerate).toHaveBeenCalledTimes(1));
+    expect(mockedRegenerate).toHaveBeenCalledWith("u1", "c1", "e1", expect.anything());
+  });
+
+  it("regenerates under the entry's OWN term, not the active selector's (#475 F1)", async () => {
+    // The rail entry is a Fall 2025 guide; the active selector says Spring 2026.
+    // Regenerating under Spring would build and persist a row against an
+    // offering the displayed guide never came from.
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Spring 2026");
+    mockedCourses.mockResolvedValue({
+      courses: [course("c1", "CS101", "Intro to CS", "Spring 2026")],
+    });
+
+    renderStudy();
+    await openRecentGuide();
+    await userEvent.click(await screen.findByRole("button", { name: /regenerate/i }));
+
+    await waitFor(() => expect(mockedRegenerate).toHaveBeenCalledTimes(1));
+    expect(mockedRegenerate).toHaveBeenCalledWith("u1", "c1", "e1", "Fall 2025");
+    expect(mockedRegenerate).not.toHaveBeenCalledWith("u1", "c1", "e1", "Spring 2026");
+  });
+
+  it("shows the opened exam in the exam picker", async () => {
+    renderStudy();
+    await openRecentGuide();
+
+    await waitFor(() => expect(examTrigger()).toHaveTextContent("Midterm 1"));
+  });
+
+  // Control, not a new behavior: this path never changes courseId, so the
+  // course-keyed reset never fires and it works today. It's what proves the
+  // defect is the reset — and it must keep working after the fix.
+  it("already worked when the entry's course was the selected one", async () => {
+    renderStudy();
+    await userEvent.click(await screen.findByRole("button", { name: /pick a course/i }));
+    await userEvent.click(await screen.findByRole("option", { name: /CS101/ }));
+    await openRecentGuide();
+
+    expect(await screen.findByRole("button", { name: /regenerate/i })).toBeEnabled();
+  });
+});
+
+describe("Study — selections that genuinely go stale still reset", () => {
+  it("switching course clears the exam selected under the old one", async () => {
+    renderStudy();
+    await openRecentGuide();
+    await screen.findByRole("button", { name: /regenerate/i });
+
+    await userEvent.click(selectTriggers()[0]);
+    await userEvent.click(await screen.findByRole("option", { name: /CS201/ }));
+
+    await waitFor(() => expect(examTrigger()).toHaveTextContent(/pick an exam/i));
+    expect(screen.queryByRole("button", { name: /regenerate/i })).toBeNull();
+  });
+
+  it("switching term drops the selection instead of reloading it under the new term", async () => {
+    window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Fall 2025");
+    renderStudy();
+    // Selected through the pickers, NOT the rail: the rail path is the one
+    // #476 breaks, and setting up through it would leave examId already ""
+    // here — the assertion below would pass without testing anything.
+    await userEvent.click(await screen.findByRole("button", { name: /pick a course/i }));
+    await userEvent.click(await screen.findByRole("option", { name: /CS101/ }));
+    await userEvent.click(examTrigger());
+    await userEvent.click(await screen.findByRole("option", { name: /Midterm 1/ }));
+    await screen.findByRole("button", { name: /regenerate/i });
+    mockedGuide.mockClear();
+
+    // The Courses & Semesters hub switches the term via localStorage + this
+    // same-tab event (lib/useActiveSemester).
+    await act(async () => {
+      window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Spring 2026");
+      window.dispatchEvent(new Event("sapling-active-semester-change"));
+    });
+
+    // An exam picked under Fall need not exist in Spring — re-reading it under
+    // the new term is a guess, and it lands on the strict resolver.
+    await waitFor(() => expect(examTrigger()).toHaveTextContent(/pick an exam/i));
+    expect(mockedGuide).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/screens/Study.recentGuides.test.tsx
+++ b/frontend/src/components/screens/Study.recentGuides.test.tsx
@@ -226,6 +226,23 @@ describe("Study — selections that genuinely go stale still reset", () => {
     expect(screen.queryByRole("button", { name: /regenerate/i })).toBeNull();
   });
 
+  // CustomSelect.commit() fires onChange for the already-selected option too,
+  // so "switching course" has to mean the value actually CHANGED. The old
+  // effect-based reset got this for free (setCourseId(same) → React bails out,
+  // the effect never re-runs); moving the reset onto the event dropped that
+  // guard, and re-confirming your own course wiped the guide you were reading.
+  it("re-picking the course already selected leaves the loaded guide alone", async () => {
+    renderStudy();
+    await openRecentGuide();
+    await screen.findByRole("button", { name: /regenerate/i });
+
+    await userEvent.click(selectTriggers()[0]);
+    await userEvent.click(await screen.findByRole("option", { name: /CS101/ }));
+
+    expect(screen.getByRole("button", { name: /regenerate/i })).toBeEnabled();
+    expect(examTrigger()).toHaveTextContent("Midterm 1");
+  });
+
   it("switching term drops the selection instead of reloading it under the new term", async () => {
     window.localStorage.setItem(ACTIVE_SEMESTER_STORAGE_KEY, "Fall 2025");
     renderStudy();

--- a/frontend/src/components/screens/Study.semester.test.tsx
+++ b/frontend/src/components/screens/Study.semester.test.tsx
@@ -150,11 +150,10 @@ describe("Study flashcards fetch respects the active semester", () => {
 });
 
 describe("Study guide path threads the right term", () => {
-  // Regenerate isn't drivable from the recent-guides rail: openRecent SETS
-  // examId, but the courseId-keyed exams effect races it and clears the exam
-  // selection (the emergent behavior tracked as #476), which leaves the
-  // Regenerate button disabled. Its one-line `semester || undefined`
-  // threading matches the read calls asserted below.
+  // Regenerate is driven from the rail in Study.recentGuides.test.tsx — it
+  // became reachable there once #476 stopped the courseId-keyed effect from
+  // clearing the exam openRecent had set. These cases stay on the READ path;
+  // regenerate's own term threading is asserted with that fix.
   it("opens a recent guide AS ITS OWN TERM, not the active selector's (#475 F1)", async () => {
     // Active selector says Fall 2025; the rail entry is a Spring 2026 guide.
     // Loading it under the active term would cache-miss on the (offering,

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -80,9 +80,13 @@ type Mode = "guide" | "cards";
 // term with no offering of the course, #475 F4; `message` carries the server's
 // sentence when it isn't the exam-deleted one), or the generation itself
 // broke. Only the second is worth a red toast, and it carries the ids + term
-// it was built from because opening a recent guide clears the exam selection —
-// the selects are not a reliable retry target. `semester` is the term the
-// failed load resolved with ("" = unscoped), so retry replays it exactly.
+// it was built from so retry replays the load that failed rather than whatever
+// the selects hold when the user gets around to clicking — they can have moved
+// on (or been reset by a course/term switch) in between, and a failed load
+// leaves nothing on screen tying them to it. `semester` is the term the failed
+// load resolved with ("" = unscoped).
+// (Until #476 the sharper reason was that a recent-open cleared the exam
+// selection outright; that's fixed — the selects now track the open.)
 type GuideProblem =
   | { kind: "missing"; message?: string }
   | { kind: "failed"; message: string; courseId: string; examId: string; semester: string };
@@ -218,6 +222,8 @@ function GuideMode({
   const [regenerating, setRegenerating] = React.useState(false);
   const [recent, setRecent] = React.useState<StudyGuideCacheEntry[]>([]);
   const [guideProblem, setGuideProblem] = React.useState<GuideProblem | null>(null);
+  // "" = resolved unscoped. See loadGuide.
+  const [loadedTerm, setLoadedTerm] = React.useState<string>("");
 
   const loadRecent = React.useCallback(async () => {
     if (!userId) return;
@@ -231,11 +237,38 @@ function GuideMode({
 
   React.useEffect(() => { loadRecent(); }, [loadRecent]);
 
-  React.useEffect(() => {
+  // Dropping the exam selection is a response to two EVENTS — the user picking
+  // a different course, and the active term changing — never to `courseId`
+  // simply differing from its last value. That distinction is the whole of
+  // #476: openRecent changes courseId too, and a courseId-keyed effect can't
+  // tell a deliberate open from a user switch, so it wiped the exam openRecent
+  // had just set. It also landed a render late, so the loader below still got
+  // one read out of the stale pair before the reset applied.
+  const clearSelection = () => {
     setExamId("");
-    setExams([]);
     setGuide(null);
     setGuideProblem(null);
+  };
+
+  const selectCourse = (next: string) => {
+    setCourseId(next);
+    clearSelection();
+  };
+
+  // A term switch re-scopes the exam list, so an exam picked under the old term
+  // need not exist in the new one. Adjusted during render (the StudyModePanel
+  // pattern above) rather than in an effect: an effect-time reset commits once
+  // on the stale pair first, re-reading the old exam under the new term and
+  // landing on the strict resolver. `null` = uninitialized, so hydration
+  // ("" → the stored term) is not a switch.
+  const [scopedTerm, setScopedTerm] = React.useState<string | null>(null);
+  if (semesterReady && scopedTerm !== semester) {
+    if (scopedTerm !== null) clearSelection();
+    setScopedTerm(semester);
+  }
+
+  React.useEffect(() => {
+    setExams([]);
     if (!courseId || !userId || !semesterReady) return;
     setLoadingExams(true);
     getStudyGuideExams(userId, courseId, semester || undefined)
@@ -263,6 +296,11 @@ function GuideMode({
     try {
       const r = await getStudyGuide(userId, cid, eid, term);
       setGuide(r.guide);
+      // The term this guide was actually resolved under — which is the entry's
+      // own term on a recent-open, not the active selector's (#475 F1).
+      // Regenerate has to replay it, or it rebuilds against a different
+      // offering than the one on screen.
+      setLoadedTerm(term ?? "");
       setGeneratedAt(r.generated_at);
       setCached(r.cached);
       if (!r.cached) loadRecent();
@@ -317,8 +355,11 @@ function GuideMode({
     setRegenerating(true);
     setGuideProblem(null);
     try {
-      // Regenerates the SELECTED term's guide — same offering the reads key on.
-      const r = await regenerateStudyGuide(userId, courseId, examId, semester || undefined);
+      // Regenerates the term the DISPLAYED guide was read under, so rebuild
+      // and read key on the same offering. Before #476 this could use the
+      // active selector safely only because the button was unreachable on the
+      // recent-open path — the one path where the two differ.
+      const r = await regenerateStudyGuide(userId, courseId, examId, loadedTerm || undefined);
       setGuide(r.guide);
       setGeneratedAt(r.generated_at);
       setCached(false);
@@ -361,7 +402,7 @@ function GuideMode({
             </div>
             <CustomSelect
               value={courseId}
-              onChange={v => setCourseId(v)}
+              onChange={selectCourse}
               placeholder="Pick a course…"
               options={courses.map(c => ({
                 value: c.course_id,

--- a/frontend/src/components/screens/Study.tsx
+++ b/frontend/src/components/screens/Study.tsx
@@ -250,7 +250,13 @@ function GuideMode({
     setGuideProblem(null);
   };
 
+  // Guarded on an actual CHANGE. CustomSelect fires onChange for the
+  // already-selected option too, and the effect this reset came out of got that
+  // for free — setCourseId(same) bails out, so the effect never re-ran. On a
+  // plain handler it has to be explicit, or re-confirming the course you are
+  // already on wipes the guide you are reading.
   const selectCourse = (next: string) => {
+    if (next === courseId) return;
     setCourseId(next);
     clearSelection();
   };
@@ -267,6 +273,15 @@ function GuideMode({
     setScopedTerm(semester);
   }
 
+  // The OPTIONS follow the active selector, deliberately: #475 pins only the
+  // recent-open's own load to the entry's term, and later picker-driven loads
+  // go back to the selector — so listing the entry's term here would offer
+  // exams that the next load would then 404 on.
+  // Known edge that leaves: open a rail entry whose term ISN'T the active one
+  // and its exam is absent from this list, so CustomSelect falls back to the
+  // placeholder while the guide and Regenerate are live and correctly aimed at
+  // `loadedTerm`. Squaring that needs the screen to track "the term I'm
+  // viewing" as one thing across list + loads — a #475 change, not this one.
   React.useEffect(() => {
     setExams([]);
     if (!courseId || !userId || !semesterReady) return;


### PR DESCRIPTION
Part of #476.

## The issue body misattributes the cause

> "the recent-guides open path clears the selected exam"

It doesn't. `openRecent` (`Study.tsx`) sets **both** ids:

```js
recentTermRef.current = entry.semester ?? "";
setCourseId(entry.course_id);
setExamId(entry.exam_id);
```

The clearing comes from the **courseId-keyed exams effect**, whose first
statement was an unconditional `setExamId("")`. That reset cannot tell
*"the user switched course"* (selection now invalid) from *"we just opened a
specific guide"* (selection deliberate and valid) — it only sees that
`courseId` differs from its last value, which `openRecent` also causes.

Both effects run in the **same commit**, so the loader still saw the intact
pair and the guide loaded; only the *next* render lost the exam. That is why
the symptom is "a guide on screen above a dead Regenerate button" rather than
"nothing opens" — and why `disabled={… || !examId}` pins the button off.

**Discriminator (pinned as a control test):** it needs a course *change* to
reproduce. A rail entry whose course is already selected never trips the
effect and worked fine on main. That test passed before the fix and still
passes after — it's what proves the mechanism is the reset, not the open path.

## The fix

The reset now happens at the two events that actually mean it:

1. **Course picker `onChange`** — the event that genuinely invalidates the exam.
2. **Term switch** — a re-scope of the exam list, so the exam picked under the
   old term need not exist in the new one.

The term case adjusts state **during render** (the `StudyModePanel` pattern
already in this file) rather than in an effect. That matters: an effect-time
reset lands a render late, so the loader commits one read of the old exam
under the *new* term first. That was the same defect's second trigger — it
reproduced on main and now has a test.

The exams effect is now purely a fetch.

## One consequence worth flagging

Making Regenerate reachable on the rail path **exposed a term hazard**.
`regenerate` sent the **active selector's** term, while a recent entry opens
under its **own** term (#475 F1). On main that was unreachable — the button
was dead on the one path where the two differ — so it was latent. Enabling
the button would have made it live: regenerating a Fall guide while the
selector says Spring rebuilds against an offering the displayed guide never
came from, which is exactly the mismatch #475 F1 fixed for reads.

Regenerate now replays the term the displayed guide was **loaded** with.

## Tests

- `Study.recentGuides.test.tsx` (new, 7 cases) — written red first:
  4 failed on the `Regenerate`/picker assertions, the term-switch case failed
  on the stale re-read, and the same-course control passed throughout.
- `Study.semester.test.tsx` — updated a comment that documented the bug as
  permanent ("Regenerate isn't drivable from the recent-guides rail").
- `e2e/study-recent-guides.spec.ts` (new) — promoted regression journey.
- `db/seed_local_rich.py` — seeds a **cached** guide so the journey can open
  the rail without generating; the `study_guide` agent has no function-mode
  handler, and the guide GET returns the cache hit before reaching it. The
  journey asserts Regenerate is *enabled* and deliberately never clicks it.

## Gates

- `tsc --noEmit` clean; `eslint src` 0 errors; `vitest run` 422/422.
- backend `pytest` 1529 passed / 32 skipped; `ruff check` clean.
- Full local e2e cycle (up → Playwright → oracles → down) in one flock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cached CS101 Fall 2025 midterm study guide for local study experiences.
  * Recent guides now preserve the associated course, exam, and semester when opened.
  * Regeneration uses the selected guide’s original term and keeps the Regenerate option available.

* **Bug Fixes**
  * Prevented outdated exam and guide selections from carrying over when switching courses or semesters.
  * Improved failed-guide retries by preserving the original study selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->