### PR TITLE
chore(db): timestamp-prefix new migrations; freeze the legacy NNNN_ set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ A FastAPI + Supabase backend that ingests student documents, calls Gemini to cla
 - backend/services/auth_guard.py:68 — `require_self` / `require_admin` FastAPI dependencies.
 - backend/agents/note_summary.py, note_concepts.py, note_chat.py — Pydantic AI agents backing the `/api/notes` agent actions (model slots in `agents/_providers.py`).
 - backend/db/connection.py:102 — `table()` factory; the only sanctioned Supabase entry point (PostgREST, no DDL).
-- backend/db/migrate.py — raw-DDL migration runner (psycopg over `SUPABASE_DB_URL`); migrations are append-only `db/migrations/*.sql` (now at 0036).
+- backend/db/migrate.py — raw-DDL migration runner (psycopg over `SUPABASE_DB_URL`); migrations are append-only `db/migrations/*.sql`, named with a UTC timestamp prefix (`YYYYMMDDHHMMSS_description.sql`). See `db/migrations/README.md`.
 
 ## Commands
 
@@ -80,7 +80,7 @@ make explore                       # Chapter 2: bounded AI exploration of the ru
 ## Conventions
 
 - All Supabase access goes through `db/connection.py::table()`. Do not instantiate `httpx` clients or import `supabase` directly elsewhere. The one sanctioned exception is `db/migrate.py`, which connects with psycopg to run DDL.
-- Schema changes are append-only numbered migrations in `backend/db/migrations/` (applied via `python -m db.migrate`); never edit an applied migration or run DDL in the Supabase dashboard.
+- Schema changes are append-only migrations in `backend/db/migrations/` (applied via `python -m db.migrate`); never edit an applied migration or run DDL in the Supabase dashboard. **New migrations use a UTC timestamp prefix** — `date -u +%Y%m%d%H%M%S` — because sequential `NNNN_` numbers are claimed at write time and only validated at merge, so concurrent branches collide. The 45 existing `NNNN_` files are frozen and must never be renamed: the ledger keys on basename, so a rename re-runs the migration. Full rationale in `backend/db/migrations/README.md`.
 - Term/offering/enrollment resolution goes through `services/academics.py`. The HTTP boundary keeps the abstract `course_id`; the graph stays on the abstract course, gradebook keys on `enrollment_id`, and study/analytics key on `offering_id`.
 - Display names are resolved via `services/profiles.py` (`get_display_name`/`get_display_names`), which decrypts off `user_profiles` — don't read name columns off `users`.
 - All LLM calls are Pydantic AI agents in `backend/agents/` (model slots in `agents/_providers.py`); there is no other sanctioned LLM seam (ADR 0024). Exactly two raw `google.genai.Client` sites remain: `services/rag_service.py`'s embedding client (request-path, `model_mode()`-gated per #439) and `scripts/_raw_gemini.py` (offline benchmark baseline, outside the request path — its docstring forbids importing it from application code).

--- a/backend/db/migrate.py
+++ b/backend/db/migrate.py
@@ -12,6 +12,7 @@ Usage:
 from __future__ import annotations
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -20,8 +21,42 @@ import psycopg
 MIGRATIONS_DIR = Path(__file__).parent / "migrations"
 
 
+# Two accepted filename shapes, both sortable and both fixed-width:
+#   NNNN_          legacy sequential prefix (frozen — see below)
+#   YYYYMMDDHHMMSS_  UTC timestamp, the convention for every NEW migration
+#
+# New migrations use a timestamp because a sequential counter is claimed when a
+# branch is written but only validated when it merges, so concurrent branches
+# routinely claim the same number.
+#
+# The legacy files are never renamed. `schema_migrations.filename` is the
+# ledger's primary key and `pending_migrations` treats an unknown basename as
+# unapplied, so renaming an applied migration re-runs it — and 0021_gradebook
+# DROPs and re-CREATEs a table.
+#
+# Ordering is unaffected, but for a narrower reason than "timestamps are
+# longer": sorting is character-by-character, so length decides nothing. Every
+# legacy file starts with "0" and every timestamp this millennium starts with
+# "2", and "0" < "2". A sequential migration numbered 3000+ would break that —
+# one more reason the legacy set is frozen.
+_MIGRATION_NAME_RE = re.compile(r"^(\d{4}|\d{14})_.+\.sql$")
+
+
+def is_valid_migration_name(name: str) -> bool:
+    """True when a filename carries a sortable, fixed-width numeric prefix.
+
+    Anything else sorts unpredictably against its siblings, which silently
+    changes apply order.
+    """
+    return bool(_MIGRATION_NAME_RE.match(name))
+
+
 def discover_migrations(migrations_dir: Path) -> list[Path]:
-    """All *.sql migration files, sorted by filename (numeric prefix = order)."""
+    """All *.sql migration files, sorted by filename.
+
+    Filename order IS apply order (see `is_valid_migration_name` for the two
+    accepted prefix shapes and why both sort correctly together).
+    """
     return sorted(Path(migrations_dir).glob("*.sql"))
 
 

--- a/backend/db/migrations/README.md
+++ b/backend/db/migrations/README.md
@@ -1,0 +1,76 @@
+# Migrations
+
+Raw DDL, applied in filename order by `python -m db.migrate`.
+
+## Naming: use a UTC timestamp
+
+```
+YYYYMMDDHHMMSS_short_description.sql
+```
+
+Generate the prefix when you create the file:
+
+```bash
+date -u +%Y%m%d%H%M%S      # e.g. 20260731224500
+```
+
+So: `20260731224500_documents_file_sha256.sql`.
+
+### Why not sequential numbers
+
+The old `NNNN_` scheme claims a number when a branch is **written** but only
+validates it when the branch **merges**. Two branches open at the same time
+routinely pick the same number, and nobody finds out until merge — or later,
+since an unpushed branch is invisible to everyone. One branch hit this twice in
+a single lifetime: first against `main`'s `0042`, then against an unpushed
+branch already holding `0043`/`0044`.
+
+A timestamp has no shared counter. Two branches would have to be created in the
+same second to collide.
+
+## The legacy `NNNN_` files are frozen — never rename them
+
+`schema_migrations.filename` is the ledger's primary key, and
+`pending_migrations` treats any basename it has not recorded as unapplied. So
+**renaming an applied migration makes the runner apply it again.**
+
+That is not a theoretical problem here. `0021_gradebook.sql` DROPs and
+re-CREATEs the enrollment-keyed `assignments` table; re-running it against an
+environment that already has data would destroy the gradebook.
+
+The two conventions coexist permanently. Ordering still works, though for a
+narrower reason than "timestamps are longer" — sorting is character by
+character, so length decides nothing. Every legacy file starts with `0`, every
+timestamp this millennium starts with `2`, and `0` < `2`. (A sequential
+migration numbered 3000+ would break that, which is another reason the legacy
+set is closed.)
+
+## Rules that have not changed
+
+- **Append-only.** Never edit a migration that has been applied anywhere.
+  Add a new one.
+- **Write idempotent DDL** — `IF NOT EXISTS`, guarded `ALTER`s — so a partially
+  applied environment can be reconciled without hand-editing the ledger.
+- **Never run DDL in the Supabase dashboard.** Schema lives here, in version
+  control. `0039_rag_vector_store.sql` exists because that rule was broken and
+  the RAG vector store had to be recovered into code afterwards.
+
+## Applying
+
+```bash
+python -m db.migrate              # apply pending
+python -m db.migrate --baseline   # record as applied WITHOUT running
+```
+
+`db/` scripts read `.env` by default. For staging/prod, run them under
+`dotenv -f .env.staging run -- python -m db.migrate` so they hit the right
+project.
+
+On Windows, set `PYTHONUTF8=1` — the runner reads files with the platform
+default encoding otherwise and dies on a non-cp1252 migration.
+
+## Guards
+
+`tests/test_migration_naming.py` fails if a new `NNNN_` file appears or a
+prefix is unsortable. `tests/test_migrations.py` pins apply order, including
+the three legacy duplicate-prefix pairs whose order is load-bearing.

--- a/backend/tests/test_migration_naming.py
+++ b/backend/tests/test_migration_naming.py
@@ -1,0 +1,106 @@
+"""Migration filename convention: timestamps for new migrations (#507 fallout).
+
+Sequential NNNN_ prefixes are claimed when a branch is WRITTEN but only
+validated when it MERGES, so two branches open at once routinely claim the same
+number. One branch hit this twice in a single lifetime — first against main's
+0042, then against an unpushed branch holding 0043/0044.
+
+A UTC timestamp prefix removes the shared counter: two branches would have to
+be created in the same second to collide.
+
+WHY THE EXISTING FILES ARE NOT RENAMED
+--------------------------------------
+`schema_migrations.filename` is the PRIMARY KEY of the ledger, and
+`pending_migrations` treats any basename not in that table as unapplied.
+Renaming an applied migration therefore makes the runner apply it AGAIN. That
+is not theoretical: `0021_gradebook.sql` DROPs and re-CREATEs the assignments
+table, so a rename would destroy the gradebook on any environment that already
+ran it.
+
+So the legacy files are frozen exactly as they are, forever, and the convention
+changes only for new migrations. Ordering still holds: "0" (0x30) sorts before
+"2" (0x32), so every NNNN_ file applies before every timestamped one, which is
+the correct order since the legacy ones came first.
+"""
+import re
+from pathlib import Path
+
+from db.migrate import discover_migrations, is_valid_migration_name
+
+MIGRATIONS_DIR = Path("db/migrations")
+
+# The complete set of sequentially-numbered migrations, frozen at the moment the
+# convention changed. Nothing may be added to this list: a new NNNN_ file is
+# exactly the mistake this convention exists to prevent, and the guard test
+# below fails if one appears.
+_LEGACY_NUMERIC_COUNT = 45
+
+
+def _names() -> list[str]:
+    return [p.name for p in discover_migrations(MIGRATIONS_DIR)]
+
+
+class TestNameValidation:
+    def test_accepts_a_utc_timestamp_prefix(self):
+        """The new convention: YYYYMMDDHHMMSS_description.sql."""
+        assert is_valid_migration_name("20260731224500_documents_file_sha256.sql")
+
+    def test_still_accepts_the_legacy_four_digit_prefix(self):
+        """The 45 existing files keep their names permanently — renaming an
+        applied migration would re-run it against the ledger."""
+        assert is_valid_migration_name("0021_gradebook.sql")
+
+    def test_rejects_a_name_with_no_sortable_prefix(self):
+        """Without a numeric prefix the file sorts unpredictably among its
+        siblings, so apply order becomes whatever the alphabet says."""
+        assert not is_valid_migration_name("add_widgets.sql")
+
+    def test_rejects_a_prefix_that_is_neither_four_nor_fourteen_digits(self):
+        """A 6- or 8-digit prefix would sort between the two schemes and break
+        the guarantee that all legacy files apply first."""
+        assert not is_valid_migration_name("202607_widgets.sql")
+        assert not is_valid_migration_name("20260731_widgets.sql")
+
+
+class TestOrderingGuarantee:
+    def test_a_timestamped_migration_sorts_after_every_legacy_one(self):
+        """The whole scheme rests on this. If it were false, a new migration
+        could apply BEFORE the schema it depends on."""
+        legacy = [n for n in _names() if re.match(r"^\d{4}_", n)]
+        newest_legacy = max(legacy)
+
+        assert "20260101000000_anything.sql" > newest_legacy
+
+    def test_the_ordering_rests_on_the_leading_digit_not_on_length(self):
+        """The guarantee is narrower than "timestamps sort last", and pinning
+        the real reason keeps the docs honest.
+
+        Comparison is character-by-character, so LENGTH does not decide it:
+        a year-1000 timestamp would sort BEFORE a 9999_ prefix, since
+        '1' < '9'. What actually holds is that every legacy file starts with
+        '0' and every timestamp this millennium starts with '2'.
+        """
+        legacy = [n for n in _names() if re.match(r"^\d{4}_", n)]
+
+        assert all(n.startswith("0") for n in legacy)
+        # A sequential migration numbered 3000+ would break this, which is
+        # another reason the legacy set is frozen.
+        assert "20260731224500_x.sql" > max(legacy)
+        assert "10000101000000_x.sql" < "9999_x.sql"  # the counter-example
+
+
+class TestNoNewSequentialMigrations:
+    """Guard, not a new behaviour: pins today's state so the NEXT sequentially
+    numbered migration fails CI instead of colliding at merge time."""
+
+    def test_every_migration_matches_one_of_the_two_conventions(self):
+        bad = [n for n in _names() if not is_valid_migration_name(n)]
+        assert bad == [], f"migrations with an invalid prefix: {bad}"
+
+    def test_no_sequential_migration_has_been_added_since_the_cutover(self):
+        legacy = [n for n in _names() if re.match(r"^\d{4}_", n)]
+        assert len(legacy) == _LEGACY_NUMERIC_COUNT, (
+            f"expected {_LEGACY_NUMERIC_COUNT} legacy NNNN_ migrations, found "
+            f"{len(legacy)}. New migrations must use a UTC timestamp prefix "
+            "(YYYYMMDDHHMMSS_description.sql) — see this module's docstring."
+        )

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -22,10 +22,9 @@ the numeric intent." That is not what the runner does. `sorted()` compares
 `_` (0x5F), applies **gradebook first** — which is exactly the required
 dependency order. `test_gradebook_applies_before_curve` pins that.
 """
-import re
 from pathlib import Path
 
-from db.migrate import discover_migrations
+from db.migrate import discover_migrations, is_valid_migration_name
 
 MIGRATIONS_DIR = "db/migrations"
 
@@ -44,10 +43,17 @@ def _order() -> list[str]:
 # ── Offline: apply-order pins (pure filename logic) ─────────────────────────
 
 
-def test_every_migration_has_a_four_digit_numeric_prefix():
-    """A file without the NNNN_ prefix sorts unpredictably and breaks ordering."""
-    bad = [n for n in _order() if not re.match(r"^\d{4}_.*\.sql$", n)]
-    assert bad == [], f"migrations without a NNNN_ prefix: {bad}"
+def test_every_migration_has_a_sortable_numeric_prefix():
+    """A file without a fixed-width numeric prefix sorts unpredictably and
+    breaks apply order.
+
+    Two shapes are accepted: the frozen legacy `NNNN_` files, and the
+    `YYYYMMDDHHMMSS_` timestamps used for every new migration. See
+    `tests/test_migration_naming.py` for why the legacy names can never be
+    converted, and `db.migrate.is_valid_migration_name` for the rule itself.
+    """
+    bad = [n for n in _order() if not is_valid_migration_name(n)]
+    assert bad == [], f"migrations with an unsortable prefix: {bad}"
 
 
 def test_migration_filenames_are_unique():


### PR DESCRIPTION
## Why

Sequential migration numbers are claimed when a branch is **written** but only validated when it **merges**, so two branches open at once routinely pick the same number.

PR #507 hit this twice in a single branch lifetime — first against `main`'s `0042`, then against an **unpushed** branch already holding `0043`/`0044`. The second one was invisible on GitHub entirely; it surfaced only because both branches had been applied to the same local database and the ledger listed all four side by side.

New migrations now use a UTC timestamp prefix:

```
YYYYMMDDHHMMSS_short_description.sql        date -u +%Y%m%d%H%M%S
```

No shared counter, so two branches would have to be created in the same second to collide.

## The existing 45 files are NOT renamed — and must never be

This is the constraint that shapes the whole change, so it's worth stating plainly.

`schema_migrations.filename` is the ledger's **primary key**, and `pending_migrations` treats any basename it hasn't recorded as unapplied. So **renaming an applied migration makes the runner apply it again.**

That is not theoretical here: `0021_gradebook.sql` DROPs and re-CREATEs the enrollment-keyed `assignments` table. A bulk rename would destroy the gradebook on every environment that has already run it.

So the two conventions coexist permanently. This PR changes what *new* migrations look like and adds a guard; it touches no existing migration file.

## Ordering still holds, for a narrower reason than you'd guess

Sorting is character-by-character, so **length decides nothing** — a year-1000 timestamp would sort *before* a `9999_` prefix, since `'1' < '9'`.

What actually holds: every legacy file starts with `0`, every timestamp this millennium starts with `2`, and `0` < `2`.

An earlier draft of this change asserted the length-based reasoning in both the code comments and the docs. Its own boundary test falsified it. The test now pins the real reason and keeps the counter-example inline, so the next reader doesn't re-derive the wrong one. A sequential migration numbered 3000+ would break the guarantee — one more reason the legacy set is closed.

## Enforcement is a test, not a note

`tests/test_migration_naming.py` fails CI if a new `NNNN_` file appears or a prefix is unsortable. A convention documented only in prose would decay; this one can't be violated silently.

The existing `test_every_migration_has_a_four_digit_numeric_prefix` had to be relaxed to accept both shapes — as written it would have rejected every timestamped migration, which is exactly the blocker that stops teams adopting this incrementally.

## Changes

| File | |
|---|---|
| `db/migrate.py` | `is_valid_migration_name()` — accepts `NNNN_` or `YYYYMMDDHHMMSS_` |
| `tests/test_migration_naming.py` | new — 8 tests incl. the no-new-sequential guard |
| `tests/test_migrations.py` | prefix test relaxed to both shapes |
| `db/migrations/README.md` | new — convention, the never-rename rule, and the ordering reasoning |
| `CLAUDE.md` | convention updated in both places it appears |

No SQL, no schema change, no migration added.

## Verification

Full suite: **1542 passed, 38 skipped, 0 failures.** `ruff check db/ tests/` clean.

## Follow-ups this enables

- **PR #507** still carries `0045`/`0046`. Converting them to timestamps is the real first adoption and permanently ends their collision problem, but it can't happen until this merges or they'd fail the current prefix test.
- The unpushed `feat/gamification-xp-achievements` holds `0043`/`0044` and should convert too, or it will collide with the next sequential migration anyone writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for UTC timestamp-based migration filenames.
  - Existing four-digit legacy migration filenames remain supported.
  - Migration files are now validated and applied according to filename order.

- **Documentation**
  - Expanded migration guidance with naming rules, timestamp commands, ordering, immutability, append-only practices, environment configuration, and platform considerations.
  - Documented validation requirements and migration workflow.

- **Tests**
  - Added coverage for valid and invalid naming formats, ordering, legacy compatibility, and prevention of new sequential migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->