### PR TITLE
fix(storage): converge the avatars bucket on public read (#316)

### DIFF
--- a/backend/db/migrations/0041_avatars_bucket_public.sql
+++ b/backend/db/migrations/0041_avatars_bucket_public.sql
@@ -1,0 +1,42 @@
+-- 0041: converge the `avatars` bucket on public read (#316).
+--
+-- Staging drift: on `sapling-staging` (ybgqdonkoqftwrmweuyv) the avatars bucket
+-- is public=false, while prod is public=true and 0029 states the intent
+-- explicitly ("`avatars` stays public (intended public read)"). Avatar <img>
+-- src values are plain public object URLs, so a private bucket serves 400s and
+-- every avatar on staging renders broken.
+--
+-- WHY THIS DRIFT NEVER SELF-HEALS (the part worth knowing):
+-- both mechanisms that "create" this bucket decline to correct an existing one.
+--   * 0011_avatars_bucket.sql INSERTs it with public=true but ends in
+--     ON CONFLICT (id) DO NOTHING — a no-op if the row already exists.
+--   * storage_service.ensure_bucket_exists (called from main.py's lifespan with
+--     public=True) treats the Storage API's 409 as success and deliberately
+--     does NOT overwrite settings, "in case an admin has intentionally tuned
+--     them in the dashboard".
+-- So a bucket that came into existence private stays private forever, no matter
+-- how many deploys or migrations run. An UPDATE is the only thing that fixes it,
+-- which is why this file exists rather than a re-run of 0011.
+--
+-- This deliberately overrides the "an admin may have tuned it" stance for THIS
+-- bucket: the read path is unauthenticated <img src> against
+-- /storage/v1/object/public/avatars/..., so private is not a valid tuning — it
+-- is broken avatars. 0029 already recorded the intent ("`avatars` stays public
+-- (intended public read)"); this asserts that state instead of assuming it.
+--
+-- Idempotent and safe across environments: a no-op where avatars is already
+-- public (prod), and affects zero rows where the bucket does not exist yet
+-- (a fresh local project before e2e-up's bucket-ensure step).
+--
+-- PRIVILEGES: touches the Supabase-managed `storage` schema, exactly as 0029
+-- does. The migrate runner connects over SUPABASE_DB_URL as the DB owner
+-- (`postgres`), which on Supabase may alter storage.buckets. If a locked-down
+-- environment's role lacks that privilege, apply this file with a
+-- storage-privileged role instead.
+--
+-- NOTE: writing this migration does not by itself fix staging — it converges
+-- on the next `python -m db.migrate` run against that project.
+
+update storage.buckets
+   set public = true
+ where id = 'avatars';


### PR DESCRIPTION
Part of #316.

## The issue's suggested fix would have worked, but not lasted

The issue proposes flipping the staging bucket to public. That fixes staging. It does not explain why staging drifted, and it leaves the same drift possible on the next environment.

**Both mechanisms that "create" this bucket decline to correct an existing one:**

- `0011_avatars_bucket.sql` inserts it with `public = true` but ends in `ON CONFLICT (id) DO NOTHING` — a no-op once the row exists.
- `storage_service.ensure_bucket_exists` (called from `main.py`'s lifespan with `public=True`) treats the Storage API's `409` as success and *deliberately* does not overwrite settings, "in case an admin has intentionally tuned them in the dashboard".

So a bucket that came into existence private stays private forever, through any number of deploys and migrations. An `UPDATE` is the only thing that corrects it — hence a new file rather than a re-run of 0011.

## The one judgment call

This deliberately overrides `ensure_bucket_exists`'s "an admin may have tuned it" stance, for this bucket only. The read path is an unauthenticated `<img src>` against `/storage/v1/object/public/avatars/...`, so private isn't a valid tuning — it's broken avatars. `0029` already recorded the intent (*"`avatars` stays public (intended public read)"*); this asserts that state instead of assuming it.

## Verification

- **From-empty replay** (`scripts/local-db-reset.sh`, not a normal cycle — `e2e-up` runs against a DB that already has the schema): the whole chain applies clean with 0041 in it.
- **Effect on a drifted bucket**: forced `avatars` to `public=false` to reproduce the staging condition, then ran the statement — flips to `true`, idempotent on re-run, and a safe zero-row no-op against a non-existent bucket id.
- Full local e2e cycle green (Playwright 37/37, oracles 0 findings).

## This does not fix staging by itself

It converges on the next `python -m db.migrate` against that project. #316 should stay open until that's run — I don't have (and shouldn't use) staging credentials for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)