### PR TITLE
fix(e2e): poll for the tutor turn's rows instead of reading once (#477)

### DIFF
--- a/frontend/e2e/tutor.spec.ts
+++ b/frontend/e2e/tutor.spec.ts
@@ -72,15 +72,26 @@ test("tutor turn renders a reply and persists encrypted to messages", async ({
   await expect(log).toContainText(TUTOR_REPLY);
 
   // ── Raw-SQL readback: the turn persisted, encrypted (#397 posture) ───────
-  const rows = (await queryRaw(
-    `SELECT role, content FROM messages
-      WHERE session_id = $1
-      ORDER BY created_at ASC`,
-    [SESSION_ID],
-  )) as { role: string; content: string }[];
+  // Polled, not read once (#477). The server persists inside on_complete and
+  // only THEN yields `done` (services/chat_stream.py) — the write really does
+  // precede the end of the turn. But the composer renders the reply off the
+  // streamed TOKENS, so the two assertions above can both pass while `done`
+  // is still in flight: a rendered reply is not a persistence signal, the
+  // rows are. Bounded poll rather than a retry or a bare sleep, per the #388
+  // zero-flake policy.
+  const readTurnRows = async () =>
+    (await queryRaw(
+      `SELECT role, content FROM messages
+        WHERE session_id = $1
+        ORDER BY created_at ASC`,
+      [SESSION_ID],
+    )) as { role: string; content: string }[];
 
   // Exactly the seeded baseline plus this turn's user + assistant rows.
-  expect(rows).toHaveLength(SEEDED_MESSAGE_COUNT + 2);
+  await expect
+    .poll(async () => (await readTurnRows()).length, { timeout: 5_000 })
+    .toBe(SEEDED_MESSAGE_COUNT + 2);
+  const rows = await readTurnRows();
   const [userRow, assistantRow] = rows.slice(-2);
   expect(userRow.role).toBe("user");
   expect(assistantRow.role).toBe("assistant");

--- a/frontend/e2e/tutor.spec.ts
+++ b/frontend/e2e/tutor.spec.ts
@@ -88,10 +88,18 @@ test("tutor turn renders a reply and persists encrypted to messages", async ({
     )) as { role: string; content: string }[];
 
   // Exactly the seeded baseline plus this turn's user + assistant rows.
+  // The rows are captured INSIDE the predicate (the events.spec.ts shape), so
+  // the count assertion and the content assertions below are the same read.
+  // Re-querying after the poll would decouple them: a duplicate-persistence
+  // regression could land a row in the gap and still slice two valid-looking
+  // rows off the end, which is precisely what this journey exists to catch.
+  let rows: { role: string; content: string }[] = [];
   await expect
-    .poll(async () => (await readTurnRows()).length, { timeout: 5_000 })
+    .poll(async () => {
+      rows = await readTurnRows();
+      return rows.length;
+    }, { timeout: 5_000 })
     .toBe(SEEDED_MESSAGE_COUNT + 2);
-  const rows = await readTurnRows();
   const [userRow, assistantRow] = rows.slice(-2);
   expect(userRow.role).toBe("user");
   expect(assistantRow.role).toBe("assistant");


### PR DESCRIPTION
Part of #477.

## Cause

The persistence assert read `messages` once, immediately after the reply text rendered — treating "the reply is on screen" as "the rows are committed". Those are different signals.

The server side is correct: `stream_agent_turn` persists inside `on_complete` and only *then* yields `done` (`backend/services/chat_stream.py:372-393`), so the write does precede the end of the turn. But the composer renders off the streamed **tokens**, so both UI assertions can pass while `done` is still in flight — leaving a window where the one-shot read sees only the 4 seeded rows. That matches the reported failure exactly (expected 6, received 4, UI assertions green).

So this is a test-side assumption, not a product regression — worth stating, since the alternative reading (rows should already be there) would have pointed at a real persistence bug.

## Fix

Bounded `expect.poll` on the row count, the idiom `events.spec.ts` already uses for its fire-and-forget rollup. Root fix rather than a retry, per the #388 zero-flake policy.

## Honest limitation

A ~1-in-6 race is not reproducible on demand, so this is **not** verified by a watched-red test. It rests on the persist-before-`done` contract above plus green cycles. What the change does guarantee: the assert can no longer fail *because it read too early* — it now waits for the condition it depends on, or fails after 5s.

## Gates

tsc clean; full local cycle green (Playwright 37/37, oracles 0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved tutor end-to-end test reliability by waiting for expected messages to be persisted before validation.
  * Updated assertions to verify message roles and encrypted content more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->