### PR TITLE
feat(promotion): one-command staging→prod promotion runner (#516)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,14 @@ SESSION-mode pooler URI (port 5432, user `postgres.<ref>`); the direct
 `db.<ref>.supabase.co` host is IPv6-only and unreachable from most networks, and
 port 6543 is transaction mode and breaks DDL. `scripts/pooler_url.py` builds it.
 
+Promotion (repo root; full runbook backend/promotion/README.md):
+
+```
+make promote                          # staging -> prod: preflight, migrate, confirm, merge, verify
+make promote ARGS="--verify-only"     # re-check the live deploy only (wait + smoke)
+make promote ARGS="--yes"             # skip the confirmation prompt (CI)
+```
+
 Docker (full stack from repo root):
 
 ```

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,12 @@
 #
 # E2E exploration (#399): boot that stack, hand a Playwright-MCP-armed Claude
 # agent the explorer prompt, then run the oracle CLI. See docs/e2e-exploration.md.
+#
+# Staging -> production promotion (#516): preflight, migrate prod, confirm,
+# merge main->production, wait for the deploy, smoke. One prompt, at the merge.
+# See backend/promotion/README.md.
 
-.PHONY: e2e-up e2e-down explore explore-down
+.PHONY: e2e-up e2e-down explore explore-down promote
 
 e2e-up:
 	scripts/e2e-up.sh
@@ -21,3 +25,6 @@ explore:
 
 explore-down:
 	scripts/explore.sh down
+
+promote:
+	cd backend && venv/bin/dotenv -f .env.production run -- venv/bin/python -m promotion $(ARGS)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,14 @@ SUPABASE_SERVICE_KEY=your-service-role-key-here
 # app runtime, which goes through PostgREST.
 SUPABASE_DB_URL=postgresql://postgres:[password]@db.your-project-ref.supabase.co:5432/postgres
 
+# Staging's migration ledger, read-only, by the promotion runner (python -m promotion, #516)
+# so it can refuse to run DDL on production that staging has never run. Optional locally and
+# in the app runtime; SESSION-mode pooler URI (port 5432, user postgres.<ref>) for the STAGING
+# project — staging is on the aws-1-us-west-2 cluster. When unset, the promotion runner cannot
+# tell "staging ran nothing" from "couldn't check" and blocks once with a clear message rather
+# than guessing; pass --skip-staging-check to proceed deliberately without this guard.
+# STAGING_SUPABASE_DB_URL=postgresql://postgres.[staging-ref]:[password]@aws-1-us-west-2.pooler.supabase.com:5432/postgres
+
 # Logfire ops/error/LLM tracing (optional). Get a write token from
 # https://logfire.pydantic.dev → your project → Settings → Write tokens.
 # When unset, Logfire stays dormant: the app behaves exactly as today with no

--- a/backend/config.py
+++ b/backend/config.py
@@ -114,5 +114,12 @@ def build_commit() -> str:
 
     Read at call time, not import time, so a test can set the env var.
     """
-    raw = os.getenv("RAILWAY_GIT_COMMIT_SHA") or os.getenv("GIT_COMMIT_SHA") or ""
-    return raw.strip()[:7].lower() or "unknown"
+    # Strip each candidate independently before picking one: `A or B` picks
+    # A whenever it is non-empty, and a whitespace-only string IS non-empty
+    # (truthy), so a blank RAILWAY_GIT_COMMIT_SHA would win over a real
+    # GIT_COMMIT_SHA and then strip down to "" — silently reporting
+    # "unknown" instead of the SHA that was actually available.
+    railway = (os.getenv("RAILWAY_GIT_COMMIT_SHA") or "").strip()
+    generic = (os.getenv("GIT_COMMIT_SHA") or "").strip()
+    raw = railway or generic
+    return raw[:7].lower() or "unknown"

--- a/backend/config.py
+++ b/backend/config.py
@@ -100,3 +100,19 @@ def get_mastery_tier(score: float) -> str:
     elif score >= 0.1:
         return "struggling"
     return "unexplored"
+
+
+def build_commit() -> str:
+    """Short git SHA of the running build, or "unknown".
+
+    The promotion runner (#516) polls /api/health until this matches the commit
+    it just promoted, which is what lets it distinguish "the deploy has not
+    landed yet" from "the deploy landed and the app is broken". Railway injects
+    RAILWAY_GIT_COMMIT_SHA; GIT_COMMIT_SHA is the generic fallback for any other
+    host. Local, Docker and E2E runs set neither and report "unknown", which the
+    runner degrades on rather than hanging.
+
+    Read at call time, not import time, so a test can set the env var.
+    """
+    raw = os.getenv("RAILWAY_GIT_COMMIT_SHA") or os.getenv("GIT_COMMIT_SHA") or ""
+    return raw.strip()[:7].lower() or "unknown"

--- a/backend/main.py
+++ b/backend/main.py
@@ -229,11 +229,15 @@ def health():
     # here vouches for the agent stages, not every byte of egress.) Not a
     # secret: it names a mode, not a key.
     from agents._providers import _model_mode
+    from config import build_commit
 
     return {
         "status": "ok",
         "service": "sapling-backend",
         "model_mode": _model_mode(),
+        # The deployed commit, so a promotion can verify the code it merged is
+        # actually the code answering (#516). "unknown" off Railway.
+        "commit": build_commit(),
     }
 
 

--- a/backend/promotion/README.md
+++ b/backend/promotion/README.md
@@ -14,21 +14,40 @@ that shipped #515.
   `staging-unknown` finding rather than guessing — `--skip-staging-check` is the
   deliberate override.
 - `gh` must be authenticated.
+- Run it from a checkout of `main` that is up to date. Preflight **blocks** if
+  the local `db/migrations/` differs from `origin/main` in any way (modified,
+  missing or extra tracked files, or untracked strays) — the thing being
+  promoted is `origin/main`, and both the audit and `db.migrate` read local
+  files. Fix: `git checkout main && git pull`, remove stray files, re-run.
+- If production carries a hotfix/revert that was never back-merged to `main`,
+  preflight **blocks** (`production-diverged`): back-merge production into
+  main first, or the merge would fail only after migrations had applied.
+  Neither of these two guards has an override flag.
 
 ## What it does
 
-1. **Preflight** (read-only): target-identity, ledger exists, no orphans,
-   staging-ran-it-first, no destructive DDL, something to promote.
+1. **Preflight** (read-only): local `db/migrations/` matches `origin/main`,
+   production is an ancestor of main, target-identity, ledger exists, no
+   orphans, staging-ran-it-first, no destructive DDL, something to promote.
 2. **Snapshot** production.
 3. **Migrate** production (`db.migrate`) — this is the irreversible step.
 4. **Snapshot** again and print the diff.
 5. **Pause** — the only prompt. By this point the migration in step 3 has
    already run and cannot be undone; this confirms the merge, not the
-   database change.
-6. **Merge** `main` → `production`, retrying through the known `gh` 502.
+   database change. Ctrl-C or a closed stdin here counts as answering `n`.
+6. **Merge** `main` → `production`, **pinned to the SHA preflight audited**
+   (`gh --match-head-commit`): commits that land on main while you sit at the
+   prompt were never scanned, so GitHub itself rejects the merge and the
+   runner fails fast telling you to re-run — that rejection is deterministic
+   and does not burn the retry loop, which exists only for the known
+   transient `gh` 502.
 7. **Wait** until `/api/health` reports the merge commit now on
    `origin/production` — not main's tip, which is never what gets deployed
-   (10 min timeout).
+   (10 min timeout). Three outcomes: verified (proceed), timeout (**no**
+   smoke — a deploy failure must not read as a smoke failure), or, when the
+   whole window reports commit `unknown` (the host injects no SHA),
+   **UNVERIFIED**: smoke still runs, but the completion line says the deploy
+   itself was never confirmed.
 8. **Smoke** the live surface.
 
 If there are pending migrations but no new commits to promote (production's
@@ -49,14 +68,19 @@ production code runs against the NEW schema. Additive DDL is fine there;
 destructive DDL is not, which is why preflight blocks on it and
 `--allow-destructive` is an explicit decision.
 
-**If you answer `n` at the prompt, the migrations are already applied.**
-Production's schema will be ahead of its code. Re-running resumes at the merge.
+**If you answer `n` at the prompt (or Ctrl-C it), the migrations are already
+applied.** Production's schema will be ahead of its code. Re-running resumes at
+the merge. The same is true when the merge is rejected because main moved:
+re-run to audit and promote the new tip.
 
 ## When smoke fails
 
 Nothing is reverted, deliberately: the migrations cannot be rolled back, so
-reverting the code would leave old code against a newer schema. The runner
-prints the revert command; reverting is your call.
+reverting the code would leave old code against a newer schema. When this run
+merged code, the runner prints the revert command; reverting is your call. On
+runs that merged nothing (migrations-only, or `--verify-only`) there is no
+revert recipe — production's HEAD is a previous promotion's merge commit, and
+reverting it would undo an unrelated, previously-working deploy.
 
 ## Re-running
 
@@ -64,7 +88,9 @@ Safe. Preflight is read-only and `db.migrate` skips what the ledger already
 records, so a re-run after a failure repeats no work.
 
 If the promotion already merged and you only want to re-check the live deploy —
-the deploy was slow, or smoke failed and you have since fixed something — use:
+the deploy was slow, smoke failed and you have since fixed something, or the
+run failed after the merge landed (the runner points at this flag itself in
+that case) — use:
 
 ```
 make promote ARGS="--verify-only"

--- a/backend/promotion/README.md
+++ b/backend/promotion/README.md
@@ -1,0 +1,68 @@
+# Promotion runbook
+
+`make promote` — staging (`main`) to production. Replaces the hand-run sequence
+that shipped #515.
+
+## Before you run it
+
+- Production's `SUPABASE_DB_URL` in `backend/.env.production` must be the
+  SESSION-mode pooler URI. Build it:
+  `python scripts/pooler_url.py .env.production aws-0-us-west-2 --raw`
+- `STAGING_SUPABASE_DB_URL` must be set (staging is on the `aws-1-us-west-2`
+  cluster) so the runner can refuse DDL that staging has never executed. If it
+  is unset and migrations are pending, preflight **blocks** with a
+  `staging-unknown` finding rather than guessing — `--skip-staging-check` is the
+  deliberate override.
+- `gh` must be authenticated.
+
+## What it does
+
+1. **Preflight** (read-only): target-identity, ledger exists, no orphans,
+   staging-ran-it-first, no destructive DDL, something to promote.
+2. **Snapshot** production.
+3. **Migrate** production (`db.migrate`).
+4. **Snapshot** again and print the diff.
+5. **Pause** — the only prompt, at the only irreversible step.
+6. **Merge** `main` → `production`, retrying through the known `gh` 502.
+7. **Wait** until `/api/health` reports the merge commit now on
+   `origin/production` — not main's tip, which is never what gets deployed
+   (10 min timeout).
+8. **Smoke** the live surface.
+
+Exit codes: `0` success or nothing to promote, `1` failure, `2` you declined.
+
+Flags: `--verify-only` (stages 7-8 only), `--allow-destructive`,
+`--skip-staging-check`, `--yes`.
+
+## The ordering you need to know about
+
+Migrations apply **before** the code merges. Between stages 3 and 6 the OLD
+production code runs against the NEW schema. Additive DDL is fine there;
+destructive DDL is not, which is why preflight blocks on it and
+`--allow-destructive` is an explicit decision.
+
+**If you answer `n` at the prompt, the migrations are already applied.**
+Production's schema will be ahead of its code. Re-running resumes at the merge.
+
+## When smoke fails
+
+Nothing is reverted, deliberately: the migrations cannot be rolled back, so
+reverting the code would leave old code against a newer schema. The runner
+prints the revert command; reverting is your call.
+
+## Re-running
+
+Safe. Preflight is read-only and `db.migrate` skips what the ledger already
+records, so a re-run after a failure repeats no work.
+
+If the promotion already merged and you only want to re-check the live deploy —
+the deploy was slow, or smoke failed and you have since fixed something — use:
+
+```
+make promote ARGS="--verify-only"
+```
+
+That skips preflight, snapshots, migrate and the merge entirely, and runs only
+the deploy wait against `origin/production`'s tip followed by smoke. A plain
+re-run would instead report `nothing-to-promote` and exit 0 without re-checking
+anything, because by then there is genuinely nothing left to promote.

--- a/backend/promotion/README.md
+++ b/backend/promotion/README.md
@@ -20,14 +20,22 @@ that shipped #515.
 1. **Preflight** (read-only): target-identity, ledger exists, no orphans,
    staging-ran-it-first, no destructive DDL, something to promote.
 2. **Snapshot** production.
-3. **Migrate** production (`db.migrate`).
+3. **Migrate** production (`db.migrate`) — this is the irreversible step.
 4. **Snapshot** again and print the diff.
-5. **Pause** — the only prompt, at the only irreversible step.
+5. **Pause** — the only prompt. By this point the migration in step 3 has
+   already run and cannot be undone; this confirms the merge, not the
+   database change.
 6. **Merge** `main` → `production`, retrying through the known `gh` 502.
 7. **Wait** until `/api/health` reports the merge commit now on
    `origin/production` — not main's tip, which is never what gets deployed
    (10 min timeout).
 8. **Smoke** the live surface.
+
+If there are pending migrations but no new commits to promote (production's
+code already matches main — see "Re-running" below), steps 5-7 are skipped
+entirely after step 4: `gh pr create` would fail outright with "No commits
+between production and main". Step 8 (smoke) still runs, since a migration
+that broke the running app is exactly the failure that stage exists to catch.
 
 Exit codes: `0` success or nothing to promote, `1` failure, `2` you declined.
 

--- a/backend/promotion/__init__.py
+++ b/backend/promotion/__init__.py
@@ -1,0 +1,10 @@
+"""Staging → production promotion runner (#516).
+
+Sequences the promotion that used to be a hand-run list of commands: preflight,
+snapshot, migrate, confirm, merge, wait for the deploy, smoke.
+
+Each module splits pure logic from IO so the logic is testable without a
+database or a network: `preflight` and `snapshot.diff` take plain data,
+`smoke.run_checks` takes an injected fetcher, and `runner` takes injected
+confirm/output callables.
+"""

--- a/backend/promotion/__main__.py
+++ b/backend/promotion/__main__.py
@@ -17,9 +17,11 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 import time
+from typing import Callable
 
 import psycopg
 
@@ -62,8 +64,59 @@ class Git:
     def commits_ahead_of(self, base: str, head: str) -> int:
         return int(_run(["git", "rev-list", "--count", f"{base}..{head}"]))
 
+    def migrations_drift(self) -> str:
+        """How the LOCAL migrations dir differs from origin/main; "" = clean.
+
+        Preflight's file listing and db_migrate.run() both read the local
+        working tree, but the thing being promoted is origin/main — so the
+        runner blocks on any mismatch. Two complementary reads, because
+        neither alone covers both failure directions: `git diff --name-status
+        origin/main` catches tracked files differing in content or presence
+        (either direction — including a stale checkout missing an origin/main
+        file) but is blind to untracked strays; `git status --porcelain`
+        catches the strays but reports nothing for a merely-old checkout.
+        Absolute pathspec, so the check is correct regardless of the cwd the
+        tool was launched from.
+        """
+        migrations = str(db_migrate.MIGRATIONS_DIR)
+        tracked = _run(["git", "diff", "--name-status", "origin/main", "--", migrations])
+        untracked = _run(["git", "status", "--porcelain", "--", migrations])
+        return "\n".join(part for part in (tracked, untracked) if part)
+
+    def is_ancestor(self, ancestor: str, descendant: str) -> bool:
+        """`git merge-base --is-ancestor`: exit 0 = yes, 1 = no.
+
+        Not routed through _run, which reads every non-zero exit as failure —
+        here exit 1 is a valid answer. Any OTHER exit (bad ref, not a repo) is
+        a real error and raises: the caller treats this guard as fail-closed,
+        so an unreadable answer must block, never pass as either boolean.
+        Same 120s no-hang discipline as _run.
+        """
+        cmd = ["git", "merge-base", "--is-ancestor", ancestor, descendant]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError("`git merge-base` timed out after 120s") from exc
+        if result.returncode == 0:
+            return True
+        if result.returncode == 1:
+            return False
+        detail = (result.stderr or result.stdout).strip()
+        raise RuntimeError(f"`git merge-base` failed ({result.returncode}): {detail}")
+
+
+# The created PR's number is the trailing path segment of the URL `gh pr
+# create` prints; anchored on /pull/ so compare/commit URLs mixed into the
+# same output never match.
+_PR_URL_RE = re.compile(r"https://\S+/pull/(\d+)\b")
+
 
 class Gh:
+    def __init__(self, sleep: Callable[[float], None] = time.sleep) -> None:
+        # Injected like runner.Ports.sleep so ensure_pr's fallback retry is
+        # testable without wall-clock waits.
+        self._sleep = sleep
+
     def ensure_pr(self, base: str, head: str, title: str) -> int:
         # --state open ONLY. `--state all` was the bug: it can return a PREVIOUS
         # promotion's already-MERGED PR (this repo's real history returns
@@ -77,29 +130,51 @@ class Gh:
         if existing:
             return int(existing)
 
-        _run([
+        created = _run([
             "gh", "pr", "create", "--base", base, "--head", head,
             "--title", title, "--body", "Automated promotion (#516).",
         ])
-        # Re-query once, not recursively: a second miss means `gh pr create`
-        # did something other than what we expect, and guessing again would
-        # just create PRs in a loop.
-        existing = _run([
-            "gh", "pr", "list", "--base", base, "--head", head, "--state", "open",
-            "--limit", "1", "--json", "number", "--jq", ".[0].number // empty",
-        ])
-        if not existing:
-            raise RuntimeError(
-                f"gh pr create for {head} -> {base} did not produce a discoverable "
-                "open PR. Check `gh pr list` manually."
-            )
-        return int(existing)
+        # `gh pr create`'s own stdout (the new PR's URL) is the one
+        # immediately-consistent source of the number: the list endpoint can
+        # lag creation by seconds, and a miss there fails the run AFTER the
+        # migration has already applied. Last match wins — gh mixes progress
+        # and warning lines into the same output.
+        urls = _PR_URL_RE.findall(created)
+        if urls:
+            return int(urls[-1])
+
+        # Fallback for an unparseable output shape: bounded list re-queries
+        # (with a pause for list-endpoint lag), never a second create —
+        # guessing again would just open PRs in a loop.
+        for attempt in range(3):
+            if attempt:
+                self._sleep(2)
+            existing = _run([
+                "gh", "pr", "list", "--base", base, "--head", head, "--state", "open",
+                "--limit", "1", "--json", "number", "--jq", ".[0].number // empty",
+            ])
+            if existing:
+                return int(existing)
+        raise RuntimeError(
+            f"gh pr create for {head} -> {base} did not produce a discoverable "
+            "open PR. Check `gh pr list` manually."
+        )
 
     def state(self, number: int) -> str:
         return _run(["gh", "pr", "view", str(number), "--json", "state", "--jq", ".state"])
 
-    def merge(self, number: int) -> None:
-        _run(["gh", "pr", "merge", str(number), "--merge"])
+    def merge(self, number: int, match_head_commit: str) -> None:
+        # Pinned to the SHA preflight audited. Unpinned, `gh pr merge --merge`
+        # merges whatever origin/main's tip is AT MERGE TIME, so commits
+        # landing while the operator sat at the confirm prompt would be
+        # promoted with their migrations never scanned nor applied. Flag
+        # verified against the gh CLI in PATH: `gh pr merge --help` documents
+        # `--match-head-commit SHA` ("Commit SHA that the pull request head
+        # must match to allow merge") — GitHub itself rejects a moved head.
+        _run([
+            "gh", "pr", "merge", str(number), "--merge",
+            "--match-head-commit", match_head_commit,
+        ])
 
 
 def _staging_recorded() -> set[str] | None:
@@ -113,9 +188,8 @@ def _staging_recorded() -> set[str] | None:
     if not url:
         return None
     try:
-        with psycopg.connect(url) as conn, conn.cursor() as cur:
-            cur.execute("SELECT filename FROM schema_migrations")
-            return {row[0] for row in cur.fetchall()}
+        with psycopg.connect(url) as conn:
+            return preflight.recorded_filenames(conn)
     except psycopg.Error as exc:
         # NOT re-raised: a stale URI, a paused staging project, or a
         # transient network fault here must not abort the whole run before
@@ -131,13 +205,11 @@ def _staging_recorded() -> set[str] | None:
 
 def _preflight_data(conn) -> dict:
     files = [p.name for p in db_migrate.discover_migrations(db_migrate.MIGRATIONS_DIR)]
-    with conn.cursor() as cur:
-        cur.execute("SELECT to_regclass('public.schema_migrations') IS NOT NULL")
-        exists = bool(cur.fetchone()[0])
-        recorded: set[str] = set()
-        if exists:
-            cur.execute("SELECT filename FROM schema_migrations")
-            recorded = {row[0] for row in cur.fetchall()}
+    # The shared ledger primitives (preflight.ledger_exists/recorded_filenames/
+    # ledger_diff) — the same ones scripts/migration_drift_report.py consumes,
+    # so this preflight and that report can never diff the ledger differently.
+    exists = preflight.ledger_exists(conn)
+    recorded: set[str] = preflight.recorded_filenames(conn) if exists else set()
 
     pending, _ = preflight.ledger_diff(files, recorded)
     pending_paths = [db_migrate.MIGRATIONS_DIR / name for name in pending]
@@ -167,13 +239,20 @@ def _confirm(prompt: str, auto_yes: bool) -> bool:
     moment a clear message matters most. Treat it exactly like a typed "n"
     instead: the runner's own "ABORTED before the merge" report already
     explains the migrations are applied and returns EXIT_ABORTED, which is a
-    far clearer outcome.
+    far clearer outcome. Ctrl-C at the prompt gets the same treatment:
+    KeyboardInterrupt is a BaseException that `main()`'s `except Exception`
+    never catches, so propagating it would skip that report for a raw
+    traceback.
     """
     if auto_yes:
         return True
     try:
         return input(f"{prompt} [y/N] ").strip().lower() in {"y", "yes"}
     except EOFError:
+        return False
+    except KeyboardInterrupt:
+        # The newline keeps the terminal's ^C echo off the report's first line.
+        print()
         return False
 
 

--- a/backend/promotion/__main__.py
+++ b/backend/promotion/__main__.py
@@ -28,14 +28,24 @@ from promotion import preflight, smoke, snapshot
 from promotion.runner import Options, Ports, run
 
 
-def _run(cmd: list[str]) -> str:
+def _run(cmd: list[str], timeout: float = 120) -> str:
     """Run a subprocess and surface its real stderr on failure.
 
     `check=True` alone collapses every git/gh failure into "returned non-zero
     exit status 1" and throws away the one line (merge conflict, bad ref,
     auth expired, ...) that would tell the operator what actually happened.
+
+    Every caller of this is a network call (git fetch, gh pr create/view/
+    merge). Without a timeout, a stalled network or a `gh` sitting on an
+    interactive prompt hangs forever with no output — possibly AFTER the
+    migration has already applied. httpx_fetch bounds its calls at 25s and
+    the deploy poll bounds itself at wait_timeout; this is the same
+    discipline applied to subprocess calls.
     """
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"`{' '.join(cmd[:2])}` timed out after {timeout}s") from exc
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip()
         raise RuntimeError(f"`{' '.join(cmd[:2])}` failed ({result.returncode}): {detail}")
@@ -107,10 +117,16 @@ def _staging_recorded() -> set[str] | None:
             cur.execute("SELECT filename FROM schema_migrations")
             return {row[0] for row in cur.fetchall()}
     except psycopg.Error as exc:
-        # Same wart _run() fixes for subprocesses: an unwrapped driver error
-        # would escape main()'s handler as a raw traceback instead of the one
-        # clean line an operator needs mid-promotion.
-        raise RuntimeError(f"could not read staging's migration ledger ({exc})") from exc
+        # NOT re-raised: a stale URI, a paused staging project, or a
+        # transient network fault here must not abort the whole run before
+        # the operator ever sees a preflight report — that would deny them
+        # the existence of --skip-staging-check at the exact moment they'd
+        # want it. Print the reason (so the degradation isn't silent) and
+        # return None, same as "the var is unset": preflight.evaluate turns
+        # that into its documented `staging-unknown` finding, whose own text
+        # says exactly this ("could not read staging's migration ledger").
+        print(f"WARNING: could not read staging's migration ledger ({exc})", file=sys.stderr)
+        return None
 
 
 def _preflight_data(conn) -> dict:
@@ -140,6 +156,27 @@ def _preflight_data(conn) -> dict:
     }
 
 
+def _confirm(prompt: str, auto_yes: bool) -> bool:
+    """The interactive confirmation gate — a plain function, not a closure
+    over `main()`'s locals, so it is directly testable.
+
+    `input()` raises `EOFError` on non-interactive stdin (no controlling
+    terminal, a closed pipe, CI invoking this without a tty). `str(EOFError())`
+    is empty, so letting it propagate would make `main()`'s handler print a
+    bare "ERROR: " — right after the migration has already applied, the exact
+    moment a clear message matters most. Treat it exactly like a typed "n"
+    instead: the runner's own "ABORTED before the merge" report already
+    explains the migrations are applied and returns EXIT_ABORTED, which is a
+    far clearer outcome.
+    """
+    if auto_yes:
+        return True
+    try:
+        return input(f"{prompt} [y/N] ").strip().lower() in {"y", "yes"}
+    except EOFError:
+        return False
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(prog="promotion")
     parser.add_argument("--allow-destructive", action="store_true")
@@ -167,9 +204,7 @@ def main() -> int:
         return 1
 
     def confirm(prompt: str) -> bool:
-        if args.yes:
-            return True
-        return input(f"{prompt} [y/N] ").strip().lower() in {"y", "yes"}
+        return _confirm(prompt, args.yes)
 
     ports = Ports(
         connect=lambda: psycopg.connect(db_url),

--- a/backend/promotion/__main__.py
+++ b/backend/promotion/__main__.py
@@ -7,6 +7,10 @@ Run from backend/ with production's env loaded:
 Flags:
     --allow-destructive      proceed despite destructive DDL in pending migrations
     --skip-staging-check     proceed despite migrations staging has never run
+    --verify-only            skip preflight/migrate/merge; just wait for the
+                              deploy to report production's current tip and run
+                              smoke. This is the real way to re-check a
+                              promotion without re-merging (see runner.Options).
     --yes                    answer the confirmation prompt automatically (CI)
 """
 from __future__ import annotations
@@ -24,55 +28,80 @@ from promotion import preflight, smoke, snapshot
 from promotion.runner import Options, Ports, run
 
 
+def _run(cmd: list[str]) -> str:
+    """Run a subprocess and surface its real stderr on failure.
+
+    `check=True` alone collapses every git/gh failure into "returned non-zero
+    exit status 1" and throws away the one line (merge conflict, bad ref,
+    auth expired, ...) that would tell the operator what actually happened.
+    """
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise RuntimeError(f"`{' '.join(cmd[:2])}` failed ({result.returncode}): {detail}")
+    return result.stdout.strip()
+
+
 class Git:
     def fetch(self) -> None:
-        subprocess.run(["git", "fetch", "origin", "--quiet"], check=True)
+        _run(["git", "fetch", "origin", "--quiet"])
 
     def head_sha(self, ref: str) -> str:
-        return subprocess.run(
-            ["git", "rev-parse", ref], check=True, capture_output=True, text=True
-        ).stdout.strip()
+        return _run(["git", "rev-parse", ref])
 
     def commits_ahead_of(self, base: str, head: str) -> int:
-        result = subprocess.run(
-            ["git", "rev-list", "--count", f"{base}..{head}"],
-            check=True, capture_output=True, text=True,
-        )
-        return int(result.stdout.strip())
+        return int(_run(["git", "rev-list", "--count", f"{base}..{head}"]))
 
 
 class Gh:
     def ensure_pr(self, base: str, head: str, title: str) -> int:
-        existing = subprocess.run(
-            ["gh", "pr", "list", "--base", base, "--head", head, "--state", "all",
-             "--limit", "1", "--json", "number,state", "--jq", ".[0].number // empty"],
-            check=True, capture_output=True, text=True,
-        ).stdout.strip()
+        # --state open ONLY. `--state all` was the bug: it can return a PREVIOUS
+        # promotion's already-MERGED PR (this repo's real history returns
+        # {"number": 515, "state": "MERGED"} for base=production/head=main), and
+        # the runner reads an already-merged PR as "resume here, skip the
+        # confirm" — silently bypassing the one human gate this tool has.
+        existing = _run([
+            "gh", "pr", "list", "--base", base, "--head", head, "--state", "open",
+            "--limit", "1", "--json", "number", "--jq", ".[0].number // empty",
+        ])
         if existing:
             return int(existing)
-        subprocess.run(
-            ["gh", "pr", "create", "--base", base, "--head", head,
-             "--title", title, "--body", "Automated promotion (#516)."],
-            check=True, capture_output=True, text=True,
-        )
-        return self.ensure_pr(base, head, title)
+
+        _run([
+            "gh", "pr", "create", "--base", base, "--head", head,
+            "--title", title, "--body", "Automated promotion (#516).",
+        ])
+        # Re-query once, not recursively: a second miss means `gh pr create`
+        # did something other than what we expect, and guessing again would
+        # just create PRs in a loop.
+        existing = _run([
+            "gh", "pr", "list", "--base", base, "--head", head, "--state", "open",
+            "--limit", "1", "--json", "number", "--jq", ".[0].number // empty",
+        ])
+        if not existing:
+            raise RuntimeError(
+                f"gh pr create for {head} -> {base} did not produce a discoverable "
+                "open PR. Check `gh pr list` manually."
+            )
+        return int(existing)
 
     def state(self, number: int) -> str:
-        return subprocess.run(
-            ["gh", "pr", "view", str(number), "--json", "state", "--jq", ".state"],
-            check=True, capture_output=True, text=True,
-        ).stdout.strip()
+        return _run(["gh", "pr", "view", str(number), "--json", "state", "--jq", ".state"])
 
     def merge(self, number: int) -> None:
-        subprocess.run(["gh", "pr", "merge", str(number), "--merge"],
-                       check=True, capture_output=True, text=True)
+        _run(["gh", "pr", "merge", str(number), "--merge"])
 
 
-def _staging_recorded() -> set[str]:
-    """Staging's ledger, so preflight can refuse DDL staging never ran."""
+def _staging_recorded() -> set[str] | None:
+    """Staging's ledger, so preflight can refuse DDL staging never ran.
+
+    None means "couldn't read it" (most commonly: the var just isn't set —
+    it ships in no .env* example in this repo), which preflight.evaluate
+    treats as "unknown", NOT as "staging has run nothing".
+    """
     url = os.environ.get("STAGING_SUPABASE_DB_URL", "").strip()
     if not url:
-        return set()
+        return None
     with psycopg.connect(url) as conn, conn.cursor() as cur:
         cur.execute("SELECT filename FROM schema_migrations")
         return {row[0] for row in cur.fetchall()}
@@ -105,6 +134,10 @@ def main() -> int:
     parser = argparse.ArgumentParser(prog="promotion")
     parser.add_argument("--allow-destructive", action="store_true")
     parser.add_argument("--skip-staging-check", action="store_true")
+    parser.add_argument(
+        "--verify-only", action="store_true",
+        help="skip preflight/migrate/merge; just wait for the deploy and run smoke",
+    )
     parser.add_argument("--yes", action="store_true")
     args = parser.parse_args()
 
@@ -137,10 +170,16 @@ def main() -> int:
         out=print,
         sleep=time.sleep,
     )
-    return run(ports, Options(
+    options = Options(
         allow_destructive=args.allow_destructive,
         skip_staging_check=args.skip_staging_check,
-    ))
+        verify_only=args.verify_only,
+    )
+    try:
+        return run(ports, options)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/backend/promotion/__main__.py
+++ b/backend/promotion/__main__.py
@@ -126,8 +126,12 @@ def _preflight_data(conn) -> dict:
     pending, _ = preflight.ledger_diff(files, recorded)
     pending_paths = [db_migrate.MIGRATIONS_DIR / name for name in pending]
     return {
-        "db_url": os.environ.get("SUPABASE_DB_URL", ""),
-        "supabase_url": os.environ.get("SUPABASE_URL", ""),
+        # .strip() to match the value main() actually connects with — an
+        # unstripped value with leading whitespace makes urlparse() (inside
+        # preflight.project_ref) yield no ref, which silently no-ops the
+        # target-mismatch guard instead of tripping it.
+        "db_url": os.environ.get("SUPABASE_DB_URL", "").strip(),
+        "supabase_url": os.environ.get("SUPABASE_URL", "").strip(),
         "ledger_exists": exists,
         "migration_files": files,
         "recorded": recorded,
@@ -186,7 +190,10 @@ def main() -> int:
     )
     try:
         return run(ports, options)
-    except RuntimeError as exc:
+    except Exception as exc:  # noqa: BLE001 — no path may exit as a raw traceback:
+        # this also covers psycopg errors from Git.commits_ahead_of's int()
+        # parse, psycopg.connect(), and anything else not already wrapped in
+        # a RuntimeError by _run()/_staging_recorded().
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 

--- a/backend/promotion/__main__.py
+++ b/backend/promotion/__main__.py
@@ -102,9 +102,15 @@ def _staging_recorded() -> set[str] | None:
     url = os.environ.get("STAGING_SUPABASE_DB_URL", "").strip()
     if not url:
         return None
-    with psycopg.connect(url) as conn, conn.cursor() as cur:
-        cur.execute("SELECT filename FROM schema_migrations")
-        return {row[0] for row in cur.fetchall()}
+    try:
+        with psycopg.connect(url) as conn, conn.cursor() as cur:
+            cur.execute("SELECT filename FROM schema_migrations")
+            return {row[0] for row in cur.fetchall()}
+    except psycopg.Error as exc:
+        # Same wart _run() fixes for subprocesses: an unwrapped driver error
+        # would escape main()'s handler as a raw traceback instead of the one
+        # clean line an operator needs mid-promotion.
+        raise RuntimeError(f"could not read staging's migration ledger ({exc})") from exc
 
 
 def _preflight_data(conn) -> dict:
@@ -141,8 +147,11 @@ def main() -> int:
     parser.add_argument("--yes", action="store_true")
     args = parser.parse_args()
 
+    # --verify-only touches no database at all (see runner.Options.verify_only:
+    # it skips preflight/snapshot/migrate entirely), so it must not be blocked
+    # by a credential this mode never uses.
     db_url = os.environ.get("SUPABASE_DB_URL", "").strip()
-    if not db_url:
+    if not db_url and not args.verify_only:
         print(
             "ERROR: SUPABASE_DB_URL is not set. Run under production's env:\n"
             "  venv/bin/dotenv -f .env.production run -- venv/bin/python -m promotion\n"

--- a/backend/promotion/__main__.py
+++ b/backend/promotion/__main__.py
@@ -1,0 +1,147 @@
+"""`python -m promotion` — the real ports wired to the real world (#516).
+
+Run from backend/ with production's env loaded:
+
+    venv/bin/dotenv -f .env.production run -- venv/bin/python -m promotion
+
+Flags:
+    --allow-destructive      proceed despite destructive DDL in pending migrations
+    --skip-staging-check     proceed despite migrations staging has never run
+    --yes                    answer the confirmation prompt automatically (CI)
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+
+import psycopg
+
+from db import migrate as db_migrate
+from promotion import preflight, smoke, snapshot
+from promotion.runner import Options, Ports, run
+
+
+class Git:
+    def fetch(self) -> None:
+        subprocess.run(["git", "fetch", "origin", "--quiet"], check=True)
+
+    def head_sha(self, ref: str) -> str:
+        return subprocess.run(
+            ["git", "rev-parse", ref], check=True, capture_output=True, text=True
+        ).stdout.strip()
+
+    def commits_ahead_of(self, base: str, head: str) -> int:
+        result = subprocess.run(
+            ["git", "rev-list", "--count", f"{base}..{head}"],
+            check=True, capture_output=True, text=True,
+        )
+        return int(result.stdout.strip())
+
+
+class Gh:
+    def ensure_pr(self, base: str, head: str, title: str) -> int:
+        existing = subprocess.run(
+            ["gh", "pr", "list", "--base", base, "--head", head, "--state", "all",
+             "--limit", "1", "--json", "number,state", "--jq", ".[0].number // empty"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        if existing:
+            return int(existing)
+        subprocess.run(
+            ["gh", "pr", "create", "--base", base, "--head", head,
+             "--title", title, "--body", "Automated promotion (#516)."],
+            check=True, capture_output=True, text=True,
+        )
+        return self.ensure_pr(base, head, title)
+
+    def state(self, number: int) -> str:
+        return subprocess.run(
+            ["gh", "pr", "view", str(number), "--json", "state", "--jq", ".state"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+    def merge(self, number: int) -> None:
+        subprocess.run(["gh", "pr", "merge", str(number), "--merge"],
+                       check=True, capture_output=True, text=True)
+
+
+def _staging_recorded() -> set[str]:
+    """Staging's ledger, so preflight can refuse DDL staging never ran."""
+    url = os.environ.get("STAGING_SUPABASE_DB_URL", "").strip()
+    if not url:
+        return set()
+    with psycopg.connect(url) as conn, conn.cursor() as cur:
+        cur.execute("SELECT filename FROM schema_migrations")
+        return {row[0] for row in cur.fetchall()}
+
+
+def _preflight_data(conn) -> dict:
+    files = [p.name for p in db_migrate.discover_migrations(db_migrate.MIGRATIONS_DIR)]
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass('public.schema_migrations') IS NOT NULL")
+        exists = bool(cur.fetchone()[0])
+        recorded: set[str] = set()
+        if exists:
+            cur.execute("SELECT filename FROM schema_migrations")
+            recorded = {row[0] for row in cur.fetchall()}
+
+    pending, _ = preflight.ledger_diff(files, recorded)
+    pending_paths = [db_migrate.MIGRATIONS_DIR / name for name in pending]
+    return {
+        "db_url": os.environ.get("SUPABASE_DB_URL", ""),
+        "supabase_url": os.environ.get("SUPABASE_URL", ""),
+        "ledger_exists": exists,
+        "migration_files": files,
+        "recorded": recorded,
+        "staging_recorded": _staging_recorded(),
+        "destructive": preflight.scan_destructive(pending_paths),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="promotion")
+    parser.add_argument("--allow-destructive", action="store_true")
+    parser.add_argument("--skip-staging-check", action="store_true")
+    parser.add_argument("--yes", action="store_true")
+    args = parser.parse_args()
+
+    db_url = os.environ.get("SUPABASE_DB_URL", "").strip()
+    if not db_url:
+        print(
+            "ERROR: SUPABASE_DB_URL is not set. Run under production's env:\n"
+            "  venv/bin/dotenv -f .env.production run -- venv/bin/python -m promotion\n"
+            "It must be the SESSION-mode pooler URI (port 5432, user postgres.<ref>); "
+            "production is on the aws-0-us-west-2 cluster. Build it with "
+            "`python scripts/pooler_url.py .env.production aws-0-us-west-2 --raw`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    def confirm(prompt: str) -> bool:
+        if args.yes:
+            return True
+        return input(f"{prompt} [y/N] ").strip().lower() in {"y", "yes"}
+
+    ports = Ports(
+        connect=lambda: psycopg.connect(db_url),
+        preflight_data=_preflight_data,
+        capture=snapshot.capture,
+        migrate=lambda conn: db_migrate.run(conn),
+        git=Git(),
+        gh=Gh(),
+        fetch=smoke.httpx_fetch,
+        confirm=confirm,
+        out=print,
+        sleep=time.sleep,
+    )
+    return run(ports, Options(
+        allow_destructive=args.allow_destructive,
+        skip_staging_check=args.skip_staging_check,
+    ))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/promotion/preflight.py
+++ b/backend/promotion/preflight.py
@@ -1,0 +1,184 @@
+"""Read-only guards that must pass before production is touched (#516).
+
+Every check here runs BEFORE any mutation. The functions are pure: callers hand
+them already-fetched data (ledger rows, file lists, commit counts), which is
+what keeps them testable offline and keeps the IO in one place — the runner.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+# Line-oriented, deliberately. A migration that is destructive on one line and
+# harmless on the next should name the line, and the runner prints it verbatim
+# so the operator judges the actual statement rather than a filename.
+DESTRUCTIVE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("DROP TABLE", re.compile(r"\bDROP\s+TABLE\b", re.I)),
+    ("DROP COLUMN", re.compile(r"\bDROP\s+COLUMN\b", re.I)),
+    ("TRUNCATE", re.compile(r"\bTRUNCATE\b", re.I)),
+    ("ALTER COLUMN ... TYPE", re.compile(r"\bALTER\s+COLUMN\b.*\bTYPE\b", re.I)),
+]
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One blocking reason. `kind` is machine-readable, `detail` is for humans."""
+
+    kind: str
+    detail: str
+
+
+def project_ref(value: str) -> str:
+    """Supabase project ref from a DB URI or an API URL; "" if unrecognised.
+
+    Three shapes are in play. The session-mode pooler carries the ref in the
+    USERNAME (`postgres.<ref>@aws-0-...`) because the host is shared across
+    projects; the direct endpoint carries it in the host (`db.<ref>.supabase.co`);
+    the REST URL carries it as the leftmost label (`<ref>.supabase.co`).
+    """
+    parsed = urlparse(value)
+    user = parsed.username or ""
+    if user.startswith("postgres."):
+        return user.split(".", 1)[1]
+    host = parsed.hostname or ""
+    if host.startswith("db.") and host.endswith(".supabase.co"):
+        return host.split(".")[1]
+    if host.endswith(".supabase.co"):
+        return host.split(".")[0]
+    return ""
+
+
+def ledger_diff(files: list[str], recorded: set[str]) -> tuple[list[str], list[str]]:
+    """(pending, orphans) — pending keeps `files` order, orphans are sorted.
+
+    An orphan is a filename the ledger records that the repo does not have: that
+    environment ran SQL this repo has never seen. Applying more on top compounds
+    it, which is why the runner treats it as blocking.
+    """
+    pending = [f for f in files if f not in recorded]
+    orphans = sorted(recorded - set(files))
+    return pending, orphans
+
+
+def staging_gap(pending: list[str], staging_recorded: set[str]) -> list[str]:
+    """Pending-on-prod migrations staging has never executed.
+
+    Production must never be the first environment to run a piece of DDL.
+    """
+    return [f for f in pending if f not in staging_recorded]
+
+
+def _strip_comments(sql: str) -> str:
+    """Blank out `--` line comments and `/* */` blocks, preserving line numbers.
+
+    The migrations in this repo carry long explanatory headers that frequently
+    NAME destructive statements while doing nothing of the kind. Scanning raw
+    text would flag most of them.
+    """
+    without_blocks = re.sub(
+        r"/\*.*?\*/",
+        lambda m: re.sub(r"[^\n]", " ", m.group(0)),
+        sql,
+        flags=re.S,
+    )
+    return "\n".join(line.split("--", 1)[0] for line in without_blocks.splitlines())
+
+
+def scan_destructive(paths: list[Path]) -> list[Finding]:
+    """Destructive DDL in the given migration files.
+
+    This matters because the runner applies migrations BEFORE the code merges,
+    so between those stages the OLD production code runs against the NEW schema.
+    Additive DDL is harmless in that window; destructive DDL is not.
+    """
+    findings: list[Finding] = []
+    for path in paths:
+        raw_lines = path.read_text().splitlines()
+        scan_lines = _strip_comments("\n".join(raw_lines)).splitlines()
+        for lineno, line in enumerate(scan_lines, 1):
+            for label, pattern in DESTRUCTIVE_PATTERNS:
+                if pattern.search(line):
+                    original = raw_lines[lineno - 1].strip()
+                    findings.append(Finding(label, f"{path.name}:{lineno}: {original}"))
+    return findings
+
+
+def evaluate(
+    *,
+    db_url: str,
+    supabase_url: str,
+    ledger_exists: bool,
+    migration_files: list[str],
+    recorded: set[str],
+    staging_recorded: set[str],
+    destructive: list[Finding],
+    commits_ahead: int,
+    allow_destructive: bool,
+    skip_staging_check: bool,
+) -> list[Finding]:
+    """All blocking findings, in the order the operator should read them.
+
+    An empty list means preflight passed and the runner may proceed.
+    """
+    findings: list[Finding] = []
+
+    db_ref, api_ref = project_ref(db_url), project_ref(supabase_url)
+    if db_ref and api_ref and db_ref != api_ref:
+        findings.append(
+            Finding(
+                "target-mismatch",
+                f"SUPABASE_DB_URL points at project {db_ref} but SUPABASE_URL "
+                f"points at {api_ref}. The env file is mixed up — refusing to migrate.",
+            )
+        )
+
+    if not ledger_exists:
+        findings.append(
+            Finding(
+                "no-ledger",
+                "schema_migrations does not exist on this database. Applying now "
+                "would treat every migration as pending and fail recreating "
+                "existing objects. Reconcile with `python -m db.migrate --baseline` "
+                "against a verified-current schema first.",
+            )
+        )
+        # Everything downstream reads the ledger, so stop describing it.
+        return findings
+
+    pending, orphans = ledger_diff(migration_files, recorded)
+    for orphan in orphans:
+        findings.append(
+            Finding("orphan", f"recorded in the ledger but absent from the repo: {orphan}")
+        )
+
+    if not skip_staging_check:
+        for name in staging_gap(pending, staging_recorded):
+            findings.append(
+                Finding(
+                    "staging-gap",
+                    f"{name} is pending on production but staging has never run it. "
+                    "Production must not be the first environment to execute DDL. "
+                    "Let migrate-staging.yml apply it first, or pass --skip-staging-check.",
+                )
+            )
+
+    if destructive and not allow_destructive:
+        for finding in destructive:
+            findings.append(
+                Finding(
+                    "destructive",
+                    f"{finding.kind} in a pending migration — {finding.detail}. "
+                    "Migrations apply before the code merges, so the old production "
+                    "code would run against this schema. Pass --allow-destructive "
+                    "if that is genuinely safe here.",
+                )
+            )
+
+    if commits_ahead == 0 and not pending:
+        findings.append(
+            Finding("nothing-to-promote", "origin/main and origin/production are identical.")
+        )
+
+    return findings

--- a/backend/promotion/preflight.py
+++ b/backend/promotion/preflight.py
@@ -3,6 +3,14 @@
 Every check here runs BEFORE any mutation. The functions are pure: callers hand
 them already-fetched data (ledger rows, file lists, commit counts), which is
 what keeps them testable offline and keeps the IO in one place — the runner.
+
+Two deliberate exceptions to that purity: `ledger_exists` and
+`recorded_filenames` take a live connection. They are the shared READ
+primitives for the migrations ledger — scripts/migration_drift_report.py
+(#317) consumes them too, alongside `ledger_diff` and `NO_LEDGER_REMEDIATION`,
+because that script's own docstring records how re-implementing this diff
+inline is exactly how it and a preflight drifted apart before. One
+implementation, two consumers, no third copy.
 """
 from __future__ import annotations
 
@@ -20,8 +28,23 @@ from urllib.parse import urlparse
 DESTRUCTIVE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("DROP TABLE", re.compile(r"\bDROP\s+TABLE\b", re.I)),
     ("DROP COLUMN", re.compile(r"\bDROP\s+COLUMN\b", re.I)),
+    ("DROP VIEW", re.compile(r"\bDROP\s+VIEW\b", re.I)),
     ("TRUNCATE", re.compile(r"\bTRUNCATE\b", re.I)),
-    ("ALTER COLUMN ... TYPE", re.compile(r"\bALTER\s+COLUMN\b.*\bTYPE\b", re.I)),
+    # TYPE must be the operation right after the column name (optionally as
+    # SET DATA TYPE) — a bare `.*TYPE` match flagged every benign ALTER COLUMN
+    # touching a column literally named `type` (0001/0009/0026 define such).
+    (
+        "ALTER COLUMN ... TYPE",
+        re.compile(r"\bALTER\s+COLUMN\s+\S+\s+(?:SET\s+DATA\s+)?TYPE\b", re.I),
+    ),
+    # Renames (table or column) break old prod code in the migrate→merge window
+    # the same way a DROP does — 0020/0024 were exactly this shape. RENAME must
+    # be the operation following the table name (not `.*`), else any identifier
+    # named "rename" would match.
+    (
+        "ALTER TABLE ... RENAME",
+        re.compile(r"\bALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?\S+\s+RENAME\b", re.I),
+    ),
 ]
 
 
@@ -65,6 +88,32 @@ def ledger_diff(files: list[str], recorded: set[str]) -> tuple[list[str], list[s
     return pending, orphans
 
 
+# The one no-ledger remediation, shared verbatim with
+# scripts/migration_drift_report.py. The embedded newline is that script's
+# exact output wrap — its CLI output can gate CI, so the constant carries the
+# script's formatting and evaluate() flattens it for the one-line finding.
+NO_LEDGER_REMEDIATION = (
+    "Reconcile with `python -m db.migrate --baseline` against a schema you\n"
+    "have verified is current, rather than applying."
+)
+
+
+def ledger_exists(conn) -> bool:
+    """Has db.migrate ever touched this database? (One of the two sanctioned
+    IO helpers here — see the module docstring.)"""
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass('public.schema_migrations') IS NOT NULL")
+        return bool(cur.fetchone()[0])
+
+
+def recorded_filenames(conn) -> set[str]:
+    """Every filename the ledger records. Callers must check `ledger_exists`
+    first — this raises on a database that has no ledger at all."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT filename FROM schema_migrations")
+        return {row[0] for row in cur.fetchall()}
+
+
 def staging_gap(pending: list[str], staging_recorded: set[str]) -> list[str]:
     """Pending-on-prod migrations staging has never executed.
 
@@ -79,14 +128,62 @@ def _strip_comments(sql: str) -> str:
     The migrations in this repo carry long explanatory headers that frequently
     NAME destructive statements while doing nothing of the kind. Scanning raw
     text would flag most of them.
+
+    A character scanner, not regexes: `--` or `/*` inside a single-quoted
+    literal is data (`'a--b'` must not swallow the DDL after it on the same
+    line), so literal state has to be tracked, including the `''` escape.
+    Block comments nest, per Postgres. Dollar-quoted bodies ($$...$$) are
+    deliberately NOT treated as literals: every one in this repo's migrations
+    is an executable DO block or function body, where `--` really is a comment
+    and DDL really runs — blanking them would hide statements from the scan.
+    Comments are blanked to same-length runs of spaces so both line numbers
+    and column offsets survive for the caller's line accounting.
     """
-    without_blocks = re.sub(
-        r"/\*.*?\*/",
-        lambda m: re.sub(r"[^\n]", " ", m.group(0)),
-        sql,
-        flags=re.S,
-    )
-    return "\n".join(line.split("--", 1)[0] for line in without_blocks.splitlines())
+    out: list[str] = []
+    i, n = 0, len(sql)
+    in_literal = False
+    depth = 0  # block-comment nesting level
+    while i < n:
+        ch = sql[i]
+        two = sql[i : i + 2]
+        if depth:
+            if two == "/*":
+                depth += 1
+                out.append("  ")
+                i += 2
+            elif two == "*/":
+                depth -= 1
+                out.append("  ")
+                i += 2
+            else:
+                out.append(ch if ch == "\n" else " ")
+                i += 1
+        elif in_literal:
+            if two == "''":  # escaped quote — the literal stays open
+                out.append(two)
+                i += 2
+            else:
+                if ch == "'":
+                    in_literal = False
+                out.append(ch)
+                i += 1
+        elif ch == "'":
+            in_literal = True
+            out.append(ch)
+            i += 1
+        elif two == "--":
+            end = sql.find("\n", i)
+            end = n if end == -1 else end
+            out.append(" " * (end - i))
+            i = end
+        elif two == "/*":
+            depth = 1
+            out.append("  ")
+            i += 2
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
 
 
 def scan_destructive(paths: list[Path]) -> list[Finding]:
@@ -134,6 +231,8 @@ def evaluate(
     staging_recorded: set[str] | None,
     destructive: list[Finding],
     commits_ahead: int,
+    migrations_drift: str,
+    production_is_ancestor: bool,
     allow_destructive: bool,
     skip_staging_check: bool,
 ) -> list[Finding]:
@@ -143,8 +242,65 @@ def evaluate(
     """
     findings: list[Finding] = []
 
+    # The two git-side guards come first: they invalidate the rest of the
+    # audit outright. `migration_files`, `recorded` and `destructive` all
+    # describe the LOCAL checkout, and db.migrate applies LOCAL files — but
+    # the thing being promoted is origin/main. Neither has an override flag,
+    # deliberately: both states are cheap to fix and never safe to wave past.
+    if migrations_drift:
+        # Both failure directions are real: a stale main means origin/main
+        # has a migration whose file is absent here — neither pending nor an
+        # orphan, so preflight would pass, the merge would land, and prod
+        # code 500s on the missing schema. A feature-branch checkout means an
+        # unmerged local migration gets applied to production.
+        offending = "; ".join(line.strip() for line in migrations_drift.splitlines())
+        findings.append(
+            Finding(
+                "migrations-drift",
+                f"the local db/migrations/ checkout does not match origin/main: "
+                f"{offending}. The promotion audits and applies origin/main's "
+                "migrations, so run it from an up-to-date main: "
+                "`git checkout main && git pull`, and remove stray files from "
+                "db/migrations/, then re-run.",
+            )
+        )
+    if not production_is_ancestor:
+        findings.append(
+            Finding(
+                "production-diverged",
+                "origin/production has commit(s) that are not on origin/main "
+                "(a hotfix or revert that was never back-merged). The merge "
+                "would fail deterministically AFTER migrations applied. "
+                "Back-merge production into main (or otherwise reconcile) "
+                "before promoting.",
+            )
+        )
+    if findings:
+        # Everything below audits the local files/ledger the guards above
+        # just discredited — stop before describing the wrong tree.
+        return findings
+
     db_ref, api_ref = project_ref(db_url), project_ref(supabase_url)
-    if db_ref and api_ref and db_ref != api_ref:
+    # An unreadable ref fails CLOSED: skipping the comparison when a var is
+    # blank or unrecognised would let an .env.production with a staging
+    # SUPABASE_DB_URL and a missing SUPABASE_URL sail through and migrate the
+    # wrong database — the exact accident this guard exists to stop.
+    unparsed = [
+        name
+        for name, ref in (("SUPABASE_DB_URL", db_ref), ("SUPABASE_URL", api_ref))
+        if not ref
+    ]
+    if unparsed:
+        findings.append(
+            Finding(
+                "target-unverified",
+                f"No Supabase project ref could be parsed from {' or '.join(unparsed)}, "
+                "so preflight cannot vouch that the DB and API point at the same "
+                "project. Set SUPABASE_DB_URL to the SESSION-mode pooler URI "
+                "(user postgres.<ref>) and SUPABASE_URL to https://<ref>.supabase.co.",
+            )
+        )
+    elif db_ref != api_ref:
         findings.append(
             Finding(
                 "target-mismatch",
@@ -159,8 +315,7 @@ def evaluate(
                 "no-ledger",
                 "schema_migrations does not exist on this database. Applying now "
                 "would treat every migration as pending and fail recreating "
-                "existing objects. Reconcile with `python -m db.migrate --baseline` "
-                "against a verified-current schema first.",
+                "existing objects. " + NO_LEDGER_REMEDIATION.replace("\n", " "),
             )
         )
         # Everything downstream reads the ledger, so stop describing it.

--- a/backend/promotion/preflight.py
+++ b/backend/promotion/preflight.py
@@ -11,8 +11,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
-# Line-oriented, deliberately. A migration that is destructive on one line and
-# harmless on the next should name the line, and the runner prints it verbatim
+# Matched against a whitespace-collapsed statement, not a single line — this
+# repo writes wrapped multi-line ALTER TABLE/ALTER COLUMN clauses in house
+# style (e.g. db/migrations/0012_gradebook.sql), so a line-oriented scan would
+# miss a destructive clause split across lines. The finding still reports the
+# statement's starting line and the runner prints the original source verbatim
 # so the operator judges the actual statement rather than a filename.
 DESTRUCTIVE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("DROP TABLE", re.compile(r"\bDROP\s+TABLE\b", re.I)),
@@ -92,14 +95,30 @@ def scan_destructive(paths: list[Path]) -> list[Finding]:
     This matters because the runner applies migrations BEFORE the code merges,
     so between those stages the OLD production code runs against the NEW schema.
     Additive DDL is harmless in that window; destructive DDL is not.
+
+    Scans whole statements (split on `;`), not individual lines: this repo's
+    house style wraps `ALTER TABLE ... ALTER COLUMN ... TYPE ...` across
+    several lines, and a keyword split across lines would evade a line-by-line
+    regex entirely. Each statement is whitespace-collapsed before matching so
+    a wrapped statement matches identically to a single-line one; the finding
+    still reports the line where the statement *begins* and the original
+    (uncollapsed) source line, so the operator sees real SQL.
     """
     findings: list[Finding] = []
     for path in paths:
         raw_lines = path.read_text().splitlines()
-        scan_lines = _strip_comments("\n".join(raw_lines)).splitlines()
-        for lineno, line in enumerate(scan_lines, 1):
+        stripped = _strip_comments("\n".join(raw_lines))
+        offset = 0
+        for statement in stripped.split(";"):
+            start = offset
+            offset += len(statement) + 1  # +1 for the ';' the split consumed
+            content_start = start + (len(statement) - len(statement.lstrip()))
+            collapsed = " ".join(statement.split())
+            if not collapsed:
+                continue
             for label, pattern in DESTRUCTIVE_PATTERNS:
-                if pattern.search(line):
+                if pattern.search(collapsed):
+                    lineno = stripped.count("\n", 0, content_start) + 1
                     original = raw_lines[lineno - 1].strip()
                     findings.append(Finding(label, f"{path.name}:{lineno}: {original}"))
     return findings

--- a/backend/promotion/preflight.py
+++ b/backend/promotion/preflight.py
@@ -131,7 +131,7 @@ def evaluate(
     ledger_exists: bool,
     migration_files: list[str],
     recorded: set[str],
-    staging_recorded: set[str],
+    staging_recorded: set[str] | None,
     destructive: list[Finding],
     commits_ahead: int,
     allow_destructive: bool,
@@ -173,15 +173,36 @@ def evaluate(
         )
 
     if not skip_staging_check:
-        for name in staging_gap(pending, staging_recorded):
-            findings.append(
-                Finding(
-                    "staging-gap",
-                    f"{name} is pending on production but staging has never run it. "
-                    "Production must not be the first environment to execute DDL. "
-                    "Let migrate-staging.yml apply it first, or pass --skip-staging-check.",
+        if staging_recorded is None:
+            # None means "couldn't read staging's ledger", which is NOT the same
+            # claim as "staging has run nothing" (an empty set). Conflating the
+            # two turned a missing STAGING_SUPABASE_DB_URL — the default
+            # experience, since the var ships in no .env* example — into a false
+            # per-migration accusation that pushed operators straight to
+            # --skip-staging-check, disabling the guard entirely. Emit one
+            # honest finding instead of guessing.
+            if pending:
+                findings.append(
+                    Finding(
+                        "staging-unknown",
+                        f"Could not read staging's migration ledger, so it is unknown "
+                        f"whether staging has run the {len(pending)} pending "
+                        "migration(s). Set STAGING_SUPABASE_DB_URL to staging's "
+                        "SESSION-mode pooler URI (staging is on the aws-1-us-west-2 "
+                        "cluster), or pass --skip-staging-check to proceed "
+                        "deliberately without this guard.",
+                    )
                 )
-            )
+        else:
+            for name in staging_gap(pending, staging_recorded):
+                findings.append(
+                    Finding(
+                        "staging-gap",
+                        f"{name} is pending on production but staging has never run it. "
+                        "Production must not be the first environment to execute DDL. "
+                        "Let migrate-staging.yml apply it first, or pass --skip-staging-check.",
+                    )
+                )
 
     if destructive and not allow_destructive:
         for finding in destructive:

--- a/backend/promotion/runner.py
+++ b/backend/promotion/runner.py
@@ -80,12 +80,15 @@ def _wait_for_deploy(ports: Ports, options: Options, target: str, out: Callable[
 def _run_smoke(
     ports: Ports, options: Options, out: Callable[[str], None], *, merged_this_run: bool = True
 ) -> int:
-    """`merged_this_run=False` is the migrations-only path (run()'s
-    `commits_ahead == 0` branch): no PR was merged, so production's git HEAD
-    is a PREVIOUS promotion's merge commit, unrelated to this run. The default
-    revert recipe below is only correct when THIS run merged something —
-    telling an operator to `git revert -m 1 HEAD` on that path would revert
-    an unrelated, previously-working deploy.
+    """`merged_this_run=False` covers every path where THIS run merged
+    nothing: the migrations-only path (run()'s `commits_ahead == 0` branch)
+    and `--verify-only` (which never merges by design). Either way,
+    production's git HEAD is a PREVIOUS promotion's merge commit — or, under
+    `--verify-only`, simply not something this invocation touched at all.
+    The default revert recipe below is only correct when THIS run itself
+    merged something; telling an operator to `git checkout production &&
+    git revert -m 1 HEAD` on either of those paths would revert an
+    unrelated, previously-working deploy.
     """
     results = smoke.run_checks(ports.fetch, options.api_base, options.web_base)
     out("\nSmoke:")
@@ -102,12 +105,12 @@ def _run_smoke(
             )
         else:
             out(
-                "\nSMOKE FAILED. No code was merged this run — production's schema "
-                "moved (the migration(s) applied above), but its code was NOT "
-                "touched, so there is no code to revert. Production's current git "
-                "HEAD is a PREVIOUS promotion's merge commit, unrelated to this "
-                "run; undoing it would revert an earlier, previously-working "
-                "deploy. Inspect the migration that just landed, not the code."
+                "\nSMOKE FAILED. No code was merged this run, so there is no code "
+                "to revert. Production's current git HEAD is a PREVIOUS "
+                "promotion's merge commit, unrelated to this run — acting on it "
+                "would undo an earlier, previously-working deploy. Inspect what "
+                "actually changed in THIS run (a migration, or nothing at all) "
+                "before doing anything else."
             )
         return EXIT_FAIL
 
@@ -115,10 +118,12 @@ def _run_smoke(
     return EXIT_OK
 
 
-def _wait_then_smoke(ports: Ports, options: Options, target: str, out: Callable[[str], None]) -> int:
+def _wait_then_smoke(
+    ports: Ports, options: Options, target: str, out: Callable[[str], None], *, merged_this_run: bool = True
+) -> int:
     if not _wait_for_deploy(ports, options, target, out):
         return EXIT_FAIL
-    return _run_smoke(ports, options, out)
+    return _run_smoke(ports, options, out, merged_this_run=merged_this_run)
 
 
 def run(ports: Ports, options: Options) -> int:
@@ -131,7 +136,11 @@ def run(ports: Ports, options: Options) -> int:
         ports.git.fetch()
         deploy_target = ports.git.head_sha("origin/production")
         out(f"--verify-only: waiting for the deploy to report {deploy_target[:7]}.")
-        return _wait_then_smoke(ports, options, deploy_target, out)
+        # --verify-only never merges by design (see Options.verify_only), so
+        # a smoke failure here must not hand out the git-revert recipe below
+        # either — see _run_smoke's docstring; this is the second door onto
+        # the same false-report bug the migrations-only path already fixed.
+        return _wait_then_smoke(ports, options, deploy_target, out, merged_this_run=False)
 
     # ---- Stage 1: preflight (read-only) --------------------------------
     ports.git.fetch()

--- a/backend/promotion/runner.py
+++ b/backend/promotion/runner.py
@@ -146,84 +146,136 @@ def run(ports: Ports, options: Options) -> int:
 
         # ---- Stage 2-4: snapshot, migrate, snapshot --------------------
         before = ports.capture(conn)
+        out(f"Target: project {preflight.project_ref(data['db_url'])} ({before.get('host', 'unknown')})")
+
+        migrate_error: Exception | None = None
         if pending:
-            applied = ports.migrate(conn)
-            out(f"Applied {len(applied)} migration(s).")
-        after = ports.capture(conn)
+            try:
+                applied = ports.migrate(conn)
+                out(f"Applied {len(applied)} migration(s).")
+            except Exception as exc:  # noqa: BLE001 — reported as an honest partial-state report, never a traceback
+                migrate_error = exc
+
+        if migrate_error is None:
+            after = ports.capture(conn)
+
+    if migrate_error is not None:
+        # apply_migration commits per file, so whatever landed before the
+        # failure is durable. Reopen a FRESH connection rather than reuse
+        # `conn`: it may be left with an aborted transaction by the failed
+        # migration, which would raise again on the very query meant to
+        # report what actually happened.
+        with ports.connect() as conn2:
+            after = ports.capture(conn2)
+        changes = snapshot.diff(before, after)
+        landed = changes["new_migrations"]
+        # Ledger inserts are part of the same per-file transaction as the SQL,
+        # so `landed` is exact, not a guess — and apply order is `pending`'s
+        # order, so the first pending name NOT in `landed` is the one that
+        # raised.
+        failed_name = next((name for name in pending if name not in landed), "unknown")
+        out(
+            f"\nMIGRATION FAILED after {len(landed)} of {len(pending)} pending "
+            f"migration(s) landed.\n"
+            f"  Failed on: {failed_name}\n"
+            f"  Error: {migrate_error}"
+        )
+        if landed:
+            out("\nDatabase changes so far:")
+            out(snapshot.format_diff(changes))
+        out(
+            "\n  WARNING: production's schema is now PARTIALLY migrated and AHEAD "
+            "of production's code. Production's code was NOT touched. Do NOT "
+            f"re-run blindly — inspect {failed_name} and the database by hand "
+            "before continuing."
+        )
+        return EXIT_FAIL
 
     changes = snapshot.diff(before, after)
     out("\nDatabase changes:")
     out(snapshot.format_diff(changes))
 
+    if commits_ahead == 0:
+        # Migrations landed but there is no new code to promote — production's
+        # DB can trail its own code (a real, recurring state; see #316/#510).
+        # `gh pr create` would fail outright with "No commits between
+        # production and main", so skip PR/merge/deploy-wait entirely. Still
+        # smoke: a migration that broke the running app is exactly the
+        # failure this stage exists to catch.
+        out("\nMigrations applied; no code to promote (production and main are level).")
+        return _run_smoke(ports, options, out)
+
     # ---- The one pause ------------------------------------------------
     number = ports.gh.ensure_pr("production", "main", f"Promote staging to production — {commits_ahead} commits")
-    already_merged = ports.gh.state(number) == "MERGED"
 
-    if not already_merged:
-        prompt = (
-            f"\nMerge PR #{number} ({commits_ahead} commits, "
-            f"{len(changes['new_migrations'])} migrations applied) into production?"
+    prompt = (
+        f"\nMerge PR #{number} ({commits_ahead} commits, "
+        f"{len(changes['new_migrations'])} migrations applied) into production?"
+    )
+    if not ports.confirm(prompt):
+        out(
+            "\nABORTED before the merge.\n"
+            "  NOTE: the migrations above are ALREADY APPLIED. Production's "
+            "schema is now AHEAD of production's code.\n"
+            "  Re-run to resume at the merge, or revert deliberately."
         )
-        if not ports.confirm(prompt):
-            out(
-                "\nABORTED before the merge.\n"
-                "  NOTE: the migrations above are ALREADY APPLIED. Production's "
-                "schema is now AHEAD of production's code.\n"
-                "  Re-run to resume at the merge, or revert deliberately."
-            )
-            return EXIT_ABORTED
+        return EXIT_ABORTED
 
-        # The gh merge 502 wedge: `gh pr merge --merge` is known to return an
-        # error (observed: HTTP 502) while the merge actually lands. Never
-        # trust the first failure — re-read the PR state, and don't trust that
-        # read blindly either: a transient failure checking state right after
-        # a merge attempt is the worst possible moment to crash the runner.
-        #
-        # `current_state` is reassigned every iteration (None on a failed
-        # read), so by the time the loop exhausts it reflects only the LAST
-        # attempt's outcome, not "was any read ever successful". That matters:
-        # e.g. attempt 1 reads OPEN, attempts 2-5 all fail to read — the
-        # runner has NOT confirmed production is unchanged, because attempts
-        # 2-5's merge() calls could have landed with no way to know. A sticky
-        # "any read ever succeeded" flag would print the accurate-sounding but
-        # false "Production code unchanged" here; only the most recent read
-        # tells us what we currently know.
-        current_state = None
-        for attempt in range(5):
-            try:
-                ports.gh.merge(number)
-            except Exception as exc:  # noqa: BLE001 — any gh failure gets re-checked
-                out(f"  merge attempt {attempt + 1} errored ({exc}); re-checking PR state")
-            try:
-                current_state = ports.gh.state(number)
-            except Exception as exc:  # noqa: BLE001 — state-read is not trusted blindly either
-                out(f"  could not re-check PR state ({exc}); retrying")
-                current_state = None
-            if current_state == "MERGED":
-                break
-            ports.sleep(options.poll_interval)
-        else:
-            if current_state is not None:
-                # The LAST state read genuinely succeeded and said "not
-                # merged" — this claim is one this run actually knows to be
-                # true right now.
-                out(f"\nPR #{number} never reported MERGED. Production code unchanged.")
-            else:
-                # The last `gh pr view` read failed. `gh.merge` may have
-                # landed on this or an earlier attempt — this run cannot
-                # tell. Saying "production unchanged" here would be exactly
-                # the false report this tool exists to prevent.
-                out(
-                    f"\nPR #{number}'s merge outcome is UNKNOWN: the last `gh pr view` "
-                    "read failed, so this run cannot confirm whether the merge "
-                    "landed or not. Do not assume either way — check "
-                    f"`gh pr view {number}` by hand before doing anything else. "
-                    "The migrations applied earlier in this run are ALREADY "
-                    "APPLIED regardless of the merge outcome."
-                )
-            return EXIT_FAIL
+    # The gh merge 502 wedge: `gh pr merge --merge` is known to return an
+    # error (observed: HTTP 502) while the merge actually lands — the merge
+    # can land seconds AFTER a read that said OPEN, not just after a read
+    # that failed outright. Never trust the first failure — re-read the PR
+    # state, and don't trust that read blindly either: a transient failure
+    # checking state right after a merge attempt is the worst possible
+    # moment to crash the runner.
+    #
+    # `current_state` is reassigned every iteration (None on a failed read),
+    # so by the time the loop exhausts it reflects only the LAST attempt's
+    # outcome. But even a successful last read is a snapshot from BEFORE this
+    # point, not a guarantee about right now — gh's own 502-while-it-lands
+    # wedge means a merge triggered above can still land after every read
+    # this run performed. So neither branch below may assert "production is
+    # unchanged" as settled fact; both report what was OBSERVED and tell the
+    # operator to verify by hand.
+    current_state = None
+    for attempt in range(5):
+        try:
+            ports.gh.merge(number)
+        except Exception as exc:  # noqa: BLE001 — any gh failure gets re-checked
+            out(f"  merge attempt {attempt + 1} errored ({exc}); re-checking PR state")
+        try:
+            current_state = ports.gh.state(number)
+        except Exception as exc:  # noqa: BLE001 — state-read is not trusted blindly either
+            out(f"  could not re-check PR state ({exc}); retrying")
+            current_state = None
+        if current_state == "MERGED":
+            break
+        ports.sleep(options.poll_interval)
     else:
-        out(f"PR #{number} is already merged — resuming at the deploy wait.")
+        if current_state is not None:
+            out(
+                f"\nPR #{number} never reported MERGED after 5 attempts. As of "
+                f"the last check, it was {current_state}. A merge triggered by "
+                "this run may still be landing — gh is known to report an "
+                "error while a merge lands seconds later. Check "
+                f"`gh pr view {number}` before doing anything else, including "
+                "re-running this tool. The migrations applied earlier in this "
+                "run are ALREADY APPLIED regardless of the merge outcome."
+            )
+        else:
+            # The last `gh pr view` read failed. `gh.merge` may have landed on
+            # this or an earlier attempt — this run cannot tell. Saying
+            # "production unchanged" here would be exactly the false report
+            # this tool exists to prevent.
+            out(
+                f"\nPR #{number}'s merge outcome is UNKNOWN: the last `gh pr view` "
+                "read failed, so this run cannot confirm whether the merge "
+                "landed or not. Do not assume either way — check "
+                f"`gh pr view {number}` by hand before doing anything else. "
+                "The migrations applied earlier in this run are ALREADY "
+                "APPLIED regardless of the merge outcome."
+            )
+        return EXIT_FAIL
 
     # `gh pr merge --merge` creates a merge commit ON production; Railway
     # deploys production, not main. So the deploy target has to be read from

--- a/backend/promotion/runner.py
+++ b/backend/promotion/runner.py
@@ -179,13 +179,16 @@ def run(ports: Ports, options: Options) -> int:
         # read blindly either: a transient failure checking state right after
         # a merge attempt is the worst possible moment to crash the runner.
         #
-        # `state_confirmed` tracks whether ANY post-merge state read actually
-        # succeeded (regardless of what it said — the loop breaks immediately
-        # on a MERGED read, so by construction every read that reaches here
-        # said "not merged yet"). This matters for the exhaustion message
-        # below: if every read failed, we genuinely do not know whether one
-        # of the merge attempts landed, and must not claim it didn't.
-        state_confirmed = False
+        # `current_state` is reassigned every iteration (None on a failed
+        # read), so by the time the loop exhausts it reflects only the LAST
+        # attempt's outcome, not "was any read ever successful". That matters:
+        # e.g. attempt 1 reads OPEN, attempts 2-5 all fail to read — the
+        # runner has NOT confirmed production is unchanged, because attempts
+        # 2-5's merge() calls could have landed with no way to know. A sticky
+        # "any read ever succeeded" flag would print the accurate-sounding but
+        # false "Production code unchanged" here; only the most recent read
+        # tells us what we currently know.
+        current_state = None
         for attempt in range(5):
             try:
                 ports.gh.merge(number)
@@ -193,7 +196,6 @@ def run(ports: Ports, options: Options) -> int:
                 out(f"  merge attempt {attempt + 1} errored ({exc}); re-checking PR state")
             try:
                 current_state = ports.gh.state(number)
-                state_confirmed = True
             except Exception as exc:  # noqa: BLE001 — state-read is not trusted blindly either
                 out(f"  could not re-check PR state ({exc}); retrying")
                 current_state = None
@@ -201,17 +203,18 @@ def run(ports: Ports, options: Options) -> int:
                 break
             ports.sleep(options.poll_interval)
         else:
-            if state_confirmed:
-                # At least one read genuinely succeeded and said "not merged" —
-                # this claim is one this run actually knows to be true.
+            if current_state is not None:
+                # The LAST state read genuinely succeeded and said "not
+                # merged" — this claim is one this run actually knows to be
+                # true right now.
                 out(f"\nPR #{number} never reported MERGED. Production code unchanged.")
             else:
-                # Every `gh pr view` read failed. `gh.merge` may have landed on
-                # any of the attempts above — this run cannot tell. Saying
-                # "production unchanged" here would be exactly the false
-                # report this tool exists to prevent.
+                # The last `gh pr view` read failed. `gh.merge` may have
+                # landed on this or an earlier attempt — this run cannot
+                # tell. Saying "production unchanged" here would be exactly
+                # the false report this tool exists to prevent.
                 out(
-                    f"\nPR #{number}'s merge outcome is UNKNOWN: every `gh pr view` "
+                    f"\nPR #{number}'s merge outcome is UNKNOWN: the last `gh pr view` "
                     "read failed, so this run cannot confirm whether the merge "
                     "landed or not. Do not assume either way — check "
                     f"`gh pr view {number}` by hand before doing anything else. "

--- a/backend/promotion/runner.py
+++ b/backend/promotion/runner.py
@@ -178,21 +178,46 @@ def run(ports: Ports, options: Options) -> int:
         # trust the first failure — re-read the PR state, and don't trust that
         # read blindly either: a transient failure checking state right after
         # a merge attempt is the worst possible moment to crash the runner.
+        #
+        # `state_confirmed` tracks whether ANY post-merge state read actually
+        # succeeded (regardless of what it said — the loop breaks immediately
+        # on a MERGED read, so by construction every read that reaches here
+        # said "not merged yet"). This matters for the exhaustion message
+        # below: if every read failed, we genuinely do not know whether one
+        # of the merge attempts landed, and must not claim it didn't.
+        state_confirmed = False
         for attempt in range(5):
             try:
                 ports.gh.merge(number)
             except Exception as exc:  # noqa: BLE001 — any gh failure gets re-checked
                 out(f"  merge attempt {attempt + 1} errored ({exc}); re-checking PR state")
             try:
-                merged_now = ports.gh.state(number) == "MERGED"
+                current_state = ports.gh.state(number)
+                state_confirmed = True
             except Exception as exc:  # noqa: BLE001 — state-read is not trusted blindly either
                 out(f"  could not re-check PR state ({exc}); retrying")
-                merged_now = False
-            if merged_now:
+                current_state = None
+            if current_state == "MERGED":
                 break
             ports.sleep(options.poll_interval)
         else:
-            out(f"\nPR #{number} never reported MERGED. Production code unchanged.")
+            if state_confirmed:
+                # At least one read genuinely succeeded and said "not merged" —
+                # this claim is one this run actually knows to be true.
+                out(f"\nPR #{number} never reported MERGED. Production code unchanged.")
+            else:
+                # Every `gh pr view` read failed. `gh.merge` may have landed on
+                # any of the attempts above — this run cannot tell. Saying
+                # "production unchanged" here would be exactly the false
+                # report this tool exists to prevent.
+                out(
+                    f"\nPR #{number}'s merge outcome is UNKNOWN: every `gh pr view` "
+                    "read failed, so this run cannot confirm whether the merge "
+                    "landed or not. Do not assume either way — check "
+                    f"`gh pr view {number}` by hand before doing anything else. "
+                    "The migrations applied earlier in this run are ALREADY "
+                    "APPLIED regardless of the merge outcome."
+                )
             return EXIT_FAIL
     else:
         out(f"PR #{number} is already merged — resuming at the deploy wait.")

--- a/backend/promotion/runner.py
+++ b/backend/promotion/runner.py
@@ -77,19 +77,38 @@ def _wait_for_deploy(ports: Ports, options: Options, target: str, out: Callable[
     return False
 
 
-def _run_smoke(ports: Ports, options: Options, out: Callable[[str], None]) -> int:
+def _run_smoke(
+    ports: Ports, options: Options, out: Callable[[str], None], *, merged_this_run: bool = True
+) -> int:
+    """`merged_this_run=False` is the migrations-only path (run()'s
+    `commits_ahead == 0` branch): no PR was merged, so production's git HEAD
+    is a PREVIOUS promotion's merge commit, unrelated to this run. The default
+    revert recipe below is only correct when THIS run merged something —
+    telling an operator to `git revert -m 1 HEAD` on that path would revert
+    an unrelated, previously-working deploy.
+    """
     results = smoke.run_checks(ports.fetch, options.api_base, options.web_base)
     out("\nSmoke:")
     out(smoke.format_results(results))
 
     if any(not r.ok for r in results):
-        out(
-            "\nSMOKE FAILED. Production was NOT reverted — the applied migrations "
-            "cannot be rolled back, so reverting the code would leave old code "
-            "against a newer schema.\n"
-            "  To revert deliberately:\n"
-            "    git checkout production && git revert -m 1 HEAD && git push origin production"
-        )
+        if merged_this_run:
+            out(
+                "\nSMOKE FAILED. Production was NOT reverted — the applied migrations "
+                "cannot be rolled back, so reverting the code would leave old code "
+                "against a newer schema.\n"
+                "  To revert deliberately:\n"
+                "    git checkout production && git revert -m 1 HEAD && git push origin production"
+            )
+        else:
+            out(
+                "\nSMOKE FAILED. No code was merged this run — production's schema "
+                "moved (the migration(s) applied above), but its code was NOT "
+                "touched, so there is no code to revert. Production's current git "
+                "HEAD is a PREVIOUS promotion's merge commit, unrelated to this "
+                "run; undoing it would revert an earlier, previously-working "
+                "deploy. Inspect the migration that just landed, not the code."
+            )
         return EXIT_FAIL
 
     out("\nPROMOTION COMPLETE — all smoke checks passed.")
@@ -170,25 +189,36 @@ def run(ports: Ports, options: Options) -> int:
         changes = snapshot.diff(before, after)
         landed = changes["new_migrations"]
         # Ledger inserts are part of the same per-file transaction as the SQL,
-        # so `landed` is exact, not a guess — and apply order is `pending`'s
-        # order, so the first pending name NOT in `landed` is the one that
-        # raised.
-        failed_name = next((name for name in pending if name not in landed), "unknown")
-        out(
-            f"\nMIGRATION FAILED after {len(landed)} of {len(pending)} pending "
-            f"migration(s) landed.\n"
-            f"  Failed on: {failed_name}\n"
-            f"  Error: {migrate_error}"
-        )
+        # so `landed` is exact, not a guess — and when something DID land,
+        # apply order is `pending`'s order, so the first pending name NOT in
+        # `landed` is provably the one that raised. But when NOTHING landed,
+        # that is NOT necessarily pending[0]'s fault: db.migrate.run() has a
+        # prologue (SET maintenance_work_mem, ensure_tracking_table) that runs
+        # BEFORE any file, and a failure there is indistinguishable from here
+        # from a failure on the first file's own SQL. Don't guess a filename
+        # in that case.
+        failed_name = next((name for name in pending if name not in landed), "unknown") if landed else None
+        out(f"\nMIGRATION FAILED after {len(landed)} of {len(pending)} pending migration(s) landed.")
+        if failed_name is not None:
+            out(f"  Failed on: {failed_name}")
+        else:
+            out("  Failed before applying any migration (see Error below).")
+        out(f"  Error: {migrate_error}")
         if landed:
             out("\nDatabase changes so far:")
             out(snapshot.format_diff(changes))
-        out(
-            "\n  WARNING: production's schema is now PARTIALLY migrated and AHEAD "
-            "of production's code. Production's code was NOT touched. Do NOT "
-            f"re-run blindly — inspect {failed_name} and the database by hand "
-            "before continuing."
-        )
+            out(
+                "\n  WARNING: production's schema is now PARTIALLY migrated and "
+                "AHEAD of production's code. Production's code was NOT touched. "
+                f"Do NOT re-run blindly — inspect {failed_name} and the database "
+                "by hand before continuing."
+            )
+        else:
+            out(
+                "\n  Production's schema is UNCHANGED — nothing landed — and its "
+                "code was NOT touched. Do NOT re-run blindly — inspect the error "
+                "above before continuing."
+            )
         return EXIT_FAIL
 
     changes = snapshot.diff(before, after)
@@ -203,7 +233,7 @@ def run(ports: Ports, options: Options) -> int:
         # smoke: a migration that broke the running app is exactly the
         # failure this stage exists to catch.
         out("\nMigrations applied; no code to promote (production and main are level).")
-        return _run_smoke(ports, options, out)
+        return _run_smoke(ports, options, out, merged_this_run=False)
 
     # ---- The one pause ------------------------------------------------
     number = ports.gh.ensure_pr("production", "main", f"Promote staging to production — {commits_ahead} commits")

--- a/backend/promotion/runner.py
+++ b/backend/promotion/runner.py
@@ -38,10 +38,81 @@ class Options:
     web_base: str = smoke.DEFAULT_WEB
     wait_timeout: int = 600
     poll_interval: int = 10
+    # Skip preflight/snapshot/migrate/PR/merge entirely and just wait-then-smoke
+    # against production's CURRENT tip. This is the real resume path: a re-run
+    # after a merge cannot resume by re-running preflight, because by then
+    # commits_ahead is 0 and nothing is pending, so preflight would report
+    # nothing-to-promote and exit clean before ever reaching the wait.
+    verify_only: bool = False
+
+
+def _wait_for_deploy(ports: Ports, options: Options, target: str, out: Callable[[str], None]) -> bool:
+    """Poll /api/health until it reports `target`. True on success (or a
+    degraded-but-proceeding 'unknown'), False on timeout."""
+    waited = 0
+    # Advance by at least 1 per iteration. poll_interval is 0 in tests (so they
+    # don't actually sleep), and incrementing by it directly would leave `waited`
+    # pinned at 0 — an infinite loop on the very timeout path the tests exist to
+    # cover.
+    tick = max(options.poll_interval, 1)
+    while waited < options.wait_timeout:
+        live = smoke.live_commit(ports.fetch, options.api_base)
+        if live == target[:7]:
+            out(f"  deploy is live ({live}).")
+            return True
+        if live == "unknown":
+            out(
+                "  WARNING: /api/health reports commit 'unknown' — the host is not "
+                "injecting a commit SHA, so the deploy cannot be confirmed. "
+                "Proceeding to smoke anyway."
+            )
+            return True
+        ports.sleep(options.poll_interval)
+        waited += tick
+    out(
+        f"\nTIMEOUT: the deploy never reported {target[:7]} after "
+        f"{options.wait_timeout}s. NOT running smoke — a deploy failure must "
+        "not look like a smoke failure. Check the Railway build."
+    )
+    return False
+
+
+def _run_smoke(ports: Ports, options: Options, out: Callable[[str], None]) -> int:
+    results = smoke.run_checks(ports.fetch, options.api_base, options.web_base)
+    out("\nSmoke:")
+    out(smoke.format_results(results))
+
+    if any(not r.ok for r in results):
+        out(
+            "\nSMOKE FAILED. Production was NOT reverted — the applied migrations "
+            "cannot be rolled back, so reverting the code would leave old code "
+            "against a newer schema.\n"
+            "  To revert deliberately:\n"
+            "    git checkout production && git revert -m 1 HEAD && git push origin production"
+        )
+        return EXIT_FAIL
+
+    out("\nPROMOTION COMPLETE — all smoke checks passed.")
+    return EXIT_OK
+
+
+def _wait_then_smoke(ports: Ports, options: Options, target: str, out: Callable[[str], None]) -> int:
+    if not _wait_for_deploy(ports, options, target, out):
+        return EXIT_FAIL
+    return _run_smoke(ports, options, out)
 
 
 def run(ports: Ports, options: Options) -> int:
     out = ports.out
+
+    if options.verify_only:
+        # No preflight, no migrate, no PR, no merge — just confirm production's
+        # CURRENT deploy is live and healthy. See Options.verify_only for why
+        # this, not "re-run the whole thing", is the real resume path.
+        ports.git.fetch()
+        deploy_target = ports.git.head_sha("origin/production")
+        out(f"--verify-only: waiting for the deploy to report {deploy_target[:7]}.")
+        return _wait_then_smoke(ports, options, deploy_target, out)
 
     # ---- Stage 1: preflight (read-only) --------------------------------
     ports.git.fetch()
@@ -68,7 +139,10 @@ def run(ports: Ports, options: Options) -> int:
             return EXIT_FAIL
 
         pending, _ = preflight.ledger_diff(data["migration_files"], data["recorded"])
-        out(f"Preflight OK. {commits_ahead} commit(s) to promote, {len(pending)} migration(s) pending.")
+        out(
+            f"Preflight OK. {commits_ahead} commit(s) to promote (main is at "
+            f"{head[:7]}), {len(pending)} migration(s) pending."
+        )
 
         # ---- Stage 2-4: snapshot, migrate, snapshot --------------------
         before = ports.capture(conn)
@@ -99,14 +173,22 @@ def run(ports: Ports, options: Options) -> int:
             )
             return EXIT_ABORTED
 
-        # The squash-merge 502 wedge: gh can error while the merge lands. Never
-        # trust the first failure — re-read the PR state.
+        # The gh merge 502 wedge: `gh pr merge --merge` is known to return an
+        # error (observed: HTTP 502) while the merge actually lands. Never
+        # trust the first failure — re-read the PR state, and don't trust that
+        # read blindly either: a transient failure checking state right after
+        # a merge attempt is the worst possible moment to crash the runner.
         for attempt in range(5):
             try:
                 ports.gh.merge(number)
             except Exception as exc:  # noqa: BLE001 — any gh failure gets re-checked
                 out(f"  merge attempt {attempt + 1} errored ({exc}); re-checking PR state")
-            if ports.gh.state(number) == "MERGED":
+            try:
+                merged_now = ports.gh.state(number) == "MERGED"
+            except Exception as exc:  # noqa: BLE001 — state-read is not trusted blindly either
+                out(f"  could not re-check PR state ({exc}); retrying")
+                merged_now = False
+            if merged_now:
                 break
             ports.sleep(options.poll_interval)
         else:
@@ -115,51 +197,12 @@ def run(ports: Ports, options: Options) -> int:
     else:
         out(f"PR #{number} is already merged — resuming at the deploy wait.")
 
-    out(f"Merged. Waiting for the deploy to report {head[:7]}.")
+    # `gh pr merge --merge` creates a merge commit ON production; Railway
+    # deploys production, not main. So the deploy target has to be read from
+    # origin/production AFTER a fresh fetch, never from main's tip — main's SHA
+    # will never appear in production's history once a merge commit exists.
+    ports.git.fetch()
+    deploy_target = ports.git.head_sha("origin/production")
+    out(f"Merged. Waiting for the deploy to report {deploy_target[:7]}.")
 
-    # ---- Stage 6: wait for the deploy ---------------------------------
-    waited = 0
-    # Advance by at least 1 per iteration. poll_interval is 0 in tests (so they
-    # don't actually sleep), and incrementing by it directly would leave `waited`
-    # pinned at 0 — an infinite loop on the very timeout path the tests exist to
-    # cover.
-    tick = max(options.poll_interval, 1)
-    while waited < options.wait_timeout:
-        live = smoke.live_commit(ports.fetch, options.api_base)
-        if live == head[:7]:
-            out(f"  deploy is live ({live}).")
-            break
-        if live == "unknown":
-            out(
-                "  WARNING: /api/health reports commit 'unknown' — the host is not "
-                "injecting a commit SHA, so the deploy cannot be confirmed. "
-                "Proceeding to smoke anyway."
-            )
-            break
-        ports.sleep(options.poll_interval)
-        waited += tick
-    else:
-        out(
-            f"\nTIMEOUT: the deploy never reported {head[:7]} after "
-            f"{options.wait_timeout}s. NOT running smoke — a deploy failure must "
-            "not look like a smoke failure. Check the Railway build."
-        )
-        return EXIT_FAIL
-
-    # ---- Stage 7: smoke ------------------------------------------------
-    results = smoke.run_checks(ports.fetch, options.api_base, options.web_base)
-    out("\nSmoke:")
-    out(smoke.format_results(results))
-
-    if any(not r.ok for r in results):
-        out(
-            "\nSMOKE FAILED. Production was NOT reverted — the applied migrations "
-            "cannot be rolled back, so reverting the code would leave old code "
-            "against a newer schema.\n"
-            "  To revert deliberately:\n"
-            "    git checkout production && git revert -m 1 HEAD && git push origin production"
-        )
-        return EXIT_FAIL
-
-    out("\nPROMOTION COMPLETE — all smoke checks passed.")
-    return EXIT_OK
+    return _wait_then_smoke(ports, options, deploy_target, out)

--- a/backend/promotion/runner.py
+++ b/backend/promotion/runner.py
@@ -8,12 +8,22 @@ Every side effect is an injected port, so the whole sequence is testable.
 """
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Any, Callable
 
 from promotion import preflight, smoke, snapshot
 
 EXIT_OK, EXIT_FAIL, EXIT_ABORTED = 0, 1, 2
+
+# The one partial-state NOTE every post-migrate failure path shares: by the
+# time the PR/merge stage runs, the migrations are durable no matter what else
+# goes wrong. One constant, not three copies, so the wording can never drift
+# between the decline, gh-failure and moved-head reports.
+MIGRATIONS_ALREADY_APPLIED_NOTE = (
+    "  NOTE: the migrations above are ALREADY APPLIED. Production's "
+    "schema is now AHEAD of production's code."
+)
 
 
 @dataclass
@@ -28,6 +38,10 @@ class Ports:
     confirm: Callable[[str], bool]
     out: Callable[[str], None]
     sleep: Callable[[float], None]
+    # Wall-clock source for the deploy-wait budget. Defaulted — the only field
+    # that may be — so __main__.py's Ports(...) construction needs no change;
+    # tests inject a fake clock that advances with each fetch/sleep.
+    monotonic: Callable[[], float] = time.monotonic
 
 
 @dataclass
@@ -46,41 +60,69 @@ class Options:
     verify_only: bool = False
 
 
-def _wait_for_deploy(ports: Ports, options: Options, target: str, out: Callable[[str], None]) -> bool:
-    """Poll /api/health until it reports `target`. True on success (or a
-    degraded-but-proceeding 'unknown'), False on timeout."""
-    waited = 0
-    # Advance by at least 1 per iteration. poll_interval is 0 in tests (so they
-    # don't actually sleep), and incrementing by it directly would leave `waited`
-    # pinned at 0 — an infinite loop on the very timeout path the tests exist to
-    # cover.
-    tick = max(options.poll_interval, 1)
-    while waited < options.wait_timeout:
+def _wait_for_deploy(ports: Ports, options: Options, target: str, out: Callable[[str], None]) -> str:
+    """Poll /api/health until it reports `target`. Returns "verified" when the
+    target commit is confirmed live, "timeout" when the window elapsed without
+    it, and "unverified" when the ENTIRE window produced only 'unknown' — the
+    host injects no commit SHA, so confirming the deploy is impossible and the
+    caller degrades to smoke without claiming verification.
+
+    'unknown' must never satisfy the wait early: the first polls land while
+    the OLD deploy is still serving, so an early 'unknown' proves nothing
+    about the new one — smoke would run against the previous deploy under a
+    verified-sounding report. But a window that ever produced a REAL SHA
+    proves the host does inject commits, so all-'unknown'-degrade must not
+    swallow that case: it times out like any other missing target.
+    """
+    saw_unknown = saw_real_sha = False
+    # Budget on real elapsed time, never on nominal ticks: each health fetch
+    # can itself take up to 25s (httpx_fetch's timeout), so `waited +=
+    # poll_interval` accounting would let a 600s budget run ~35 minutes of
+    # wall clock during an incident. Termination therefore depends on the
+    # clock advancing — time.monotonic always does; tests must inject a fake
+    # that advances with each fetch/sleep (a frozen clock loops forever).
+    start = ports.monotonic()
+    while ports.monotonic() - start < options.wait_timeout:
         live = smoke.live_commit(ports.fetch, options.api_base)
         if live == target[:7]:
             out(f"  deploy is live ({live}).")
-            return True
+            return "verified"
         if live == "unknown":
-            out(
-                "  WARNING: /api/health reports commit 'unknown' — the host is not "
-                "injecting a commit SHA, so the deploy cannot be confirmed. "
-                "Proceeding to smoke anyway."
-            )
-            return True
+            saw_unknown = True
+        elif live:  # a real, non-matching SHA ("" = unreachable, proves nothing)
+            saw_real_sha = True
         ports.sleep(options.poll_interval)
-        waited += tick
+    if saw_unknown and not saw_real_sha:
+        out(
+            f"\nUNVERIFIED: /api/health reported commit 'unknown' for the whole "
+            f"{options.wait_timeout}s window — the host is not injecting a "
+            "commit SHA, so the deploy cannot be confirmed at all. Proceeding "
+            "to smoke, but the checks may exercise the PREVIOUS deploy."
+        )
+        return "unverified"
     out(
         f"\nTIMEOUT: the deploy never reported {target[:7]} after "
         f"{options.wait_timeout}s. NOT running smoke — a deploy failure must "
         "not look like a smoke failure. Check the Railway build."
     )
-    return False
+    return "timeout"
 
 
 def _run_smoke(
-    ports: Ports, options: Options, out: Callable[[str], None], *, merged_this_run: bool = True
+    ports: Ports,
+    options: Options,
+    out: Callable[[str], None],
+    *,
+    merged_this_run: bool = True,
+    deploy_verified: bool = True,
 ) -> int:
-    """`merged_this_run=False` covers every path where THIS run merged
+    """`deploy_verified=False` is the all-'unknown' degrade from
+    _wait_for_deploy: smoke still runs, but the completion line must not claim
+    the deploy was verified — the checks may have exercised the PREVIOUS
+    deploy, and a clean "PROMOTION COMPLETE" would be the exact false report
+    this tool exists to prevent.
+
+    `merged_this_run=False` covers every path where THIS run merged
     nothing: the migrations-only path (run()'s `commits_ahead == 0` branch)
     and `--verify-only` (which never merges by design). Either way,
     production's git HEAD is a PREVIOUS promotion's merge commit — or, under
@@ -114,16 +156,99 @@ def _run_smoke(
             )
         return EXIT_FAIL
 
-    out("\nPROMOTION COMPLETE — all smoke checks passed.")
+    if deploy_verified:
+        out("\nPROMOTION COMPLETE — all smoke checks passed.")
+    else:
+        out(
+            "\nSMOKE PASSED, but the deploy itself was NEVER VERIFIED — "
+            "/api/health reports no commit SHA, so the checks may have run "
+            "against the PREVIOUS deploy. Confirm the new deploy actually "
+            "landed (Railway dashboard) before treating this promotion as "
+            "complete."
+        )
     return EXIT_OK
 
 
 def _wait_then_smoke(
     ports: Ports, options: Options, target: str, out: Callable[[str], None], *, merged_this_run: bool = True
 ) -> int:
-    if not _wait_for_deploy(ports, options, target, out):
+    outcome = _wait_for_deploy(ports, options, target, out)
+    if outcome == "timeout":
         return EXIT_FAIL
-    return _run_smoke(ports, options, out, merged_this_run=merged_this_run)
+    return _run_smoke(
+        ports, options, out, merged_this_run=merged_this_run, deploy_verified=outcome == "verified"
+    )
+
+
+def _report_migration_failure(
+    ports: Ports, out: Callable[[str], None], before: dict, pending: list[str], error: Exception
+) -> None:
+    """The honest partial-state report for a failed migrate stage.
+
+    apply_migration commits per file, so whatever landed before the failure
+    is durable. Reopen a FRESH connection rather than reuse the migrate
+    stage's: it may be left with an aborted transaction by the failed
+    migration, which would raise again on the very query meant to report what
+    actually happened. And the reconnect itself may fail — the likely cause
+    of the migrate failure is a dead database — so a capture failure here
+    degrades the report (no landed count), never discards it.
+    """
+    after: dict | None = None
+    capture_error: Exception | None = None
+    try:
+        with ports.connect() as conn:
+            after = ports.capture(conn)
+    except Exception as exc:  # noqa: BLE001 — a dead DB must not cost the operator this report
+        capture_error = exc
+
+    if after is None:
+        out(f"\nMIGRATION FAILED with {len(pending)} migration(s) pending.")
+        out(f"  Error: {error}")
+        out(
+            f"  The post-failure snapshot could not be captured ({capture_error}), "
+            "so it is UNKNOWN how many of the pending migrations landed."
+        )
+        out(
+            "\n  WARNING: production's schema may be PARTIALLY migrated and "
+            "AHEAD of production's code. Production's code was NOT touched. "
+            "Do NOT re-run blindly — inspect the database by hand before "
+            "continuing."
+        )
+        return
+
+    changes = snapshot.diff(before, after)
+    landed = changes["new_migrations"]
+    # Ledger inserts are part of the same per-file transaction as the SQL,
+    # so `landed` is exact, not a guess — and when something DID land,
+    # apply order is `pending`'s order, so the first pending name NOT in
+    # `landed` is provably the one that raised. But when NOTHING landed,
+    # that is NOT necessarily pending[0]'s fault: db.migrate.run() has a
+    # prologue (SET maintenance_work_mem, ensure_tracking_table) that runs
+    # BEFORE any file, and a failure there is indistinguishable from here
+    # from a failure on the first file's own SQL. Don't guess a filename
+    # in that case.
+    failed_name = next((name for name in pending if name not in landed), "unknown") if landed else None
+    out(f"\nMIGRATION FAILED after {len(landed)} of {len(pending)} pending migration(s) landed.")
+    if failed_name is not None:
+        out(f"  Failed on: {failed_name}")
+    else:
+        out("  Failed before applying any migration (see Error below).")
+    out(f"  Error: {error}")
+    if landed:
+        out("\nDatabase changes so far:")
+        out(snapshot.format_diff(changes))
+        out(
+            "\n  WARNING: production's schema is now PARTIALLY migrated and "
+            "AHEAD of production's code. Production's code was NOT touched. "
+            f"Do NOT re-run blindly — inspect {failed_name} and the database "
+            "by hand before continuing."
+        )
+    else:
+        out(
+            "\n  Production's schema is UNCHANGED — nothing landed — and its "
+            "code was NOT touched. Do NOT re-run blindly — inspect the error "
+            "above before continuing."
+        )
 
 
 def run(ports: Ports, options: Options) -> int:
@@ -144,13 +269,28 @@ def run(ports: Ports, options: Options) -> int:
 
     # ---- Stage 1: preflight (read-only) --------------------------------
     ports.git.fetch()
+    # `head` is the audited SHA: everything preflight vouches for below —
+    # commits_ahead, the migration listing, the destructive scan — is anchored
+    # to origin/main AS OF THIS FETCH. The merge stage pins to this same SHA
+    # (gh --match-head-commit) so commits landing after this moment can never
+    # ride along unscanned.
     head = ports.git.head_sha("origin/main")
     commits_ahead = ports.git.commits_ahead_of("origin/production", "origin/main")
+    # Git-side guard facts, resolved AFTER the fetch and BEFORE any DDL can
+    # apply. Both are blocking in preflight.evaluate: a migrations dir that
+    # differs from origin/main (content, presence, or untracked strays), and
+    # an origin/production that is not an ancestor of origin/main. is_ancestor
+    # fails CLOSED — a git error raises here, caught by __main__'s catch-all,
+    # and nothing has been migrated yet.
+    migrations_drift = ports.git.migrations_drift()
+    production_is_ancestor = ports.git.is_ancestor("origin/production", "origin/main")
 
     with ports.connect() as conn:
         data = ports.preflight_data(conn)
         findings = preflight.evaluate(
             commits_ahead=commits_ahead,
+            migrations_drift=migrations_drift,
+            production_is_ancestor=production_is_ancestor,
             allow_destructive=options.allow_destructive,
             skip_staging_check=options.skip_staging_check,
             **data,
@@ -162,6 +302,9 @@ def run(ports: Ports, options: Options) -> int:
                 out(f"  [{finding.kind}] {finding.detail}")
             if not blocking:
                 out("Nothing to promote — production already matches main.")
+                # This is also where a plain re-run lands after a promotion
+                # that merged but then failed before verify/smoke.
+                out("  (To re-check the live deploy, re-run with --verify-only.)")
                 return EXIT_OK
             out("\nPREFLIGHT FAILED — production was not touched.")
             return EXIT_FAIL
@@ -183,51 +326,16 @@ def run(ports: Ports, options: Options) -> int:
                 out(f"Applied {len(applied)} migration(s).")
             except Exception as exc:  # noqa: BLE001 — reported as an honest partial-state report, never a traceback
                 migrate_error = exc
+                # Report from INSIDE the with-block: if the connection died,
+                # `conn.__exit__`'s commit can itself raise on the way out,
+                # and that second exception must find the MIGRATION FAILED
+                # report already emitted — not mask it.
+                _report_migration_failure(ports, out, before, pending, exc)
 
         if migrate_error is None:
             after = ports.capture(conn)
 
     if migrate_error is not None:
-        # apply_migration commits per file, so whatever landed before the
-        # failure is durable. Reopen a FRESH connection rather than reuse
-        # `conn`: it may be left with an aborted transaction by the failed
-        # migration, which would raise again on the very query meant to
-        # report what actually happened.
-        with ports.connect() as conn2:
-            after = ports.capture(conn2)
-        changes = snapshot.diff(before, after)
-        landed = changes["new_migrations"]
-        # Ledger inserts are part of the same per-file transaction as the SQL,
-        # so `landed` is exact, not a guess — and when something DID land,
-        # apply order is `pending`'s order, so the first pending name NOT in
-        # `landed` is provably the one that raised. But when NOTHING landed,
-        # that is NOT necessarily pending[0]'s fault: db.migrate.run() has a
-        # prologue (SET maintenance_work_mem, ensure_tracking_table) that runs
-        # BEFORE any file, and a failure there is indistinguishable from here
-        # from a failure on the first file's own SQL. Don't guess a filename
-        # in that case.
-        failed_name = next((name for name in pending if name not in landed), "unknown") if landed else None
-        out(f"\nMIGRATION FAILED after {len(landed)} of {len(pending)} pending migration(s) landed.")
-        if failed_name is not None:
-            out(f"  Failed on: {failed_name}")
-        else:
-            out("  Failed before applying any migration (see Error below).")
-        out(f"  Error: {migrate_error}")
-        if landed:
-            out("\nDatabase changes so far:")
-            out(snapshot.format_diff(changes))
-            out(
-                "\n  WARNING: production's schema is now PARTIALLY migrated and "
-                "AHEAD of production's code. Production's code was NOT touched. "
-                f"Do NOT re-run blindly — inspect {failed_name} and the database "
-                "by hand before continuing."
-            )
-        else:
-            out(
-                "\n  Production's schema is UNCHANGED — nothing landed — and its "
-                "code was NOT touched. Do NOT re-run blindly — inspect the error "
-                "above before continuing."
-            )
         return EXIT_FAIL
 
     changes = snapshot.diff(before, after)
@@ -245,7 +353,24 @@ def run(ports: Ports, options: Options) -> int:
         return _run_smoke(ports, options, out, merged_this_run=False)
 
     # ---- The one pause ------------------------------------------------
-    number = ports.gh.ensure_pr("production", "main", f"Promote staging to production — {commits_ahead} commits")
+    # From here to the confirm prompt, the migrations above are already
+    # durable. A gh failure (expired auth, network) must not surface as
+    # __main__'s bare one-line ERROR with none of the partial-state reporting
+    # the decline/migrate-failed paths emit: report first, then re-raise —
+    # the catch-all's ERROR line supplements the report instead of replacing it.
+    try:
+        number = ports.gh.ensure_pr(
+            "production", "main", f"Promote staging to production — {commits_ahead} commits"
+        )
+    except Exception:
+        out(
+            "\nFAILED before the merge (could not create/find the promotion PR — "
+            "see Error below).\n"
+            + MIGRATIONS_ALREADY_APPLIED_NOTE
+            + "\n  Fix the gh failure (auth, network) and re-run to resume at the "
+            "merge, or revert deliberately."
+        )
+        raise
 
     prompt = (
         f"\nMerge PR #{number} ({commits_ahead} commits, "
@@ -254,9 +379,8 @@ def run(ports: Ports, options: Options) -> int:
     if not ports.confirm(prompt):
         out(
             "\nABORTED before the merge.\n"
-            "  NOTE: the migrations above are ALREADY APPLIED. Production's "
-            "schema is now AHEAD of production's code.\n"
-            "  Re-run to resume at the merge, or revert deliberately."
+            + MIGRATIONS_ALREADY_APPLIED_NOTE
+            + "\n  Re-run to resume at the merge, or revert deliberately."
         )
         return EXIT_ABORTED
 
@@ -279,7 +403,12 @@ def run(ports: Ports, options: Options) -> int:
     current_state = None
     for attempt in range(5):
         try:
-            ports.gh.merge(number)
+            # Pinned to `head`, the SHA stage-1 preflight audited: GitHub
+            # itself (gh --match-head-commit) rejects the merge if main's tip
+            # moved while the operator sat at the confirm prompt — commits in
+            # that window were never destructive-scanned and their migrations
+            # never applied, so they must not ride along.
+            ports.gh.merge(number, head)
         except Exception as exc:  # noqa: BLE001 — any gh failure gets re-checked
             out(f"  merge attempt {attempt + 1} errored ({exc}); re-checking PR state")
         try:
@@ -289,6 +418,33 @@ def run(ports: Ports, options: Options) -> int:
             current_state = None
         if current_state == "MERGED":
             break
+        # A --match-head-commit rejection is DETERMINISTIC — retrying can
+        # never make a moved main match again — so it must not burn the
+        # transient-502 retry budget above. Detect it by re-reading
+        # origin/main rather than by matching gh's error text (which gh does
+        # not guarantee), but only when the PR state was READ and says
+        # non-merged: an unreadable state keeps the loop's careful
+        # unknown-outcome reporting below, and a failed re-read here falls
+        # through to the transient path rather than guessing.
+        if current_state is not None:
+            try:
+                ports.git.fetch()
+                main_now = ports.git.head_sha("origin/main")
+            except Exception as exc:  # noqa: BLE001 — can't tell; treat as transient
+                out(f"  could not re-read origin/main ({exc}); treating as transient")
+                main_now = None
+            if main_now is not None and main_now != head:
+                out(
+                    f"\nMERGE REJECTED — origin/main moved since preflight "
+                    f"(audited {head[:7]}, now {main_now[:7]}). The merge is "
+                    "pinned to the audited SHA, so the new commits — never "
+                    "destructive-scanned, their migrations never applied — "
+                    "were NOT promoted. Re-run `make promote` to audit and "
+                    "promote the new tip."
+                )
+                if changes["new_migrations"]:
+                    out(MIGRATIONS_ALREADY_APPLIED_NOTE)
+                return EXIT_FAIL
         ports.sleep(options.poll_interval)
     else:
         if current_state is not None:
@@ -320,8 +476,21 @@ def run(ports: Ports, options: Options) -> int:
     # deploys production, not main. So the deploy target has to be read from
     # origin/production AFTER a fresh fetch, never from main's tip — main's SHA
     # will never appear in production's history once a merge commit exists.
-    ports.git.fetch()
-    deploy_target = ports.git.head_sha("origin/production")
+    try:
+        ports.git.fetch()
+        deploy_target = ports.git.head_sha("origin/production")
+    except Exception as exc:  # noqa: BLE001 — a transient git failure must not strand a landed merge
+        # A plain re-run from here would see commits_ahead == 0 and exit 0
+        # "Nothing to promote" — the promoted deploy would never be verified
+        # or smoked. Point at the flag that actually resumes.
+        out(
+            f"\nThe MERGE HAS LANDED (PR #{number} reports MERGED), but reading "
+            f"production's new tip failed ({exc}), so the deploy was never "
+            "verified and smoke never ran. Re-run with --verify-only to check "
+            "the live deploy — a plain re-run would report nothing to promote "
+            "and exit clean without verifying anything."
+        )
+        return EXIT_FAIL
     out(f"Merged. Waiting for the deploy to report {deploy_target[:7]}.")
 
     return _wait_then_smoke(ports, options, deploy_target, out)

--- a/backend/promotion/runner.py
+++ b/backend/promotion/runner.py
@@ -1,0 +1,165 @@
+"""Stage sequencing for the staging -> production promotion (#516).
+
+Ordering is DB-first: migrations apply BEFORE the code merges, which is what the
+destructive-DDL guard in preflight exists to protect. Between the migrate stage
+and the merge, the OLD production code runs against the NEW schema.
+
+Every side effect is an injected port, so the whole sequence is testable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from promotion import preflight, smoke, snapshot
+
+EXIT_OK, EXIT_FAIL, EXIT_ABORTED = 0, 1, 2
+
+
+@dataclass
+class Ports:
+    connect: Callable[[], Any]
+    preflight_data: Callable[[Any], dict]
+    capture: Callable[[Any], dict]
+    migrate: Callable[[Any], list[str]]
+    git: Any
+    gh: Any
+    fetch: Callable[[str, str], tuple[int | None, str]]
+    confirm: Callable[[str], bool]
+    out: Callable[[str], None]
+    sleep: Callable[[float], None]
+
+
+@dataclass
+class Options:
+    allow_destructive: bool = False
+    skip_staging_check: bool = False
+    api_base: str = smoke.DEFAULT_API
+    web_base: str = smoke.DEFAULT_WEB
+    wait_timeout: int = 600
+    poll_interval: int = 10
+
+
+def run(ports: Ports, options: Options) -> int:
+    out = ports.out
+
+    # ---- Stage 1: preflight (read-only) --------------------------------
+    ports.git.fetch()
+    head = ports.git.head_sha("origin/main")
+    commits_ahead = ports.git.commits_ahead_of("origin/production", "origin/main")
+
+    with ports.connect() as conn:
+        data = ports.preflight_data(conn)
+        findings = preflight.evaluate(
+            commits_ahead=commits_ahead,
+            allow_destructive=options.allow_destructive,
+            skip_staging_check=options.skip_staging_check,
+            **data,
+        )
+
+        if findings:
+            blocking = [f for f in findings if f.kind != "nothing-to-promote"]
+            for finding in findings:
+                out(f"  [{finding.kind}] {finding.detail}")
+            if not blocking:
+                out("Nothing to promote — production already matches main.")
+                return EXIT_OK
+            out("\nPREFLIGHT FAILED — production was not touched.")
+            return EXIT_FAIL
+
+        pending, _ = preflight.ledger_diff(data["migration_files"], data["recorded"])
+        out(f"Preflight OK. {commits_ahead} commit(s) to promote, {len(pending)} migration(s) pending.")
+
+        # ---- Stage 2-4: snapshot, migrate, snapshot --------------------
+        before = ports.capture(conn)
+        if pending:
+            applied = ports.migrate(conn)
+            out(f"Applied {len(applied)} migration(s).")
+        after = ports.capture(conn)
+
+    changes = snapshot.diff(before, after)
+    out("\nDatabase changes:")
+    out(snapshot.format_diff(changes))
+
+    # ---- The one pause ------------------------------------------------
+    number = ports.gh.ensure_pr("production", "main", f"Promote staging to production — {commits_ahead} commits")
+    already_merged = ports.gh.state(number) == "MERGED"
+
+    if not already_merged:
+        prompt = (
+            f"\nMerge PR #{number} ({commits_ahead} commits, "
+            f"{len(changes['new_migrations'])} migrations applied) into production?"
+        )
+        if not ports.confirm(prompt):
+            out(
+                "\nABORTED before the merge.\n"
+                "  NOTE: the migrations above are ALREADY APPLIED. Production's "
+                "schema is now AHEAD of production's code.\n"
+                "  Re-run to resume at the merge, or revert deliberately."
+            )
+            return EXIT_ABORTED
+
+        # The squash-merge 502 wedge: gh can error while the merge lands. Never
+        # trust the first failure — re-read the PR state.
+        for attempt in range(5):
+            try:
+                ports.gh.merge(number)
+            except Exception as exc:  # noqa: BLE001 — any gh failure gets re-checked
+                out(f"  merge attempt {attempt + 1} errored ({exc}); re-checking PR state")
+            if ports.gh.state(number) == "MERGED":
+                break
+            ports.sleep(options.poll_interval)
+        else:
+            out(f"\nPR #{number} never reported MERGED. Production code unchanged.")
+            return EXIT_FAIL
+    else:
+        out(f"PR #{number} is already merged — resuming at the deploy wait.")
+
+    out(f"Merged. Waiting for the deploy to report {head[:7]}.")
+
+    # ---- Stage 6: wait for the deploy ---------------------------------
+    waited = 0
+    # Advance by at least 1 per iteration. poll_interval is 0 in tests (so they
+    # don't actually sleep), and incrementing by it directly would leave `waited`
+    # pinned at 0 — an infinite loop on the very timeout path the tests exist to
+    # cover.
+    tick = max(options.poll_interval, 1)
+    while waited < options.wait_timeout:
+        live = smoke.live_commit(ports.fetch, options.api_base)
+        if live == head[:7]:
+            out(f"  deploy is live ({live}).")
+            break
+        if live == "unknown":
+            out(
+                "  WARNING: /api/health reports commit 'unknown' — the host is not "
+                "injecting a commit SHA, so the deploy cannot be confirmed. "
+                "Proceeding to smoke anyway."
+            )
+            break
+        ports.sleep(options.poll_interval)
+        waited += tick
+    else:
+        out(
+            f"\nTIMEOUT: the deploy never reported {head[:7]} after "
+            f"{options.wait_timeout}s. NOT running smoke — a deploy failure must "
+            "not look like a smoke failure. Check the Railway build."
+        )
+        return EXIT_FAIL
+
+    # ---- Stage 7: smoke ------------------------------------------------
+    results = smoke.run_checks(ports.fetch, options.api_base, options.web_base)
+    out("\nSmoke:")
+    out(smoke.format_results(results))
+
+    if any(not r.ok for r in results):
+        out(
+            "\nSMOKE FAILED. Production was NOT reverted — the applied migrations "
+            "cannot be rolled back, so reverting the code would leave old code "
+            "against a newer schema.\n"
+            "  To revert deliberately:\n"
+            "    git checkout production && git revert -m 1 HEAD && git push origin production"
+        )
+        return EXIT_FAIL
+
+    out("\nPROMOTION COMPLETE — all smoke checks passed.")
+    return EXIT_OK

--- a/backend/promotion/smoke.py
+++ b/backend/promotion/smoke.py
@@ -1,0 +1,101 @@
+"""Post-deploy smoke checks against the live production surface (#516).
+
+Unauthenticated surface only. A 401/403 on a guarded route is a PASS: it proves
+the router is MOUNTED, and the failure mode this catches is a 404 from code that
+never shipped.
+
+Checks are DATA, and the fetcher is injected, so the suite is testable without a
+network. Deliberately excluded: assertions about specific term data (#515 asserted
+`fall-2026` and a start date), which pass today and rot next term.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+DEFAULT_API = "https://api.saplinglearn.com"
+DEFAULT_WEB = "https://saplinglearn.com"
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    target: str  # "api" | "web"
+    path: str
+    expect_status: tuple[int, ...]
+    expect_body: str = ""
+    method: str = "GET"
+
+
+@dataclass
+class Result:
+    check: Check
+    ok: bool
+    status: int | None
+    detail: str
+
+
+CHECKS: list[Check] = [
+    Check("api health", "api", "/api/health", (200,), '"status":"ok"'),
+    # Mounted-not-404. These routers only exist in promoted code.
+    Check("academics mounted", "api", "/api/semesters", (200,)),
+    Check("notes mounted", "api", "/api/notes", (200, 401, 403, 405)),
+    Check("admin analytics mounted", "api", "/api/admin/analytics/usage/summary", (401, 403)),
+    Check("auth entrypoint", "api", "/api/auth/google", (200, 302, 307, 400, 401)),
+    # The local/test session minter must be OFF in production. POST specifically:
+    # a GET returns 405, which would mask a live endpoint.
+    Check("test-login disabled", "api", "/api/auth/test-login", (404,), method="POST"),
+    Check("web root", "web", "/", (200,), "<"),
+    # Proves the frontend worker's build-time BACKEND_URL is right; a wrong one 500s.
+    Check("web -> api proxy", "web", "/api/health", (200,), '"status":"ok"'),
+]
+
+
+def run_checks(fetch, api_base: str, web_base: str, checks: list[Check] | None = None) -> list[Result]:
+    """Run each check through `fetch(method, url) -> (status | None, body)`."""
+    results: list[Result] = []
+    for check in checks if checks is not None else CHECKS:
+        base = api_base if check.target == "api" else web_base
+        url = f"{base.rstrip('/')}{check.path}"
+        status, body = fetch(check.method, url)
+
+        if status is None:
+            results.append(Result(check, False, None, f"no response from {url}: {body[:120]}"))
+            continue
+        if status not in check.expect_status:
+            expected = "/".join(str(s) for s in check.expect_status)
+            results.append(Result(check, False, status, f"{url} -> {status}, expected {expected}"))
+            continue
+        if check.expect_body and check.expect_body not in body:
+            results.append(Result(check, False, status, f"{url} -> {status} but missing {check.expect_body!r}"))
+            continue
+        results.append(Result(check, True, status, f"{url} -> {status}"))
+    return results
+
+
+def live_commit(fetch, api_base: str) -> str:
+    """Deployed short SHA from /api/health, or "" if unreachable/unparseable."""
+    status, body = fetch("GET", f"{api_base.rstrip('/')}/api/health")
+    if status != 200:
+        return ""
+    try:
+        return str(json.loads(body).get("commit", ""))
+    except (ValueError, AttributeError):
+        return ""
+
+
+def format_results(results: list[Result]) -> str:
+    return "\n".join(
+        f"  {'PASS' if r.ok else 'FAIL'}  {r.check.name}  ({r.detail})" for r in results
+    )
+
+
+def httpx_fetch(method: str, url: str) -> tuple[int | None, str]:
+    """Real IO. Imported lazily so importing this module costs nothing."""
+    import httpx
+
+    try:
+        response = httpx.request(method, url, timeout=25.0, follow_redirects=False)
+        return response.status_code, response.text
+    except httpx.HTTPError as exc:  # DNS, TLS, timeout, refused
+        return None, str(exc)

--- a/backend/promotion/snapshot.py
+++ b/backend/promotion/snapshot.py
@@ -1,0 +1,75 @@
+"""Before/after snapshots of the production database (#516).
+
+The point is evidence, not monitoring: capture once before migrating and once
+after, then diff, so the operator confirming the merge sees exactly what the
+migration did — and so a failed promotion has an artifact to reason about
+instead of terminal scrollback.
+
+SELECTs only. Nothing here writes.
+"""
+from __future__ import annotations
+
+LEDGER_EXISTS_SQL = "SELECT to_regclass('public.schema_migrations') IS NOT NULL"
+LEDGER_SQL = "SELECT filename FROM schema_migrations ORDER BY filename"
+TABLES_SQL = """
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+    ORDER BY table_name
+"""
+
+
+def capture(conn) -> dict:
+    """Ledger contents and per-table row counts for the connected database."""
+    snapshot: dict = {"host": getattr(conn.info, "host", "unknown")}
+
+    with conn.cursor() as cur:
+        cur.execute(LEDGER_EXISTS_SQL)
+        exists = bool(cur.fetchone()[0])
+        snapshot["ledger_exists"] = exists
+
+        ledger: list[str] = []
+        if exists:
+            cur.execute(LEDGER_SQL)
+            ledger = [row[0] for row in cur.fetchall()]
+        snapshot["ledger"] = ledger
+
+        cur.execute(TABLES_SQL)
+        names = [row[0] for row in cur.fetchall()]
+
+        counts: dict[str, int] = {}
+        for name in names:
+            # Identifier comes from information_schema, never from user input,
+            # and count(*) takes no bindable parameter for a table name.
+            cur.execute(f'SELECT count(*) FROM public."{name}"')
+            counts[name] = cur.fetchone()[0]
+        snapshot["tables"] = counts
+
+    return snapshot
+
+
+def diff(before: dict, after: dict) -> dict:
+    """What changed between two snapshots."""
+    b, a = before.get("tables", {}), after.get("tables", {})
+    return {
+        "new_tables": sorted(set(a) - set(b)),
+        "dropped_tables": sorted(set(b) - set(a)),
+        "count_changes": {k: (b[k], a[k]) for k in sorted(set(b) & set(a)) if b[k] != a[k]},
+        "new_migrations": [m for m in after.get("ledger", []) if m not in set(before.get("ledger", []))],
+    }
+
+
+def format_diff(d: dict) -> str:
+    """Human-readable diff for the confirmation prompt and the final report."""
+    lines: list[str] = []
+    if d["new_migrations"]:
+        lines.append(f"  migrations applied ({len(d['new_migrations'])}):")
+        lines += [f"    + {m}" for m in d["new_migrations"]]
+    if d["new_tables"]:
+        lines.append(f"  new tables: {', '.join(d['new_tables'])}")
+    if d["dropped_tables"]:
+        lines.append(f"  DROPPED tables: {', '.join(d['dropped_tables'])}")
+    if d["count_changes"]:
+        lines.append("  row-count changes:")
+        lines += [f"    {t}: {old} -> {new}" for t, (old, new) in d["count_changes"].items()]
+    return "\n".join(lines) if lines else "  no schema or row-count changes"

--- a/backend/scripts/migration_drift_report.py
+++ b/backend/scripts/migration_drift_report.py
@@ -36,6 +36,12 @@ non-idempotent collision, or a data blocker), 0 clean. Nonzero means "do not
 apply on top of this" — so the report can gate CI directly rather than being
 re-implemented inline, which is how the workflow preflight and this script
 drifted apart in the first place.
+
+The ledger primitives (pending/orphans, ledger reads, the no-ledger guidance)
+are imported from promotion.preflight — the same implementation the promotion
+runner's preflight consumes (#516) — so the two cannot drift apart again. The
+extra checks (number collision, ALREADY EXISTS, data blockers) remain this
+script's own.
 """
 from __future__ import annotations
 
@@ -45,6 +51,18 @@ import re
 import sys
 
 import psycopg
+
+# Run as a script (`python scripts/migration_drift_report.py` from backend/),
+# sys.path[0] is scripts/ — put backend/ there so the shared promotion
+# primitives resolve; same pattern as the other scripts in this directory.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from promotion.preflight import (  # noqa: E402
+    NO_LEDGER_REMEDIATION,
+    ledger_diff,
+    ledger_exists,
+    recorded_filenames,
+)
 
 MIGRATIONS = pathlib.Path(__file__).resolve().parent.parent / "db" / "migrations"
 
@@ -80,21 +98,13 @@ def main() -> int:
     files = sorted(p.name for p in MIGRATIONS.glob("*.sql"))
     conn = psycopg.connect(url)
 
-    has_ledger = conn.execute(
-        "SELECT count(*) FROM information_schema.tables WHERE table_name = %s",
-        ("schema_migrations",),
-    ).fetchone()[0]
-    if not has_ledger:
+    if not ledger_exists(conn):
         print("NO LEDGER — this database has never been migrated by db/migrate.py.")
-        print("Reconcile with `python -m db.migrate --baseline` against a schema you")
-        print("have verified is current, rather than applying.")
+        print(NO_LEDGER_REMEDIATION)
         return 1
 
-    recorded = {
-        r[0] for r in conn.execute("SELECT filename FROM schema_migrations").fetchall()
-    }
-    pending = [f for f in files if f not in recorded]
-    orphans = sorted(recorded - set(files))
+    recorded = recorded_filenames(conn)
+    pending, orphans = ledger_diff(files, recorded)
 
     print(f"on disk {len(files)} | recorded {len(recorded)} | pending {len(pending)}\n")
 

--- a/backend/tests/test_health_build_commit.py
+++ b/backend/tests/test_health_build_commit.py
@@ -38,6 +38,17 @@ def test_build_commit_ignores_blank_value(monkeypatch):
     assert build_commit() == "unknown"
 
 
+def test_build_commit_falls_back_when_railway_is_whitespace_only(monkeypatch):
+    """`A or B` alone would pick a whitespace-only RAILWAY_GIT_COMMIT_SHA over
+    a real GIT_COMMIT_SHA, because whitespace is truthy — then strip it down
+    to "" and report "unknown" despite a valid SHA being available. Each
+    candidate must be stripped BEFORE the fallback decision, not after.
+    """
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "   ")
+    monkeypatch.setenv("GIT_COMMIT_SHA", "abcdef1234567")
+    assert build_commit() == "abcdef1"
+
+
 def test_health_reports_commit(client, monkeypatch):
     monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "deadbeefcafe")
     body = client.get("/api/health").json()

--- a/backend/tests/test_health_build_commit.py
+++ b/backend/tests/test_health_build_commit.py
@@ -1,0 +1,51 @@
+"""/api/health must report the deployed commit (#516).
+
+The promotion runner polls this to tell "not deployed yet" from "deployed and
+broken". A short SHA is no more sensitive than the model_mode already exposed.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from config import build_commit
+import main
+
+
+@pytest.fixture
+def client():
+    return TestClient(main.app)
+
+
+def test_build_commit_reads_railway_env(monkeypatch):
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "abc1234567890def")
+    assert build_commit() == "abc1234"
+
+
+def test_build_commit_is_unknown_when_unset(monkeypatch):
+    monkeypatch.delenv("RAILWAY_GIT_COMMIT_SHA", raising=False)
+    monkeypatch.delenv("GIT_COMMIT_SHA", raising=False)
+    assert build_commit() == "unknown"
+
+
+def test_build_commit_falls_back_to_generic_env(monkeypatch):
+    monkeypatch.delenv("RAILWAY_GIT_COMMIT_SHA", raising=False)
+    monkeypatch.setenv("GIT_COMMIT_SHA", "0f1e2d3c4b5a")
+    assert build_commit() == "0f1e2d3"
+
+
+def test_build_commit_ignores_blank_value(monkeypatch):
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "   ")
+    monkeypatch.delenv("GIT_COMMIT_SHA", raising=False)
+    assert build_commit() == "unknown"
+
+
+def test_health_reports_commit(client, monkeypatch):
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "deadbeefcafe")
+    body = client.get("/api/health").json()
+    assert body["status"] == "ok"
+    assert body["commit"] == "deadbee"
+
+
+def test_health_keeps_existing_keys(client):
+    body = client.get("/api/health").json()
+    assert body["service"] == "sapling-backend"
+    assert "model_mode" in body

--- a/backend/tests/test_migration_drift_report.py
+++ b/backend/tests/test_migration_drift_report.py
@@ -1,0 +1,161 @@
+"""Characterization tests for scripts/migration_drift_report.py (#317).
+
+The script's CLI contract — sections, messages, exit codes (2 no env var,
+1 drift, 0 clean) — can gate CI, so these pin its observable behavior while
+the ledger-diff primitives underneath it move to their shared home in
+promotion.preflight (#516). The script's own extra checks (number collision,
+ALREADY EXISTS, data blockers) stay its own; only the shared primitives are
+unified, and the identity test at the top is what keeps the two from ever
+re-implementing the diff apart again.
+"""
+from types import SimpleNamespace
+
+import scripts.migration_drift_report as drift
+from promotion import preflight
+
+
+def test_ledger_primitives_are_the_promotion_preflight_implementation():
+    """THE finding: the pending/orphans computation, the ledger reads and the
+    no-ledger guidance used to be re-implemented inline here, which is exactly
+    how this script and the workflow preflight drifted apart before (#317's
+    own docstring warns about it). The script must consume the promotion
+    preflight's objects, not copies of them.
+    """
+    assert drift.ledger_diff is preflight.ledger_diff
+    assert drift.ledger_exists is preflight.ledger_exists
+    assert drift.recorded_filenames is preflight.recorded_filenames
+    assert drift.NO_LEDGER_REMEDIATION is preflight.NO_LEDGER_REMEDIATION
+
+
+class _FakeCursor:
+    """Serves the two shared-primitive reads: ledger_exists (execute +
+    fetchone) and recorded_filenames (execute + fetchall)."""
+
+    def __init__(self, conn):
+        self._conn = conn
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, params=None):
+        pass
+
+    def fetchone(self):
+        return (self._conn.has_ledger,)
+
+    def fetchall(self):
+        return [(name,) for name in sorted(self._conn.recorded)]
+
+
+class _NothingExists:
+    """Result of the script's own existence/blocker probes: nothing exists."""
+
+    def fetchone(self):
+        return (0,)
+
+    def fetchall(self):
+        return []
+
+
+class FakeConn:
+    """Just enough of psycopg's Connection for the script's reads: the shared
+    primitives go through cursor(); the script's own ALREADY-EXISTS and
+    DATA-BLOCKERS probes go through conn.execute()."""
+
+    def __init__(self, recorded=frozenset(), has_ledger=True):
+        self.recorded = set(recorded)
+        self.has_ledger = has_ledger
+
+    def cursor(self):
+        return _FakeCursor(self)
+
+    def execute(self, sql, params=None):
+        return _NothingExists()
+
+    def rollback(self):
+        pass
+
+
+def run_script(monkeypatch, capsys, tmp_path, files, recorded, has_ledger=True):
+    """Run main() against a fabricated migrations dir and a fake ledger."""
+    for name in files:
+        (tmp_path / name).write_text("CREATE TABLE IF NOT EXISTS t (id int);\n")
+    monkeypatch.setattr(drift, "MIGRATIONS", tmp_path)
+    monkeypatch.setattr(
+        drift, "psycopg", SimpleNamespace(connect=lambda url: FakeConn(recorded, has_ledger))
+    )
+    monkeypatch.setenv("SUPABASE_DB_URL", "postgresql://postgres:pw@example:5432/postgres")
+    rc = drift.main()
+    return rc, capsys.readouterr().out
+
+
+def test_clean_ledger_exits_zero(monkeypatch, capsys, tmp_path):
+    rc, out = run_script(
+        monkeypatch, capsys, tmp_path,
+        files=["0001_a.sql", "0002_b.sql"],
+        recorded={"0001_a.sql", "0002_b.sql"},
+    )
+    assert rc == 0
+    assert "on disk 2 | recorded 2 | pending 0" in out
+    assert "DRIFT" not in out
+
+
+def test_pending_alone_is_not_drift(monkeypatch, capsys, tmp_path):
+    """The normal state of an environment that is merely behind: exit 0, so a
+    CI gate on this script does not block ordinary catch-up applies."""
+    rc, out = run_script(
+        monkeypatch, capsys, tmp_path,
+        files=["0001_a.sql", "0002_b.sql"],
+        recorded={"0001_a.sql"},
+    )
+    assert rc == 0
+    assert "  0002_b.sql" in out  # listed under PENDING
+    assert "DRIFT" not in out
+
+
+def test_orphan_is_drift_and_exits_one(monkeypatch, capsys, tmp_path):
+    rc, out = run_script(
+        monkeypatch, capsys, tmp_path,
+        files=["0001_a.sql"],
+        recorded={"0001_a.sql", "0009_ghost.sql"},
+    )
+    assert rc == 1
+    assert "  0009_ghost.sql" in out
+    assert "DRIFT — do not apply on top of this:" in out
+    assert "1 orphan(s) recorded but absent from the repo" in out
+
+
+def test_orphan_number_collision_note_is_preserved(monkeypatch, capsys, tmp_path):
+    """The script's own extra checks stay the script's — unification of the
+    diff primitives must not lose the number-collision annotation."""
+    rc, out = run_script(
+        monkeypatch, capsys, tmp_path,
+        files=["0001_a.sql", "0002_b.sql"],
+        recorded={"0001_a.sql", "0002_b.sql", "0002_zzz.sql"},
+    )
+    assert rc == 1
+    assert "0002_zzz.sql  <-- NUMBER COLLIDES WITH 0002_b.sql" in out
+
+
+def test_no_ledger_exits_one_with_the_exact_guidance(monkeypatch, capsys, tmp_path):
+    """Byte-exact: this block is the script's most-quoted output, and its
+    remediation text is now the shared NO_LEDGER_REMEDIATION constant — the
+    move must not reformat it."""
+    rc, out = run_script(
+        monkeypatch, capsys, tmp_path, files=["0001_a.sql"], recorded=set(), has_ledger=False
+    )
+    assert rc == 1
+    assert out == (
+        "NO LEDGER — this database has never been migrated by db/migrate.py.\n"
+        "Reconcile with `python -m db.migrate --baseline` against a schema you\n"
+        "have verified is current, rather than applying.\n"
+    )
+
+
+def test_missing_db_url_exits_two(monkeypatch, capsys):
+    monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+    assert drift.main() == 2
+    assert "SUPABASE_DB_URL is not set" in capsys.readouterr().err

--- a/backend/tests/test_promotion_main.py
+++ b/backend/tests/test_promotion_main.py
@@ -1,17 +1,21 @@
-"""Direct coverage for promotion/__main__.py's `gh` argv shape (#516).
+"""Direct coverage for promotion/__main__.py's real-IO glue (#516).
 
-Everything else in __main__.py is real-IO glue (subprocess/psycopg) that stays
+Most of __main__.py is real-IO glue (subprocess/psycopg) that stays
 deliberately untested per the coordinator's explicit deferral in
-task-5-report.md. This one seam is the exception: `Gh.ensure_pr`'s
-`--state open` filter is the exact line whose earlier regression
-(`--state all`) silently returned a PREVIOUS promotion's already-MERGED PR,
-which the runner then read as "resume here, skip the confirm" — bypassing the
-only human confirmation gate this tool has, with CI staying green the whole
-time. Nothing today would catch a future edit reverting that filter; this
-test does, by faking `_run` rather than shelling out to a real `gh`.
+task-5-report.md. Two seams are the exception, both faked rather than
+shelling/reading out to the real world:
+
+- `Gh.ensure_pr`'s `--state open` filter is the exact line whose earlier
+  regression (`--state all`) silently returned a PREVIOUS promotion's
+  already-MERGED PR, which the runner then read as "resume here, skip the
+  confirm" — bypassing the only human confirmation gate this tool has, with
+  CI staying green the whole time.
+- `_confirm`'s EOFError handling: `input()` raises EOFError on non-interactive
+  stdin, and `str(EOFError())` is empty, so letting it propagate used to make
+  `main()` print a bare "ERROR: " right after the migration had already
+  applied — the exact moment a clear message matters most.
 """
 import promotion.__main__ as promotion_main
-from promotion.__main__ import Gh
 
 
 def test_ensure_pr_only_ever_returns_an_open_pr_never_a_merged_one(monkeypatch):
@@ -43,10 +47,36 @@ def test_ensure_pr_only_ever_returns_an_open_pr_never_a_merged_one(monkeypatch):
 
     monkeypatch.setattr(promotion_main, "_run", fake_run)
 
-    number = Gh().ensure_pr("production", "main", "Promote staging to production")
+    number = promotion_main.Gh().ensure_pr("production", "main", "Promote staging to production")
 
     assert number == 999
     assert number != 515  # never the stale merged PR from a previous promotion
     assert created == [1]  # a new PR really was created, not silently skipped
     list_calls = [c for c in calls if c[:3] == ["gh", "pr", "list"]]
     assert len(list_calls) == 2  # one miss, one re-query after create — no recursion
+
+
+def test_confirm_treats_eof_as_declined(monkeypatch):
+    """Non-interactive stdin (no controlling terminal, a closed pipe, CI
+    running this without a tty) raises EOFError from input(). Must degrade
+    to a normal decline (False), not propagate and blank out the error
+    message main() would otherwise print.
+    """
+
+    def raise_eof(prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", raise_eof)
+    assert promotion_main._confirm("Merge?", auto_yes=False) is False
+
+
+def test_confirm_auto_yes_never_touches_input(monkeypatch):
+    """--yes must short-circuit before input() is even called — including
+    under EOF conditions, which is exactly the CI scenario --yes exists for.
+    """
+
+    def raise_if_called(prompt):
+        raise AssertionError("input() must not be called when auto_yes is True")
+
+    monkeypatch.setattr("builtins.input", raise_if_called)
+    assert promotion_main._confirm("Merge?", auto_yes=True) is True

--- a/backend/tests/test_promotion_main.py
+++ b/backend/tests/test_promotion_main.py
@@ -1,0 +1,52 @@
+"""Direct coverage for promotion/__main__.py's `gh` argv shape (#516).
+
+Everything else in __main__.py is real-IO glue (subprocess/psycopg) that stays
+deliberately untested per the coordinator's explicit deferral in
+task-5-report.md. This one seam is the exception: `Gh.ensure_pr`'s
+`--state open` filter is the exact line whose earlier regression
+(`--state all`) silently returned a PREVIOUS promotion's already-MERGED PR,
+which the runner then read as "resume here, skip the confirm" — bypassing the
+only human confirmation gate this tool has, with CI staying green the whole
+time. Nothing today would catch a future edit reverting that filter; this
+test does, by faking `_run` rather than shelling out to a real `gh`.
+"""
+import promotion.__main__ as promotion_main
+from promotion.__main__ import Gh
+
+
+def test_ensure_pr_only_ever_returns_an_open_pr_never_a_merged_one(monkeypatch):
+    """Fixture shaped like this repo's real regression: PR #515 (base=
+    production, head=main) is MERGED from a previous promotion. A correct
+    `--state open` query for that pair finds nothing, so ensure_pr creates a
+    new PR and the SECOND `--state open` re-query discovers it as #999.
+
+    If ensure_pr regressed to `--state all` (or dropped the flag), the FIRST
+    query would itself return 515 — the merged PR from last time — and
+    ensure_pr would hand it straight back without ever calling `gh pr create`.
+    """
+    calls: list[list[str]] = []
+    created: list[int] = []
+
+    def fake_run(cmd: list[str]) -> str:
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "pr", "list"]:
+            assert "--state" in cmd, f"ensure_pr must filter by --state: {cmd}"
+            state = cmd[cmd.index("--state") + 1]
+            assert state == "open", f"ensure_pr must use --state open, got {state!r}: {cmd}"
+            if created:
+                return "999"  # the PR just created below, now open
+            return ""  # PR #515 is MERGED, not open — correctly invisible here
+        if cmd[:3] == ["gh", "pr", "create"]:
+            created.append(1)
+            return ""
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(promotion_main, "_run", fake_run)
+
+    number = Gh().ensure_pr("production", "main", "Promote staging to production")
+
+    assert number == 999
+    assert number != 515  # never the stale merged PR from a previous promotion
+    assert created == [1]  # a new PR really was created, not silently skipped
+    list_calls = [c for c in calls if c[:3] == ["gh", "pr", "list"]]
+    assert len(list_calls) == 2  # one miss, one re-query after create — no recursion

--- a/backend/tests/test_promotion_main.py
+++ b/backend/tests/test_promotion_main.py
@@ -1,9 +1,10 @@
 """Direct coverage for promotion/__main__.py's real-IO glue (#516).
 
-Most of __main__.py is real-IO glue (subprocess/psycopg) that stays
-deliberately untested per the coordinator's explicit deferral in
-task-5-report.md. Two seams are the exception, both faked rather than
-shelling/reading out to the real world:
+`__main__.py` wraps real IO (subprocess/psycopg), but every seam that
+matters is reachable hermetically by monkeypatching the ONE library call at
+the boundary (`subprocess.run`, `psycopg.connect`, `builtins.input`) rather
+than shelling/reading out to the real world. No process is spawned and no
+database is contacted by anything in this file.
 
 - `Gh.ensure_pr`'s `--state open` filter is the exact line whose earlier
   regression (`--state all`) silently returned a PREVIOUS promotion's
@@ -14,7 +15,20 @@ shelling/reading out to the real world:
   stdin, and `str(EOFError())` is empty, so letting it propagate used to make
   `main()` print a bare "ERROR: " right after the migration had already
   applied — the exact moment a clear message matters most.
+- `_run`'s subprocess timeout: every caller (`git fetch`, `gh pr
+  create`/`view`/`merge`) is a network call: a future edit that silently
+  drops the `timeout` kwarg reintroduces a hang that can strand a promotion
+  AFTER the migration has applied, with CI staying green throughout.
+- `_staging_recorded`'s degrade-not-abort behavior: a stale URI, a paused
+  staging project, or a transient network fault must produce the documented
+  `staging-unknown` preflight finding, not abort the whole run before the
+  operator ever sees a report.
 """
+import subprocess
+
+import psycopg
+import pytest
+
 import promotion.__main__ as promotion_main
 
 
@@ -80,3 +94,64 @@ def test_confirm_auto_yes_never_touches_input(monkeypatch):
 
     monkeypatch.setattr("builtins.input", raise_if_called)
     assert promotion_main._confirm("Merge?", auto_yes=True) is True
+
+
+def test_run_passes_a_timeout_to_subprocess(monkeypatch):
+    """A future edit that silently drops the `timeout` kwarg reintroduces the
+    hang this fix closes: a stalled git/gh network call, or `gh` sitting on
+    an interactive prompt, blocking forever — possibly AFTER the migration
+    has already applied, with CI staying green the whole time.
+    """
+    recorded_kwargs: dict = {}
+
+    def fake_subprocess_run(cmd, **kwargs):
+        recorded_kwargs.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(promotion_main.subprocess, "run", fake_subprocess_run)
+
+    promotion_main._run(["git", "fetch"])
+
+    assert recorded_kwargs.get("timeout") is not None
+
+
+def test_run_converts_timeout_expired_to_a_clean_runtime_error(monkeypatch):
+    """A raw subprocess.TimeoutExpired must not propagate — every other
+    _run failure surfaces as a RuntimeError naming the command, and a
+    timeout is no exception to that discipline.
+    """
+
+    def fake_subprocess_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+
+    monkeypatch.setattr(promotion_main.subprocess, "run", fake_subprocess_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        promotion_main._run(["git", "fetch"])
+    text = str(exc_info.value).lower()
+    assert "git fetch" in text
+    assert "timed out" in text
+
+
+def test_staging_recorded_degrades_to_none_on_connection_failure(monkeypatch, capsys):
+    """A stale STAGING_SUPABASE_DB_URL, a paused staging project, or a
+    transient network fault must not abort the whole run before the operator
+    ever sees a preflight report — it must degrade to the same "unknown"
+    signal as the var being unset (None), not re-raise, and the reason must
+    still be surfaced (not silently swallowed).
+    """
+    monkeypatch.setenv(
+        "STAGING_SUPABASE_DB_URL",
+        "postgresql://postgres.stg:pw@aws-1-us-west-2.pooler.supabase.com:5432/postgres",
+    )
+
+    def fake_connect(url):
+        raise psycopg.OperationalError("connection refused")
+
+    monkeypatch.setattr(promotion_main.psycopg, "connect", fake_connect)
+
+    result = promotion_main._staging_recorded()
+
+    assert result is None
+    captured = capsys.readouterr()
+    assert "connection refused" in captured.err

--- a/backend/tests/test_promotion_main.py
+++ b/backend/tests/test_promotion_main.py
@@ -11,10 +11,18 @@ database is contacted by anything in this file.
   already-MERGED PR, which the runner then read as "resume here, skip the
   confirm" — bypassing the only human confirmation gate this tool has, with
   CI staying green the whole time.
+- `Gh.ensure_pr`'s create-stdout parsing: `gh pr create` prints the new PR's
+  URL, the one immediately-consistent source of the number. The `gh pr list`
+  re-query is only a bounded fallback — the list endpoint can lag creation by
+  seconds, and a single immediate miss used to fail the run AFTER production's
+  migrations had already irreversibly applied.
 - `_confirm`'s EOFError handling: `input()` raises EOFError on non-interactive
   stdin, and `str(EOFError())` is empty, so letting it propagate used to make
   `main()` print a bare "ERROR: " right after the migration had already
   applied — the exact moment a clear message matters most.
+- `_confirm`'s KeyboardInterrupt handling: Ctrl-C at the prompt is a
+  BaseException that `main()`'s `except Exception` never catches, so it used
+  to escape as a raw traceback instead of the runner's ABORTED report.
 - `_run`'s subprocess timeout: every caller (`git fetch`, `gh pr
   create`/`view`/`merge`) is a network call: a future edit that silently
   drops the `timeout` kwarg reintroduces a hang that can strand a promotion
@@ -70,6 +78,129 @@ def test_ensure_pr_only_ever_returns_an_open_pr_never_a_merged_one(monkeypatch):
     assert len(list_calls) == 2  # one miss, one re-query after create — no recursion
 
 
+def test_ensure_pr_takes_the_number_from_create_stdout(monkeypatch):
+    """`gh pr create` prints the new PR's URL on stdout — the one
+    immediately-consistent source of the number. `gh pr list` can lag
+    creation by seconds, and a miss there used to exit 1 AFTER production's
+    migrations had already irreversibly applied. When create's output parses,
+    the laggy list endpoint must not be consulted again at all.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str]) -> str:
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return ""
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return "https://github.com/owner/sapling/pull/1234"
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(promotion_main, "_run", fake_run)
+
+    number = promotion_main.Gh().ensure_pr("production", "main", "Promote staging to production")
+
+    assert number == 1234
+    assert len([c for c in calls if c[:3] == ["gh", "pr", "list"]]) == 1  # no re-query
+
+
+def test_ensure_pr_parsing_tolerates_extra_lines_and_whitespace(monkeypatch):
+    """gh mixes progress/warning lines into its output, and only the LAST
+    /pull/<n>-shaped URL is the created PR — a compare URL or any other link
+    earlier in the output must not be mistaken for it.
+    """
+
+    def fake_run(cmd: list[str]) -> str:
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return ""
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return (
+                "Warning: 2 uncommitted changes\n"
+                "Creating pull request for main into production in owner/sapling\n"
+                "https://github.com/owner/sapling/compare/production...main\n"
+                "\n"
+                "https://github.com/owner/sapling/pull/1234 \n"
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(promotion_main, "_run", fake_run)
+
+    number = promotion_main.Gh().ensure_pr("production", "main", "Promote staging to production")
+
+    assert number == 1234
+
+
+def test_ensure_pr_falls_back_to_bounded_list_retry_when_stdout_is_unparseable(monkeypatch):
+    """If gh's output shape ever changes and no /pull/<n> URL parses, the
+    list re-query remains — but bounded and retried through the injected
+    sleep, because the list endpoint can lag creation by seconds and a single
+    immediate miss used to fail the run AFTER the migration had applied.
+    Never a second create: guessing again would just open PRs in a loop.
+    """
+    calls: list[list[str]] = []
+    sleeps: list[float] = []
+    list_results = iter(["", "", "", "999"])  # initial miss, then lag, lag, found
+
+    def fake_run(cmd: list[str]) -> str:
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return next(list_results)
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return "pull request created"  # no URL anywhere
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(promotion_main, "_run", fake_run)
+
+    number = promotion_main.Gh(sleep=sleeps.append).ensure_pr(
+        "production", "main", "Promote staging to production"
+    )
+
+    assert number == 999
+    assert len(sleeps) == 2  # no sleep before the first fallback attempt
+    assert len([c for c in calls if c[:3] == ["gh", "pr", "create"]]) == 1
+
+
+def test_ensure_pr_raises_after_exhausting_the_bounded_fallback(monkeypatch):
+    """The fallback retry is bounded: when every re-query misses, the run
+    must still end in the clear "did not produce a discoverable open PR"
+    error rather than polling forever or creating another PR.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str]) -> str:
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return ""
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return "pull request created"  # no URL anywhere
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(promotion_main, "_run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        promotion_main.Gh(sleep=lambda _s: None).ensure_pr(
+            "production", "main", "Promote staging to production"
+        )
+
+    assert "discoverable" in str(exc_info.value)
+    assert len([c for c in calls if c[:3] == ["gh", "pr", "create"]]) == 1
+    assert len([c for c in calls if c[:3] == ["gh", "pr", "list"]]) == 4  # initial + 3 retries
+
+
+def test_ensure_pr_returns_an_already_open_pr_without_creating(monkeypatch):
+    """The pre-create path is untouched by the stdout parsing: an already
+    open PR for the pair is returned from the first list query alone.
+    """
+
+    def fake_run(cmd: list[str]) -> str:
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return "42"
+        raise AssertionError(f"only the initial list query may run: {cmd}")
+
+    monkeypatch.setattr(promotion_main, "_run", fake_run)
+
+    assert promotion_main.Gh().ensure_pr("production", "main", "t") == 42
+
+
 def test_confirm_treats_eof_as_declined(monkeypatch):
     """Non-interactive stdin (no controlling terminal, a closed pipe, CI
     running this without a tty) raises EOFError from input(). Must degrade
@@ -82,6 +213,23 @@ def test_confirm_treats_eof_as_declined(monkeypatch):
 
     monkeypatch.setattr("builtins.input", raise_eof)
     assert promotion_main._confirm("Merge?", auto_yes=False) is False
+
+
+def test_confirm_treats_ctrl_c_as_declined(monkeypatch, capsys):
+    """Ctrl-C at the prompt raises KeyboardInterrupt — a BaseException that
+    main()'s `except Exception` never catches, so it used to escape as a raw
+    traceback and skip the runner's ABORTED report (the one that says the
+    migrations are ALREADY APPLIED). Must degrade to a decline like EOF, with
+    a leading newline so the terminal's ^C echo doesn't mangle the report's
+    first line.
+    """
+
+    def raise_interrupt(prompt):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", raise_interrupt)
+    assert promotion_main._confirm("Merge?", auto_yes=False) is False
+    assert capsys.readouterr().out == "\n"
 
 
 def test_confirm_auto_yes_never_touches_input(monkeypatch):
@@ -131,6 +279,137 @@ def test_run_converts_timeout_expired_to_a_clean_runtime_error(monkeypatch):
     text = str(exc_info.value).lower()
     assert "git fetch" in text
     assert "timed out" in text
+
+
+def test_gh_merge_pins_to_the_given_head_commit(monkeypatch):
+    """The merge must carry gh's --match-head-commit so GitHub itself rejects
+    a moved main — without it, `gh pr merge --merge` merges whatever the tip
+    is at merge time, promoting confirm-pause commits unscanned. (Flag
+    verified against the gh CLI in PATH: `gh pr merge --help` documents
+    `--match-head-commit SHA`.)
+    """
+    cmds: list[list[str]] = []
+
+    def fake_run(cmd: list[str]) -> str:
+        cmds.append(cmd)
+        return ""
+
+    monkeypatch.setattr(promotion_main, "_run", fake_run)
+
+    promotion_main.Gh().merge(999, "abc1234def")
+
+    [cmd] = cmds
+    assert cmd[:4] == ["gh", "pr", "merge", "999"]
+    assert "--merge" in cmd
+    assert cmd[cmd.index("--match-head-commit") + 1] == "abc1234def"
+
+
+def test_git_migrations_drift_combines_tracked_diff_and_untracked_status(monkeypatch):
+    """The guard needs BOTH reads: `git diff --name-status origin/main` sees
+    tracked files differing in content or presence (either direction) but is
+    blind to untracked strays; `git status --porcelain` sees the strays but
+    reports nothing for a checkout that is merely on an old commit. Each must
+    be scoped to the migrations dir, and both outputs must surface so the
+    blocking finding can name the offending files.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str]) -> str:
+        calls.append(cmd)
+        if cmd[:2] == ["git", "diff"]:
+            assert "--name-status" in cmd and "origin/main" in cmd
+            return "M\tbackend/db/migrations/0002_b.sql"
+        if cmd[:2] == ["git", "status"]:
+            assert "--porcelain" in cmd
+            return "?? backend/db/migrations/0099_stray.sql"
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(promotion_main, "_run", fake_run)
+
+    drift = promotion_main.Git().migrations_drift()
+
+    assert "0002_b.sql" in drift and "0099_stray.sql" in drift
+    assert len(calls) == 2
+    for cmd in calls:
+        # pathspec-scoped to the migrations dir, behind the `--` separator
+        sep = cmd.index("--")
+        assert cmd[sep + 1].endswith("migrations")
+
+
+def test_git_migrations_drift_is_empty_when_clean(monkeypatch):
+    monkeypatch.setattr(promotion_main, "_run", lambda cmd: "")
+    assert promotion_main.Git().migrations_drift() == ""
+
+
+def test_git_is_ancestor_maps_exit_codes_and_fails_closed(monkeypatch):
+    """`git merge-base --is-ancestor` speaks in exit codes: 0 = ancestor,
+    1 = not an ancestor, anything else = a real error (bad ref, not a repo).
+    _run would collapse exit 1 into a failure, so this port reads the code
+    itself — and an unexpected code must RAISE (fail closed), never be read
+    as either answer.
+    """
+    returncode = 0
+
+    def fake_subprocess_run(cmd, **kwargs):
+        assert cmd[:3] == ["git", "merge-base", "--is-ancestor"]
+        assert kwargs.get("timeout") is not None  # same no-hang discipline as _run
+        return subprocess.CompletedProcess(cmd, returncode, stdout="", stderr="fatal: bad ref")
+
+    monkeypatch.setattr(promotion_main.subprocess, "run", fake_subprocess_run)
+
+    git = promotion_main.Git()
+    assert git.is_ancestor("origin/production", "origin/main") is True
+    returncode = 1
+    assert git.is_ancestor("origin/production", "origin/main") is False
+    returncode = 128
+    with pytest.raises(RuntimeError, match="bad ref"):
+        git.is_ancestor("origin/production", "origin/main")
+
+
+def test_preflight_data_reads_the_ledger_through_the_shared_primitives(monkeypatch):
+    """_preflight_data's ledger reads must behave exactly like the shared
+    promotion.preflight primitives the drift report consumes (#317/#516) —
+    the inline cursor code it used to carry is the re-implementation pattern
+    that let the two drift apart before. Behavioral pin: existence flag and
+    recorded set come through the shared reads, and a fully-recorded ledger
+    yields no pending work (so no destructive scan fires).
+    """
+    from db import migrate as db_migrate
+
+    all_files = {p.name for p in db_migrate.discover_migrations(db_migrate.MIGRATIONS_DIR)}
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def execute(self, sql, params=None):
+            pass
+
+        def fetchone(self):
+            return (True,)
+
+        def fetchall(self):
+            return [(name,) for name in sorted(all_files)]
+
+    class Conn:
+        def cursor(self):
+            return Cursor()
+
+    monkeypatch.setenv(
+        "SUPABASE_DB_URL",
+        "postgresql://postgres.ref1:p@aws-0-us-west-2.pooler.supabase.com:5432/postgres",
+    )
+    monkeypatch.setenv("SUPABASE_URL", "https://ref1.supabase.co")
+    monkeypatch.delenv("STAGING_SUPABASE_DB_URL", raising=False)
+
+    data = promotion_main._preflight_data(Conn())
+
+    assert data["ledger_exists"] is True
+    assert data["recorded"] == all_files
+    assert data["destructive"] == []  # nothing pending -> nothing scanned
 
 
 def test_staging_recorded_degrades_to_none_on_connection_failure(monkeypatch, capsys):

--- a/backend/tests/test_promotion_preflight.py
+++ b/backend/tests/test_promotion_preflight.py
@@ -95,6 +95,44 @@ def test_scan_destructive_clean_migration_passes(tmp_path):
     assert scan_destructive([f]) == []
 
 
+def test_scan_destructive_flags_wrapped_type_change(tmp_path):
+    """House style wraps ALTER COLUMN ... TYPE across lines; must not evade the scan."""
+    f = tmp_path / "0056_w.sql"
+    f.write_text(
+        "ALTER TABLE assignments\n"
+        "  ALTER COLUMN points_possible\n"
+        "  TYPE numeric\n"
+        "  USING points_possible::numeric;\n"
+    )
+    assert [x.kind for x in scan_destructive([f])] == ["ALTER COLUMN ... TYPE"]
+
+
+def test_scan_destructive_flags_wrapped_drop_column(tmp_path):
+    f = tmp_path / "0057_w.sql"
+    f.write_text("ALTER TABLE t\n  DROP COLUMN old;\n")
+    assert [x.kind for x in scan_destructive([f])] == ["DROP COLUMN"]
+
+
+def test_scan_destructive_ignores_wrapped_drop_not_null(tmp_path):
+    """Real benign shape from 0012_gradebook.sql: DROP NOT NULL is not DROP COLUMN."""
+    f = tmp_path / "0058_ok.sql"
+    f.write_text("ALTER TABLE assignments\n  ALTER COLUMN due_date DROP NOT NULL;\n")
+    assert scan_destructive([f]) == []
+
+
+def test_scan_destructive_wrapped_statement_reports_start_line(tmp_path):
+    f = tmp_path / "0059_w.sql"
+    f.write_text(
+        "CREATE TABLE ok (id int);\n"
+        "\n"
+        "ALTER TABLE t\n"
+        "  DROP COLUMN old;\n"
+    )
+    findings = scan_destructive([f])
+    assert [x.kind for x in findings] == ["DROP COLUMN"]
+    assert findings[0].detail.startswith("0059_w.sql:3:")
+
+
 def _evaluate(**over):
     kwargs = dict(
         db_url=POOLER,

--- a/backend/tests/test_promotion_preflight.py
+++ b/backend/tests/test_promotion_preflight.py
@@ -3,6 +3,8 @@
 Every function here is pure — it takes plain data, so these tests need no
 database, no network and no credentials.
 """
+from pathlib import Path
+
 from promotion.preflight import (
     Finding,
     evaluate,
@@ -74,6 +76,74 @@ def test_scan_destructive_flags_type_change(tmp_path):
     assert [x.kind for x in scan_destructive([f])] == ["ALTER COLUMN ... TYPE"]
 
 
+def test_scan_destructive_flags_set_data_type(tmp_path):
+    """SET DATA TYPE is the spelled-out form of the same destructive change."""
+    f = tmp_path / "0068_t.sql"
+    f.write_text("ALTER TABLE t ALTER COLUMN amount SET DATA TYPE numeric;\n")
+    assert [x.kind for x in scan_destructive([f])] == ["ALTER COLUMN ... TYPE"]
+
+
+def test_scan_destructive_flags_type_change_on_quoted_column(tmp_path):
+    f = tmp_path / "0069_t.sql"
+    f.write_text('ALTER TABLE t ALTER COLUMN "type" TYPE text;\n')
+    assert [x.kind for x in scan_destructive([f])] == ["ALTER COLUMN ... TYPE"]
+
+
+def test_scan_destructive_ignores_set_not_null_on_column_named_type(tmp_path):
+    """This repo has columns literally named `type` (0001/0009/0026); a benign
+    ALTER on one is not a type change."""
+    f = tmp_path / "0070_ok.sql"
+    f.write_text("ALTER TABLE events ALTER COLUMN type SET NOT NULL;\n")
+    assert scan_destructive([f]) == []
+
+
+def test_scan_destructive_ignores_drop_default_on_column_named_type(tmp_path):
+    f = tmp_path / "0071_ok.sql"
+    f.write_text("ALTER TABLE cosmetics ALTER COLUMN type DROP DEFAULT;\n")
+    assert scan_destructive([f]) == []
+
+
+def test_repo_migrations_with_type_columns_scan_clean_of_type_changes():
+    """The three real migrations that define columns named `type` must not
+    produce an ALTER-COLUMN-TYPE finding — none of them changes a type."""
+    migrations = Path(__file__).resolve().parents[1] / "db" / "migrations"
+    paths = [
+        migrations / "0001_baseline_schema.sql",
+        migrations / "0009_cosmetics.sql",
+        migrations / "0026_ops.sql",
+    ]
+    assert all(p.is_file() for p in paths)
+    kinds = {x.kind for x in scan_destructive(paths)}
+    assert "ALTER COLUMN ... TYPE" not in kinds
+
+
+def test_scan_destructive_flags_table_rename(tmp_path):
+    """Real shape from 0020_academics_split.sql — old prod code breaks on it
+    in the migrate→merge window exactly like a DROP TABLE."""
+    f = tmp_path / "0060_r.sql"
+    f.write_text("ALTER TABLE courses RENAME TO course_offerings;\n")
+    assert [x.kind for x in scan_destructive([f])] == ["ALTER TABLE ... RENAME"]
+
+
+def test_scan_destructive_flags_column_rename(tmp_path):
+    f = tmp_path / "0061_r.sql"
+    f.write_text("ALTER TABLE enrollments RENAME COLUMN course_id TO offering_id;\n")
+    assert [x.kind for x in scan_destructive([f])] == ["ALTER TABLE ... RENAME"]
+
+
+def test_scan_destructive_flags_drop_view(tmp_path):
+    f = tmp_path / "0062_v.sql"
+    f.write_text("DROP VIEW IF EXISTS leaderboard;\n")
+    assert [x.kind for x in scan_destructive([f])] == ["DROP VIEW"]
+
+
+def test_scan_destructive_ignores_column_named_rename(tmp_path):
+    """RENAME must be the operation after the table name, not any identifier."""
+    f = tmp_path / "0063_ok.sql"
+    f.write_text("ALTER TABLE t ADD COLUMN rename text;\n")
+    assert scan_destructive([f]) == []
+
+
 def test_scan_destructive_ignores_line_comments(tmp_path):
     """The repo's migrations explain themselves at length; a mention is not a DROP."""
     f = tmp_path / "0053_c.sql"
@@ -84,6 +154,43 @@ def test_scan_destructive_ignores_line_comments(tmp_path):
 def test_scan_destructive_ignores_block_comments(tmp_path):
     f = tmp_path / "0054_c.sql"
     f.write_text("/*\n  We used to TRUNCATE here.\n*/\nCREATE TABLE ok (id int);\n")
+    assert scan_destructive([f]) == []
+
+
+def test_scan_destructive_sees_ddl_after_dashes_inside_literal(tmp_path):
+    """`--` inside a string literal is data, not a comment — the DROP after the
+    literal must not vanish with the rest of the line."""
+    f = tmp_path / "0064_lit.sql"
+    f.write_text("INSERT INTO t (note) VALUES ('a--b'); DROP TABLE users;\n")
+    assert [x.kind for x in scan_destructive([f])] == ["DROP TABLE"]
+
+
+def test_scan_destructive_sees_ddl_after_escaped_quote_in_literal(tmp_path):
+    """'' is an escaped quote — the literal is still open across it."""
+    f = tmp_path / "0065_esc.sql"
+    f.write_text("INSERT INTO t (note) VALUES ('it''s -- data'); DROP TABLE users;\n")
+    assert [x.kind for x in scan_destructive([f])] == ["DROP TABLE"]
+
+
+def test_scan_destructive_block_comment_markers_inside_literals(tmp_path):
+    """/* and */ inside literals are data; treating them as comment delimiters
+    would blank the TRUNCATE sitting between the two statements."""
+    f = tmp_path / "0066_blk.sql"
+    f.write_text(
+        "INSERT INTO t (note) VALUES ('open /* marker');\n"
+        "TRUNCATE cache;\n"
+        "INSERT INTO t (note) VALUES ('close */ marker');\n"
+    )
+    findings = scan_destructive([f])
+    assert [x.kind for x in findings] == ["TRUNCATE"]
+    assert "0066_blk.sql:2" in findings[0].detail
+
+
+def test_scan_destructive_still_ignores_comment_after_literal(tmp_path):
+    """A closed literal hands control back to the SQL lexer — a real comment
+    after it is still a comment."""
+    f = tmp_path / "0067_ok.sql"
+    f.write_text("INSERT INTO t (note) VALUES ('a'); -- replaces the DROP TABLE step\n")
     assert scan_destructive([f]) == []
 
 
@@ -142,6 +249,8 @@ def _evaluate(**over):
         staging_recorded={"0001_a.sql", "0002_b.sql"},
         destructive=[],
         commits_ahead=3,
+        migrations_drift="",
+        production_is_ancestor=True,
         allow_destructive=False,
         skip_staging_check=False,
     )
@@ -153,9 +262,69 @@ def test_evaluate_clean_case_has_no_findings():
     assert _evaluate() == []
 
 
+def test_evaluate_blocks_on_migrations_drift():
+    """The preflight file listing and db.migrate both read the LOCAL working
+    tree, but the thing being promoted is origin/main. A checkout that differs
+    invalidates the whole audit in both directions: a stale main hides an
+    origin/main migration from preflight entirely (neither pending nor an
+    orphan — it never applies, and prod code 500s on the missing schema); a
+    feature-branch checkout applies an unmerged migration to production. The
+    finding must name the offending files and the remediation.
+    """
+    findings = _evaluate(
+        migrations_drift="M\tbackend/db/migrations/0002_b.sql\n?? backend/db/migrations/0099_stray.sql"
+    )
+    assert [f.kind for f in findings] == ["migrations-drift"]
+    detail = findings[0].detail
+    assert "0002_b.sql" in detail and "0099_stray.sql" in detail  # the offending state
+    assert "origin/main" in detail
+    # the remediation: checkout main, pull, remove stray files
+    assert "git checkout main" in detail
+    assert "pull" in detail
+    assert "stray" in detail
+
+
+def test_evaluate_blocks_when_production_not_ancestor_of_main():
+    """A production hotfix/revert never back-merged to main makes the merge
+    fail deterministically AFTER migrations applied, with the retry loop then
+    misdirecting the operator ("may still be landing"). Preflight must catch
+    it before any DDL, and say how to reconcile.
+    """
+    findings = _evaluate(production_is_ancestor=False)
+    assert [f.kind for f in findings] == ["production-diverged"]
+    detail = findings[0].detail.lower()
+    assert "back-merge" in detail
+    assert "not on" in detail  # names the offending state: commits not on main
+
+
 def test_evaluate_blocks_on_project_ref_mismatch():
     findings = _evaluate(supabase_url="https://zzzzzzzzzzzzzzzz.supabase.co")
     assert [f.kind for f in findings] == ["target-mismatch"]
+
+
+def test_evaluate_blocks_when_db_ref_unparseable():
+    """An unrecognised DB URI must fail CLOSED, not silently skip the guard.
+
+    The failure this reproduces: .env.production carries a SUPABASE_DB_URL the
+    parser can't read (or one copy-pasted from staging alongside a blank
+    SUPABASE_URL) — the mismatch check must not vouch for a target it can't see.
+    """
+    findings = _evaluate(db_url="postgresql://postgres:pw@127.0.0.1:54322/postgres")
+    assert [f.kind for f in findings] == ["target-unverified"]
+    assert "SUPABASE_DB_URL" in findings[0].detail
+
+
+def test_evaluate_blocks_when_api_ref_unparseable():
+    findings = _evaluate(supabase_url="")
+    assert [f.kind for f in findings] == ["target-unverified"]
+    assert "SUPABASE_URL" in findings[0].detail
+
+
+def test_evaluate_blocks_once_when_both_refs_unparseable():
+    findings = _evaluate(db_url="", supabase_url="")
+    assert [f.kind for f in findings] == ["target-unverified"]
+    assert "SUPABASE_DB_URL" in findings[0].detail
+    assert "SUPABASE_URL" in findings[0].detail
 
 
 def test_evaluate_blocks_when_ledger_missing():

--- a/backend/tests/test_promotion_preflight.py
+++ b/backend/tests/test_promotion_preflight.py
@@ -3,8 +3,6 @@
 Every function here is pure — it takes plain data, so these tests need no
 database, no network and no credentials.
 """
-from pathlib import Path
-
 from promotion.preflight import (
     Finding,
     evaluate,

--- a/backend/tests/test_promotion_preflight.py
+++ b/backend/tests/test_promotion_preflight.py
@@ -108,8 +108,9 @@ def test_scan_destructive_flags_wrapped_type_change(tmp_path):
 
 
 def test_scan_destructive_flags_wrapped_drop_column(tmp_path):
-    f = tmp_path / "0057_w.sql"
-    f.write_text("ALTER TABLE t\n  DROP COLUMN old;\n")
+    """The keywords themselves straddle the break — this fails under a line-oriented scan."""
+    f = tmp_path / "0057_wrapped.sql"
+    f.write_text("ALTER TABLE t\n  DROP\n  COLUMN old;\n")
     assert [x.kind for x in scan_destructive([f])] == ["DROP COLUMN"]
 
 

--- a/backend/tests/test_promotion_preflight.py
+++ b/backend/tests/test_promotion_preflight.py
@@ -1,0 +1,164 @@
+"""Preflight guards for the prod promotion runner (#516).
+
+Every function here is pure — it takes plain data, so these tests need no
+database, no network and no credentials.
+"""
+from pathlib import Path
+
+from promotion.preflight import (
+    Finding,
+    evaluate,
+    ledger_diff,
+    project_ref,
+    scan_destructive,
+    staging_gap,
+)
+
+POOLER = "postgresql://postgres.abcdefghijklmnop:pw@aws-0-us-west-2.pooler.supabase.com:5432/postgres"
+DIRECT = "postgresql://postgres:pw@db.abcdefghijklmnop.supabase.co:5432/postgres"
+API = "https://abcdefghijklmnop.supabase.co"
+
+
+def test_project_ref_from_pooler_uri():
+    assert project_ref(POOLER) == "abcdefghijklmnop"
+
+
+def test_project_ref_from_direct_uri():
+    assert project_ref(DIRECT) == "abcdefghijklmnop"
+
+
+def test_project_ref_from_api_url():
+    assert project_ref(API) == "abcdefghijklmnop"
+
+
+def test_project_ref_unknown_shape_is_empty():
+    assert project_ref("postgresql://postgres:pw@127.0.0.1:54322/postgres") == ""
+
+
+def test_ledger_diff_reports_pending_in_file_order():
+    files = ["0001_a.sql", "0002_b.sql", "0003_c.sql"]
+    pending, orphans = ledger_diff(files, {"0001_a.sql"})
+    assert pending == ["0002_b.sql", "0003_c.sql"]
+    assert orphans == []
+
+
+def test_ledger_diff_reports_orphans():
+    pending, orphans = ledger_diff(["0001_a.sql"], {"0001_a.sql", "0099_ghost.sql"})
+    assert pending == []
+    assert orphans == ["0099_ghost.sql"]
+
+
+def test_staging_gap_flags_migrations_staging_never_ran():
+    assert staging_gap(["0002_b.sql", "0003_c.sql"], {"0002_b.sql"}) == ["0003_c.sql"]
+
+
+def test_staging_gap_empty_when_staging_is_ahead():
+    assert staging_gap(["0002_b.sql"], {"0002_b.sql", "0003_c.sql"}) == []
+
+
+def test_scan_destructive_flags_drop_table(tmp_path):
+    f = tmp_path / "0050_x.sql"
+    f.write_text("CREATE TABLE a (id int);\nDROP TABLE legacy_grades;\n")
+    findings = scan_destructive([f])
+    assert [x.kind for x in findings] == ["DROP TABLE"]
+    assert "0050_x.sql:2" in findings[0].detail
+
+
+def test_scan_destructive_flags_drop_column_and_truncate(tmp_path):
+    f = tmp_path / "0051_y.sql"
+    f.write_text("ALTER TABLE t DROP COLUMN old;\nTRUNCATE TABLE cache;\n")
+    assert {x.kind for x in scan_destructive([f])} == {"DROP COLUMN", "TRUNCATE"}
+
+
+def test_scan_destructive_flags_type_change(tmp_path):
+    f = tmp_path / "0052_z.sql"
+    f.write_text("ALTER TABLE t ALTER COLUMN amount TYPE numeric;\n")
+    assert [x.kind for x in scan_destructive([f])] == ["ALTER COLUMN ... TYPE"]
+
+
+def test_scan_destructive_ignores_line_comments(tmp_path):
+    """The repo's migrations explain themselves at length; a mention is not a DROP."""
+    f = tmp_path / "0053_c.sql"
+    f.write_text("-- this replaces the old DROP TABLE approach\nCREATE TABLE ok (id int);\n")
+    assert scan_destructive([f]) == []
+
+
+def test_scan_destructive_ignores_block_comments(tmp_path):
+    f = tmp_path / "0054_c.sql"
+    f.write_text("/*\n  We used to TRUNCATE here.\n*/\nCREATE TABLE ok (id int);\n")
+    assert scan_destructive([f]) == []
+
+
+def test_scan_destructive_clean_migration_passes(tmp_path):
+    f = tmp_path / "0055_ok.sql"
+    f.write_text("CREATE TABLE IF NOT EXISTS t (id int);\nCREATE INDEX ON t (id);\n")
+    assert scan_destructive([f]) == []
+
+
+def _evaluate(**over):
+    kwargs = dict(
+        db_url=POOLER,
+        supabase_url=API,
+        ledger_exists=True,
+        migration_files=["0001_a.sql", "0002_b.sql"],
+        recorded={"0001_a.sql"},
+        staging_recorded={"0001_a.sql", "0002_b.sql"},
+        destructive=[],
+        commits_ahead=3,
+        allow_destructive=False,
+        skip_staging_check=False,
+    )
+    kwargs.update(over)
+    return evaluate(**kwargs)
+
+
+def test_evaluate_clean_case_has_no_findings():
+    assert _evaluate() == []
+
+
+def test_evaluate_blocks_on_project_ref_mismatch():
+    findings = _evaluate(supabase_url="https://zzzzzzzzzzzzzzzz.supabase.co")
+    assert [f.kind for f in findings] == ["target-mismatch"]
+
+
+def test_evaluate_blocks_when_ledger_missing():
+    assert "no-ledger" in [f.kind for f in _evaluate(ledger_exists=False)]
+
+
+def test_evaluate_blocks_on_orphans():
+    findings = _evaluate(recorded={"0001_a.sql", "0099_ghost.sql"})
+    assert "orphan" in [f.kind for f in findings]
+
+
+def test_evaluate_blocks_when_staging_has_not_run_it():
+    findings = _evaluate(staging_recorded={"0001_a.sql"})
+    assert "staging-gap" in [f.kind for f in findings]
+
+
+def test_evaluate_staging_check_can_be_skipped():
+    findings = _evaluate(staging_recorded={"0001_a.sql"}, skip_staging_check=True)
+    assert "staging-gap" not in [f.kind for f in findings]
+
+
+def test_evaluate_blocks_on_destructive_ddl():
+    findings = _evaluate(destructive=[Finding("DROP TABLE", "0002_b.sql:4: DROP TABLE x;")])
+    assert "destructive" in [f.kind for f in findings]
+
+
+def test_evaluate_destructive_can_be_allowed():
+    findings = _evaluate(
+        destructive=[Finding("DROP TABLE", "0002_b.sql:4: DROP TABLE x;")],
+        allow_destructive=True,
+    )
+    assert "destructive" not in [f.kind for f in findings]
+
+
+def test_evaluate_reports_nothing_to_promote():
+    findings = _evaluate(commits_ahead=0, recorded={"0001_a.sql", "0002_b.sql"})
+    assert [f.kind for f in findings] == ["nothing-to-promote"]
+
+
+def test_evaluate_allows_a_migration_only_promotion():
+    """Code is level but the schema is behind — that is still work to do."""
+    findings = _evaluate(commits_ahead=0)  # default fixture leaves 0002_b.sql pending
+    assert findings == []

--- a/backend/tests/test_promotion_preflight.py
+++ b/backend/tests/test_promotion_preflight.py
@@ -177,6 +177,31 @@ def test_evaluate_staging_check_can_be_skipped():
     assert "staging-gap" not in [f.kind for f in findings]
 
 
+def test_evaluate_unknown_staging_ledger_with_pending_blocks_once():
+    """Missing STAGING_SUPABASE_DB_URL must not be silently read as 'nothing ran'.
+
+    None (unreadable) and set() (read, empty) are different claims. Conflating
+    them turned the default no-env-var experience into a false per-migration
+    accusation. This must be exactly one finding, not one per pending migration.
+    """
+    findings = _evaluate(staging_recorded=None)  # default fixture leaves 0002_b.sql pending
+    kinds = [f.kind for f in findings]
+    assert kinds == ["staging-unknown"]
+    assert "STAGING_SUPABASE_DB_URL" in findings[0].detail
+    assert "aws-1-us-west-2" in findings[0].detail
+
+
+def test_evaluate_unknown_staging_ledger_with_nothing_pending_is_silent():
+    """No pending migrations means the unreadable ledger never mattered."""
+    findings = _evaluate(staging_recorded=None, recorded={"0001_a.sql", "0002_b.sql"})
+    assert "staging-unknown" not in [f.kind for f in findings]
+
+
+def test_evaluate_unknown_staging_ledger_can_be_skipped():
+    findings = _evaluate(staging_recorded=None, skip_staging_check=True)
+    assert "staging-unknown" not in [f.kind for f in findings]
+
+
 def test_evaluate_blocks_on_destructive_ddl():
     findings = _evaluate(destructive=[Finding("DROP TABLE", "0002_b.sql:4: DROP TABLE x;")])
     assert "destructive" in [f.kind for f in findings]

--- a/backend/tests/test_promotion_runner.py
+++ b/backend/tests/test_promotion_runner.py
@@ -242,6 +242,36 @@ def test_merge_retries_through_a_transient_failure():
     assert run(*build(kwargs)) == 0
 
 
+def test_merge_state_unreadable_does_not_claim_production_unchanged():
+    """If every post-merge `gh pr view` fails, the merge may still have landed
+    on one of the 5 attempts — this run just could never confirm it. Claiming
+    "production code unchanged" here would be a real false report, the exact
+    class of bug this tool exists to prevent. It must say UNKNOWN instead.
+    """
+
+    class UnreadableStateGh(FakeGh):
+        def __init__(self):
+            super().__init__()
+            self.state_calls = 0
+
+        def state(self, number):
+            self.state_calls += 1
+            if self.state_calls == 1:
+                return "OPEN"  # the pre-confirm already_merged check
+            raise RuntimeError("gh: pr view failed (rate limited)")
+
+        def merge(self, number):
+            self.calls.append("merge")
+            self.merged = True  # it may well have landed...
+
+    lines = []
+    kwargs = make_ports(gh=UnreadableStateGh(), out=lines.append)
+    assert run(*build(kwargs)) == 1
+    text = "\n".join(lines).lower()
+    assert "unchanged" not in text
+    assert "unknown" in text
+
+
 def test_nothing_to_promote_exits_clean():
     kwargs = make_ports()
     kwargs["git"].commits_ahead = 0
@@ -262,11 +292,23 @@ def test_verify_only_skips_promotion_and_just_waits_and_smokes():
     the wait" story is unreachable: after a real merge, a fresh `run()` sees
     commits_ahead == 0 and nothing pending, so preflight reports
     nothing-to-promote and exits clean before ever reaching the wait).
-    --verify-only skips preflight/snapshot/migrate/PR/merge entirely.
+    --verify-only skips preflight/snapshot/migrate/PR/merge entirely, but the
+    wait-then-smoke tail must still genuinely run — a stub that just returns
+    EXIT_OK would satisfy the "nothing mutating happened" assertions alone,
+    so this also has to prove the fetcher was actually driven through both
+    the deploy wait (/api/health) and a smoke-only check.
     """
     connect_calls = []
     migrated = []
+    fetch_urls = []
     kwargs = make_ports()
+    original_fetch = kwargs["fetch"]
+
+    def spy_fetch(method, url):
+        fetch_urls.append(url)
+        return original_fetch(method, url)
+
+    kwargs["fetch"] = spy_fetch
     kwargs["connect"] = lambda: connect_calls.append(1) or FakeConn()
     kwargs["migrate"] = lambda conn: migrated.append(1) or ["should-not-run"]
     gh = kwargs["gh"]
@@ -274,6 +316,11 @@ def test_verify_only_skips_promotion_and_just_waits_and_smokes():
     assert connect_calls == []  # no preflight/snapshot/migrate — no DB touched
     assert migrated == []
     assert gh.calls == []  # no ensure_pr, no merge
+    assert any(u.endswith("/api/health") for u in fetch_urls)  # the deploy wait ran
+    # /api/semesters is only ever requested by smoke.run_checks (CHECKS), never
+    # by the wait loop (which only ever calls /api/health) — its presence is
+    # proof smoke genuinely executed, not just that the wait loop did.
+    assert any(u.endswith("/api/semesters") for u in fetch_urls)
 
 
 def test_unknown_live_commit_degrades_instead_of_hanging():

--- a/backend/tests/test_promotion_runner.py
+++ b/backend/tests/test_promotion_runner.py
@@ -1,0 +1,268 @@
+"""Stage sequencing for the promotion runner (#516).
+
+Every port is injected, so the whole flow runs in-process with no database,
+no network, no git and no gh.
+"""
+import json
+
+from promotion.runner import Options, Ports, run
+
+# Compact separators on purpose: FastAPI emits `{"status":"ok",...}` with no
+# spaces, and smoke's `api health` check looks for the literal `"status":"ok"`.
+# json.dumps' default `", "`/`": "` separators would not contain that substring,
+# so a faithful fake has to match the real wire format.
+COMPACT = (",", ":")
+HEALTH_OLD = json.dumps({"status": "ok", "commit": "old1111"}, separators=COMPACT)
+HEALTH_NEW = json.dumps({"status": "ok", "commit": "new2222"}, separators=COMPACT)
+
+
+class FakeGit:
+    def __init__(self, head="new2222", commits_ahead=3):
+        self.head = head
+        self.commits_ahead = commits_ahead
+        self.calls = []
+
+    def fetch(self):
+        self.calls.append("fetch")
+
+    def head_sha(self, ref):
+        self.calls.append(f"head:{ref}")
+        return self.head
+
+    def commits_ahead_of(self, base, head):
+        return self.commits_ahead
+
+
+class FakeGh:
+    def __init__(self):
+        self.merged = False
+        self.calls = []
+
+    def ensure_pr(self, base, head, title):
+        self.calls.append("ensure_pr")
+        return 999
+
+    def state(self, number):
+        return "MERGED" if self.merged else "OPEN"
+
+    def merge(self, number):
+        self.calls.append("merge")
+        self.merged = True
+
+
+def make_ports(**over):
+    """Happy path by default; override one port per test."""
+    fake_git, fake_gh = FakeGit(), FakeGh()
+    healths = [HEALTH_OLD, HEALTH_NEW, HEALTH_NEW, HEALTH_NEW, HEALTH_NEW]
+
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, healths.pop(0) if healths else HEALTH_NEW
+        if url.endswith("/api/auth/test-login"):
+            return 404, ""
+        if "analytics" in url:
+            return 401, ""
+        return 200, "<html>"
+
+    ports = dict(
+        connect=lambda: FakeConn(),
+        migrate=lambda conn: ["0002_b.sql"],
+        preflight_data=lambda conn: dict(
+            ledger_exists=True,
+            migration_files=["0001_a.sql", "0002_b.sql"],
+            recorded={"0001_a.sql"},
+            staging_recorded={"0001_a.sql", "0002_b.sql"},
+            destructive=[],
+            db_url="postgresql://postgres.ref1:p@aws-0-us-west-2.pooler.supabase.com:5432/postgres",
+            supabase_url="https://ref1.supabase.co",
+        ),
+        snapshots=[
+            {"tables": {"users": 8}, "ledger": ["0001_a.sql"]},
+            {"tables": {"users": 8, "events": 0}, "ledger": ["0001_a.sql", "0002_b.sql"]},
+        ],
+        git=fake_git,
+        gh=fake_gh,
+        fetch=fetch,
+        confirm=lambda prompt: True,
+        out=lambda line: None,
+        sleep=lambda seconds: None,
+    )
+    ports.update(over)
+    return ports
+
+
+class FakeConn:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def build(ports_kwargs, **option_over):
+    """Assemble Ports/Options from the dict make_ports returns."""
+    snapshots = list(ports_kwargs.pop("snapshots"))
+    preflight_data = ports_kwargs.pop("preflight_data")
+    migrate = ports_kwargs.pop("migrate")
+    ports = Ports(
+        connect=ports_kwargs["connect"],
+        preflight_data=preflight_data,
+        capture=lambda conn: snapshots.pop(0),
+        migrate=migrate,
+        git=ports_kwargs["git"],
+        gh=ports_kwargs["gh"],
+        fetch=ports_kwargs["fetch"],
+        confirm=ports_kwargs["confirm"],
+        out=ports_kwargs["out"],
+        sleep=ports_kwargs["sleep"],
+    )
+    options = Options(**{"wait_timeout": 5, "poll_interval": 0, **option_over})
+    return ports, options
+
+
+def test_happy_path_returns_zero_and_merges():
+    kwargs = make_ports()
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 0
+    assert "merge" in gh.calls
+
+
+def test_preflight_failure_aborts_before_migrating():
+    migrated = []
+    kwargs = make_ports(migrate=lambda conn: migrated.append(1) or [])
+    kwargs["preflight_data"] = lambda conn: dict(
+        ledger_exists=True,
+        migration_files=["0001_a.sql"],
+        recorded={"0001_a.sql", "0099_ghost.sql"},  # orphan
+        staging_recorded={"0001_a.sql"},
+        destructive=[],
+        db_url="postgresql://postgres.ref1:p@aws-0-us-west-2.pooler.supabase.com:5432/postgres",
+        supabase_url="https://ref1.supabase.co",
+    )
+    assert run(*build(kwargs)) == 1
+    assert migrated == []
+    assert kwargs["gh"].calls == []
+
+
+def test_declining_the_prompt_stops_without_merging():
+    kwargs = make_ports(confirm=lambda prompt: False)
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 2
+    # ensure_pr runs BEFORE the prompt on purpose — the prompt names the PR
+    # number, and an already-merged PR is how a re-run resumes. Declining must
+    # leave the PR open and unmerged, not uncreated.
+    assert "merge" not in gh.calls
+    assert gh.merged is False
+
+
+def test_declining_warns_that_migrations_already_applied():
+    lines = []
+    kwargs = make_ports(confirm=lambda prompt: False, out=lines.append)
+    run(*build(kwargs))
+    text = "\n".join(lines).lower()
+    assert "schema" in text and "ahead" in text
+
+
+def test_wait_timeout_does_not_run_smoke():
+    """A deploy that never lands must not be reported as a smoke failure."""
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, HEALTH_OLD  # never advances
+        raise AssertionError("smoke must not run after a wait timeout")
+
+    kwargs = make_ports(fetch=fetch)
+    assert run(*build(kwargs)) == 1
+
+
+def test_smoke_failure_returns_nonzero():
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, HEALTH_NEW
+        return 500, "boom"
+
+    kwargs = make_ports(fetch=fetch)
+    assert run(*build(kwargs)) == 1
+
+
+def test_smoke_failure_prints_the_revert_command():
+    lines = []
+
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, HEALTH_NEW
+        return 500, "boom"
+
+    kwargs = make_ports(fetch=fetch, out=lines.append)
+    run(*build(kwargs))
+    assert "git revert" in "\n".join(lines)
+
+
+def test_smoke_failure_does_not_revert_anything():
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, HEALTH_NEW
+        return 500, "boom"
+
+    kwargs = make_ports(fetch=fetch)
+    gh = kwargs["gh"]
+    run(*build(kwargs))
+    assert "revert" not in " ".join(gh.calls)
+
+
+def test_merge_retries_through_a_transient_failure():
+    """The known gh squash-merge 502: error raised, but the PR does merge."""
+
+    class FlakyGh(FakeGh):
+        def __init__(self):
+            super().__init__()
+            self.attempts = 0
+
+        def merge(self, number):
+            self.attempts += 1
+            self.merged = True  # it landed despite the error
+            if self.attempts == 1:
+                raise RuntimeError("HTTP 502")
+
+    kwargs = make_ports(gh=FlakyGh())
+    assert run(*build(kwargs)) == 0
+
+
+def test_nothing_to_promote_exits_clean():
+    kwargs = make_ports()
+    kwargs["git"].commits_ahead = 0
+    kwargs["preflight_data"] = lambda conn: dict(
+        ledger_exists=True,
+        migration_files=["0001_a.sql"],
+        recorded={"0001_a.sql"},
+        staging_recorded={"0001_a.sql"},
+        destructive=[],
+        db_url="postgresql://postgres.ref1:p@aws-0-us-west-2.pooler.supabase.com:5432/postgres",
+        supabase_url="https://ref1.supabase.co",
+    )
+    assert run(*build(kwargs)) == 0
+
+
+def test_already_merged_pr_resumes_at_wait_and_smoke():
+    """Re-running after a failure must not re-merge."""
+    kwargs = make_ports()
+    gh = kwargs["gh"]
+    gh.merged = True
+    assert run(*build(kwargs)) == 0
+    assert "merge" not in gh.calls
+
+
+def test_unknown_live_commit_degrades_instead_of_hanging():
+    """No Railway env var: don't wait forever, warn and smoke anyway."""
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, json.dumps({"status": "ok", "commit": "unknown"}, separators=COMPACT)
+        if url.endswith("/api/auth/test-login"):
+            return 404, ""
+        if "analytics" in url:
+            return 401, ""
+        return 200, "<html>"
+
+    lines = []
+    kwargs = make_ports(fetch=fetch, out=lines.append)
+    assert run(*build(kwargs)) == 0
+    assert "unknown" in "\n".join(lines).lower()

--- a/backend/tests/test_promotion_runner.py
+++ b/backend/tests/test_promotion_runner.py
@@ -92,8 +92,12 @@ def make_ports(**over):
             supabase_url="https://ref1.supabase.co",
         ),
         snapshots=[
-            {"tables": {"users": 8}, "ledger": ["0001_a.sql"]},
-            {"tables": {"users": 8, "events": 0}, "ledger": ["0001_a.sql", "0002_b.sql"]},
+            {"host": "aws-0-us-west-2.pooler.supabase.com", "tables": {"users": 8}, "ledger": ["0001_a.sql"]},
+            {
+                "host": "aws-0-us-west-2.pooler.supabase.com",
+                "tables": {"users": 8, "events": 0},
+                "ledger": ["0001_a.sql", "0002_b.sql"],
+            },
         ],
         git=fake_git,
         gh=fake_gh,
@@ -164,8 +168,7 @@ def test_declining_the_prompt_stops_without_merging():
     gh = kwargs["gh"]
     assert run(*build(kwargs)) == 2
     # ensure_pr runs BEFORE the prompt on purpose — the prompt names the PR
-    # number, and an already-merged PR is how a re-run resumes. Declining must
-    # leave the PR open and unmerged, not uncreated.
+    # number. Declining must leave the PR open and unmerged, not uncreated.
     assert "merge" not in gh.calls
     assert gh.merged is False
 
@@ -250,14 +253,7 @@ def test_merge_state_unreadable_does_not_claim_production_unchanged():
     """
 
     class UnreadableStateGh(FakeGh):
-        def __init__(self):
-            super().__init__()
-            self.state_calls = 0
-
         def state(self, number):
-            self.state_calls += 1
-            if self.state_calls == 1:
-                return "OPEN"  # the pre-confirm already_merged check
             raise RuntimeError("gh: pr view failed (rate limited)")
 
         def merge(self, number):
@@ -288,10 +284,10 @@ def test_merge_state_stale_confirmation_does_not_claim_production_unchanged():
 
         def state(self, number):
             self.state_calls += 1
-            # call 1 = the pre-confirm already_merged check; call 2 = the
-            # FIRST retry-loop read. Both succeed and say OPEN. Every read
-            # after that (covering merge attempts 2-5) fails.
-            if self.state_calls <= 2:
+            # call 1 = the FIRST retry-loop read (after merge attempt 1),
+            # which succeeds and says OPEN. Every read after that (covering
+            # merge attempts 2-5) fails.
+            if self.state_calls == 1:
                 return "OPEN"
             raise RuntimeError("gh: pr view failed (rate limited)")
 
@@ -308,6 +304,32 @@ def test_merge_state_stale_confirmation_does_not_claim_production_unchanged():
     assert "gh pr view" in text
 
 
+def test_merge_stays_open_after_retries_is_reported_as_observation_not_fact():
+    """CRITICAL: rounds 2-3 fixed read FAILURE; this is read STALENESS. Even
+    when every post-merge read succeeds and consistently says OPEN, gh's own
+    documented squash/merge-502-while-it-lands wedge means a merge triggered
+    by this run can land seconds AFTER the last read this run performed.
+    "Error returned" does not mean "definitely nothing happened". The
+    exhaustion message must report what was OBSERVED, not assert "production
+    is unchanged" as a settled fact this run cannot actually know.
+    """
+
+    class NeverLandsGh(FakeGh):
+        def merge(self, number):
+            self.calls.append("merge")
+            # Deliberately never sets self.merged — every state() read below
+            # (inherited from FakeGh, keyed on self.merged) genuinely, and
+            # consistently, returns "OPEN".
+
+    lines = []
+    kwargs = make_ports(gh=NeverLandsGh(), out=lines.append)
+    assert run(*build(kwargs)) == 1
+    text = "\n".join(lines).lower()
+    assert "unchanged" not in text
+    assert "gh pr view" in text
+    assert "may still be landing" in text
+
+
 def test_nothing_to_promote_exits_clean():
     kwargs = make_ports()
     kwargs["git"].commits_ahead = 0
@@ -321,6 +343,106 @@ def test_nothing_to_promote_exits_clean():
         supabase_url="https://ref1.supabase.co",
     )
     assert run(*build(kwargs)) == 0
+
+
+def test_migration_failure_reports_partial_state_not_a_traceback():
+    """apply_migration commits per file (db/migrate.py), so a failure partway
+    through 3 pending migrations still leaves earlier ones durably applied
+    and recorded. This is exactly the moment the tool's whole purpose is an
+    honest state report: it must say how many landed and which file failed,
+    warn that the schema is now ahead of the code, and return EXIT_FAIL —
+    never let the exception propagate as a raw traceback.
+    """
+
+    def failing_migrate(conn):
+        raise RuntimeError('syntax error at or near "FOO" in 0003_c.sql')
+
+    lines = []
+    kwargs = make_ports(migrate=failing_migrate, out=lines.append)
+    kwargs["preflight_data"] = lambda conn: dict(
+        ledger_exists=True,
+        migration_files=["0001_a.sql", "0002_b.sql", "0003_c.sql"],
+        recorded={"0001_a.sql"},
+        staging_recorded={"0001_a.sql", "0002_b.sql", "0003_c.sql"},
+        destructive=[],
+        db_url="postgresql://postgres.ref1:p@aws-0-us-west-2.pooler.supabase.com:5432/postgres",
+        supabase_url="https://ref1.supabase.co",
+    )
+    # before: only 0001_a.sql recorded. after (re-captured on a FRESH
+    # connection post-failure): 0002_b.sql landed and committed; 0003_c.sql
+    # never did — that is what actually failed.
+    kwargs["snapshots"] = [
+        {"host": "aws-0-us-west-2.pooler.supabase.com", "tables": {"users": 8}, "ledger": ["0001_a.sql"]},
+        {
+            "host": "aws-0-us-west-2.pooler.supabase.com",
+            "tables": {"users": 8},
+            "ledger": ["0001_a.sql", "0002_b.sql"],
+        },
+    ]
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 1
+    assert gh.calls == []  # a migration failure must never reach the PR/merge stage
+    text = "\n".join(lines)
+    assert "1 of 2" in text  # 1 of the 2 pending migrations landed
+    assert "0003_c.sql" in text  # names the migration that actually failed
+    assert "syntax error" in text  # surfaces the real driver error
+    assert "ahead" in text.lower()  # schema-ahead-of-code warning, same as the decline path
+
+
+def test_target_line_printed_before_migrate_runs():
+    """Names the DB project about to receive DDL, before the DDL runs — the
+    only way an operator can catch a .env file pointing at the wrong project
+    (matching SUPABASE_DB_URL/SUPABASE_URL refs proves nothing if BOTH
+    consistently hold the wrong project's credentials) before, not after,
+    migrations actually apply.
+    """
+    order = []
+    kwargs = make_ports()
+    kwargs["out"] = lambda line: order.append(("out", line))
+    kwargs["migrate"] = lambda conn: order.append(("migrate", None)) or ["0002_b.sql"]
+    assert run(*build(kwargs)) == 0
+
+    target_idx = next(
+        i for i, (kind, line) in enumerate(order) if kind == "out" and line.startswith("Target:")
+    )
+    migrate_idx = next(i for i, (kind, _) in enumerate(order) if kind == "migrate")
+    assert target_idx < migrate_idx
+    _, target_line = order[target_idx]
+    assert "ref1" in target_line  # the project ref parsed out of db_url
+
+
+def test_migrations_only_promotion_skips_pr_and_still_smokes():
+    """Production's DB can trail its own code (a real, recurring state — see
+    #316/#510): commits_ahead can be 0 while a migration is still pending.
+    `gh pr create` would fail outright ("No commits between production and
+    main"), so this path must skip PR/merge/deploy-wait entirely — but still
+    smoke, since a migration that broke the running app is exactly the
+    failure that stage exists to catch.
+    """
+    lines = []
+    kwargs = make_ports(out=lines.append)
+    kwargs["git"].commits_ahead = 0
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 0
+    assert gh.calls == []  # no ensure_pr, no merge — nothing to promote via PR
+    text = "\n".join(lines).lower()
+    assert "migrations applied" in text and "no code to promote" in text
+
+
+def test_migrations_only_promotion_fails_if_smoke_fails():
+    """The EXIT_FAIL branch of the migrations-only path must be wired to a
+    real smoke result, not a stub that always reports success."""
+
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, HEALTH_NEW
+        return 500, "boom"
+
+    kwargs = make_ports(fetch=fetch)
+    kwargs["git"].commits_ahead = 0
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 1
+    assert gh.calls == []
 
 
 def test_verify_only_skips_promotion_and_just_waits_and_smokes():

--- a/backend/tests/test_promotion_runner.py
+++ b/backend/tests/test_promotion_runner.py
@@ -80,7 +80,7 @@ def make_ports(**over):
         return 200, "<html>"
 
     ports = dict(
-        connect=lambda: FakeConn(),
+        connect=FakeConn,
         migrate=lambda conn: ["0002_b.sql"],
         preflight_data=lambda conn: dict(
             ledger_exists=True,
@@ -533,6 +533,30 @@ def test_verify_only_skips_promotion_and_just_waits_and_smokes():
     # by the wait loop (which only ever calls /api/health) — its presence is
     # proof smoke genuinely executed too, not just the wait.
     assert any(u.endswith("/api/semesters") for u in fetch_urls)
+
+
+def test_verify_only_smoke_failure_does_not_print_revert_recipe():
+    """--verify-only never merges by design (see Options.verify_only), so a
+    smoke failure under it must not get _run_smoke's default
+    `git checkout production && git revert -m 1 HEAD` recipe either — that
+    would tell the operator to revert a PREVIOUS promotion's merge commit
+    that this invocation had nothing to do with. This is the second door
+    onto the same false-report bug the migrations-only path already fixed:
+    _wait_then_smoke must forward merged_this_run, not just _run_smoke's
+    other direct callers.
+    """
+
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, HEALTH_NEW
+        return 500, "boom"
+
+    lines = []
+    kwargs = make_ports(fetch=fetch, out=lines.append)
+    assert run(*build(kwargs, verify_only=True)) == 1
+    text = "\n".join(lines)
+    assert "git revert" not in text
+    assert "No code was merged this run" in text
 
 
 def test_unknown_live_commit_degrades_instead_of_hanging():

--- a/backend/tests/test_promotion_runner.py
+++ b/backend/tests/test_promotion_runner.py
@@ -13,12 +13,22 @@ from promotion.runner import Options, Ports, run
 # so a faithful fake has to match the real wire format.
 COMPACT = (",", ":")
 HEALTH_OLD = json.dumps({"status": "ok", "commit": "old1111"}, separators=COMPACT)
-HEALTH_NEW = json.dumps({"status": "ok", "commit": "new2222"}, separators=COMPACT)
+# The deployed commit is production's merge-commit SHA, NOT main's tip — `gh pr
+# merge --merge` creates a merge commit ON production, and Railway deploys
+# production. HEALTH_NEW deliberately carries FakeGit's "origin/production" SHA
+# ("prod222"), distinct from "origin/main"'s ("main111"), so a wait loop that
+# (wrongly) compares against main instead can never match it — verified by
+# hand: temporarily pointing runner.py's post-merge wait at origin/main makes
+# test_happy_path_returns_zero_and_merges fail (times out, returns 1).
+HEALTH_NEW = json.dumps({"status": "ok", "commit": "prod222"}, separators=COMPACT)
 
 
 class FakeGit:
-    def __init__(self, head="new2222", commits_ahead=3):
-        self.head = head
+    """Distinct SHAs per ref — a fake that returned the same SHA for every ref
+    could never catch a wait loop comparing against the wrong one."""
+
+    def __init__(self, main_sha="main111", production_sha="prod222", commits_ahead=3):
+        self.shas = {"origin/main": main_sha, "origin/production": production_sha}
         self.commits_ahead = commits_ahead
         self.calls = []
 
@@ -27,7 +37,7 @@ class FakeGit:
 
     def head_sha(self, ref):
         self.calls.append(f"head:{ref}")
-        return self.head
+        return self.shas[ref]
 
     def commits_ahead_of(self, base, head):
         return self.commits_ahead
@@ -48,6 +58,11 @@ class FakeGh:
     def merge(self, number):
         self.calls.append("merge")
         self.merged = True
+
+    def revert(self, number):
+        """The runner must NEVER call this — see
+        test_smoke_failure_does_not_revert_anything."""
+        self.calls.append("revert")
 
 
 def make_ports(**over):
@@ -210,7 +225,7 @@ def test_smoke_failure_does_not_revert_anything():
 
 
 def test_merge_retries_through_a_transient_failure():
-    """The known gh squash-merge 502: error raised, but the PR does merge."""
+    """The known `gh pr merge --merge` 502: error raised, but the PR does merge."""
 
     class FlakyGh(FakeGh):
         def __init__(self):
@@ -242,13 +257,23 @@ def test_nothing_to_promote_exits_clean():
     assert run(*build(kwargs)) == 0
 
 
-def test_already_merged_pr_resumes_at_wait_and_smoke():
-    """Re-running after a failure must not re-merge."""
+def test_verify_only_skips_promotion_and_just_waits_and_smokes():
+    """--verify-only IS the resume path (the brief's "already-merged PR resumes
+    the wait" story is unreachable: after a real merge, a fresh `run()` sees
+    commits_ahead == 0 and nothing pending, so preflight reports
+    nothing-to-promote and exits clean before ever reaching the wait).
+    --verify-only skips preflight/snapshot/migrate/PR/merge entirely.
+    """
+    connect_calls = []
+    migrated = []
     kwargs = make_ports()
+    kwargs["connect"] = lambda: connect_calls.append(1) or FakeConn()
+    kwargs["migrate"] = lambda conn: migrated.append(1) or ["should-not-run"]
     gh = kwargs["gh"]
-    gh.merged = True
-    assert run(*build(kwargs)) == 0
-    assert "merge" not in gh.calls
+    assert run(*build(kwargs, verify_only=True)) == 0
+    assert connect_calls == []  # no preflight/snapshot/migrate — no DB touched
+    assert migrated == []
+    assert gh.calls == []  # no ensure_pr, no merge
 
 
 def test_unknown_live_commit_degrades_instead_of_hanging():

--- a/backend/tests/test_promotion_runner.py
+++ b/backend/tests/test_promotion_runner.py
@@ -5,6 +5,8 @@ no network, no git and no gh.
 """
 import json
 
+import pytest
+
 from promotion.runner import Options, Ports, run
 
 # Compact separators on purpose: FastAPI emits `{"status":"ok",...}` with no
@@ -21,6 +23,9 @@ HEALTH_OLD = json.dumps({"status": "ok", "commit": "old1111"}, separators=COMPAC
 # hand: temporarily pointing runner.py's post-merge wait at origin/main makes
 # test_happy_path_returns_zero_and_merges fail (times out, returns 1).
 HEALTH_NEW = json.dumps({"status": "ok", "commit": "prod222"}, separators=COMPACT)
+# What /api/health serves when the host injects no commit SHA (no Railway env
+# var): reachable, healthy, but impossible to match against any deploy target.
+HEALTH_UNKNOWN = json.dumps({"status": "ok", "commit": "unknown"}, separators=COMPACT)
 
 
 class FakeGit:
@@ -42,11 +47,25 @@ class FakeGit:
     def commits_ahead_of(self, base, head):
         return self.commits_ahead
 
+    def migrations_drift(self):
+        """How the local db/migrations/ checkout differs from origin/main
+        ("" = matches exactly). Clean by default; drift tests override."""
+        return ""
+
+    def is_ancestor(self, ancestor, descendant):
+        """git merge-base --is-ancestor. True by default (production is an
+        ancestor of main); divergence tests override."""
+        return True
+
 
 class FakeGh:
     def __init__(self):
         self.merged = False
         self.calls = []
+        # Every SHA the runner pinned a merge to (gh --match-head-commit) —
+        # the pin is how commits landing during the confirm pause are kept
+        # from being promoted unscanned.
+        self.match_head_commits = []
 
     def ensure_pr(self, base, head, title):
         self.calls.append("ensure_pr")
@@ -55,8 +74,9 @@ class FakeGh:
     def state(self, number):
         return "MERGED" if self.merged else "OPEN"
 
-    def merge(self, number):
+    def merge(self, number, match_head_commit):
         self.calls.append("merge")
+        self.match_head_commits.append(match_head_commit)
         self.merged = True
 
     def revert(self, number):
@@ -118,6 +138,26 @@ class FakeConn:
         return False
 
 
+class OperationalError(Exception):
+    """Stand-in for psycopg.OperationalError (dead server, refused connection).
+    The runner must catch broadly, not by driver type — asserted by tests that
+    raise THIS class where the real code would see psycopg's."""
+
+
+class TickingClock:
+    """Deterministic stand-in for time.monotonic: advances 1s per read. The
+    wait loop budgets on real elapsed time, so its termination depends on the
+    clock moving — with the real clock and instant fakes, every timeout-path
+    test would spin for wait_timeout REAL seconds."""
+
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        self.now += 1.0
+        return self.now
+
+
 def build(ports_kwargs, **option_over):
     """Assemble Ports/Options from the dict make_ports returns."""
     snapshots = list(ports_kwargs.pop("snapshots"))
@@ -134,6 +174,7 @@ def build(ports_kwargs, **option_over):
         confirm=ports_kwargs["confirm"],
         out=ports_kwargs["out"],
         sleep=ports_kwargs["sleep"],
+        monotonic=ports_kwargs.get("monotonic", TickingClock()),
     )
     options = Options(**{"wait_timeout": 5, "poll_interval": 0, **option_over})
     return ports, options
@@ -161,6 +202,59 @@ def test_preflight_failure_aborts_before_migrating():
     assert run(*build(kwargs)) == 1
     assert migrated == []
     assert kwargs["gh"].calls == []
+
+
+def test_migrations_drift_blocks_before_any_ddl():
+    """Preflight lists LOCAL migration files and the migrate port applies
+    LOCAL files, but the thing being promoted is origin/main — a checkout that
+    doesn't match makes the whole audit describe the wrong SQL. Any drift
+    (tracked diff either direction, or untracked strays) must block before
+    migrate and before the PR/merge stage, with no override flag.
+    """
+
+    class DriftedGit(FakeGit):
+        def migrations_drift(self):
+            return "M\tbackend/db/migrations/0002_b.sql\n?? backend/db/migrations/0099_stray.sql"
+
+    migrated = []
+    lines = []
+    kwargs = make_ports(
+        git=DriftedGit(), migrate=lambda conn: migrated.append(1) or [], out=lines.append
+    )
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 1
+    assert migrated == []  # blocked BEFORE any DDL could apply
+    assert gh.calls == []  # and before the PR/merge stage
+    text = "\n".join(lines)
+    assert "0099_stray.sql" in text  # names the offending state
+    assert "git checkout main" in text  # and the remediation
+    assert "PREFLIGHT FAILED" in text
+
+
+def test_production_divergence_blocks_before_any_ddl():
+    """origin/production carrying a commit that is not on origin/main (an
+    un-back-merged hotfix/revert) makes the eventual merge fail
+    deterministically AFTER migrations applied. The ancestry guard must block
+    at preflight, before any DDL.
+    """
+
+    class DivergedGit(FakeGit):
+        def is_ancestor(self, ancestor, descendant):
+            assert (ancestor, descendant) == ("origin/production", "origin/main")
+            return False
+
+    migrated = []
+    lines = []
+    kwargs = make_ports(
+        git=DivergedGit(), migrate=lambda conn: migrated.append(1) or [], out=lines.append
+    )
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 1
+    assert migrated == []
+    assert gh.calls == []
+    text = "\n".join(lines).lower()
+    assert "back-merge" in text
+    assert "preflight failed" in text
 
 
 def test_declining_the_prompt_stops_without_merging():
@@ -227,6 +321,93 @@ def test_smoke_failure_does_not_revert_anything():
     assert "revert" not in " ".join(gh.calls)
 
 
+def test_merge_is_pinned_to_the_audited_main_sha():
+    """`gh pr merge --merge` unpinned merges whatever origin/main's tip is AT
+    MERGE TIME — commits landing while the operator sits at the confirm prompt
+    would be promoted with their migrations never destructive-scanned nor
+    applied. The merge port must receive the SHA stage-1 preflight audited
+    (origin/main as of the preflight fetch) for gh's --match-head-commit.
+    """
+    kwargs = make_ports()
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 0
+    assert gh.match_head_commits == ["main111"]  # FakeGit's origin/main at preflight
+
+
+def test_moved_main_fails_fast_without_burning_the_retry_loop():
+    """A --match-head-commit rejection is DETERMINISTIC — origin/main moved,
+    and retrying can never make it match again. The retry loop exists for the
+    transient gh 502 wedge; burning its 5 attempts here ends in the 'may
+    still be landing' misdirection. The runner must detect the moved head
+    (re-read origin/main), fail fast on the first attempt with both SHAs and
+    a re-run pointer, warn that this run's migrations are already applied,
+    and exit non-zero.
+    """
+
+    class MovedMainGit(FakeGit):
+        """origin/main reads 'moved77' on every read after stage-1 preflight's."""
+
+        def head_sha(self, ref):
+            sha = super().head_sha(ref)
+            if ref == "origin/main" and self.calls.count("head:origin/main") > 1:
+                return "moved77"
+            return sha
+
+    class RejectingGh(FakeGh):
+        def merge(self, number, match_head_commit):
+            self.calls.append("merge")
+            raise RuntimeError("Head branch was modified. Review and try the merge again. (HTTP 405)")
+
+    lines = []
+    kwargs = make_ports(git=MovedMainGit(), gh=RejectingGh(), out=lines.append)
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 1
+    assert gh.calls.count("merge") == 1  # deterministic rejection: no retries burned
+    text = "\n".join(lines)
+    assert "main111" in text and "moved77" in text  # audited vs now
+    assert "make promote" in text  # the remediation: re-run
+    assert "ALREADY APPLIED" in text  # migrations landed this run — still warned
+    assert "may still be landing" not in text  # not the transient-wedge misdirection
+
+
+def test_moved_main_without_migrations_skips_the_already_applied_warning():
+    """When nothing was pending, the fail-fast report must not claim
+    migrations were applied this run — that would be its own false report.
+    """
+
+    class MovedMainGit(FakeGit):
+        def head_sha(self, ref):
+            sha = super().head_sha(ref)
+            if ref == "origin/main" and self.calls.count("head:origin/main") > 1:
+                return "moved77"
+            return sha
+
+    class RejectingGh(FakeGh):
+        def merge(self, number, match_head_commit):
+            self.calls.append("merge")
+            raise RuntimeError("Head branch was modified. (HTTP 405)")
+
+    lines = []
+    kwargs = make_ports(git=MovedMainGit(), gh=RejectingGh(), out=lines.append)
+    kwargs["preflight_data"] = lambda conn: dict(
+        ledger_exists=True,
+        migration_files=["0001_a.sql"],
+        recorded={"0001_a.sql"},  # nothing pending
+        staging_recorded={"0001_a.sql"},
+        destructive=[],
+        db_url="postgresql://postgres.ref1:p@aws-0-us-west-2.pooler.supabase.com:5432/postgres",
+        supabase_url="https://ref1.supabase.co",
+    )
+    kwargs["snapshots"] = [
+        {"host": "aws-0-us-west-2.pooler.supabase.com", "tables": {"users": 8}, "ledger": ["0001_a.sql"]},
+        {"host": "aws-0-us-west-2.pooler.supabase.com", "tables": {"users": 8}, "ledger": ["0001_a.sql"]},
+    ]
+    assert run(*build(kwargs)) == 1
+    text = "\n".join(lines)
+    assert "moved77" in text
+    assert "ALREADY APPLIED" not in text
+
+
 def test_merge_retries_through_a_transient_failure():
     """The known `gh pr merge --merge` 502: error raised, but the PR does merge."""
 
@@ -235,7 +416,7 @@ def test_merge_retries_through_a_transient_failure():
             super().__init__()
             self.attempts = 0
 
-        def merge(self, number):
+        def merge(self, number, match_head_commit):
             self.attempts += 1
             self.merged = True  # it landed despite the error
             if self.attempts == 1:
@@ -256,7 +437,7 @@ def test_merge_state_unreadable_does_not_claim_production_unchanged():
         def state(self, number):
             raise RuntimeError("gh: pr view failed (rate limited)")
 
-        def merge(self, number):
+        def merge(self, number, match_head_commit):
             self.calls.append("merge")
             self.merged = True  # it may well have landed...
 
@@ -291,7 +472,7 @@ def test_merge_state_stale_confirmation_does_not_claim_production_unchanged():
                 return "OPEN"
             raise RuntimeError("gh: pr view failed (rate limited)")
 
-        def merge(self, number):
+        def merge(self, number, match_head_commit):
             self.calls.append("merge")
             self.merged = True  # any of attempts 2-5 may have landed...
 
@@ -315,7 +496,7 @@ def test_merge_stays_open_after_retries_is_reported_as_observation_not_fact():
     """
 
     class NeverLandsGh(FakeGh):
-        def merge(self, number):
+        def merge(self, number, match_head_commit):
             self.calls.append("merge")
             # Deliberately never sets self.merged — every state() read below
             # (inherited from FakeGh, keyed on self.merged) genuinely, and
@@ -328,6 +509,29 @@ def test_merge_stays_open_after_retries_is_reported_as_observation_not_fact():
     assert "unchanged" not in text
     assert "gh pr view" in text
     assert "may still be landing" in text
+
+
+def test_ensure_pr_failure_after_migrate_still_reports_schema_ahead():
+    """By the time ensure_pr runs, the migrations are durably applied. A gh
+    failure there (expired auth, network) must not surface as __main__'s bare
+    one-line ERROR: the operator would get NONE of the partial-state report
+    the decline/migrate-failed paths carefully emit. The runner must print
+    the ALREADY-APPLIED / schema-AHEAD-of-code report first; re-raising after
+    that is fine — the catch-all's ERROR line then supplements the report.
+    """
+
+    class DeadGh(FakeGh):
+        def ensure_pr(self, base, head, title):
+            raise RuntimeError("gh: HTTP 401 bad credentials")
+
+    lines = []
+    kwargs = make_ports(gh=DeadGh(), out=lines.append)
+    with pytest.raises(RuntimeError, match="bad credentials"):
+        run(*build(kwargs))
+    text = "\n".join(lines)
+    assert "ALREADY APPLIED" in text
+    assert "AHEAD" in text
+    assert "re-run" in text.lower()  # what to do next, same as the decline path
 
 
 def test_nothing_to_promote_exits_clean():
@@ -343,6 +547,59 @@ def test_nothing_to_promote_exits_clean():
         supabase_url="https://ref1.supabase.co",
     )
     assert run(*build(kwargs)) == 0
+
+
+def test_post_merge_git_failure_reports_merge_landed_and_points_at_verify_only():
+    """A transient git failure right AFTER the merge landed must not abort as
+    a bare error: a subsequent plain re-run sees commits_ahead == 0 and exits
+    0 "Nothing to promote", so the promoted deploy would never be verified or
+    smoked. The runner must say the MERGE HAS LANDED, that verification could
+    not run, and point at --verify-only — and still exit non-zero.
+    """
+
+    class DiesAfterMergeGit(FakeGit):
+        def fetch(self):
+            super().fetch()
+            # Call 1 is stage-1 preflight; call 2 is the post-merge re-fetch.
+            if self.calls.count("fetch") == 2:
+                raise RuntimeError("could not resolve host: github.com")
+
+    fetched_urls = []
+
+    def fetch(method, url):
+        fetched_urls.append(url)
+        raise AssertionError("neither the deploy wait nor smoke may run after the git failure")
+
+    lines = []
+    kwargs = make_ports(git=DiesAfterMergeGit(), fetch=fetch, out=lines.append)
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 1
+    assert gh.merged is True  # the merge really did land before git died
+    assert fetched_urls == []
+    text = "\n".join(lines)
+    assert "MERGE HAS LANDED" in text
+    assert "--verify-only" in text
+
+
+def test_nothing_to_promote_mentions_verify_only():
+    """A plain re-run after a partial post-merge failure lands exactly here —
+    without a pointer at --verify-only, that re-run is a dead end that exits
+    0 while the promoted deploy is still unverified and unsmoked.
+    """
+    lines = []
+    kwargs = make_ports(out=lines.append)
+    kwargs["git"].commits_ahead = 0
+    kwargs["preflight_data"] = lambda conn: dict(
+        ledger_exists=True,
+        migration_files=["0001_a.sql"],
+        recorded={"0001_a.sql"},
+        staging_recorded={"0001_a.sql"},
+        destructive=[],
+        db_url="postgresql://postgres.ref1:p@aws-0-us-west-2.pooler.supabase.com:5432/postgres",
+        supabase_url="https://ref1.supabase.co",
+    )
+    assert run(*build(kwargs)) == 0
+    assert "--verify-only" in "\n".join(lines)
 
 
 def test_migration_failure_reports_partial_state_not_a_traceback():
@@ -415,6 +672,73 @@ def test_migration_failure_before_any_file_lands_does_not_blame_pending_zero():
     assert "partially migrated" not in text.lower()  # nothing landed — it did not partially migrate
     assert "unchanged" in text.lower()  # the honest claim: the schema did not move at all
     assert "connection reset by peer" in text  # still surfaces the real error
+
+
+def test_migration_failure_report_survives_dead_recovery_connection():
+    """The likely cause of a migrate failure is a dead database — in which
+    case the recovery reconnect fails too. That second failure must DEGRADE
+    the MIGRATION FAILED report (no landed count, say the snapshot could not
+    be captured and why), never crash the runner and discard the report
+    entirely — the failed-migration error and do-not-re-run warning are the
+    whole point of this path.
+    """
+
+    def failing_migrate(conn):
+        raise RuntimeError("server closed the connection unexpectedly")
+
+    connects = []
+
+    def connect():
+        connects.append(1)
+        if len(connects) > 1:  # the post-failure recovery reconnect
+            raise OperationalError("connection refused")
+        return FakeConn()
+
+    lines = []
+    kwargs = make_ports(migrate=failing_migrate, out=lines.append, connect=connect)
+    assert run(*build(kwargs)) == 1
+    text = "\n".join(lines)
+    assert "MIGRATION FAILED" in text
+    assert "server closed the connection unexpectedly" in text  # the migrate error itself
+    assert "could not be captured" in text  # the degraded-snapshot note...
+    assert "connection refused" in text  # ...and why
+    assert "do not re-run blindly" in text.lower()
+    assert "ahead" in text.lower()  # schema may now lead the code — still warned
+
+
+def test_migration_failure_report_prints_before_connection_exit_raises():
+    """If the migrate stage's connection died, the outer with-block's __exit__
+    commit can itself raise on the way out of run(). That second exception may
+    propagate (the catch-all in __main__ still prints it), but only AFTER the
+    MIGRATION FAILED report is already on the operator's screen — an __exit__
+    raise must not be able to mask the report.
+    """
+
+    class DeadOnExitConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            raise OperationalError("SSL connection has been closed unexpectedly")
+
+    connects = []
+
+    def connect():
+        connects.append(1)
+        # First connection (preflight/snapshot/migrate) dies on exit; the
+        # recovery reconnect works, so the FULL report is available.
+        return DeadOnExitConn() if len(connects) == 1 else FakeConn()
+
+    def failing_migrate(conn):
+        raise RuntimeError('syntax error at or near "FOO"')
+
+    lines = []
+    kwargs = make_ports(migrate=failing_migrate, out=lines.append, connect=connect)
+    with pytest.raises(OperationalError):
+        run(*build(kwargs))
+    text = "\n".join(lines)
+    assert "MIGRATION FAILED" in text
+    assert "syntax error" in text
 
 
 def test_target_line_printed_before_migrate_runs():
@@ -560,10 +884,45 @@ def test_verify_only_smoke_failure_does_not_print_revert_recipe():
 
 
 def test_unknown_live_commit_degrades_instead_of_hanging():
-    """No Railway env var: don't wait forever, warn and smoke anyway."""
+    """No Railway env var: /api/health says 'unknown' for the WHOLE window.
+    Don't wait forever — but don't declare success off the first poll either
+    (right after the merge, the OLD deploy is still serving; one 'unknown'
+    proves nothing about the new one). Only after the entire window yields
+    nothing but 'unknown' may the runner degrade to smoke, and then the final
+    report must not claim the deploy was verified.
+    """
+    sleep_calls = []
+
     def fetch(method, url):
         if url.endswith("/api/health"):
-            return 200, json.dumps({"status": "ok", "commit": "unknown"}, separators=COMPACT)
+            return 200, HEALTH_UNKNOWN
+        if url.endswith("/api/auth/test-login"):
+            return 404, ""
+        if "analytics" in url:
+            return 401, ""
+        return 200, "<html>"
+
+    lines = []
+    kwargs = make_ports(fetch=fetch, out=lines.append)
+    kwargs["sleep"] = lambda seconds: sleep_calls.append(seconds)
+    assert run(*build(kwargs)) == 0
+    text = "\n".join(lines)
+    assert len(sleep_calls) >= 2  # kept polling past the first 'unknown'
+    assert "NEVER VERIFIED" in text  # the honest completion line...
+    assert "PROMOTION COMPLETE — all smoke checks passed." not in text  # ...not the verified one
+
+
+def test_unknown_on_first_poll_keeps_waiting_for_the_real_sha():
+    """The first poll lands BEFORE the new deploy could possibly be serving —
+    an 'unknown' there must be treated like any other non-matching answer and
+    polled through, or smoke silently runs against the still-serving OLD
+    deploy and the run prints a false PROMOTION COMPLETE.
+    """
+    healths = [HEALTH_UNKNOWN, HEALTH_UNKNOWN, HEALTH_NEW]
+
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, healths.pop(0) if healths else HEALTH_NEW
         if url.endswith("/api/auth/test-login"):
             return 404, ""
         if "analytics" in url:
@@ -573,4 +932,62 @@ def test_unknown_live_commit_degrades_instead_of_hanging():
     lines = []
     kwargs = make_ports(fetch=fetch, out=lines.append)
     assert run(*build(kwargs)) == 0
-    assert "unknown" in "\n".join(lines).lower()
+    text = "\n".join(lines)
+    assert "deploy is live" in text  # the wait genuinely confirmed prod222
+    assert "PROMOTION COMPLETE — all smoke checks passed." in text
+
+
+def test_wait_budget_is_wall_clock_not_nominal_ticks():
+    """Each health fetch can itself take up to 25s (httpx_fetch's timeout).
+    A budget accounted as `waited += poll_interval` ignores that entirely, so
+    a 600s wait_timeout can run ~35 minutes of wall clock during an incident
+    — exactly when an operator is watching it. The budget must be real
+    elapsed time read off the monotonic port.
+    """
+
+    class Clock:
+        def __init__(self):
+            self.now = 0.0
+
+        def __call__(self):
+            return self.now
+
+    clock = Clock()
+    polls = []
+
+    def fetch(method, url):
+        if not url.endswith("/api/health"):
+            raise AssertionError("smoke must not run after a wait timeout")
+        polls.append(url)
+        clock.now += 25.0  # a hung health endpoint eating the full httpx timeout
+        return 200, HEALTH_OLD  # never advances to the target
+
+    def sleep(seconds):
+        clock.now += seconds
+
+    kwargs = make_ports(fetch=fetch, sleep=sleep)
+    kwargs["monotonic"] = clock
+    ports, options = build(kwargs, wait_timeout=100, poll_interval=10)
+    assert run(ports, options) == 1
+    # 100s of wall clock at 35s per fetch+sleep round = 3 polls — not the 10
+    # that nominal-tick accounting (wait_timeout / poll_interval) would allow.
+    assert len(polls) == 3
+
+
+def test_unknown_mixed_with_real_sha_is_a_timeout_not_a_degrade():
+    """A window that ever produced a REAL (non-matching) SHA proves the host
+    DOES inject commits — the target simply never showed up. That is the
+    plain deploy-timeout case: no smoke, EXIT_FAIL, not the degraded
+    'verification impossible' path.
+    """
+    healths = [HEALTH_UNKNOWN, HEALTH_OLD]
+
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, healths.pop(0) if healths else HEALTH_OLD
+        raise AssertionError("smoke must not run after a wait timeout")
+
+    lines = []
+    kwargs = make_ports(fetch=fetch, out=lines.append)
+    assert run(*build(kwargs)) == 1
+    assert "TIMEOUT" in "\n".join(lines)

--- a/backend/tests/test_promotion_runner.py
+++ b/backend/tests/test_promotion_runner.py
@@ -389,6 +389,34 @@ def test_migration_failure_reports_partial_state_not_a_traceback():
     assert "ahead" in text.lower()  # schema-ahead-of-code warning, same as the decline path
 
 
+def test_migration_failure_before_any_file_lands_does_not_blame_pending_zero():
+    """db.migrate.run() has a prologue (SET maintenance_work_mem,
+    ensure_tracking_table) that runs BEFORE any migration file — a failure
+    there is indistinguishable, from the runner's side, from a failure on
+    the first pending file's own SQL. Zero landed either way, so the runner
+    must not confidently name pending[0] as "the" failed migration, and must
+    not claim the schema is "PARTIALLY migrated" when nothing landed at all.
+    """
+
+    def failing_migrate(conn):
+        raise RuntimeError("connection reset by peer")  # e.g. the SET fails, not any file
+
+    lines = []
+    kwargs = make_ports(migrate=failing_migrate, out=lines.append)
+    # after (re-captured post-failure) matches before exactly: nothing landed.
+    kwargs["snapshots"] = [
+        {"host": "aws-0-us-west-2.pooler.supabase.com", "tables": {"users": 8}, "ledger": ["0001_a.sql"]},
+        {"host": "aws-0-us-west-2.pooler.supabase.com", "tables": {"users": 8}, "ledger": ["0001_a.sql"]},
+    ]
+    assert run(*build(kwargs)) == 1
+    text = "\n".join(lines)
+    assert "0 of 1" in text
+    assert "0002_b.sql" not in text  # never blames the one pending migration by name
+    assert "partially migrated" not in text.lower()  # nothing landed — it did not partially migrate
+    assert "unchanged" in text.lower()  # the honest claim: the schema did not move at all
+    assert "connection reset by peer" in text  # still surfaces the real error
+
+
 def test_target_line_printed_before_migrate_runs():
     """Names the DB project about to receive DDL, before the DDL runs — the
     only way an operator can catch a .env file pointing at the wrong project
@@ -431,18 +459,30 @@ def test_migrations_only_promotion_skips_pr_and_still_smokes():
 
 def test_migrations_only_promotion_fails_if_smoke_fails():
     """The EXIT_FAIL branch of the migrations-only path must be wired to a
-    real smoke result, not a stub that always reports success."""
+    real smoke result, not a stub that always reports success.
+
+    IMPORTANT: this path must NOT hand the operator `_run_smoke`'s default
+    `git revert -m 1 HEAD` recipe. No PR was merged this run, so
+    production's git HEAD is a PREVIOUS promotion's merge commit, unrelated
+    to this run — that instruction would revert an unrelated, previously
+    working deploy. There is no code to revert here in the first place; the
+    thing to inspect is the migration that just landed.
+    """
 
     def fetch(method, url):
         if url.endswith("/api/health"):
             return 200, HEALTH_NEW
         return 500, "boom"
 
-    kwargs = make_ports(fetch=fetch)
+    lines = []
+    kwargs = make_ports(fetch=fetch, out=lines.append)
     kwargs["git"].commits_ahead = 0
     gh = kwargs["gh"]
     assert run(*build(kwargs)) == 1
     assert gh.calls == []
+    text = "\n".join(lines)
+    assert "git revert" not in text
+    assert "No code was merged this run" in text
 
 
 def test_verify_only_skips_promotion_and_just_waits_and_smokes():

--- a/backend/tests/test_promotion_runner.py
+++ b/backend/tests/test_promotion_runner.py
@@ -272,6 +272,42 @@ def test_merge_state_unreadable_does_not_claim_production_unchanged():
     assert "unknown" in text
 
 
+def test_merge_state_stale_confirmation_does_not_claim_production_unchanged():
+    """The all-reads-fail case above is only the narrowest instance. Here the
+    FIRST post-merge read succeeds (genuinely not merged yet), but every read
+    after that fails — so 4 more merge() attempts happen with no way to know
+    whether one of them landed. A flag that only remembers "was any read ever
+    successful" would print the accurate-sounding but false "Production code
+    unchanged" here; only the MOST RECENT read's outcome is trustworthy.
+    """
+
+    class StaleThenUnreadableGh(FakeGh):
+        def __init__(self):
+            super().__init__()
+            self.state_calls = 0
+
+        def state(self, number):
+            self.state_calls += 1
+            # call 1 = the pre-confirm already_merged check; call 2 = the
+            # FIRST retry-loop read. Both succeed and say OPEN. Every read
+            # after that (covering merge attempts 2-5) fails.
+            if self.state_calls <= 2:
+                return "OPEN"
+            raise RuntimeError("gh: pr view failed (rate limited)")
+
+        def merge(self, number):
+            self.calls.append("merge")
+            self.merged = True  # any of attempts 2-5 may have landed...
+
+    lines = []
+    kwargs = make_ports(gh=StaleThenUnreadableGh(), out=lines.append)
+    assert run(*build(kwargs)) == 1
+    text = "\n".join(lines).lower()
+    assert "unchanged" not in text
+    assert "unknown" in text
+    assert "gh pr view" in text
+
+
 def test_nothing_to_promote_exits_clean():
     kwargs = make_ports()
     kwargs["git"].commits_ahead = 0
@@ -293,22 +329,36 @@ def test_verify_only_skips_promotion_and_just_waits_and_smokes():
     commits_ahead == 0 and nothing pending, so preflight reports
     nothing-to-promote and exits clean before ever reaching the wait).
     --verify-only skips preflight/snapshot/migrate/PR/merge entirely, but the
-    wait-then-smoke tail must still genuinely run — a stub that just returns
-    EXIT_OK would satisfy the "nothing mutating happened" assertions alone,
-    so this also has to prove the fetcher was actually driven through both
-    the deploy wait (/api/health) and a smoke-only check.
+    wait-then-smoke tail must still genuinely run.
+
+    /api/health alone does NOT prove the wait loop ran: it is ALSO one of
+    smoke's own CHECKS (smoke.py), hit by run_checks independently of any
+    wait — a run() that short-circuited straight to _run_smoke would still
+    fetch /api/health once and pass a naive "was /api/health fetched?" check.
+    So the health fake here reports a non-matching commit on the first poll
+    and the matching one only on the second, forcing the wait loop to
+    iterate (and therefore sleep) at least once — a signal ONLY the wait
+    loop can produce — and `sleep` is spied on directly.
     """
     connect_calls = []
     migrated = []
     fetch_urls = []
-    kwargs = make_ports()
-    original_fetch = kwargs["fetch"]
+    sleep_calls = []
+    health_sequence = [HEALTH_OLD, HEALTH_NEW, HEALTH_NEW, HEALTH_NEW, HEALTH_NEW]
 
-    def spy_fetch(method, url):
+    def fetch(method, url):
         fetch_urls.append(url)
-        return original_fetch(method, url)
+        if url.endswith("/api/health"):
+            return 200, health_sequence.pop(0) if health_sequence else HEALTH_NEW
+        if url.endswith("/api/auth/test-login"):
+            return 404, ""
+        if "analytics" in url:
+            return 401, ""
+        return 200, "<html>"
 
-    kwargs["fetch"] = spy_fetch
+    kwargs = make_ports()
+    kwargs["fetch"] = fetch
+    kwargs["sleep"] = lambda seconds: sleep_calls.append(seconds)
     kwargs["connect"] = lambda: connect_calls.append(1) or FakeConn()
     kwargs["migrate"] = lambda conn: migrated.append(1) or ["should-not-run"]
     gh = kwargs["gh"]
@@ -316,10 +366,10 @@ def test_verify_only_skips_promotion_and_just_waits_and_smokes():
     assert connect_calls == []  # no preflight/snapshot/migrate — no DB touched
     assert migrated == []
     assert gh.calls == []  # no ensure_pr, no merge
-    assert any(u.endswith("/api/health") for u in fetch_urls)  # the deploy wait ran
+    assert len(sleep_calls) >= 1  # only the wait loop sleeps in --verify-only
     # /api/semesters is only ever requested by smoke.run_checks (CHECKS), never
     # by the wait loop (which only ever calls /api/health) — its presence is
-    # proof smoke genuinely executed, not just that the wait loop did.
+    # proof smoke genuinely executed too, not just the wait.
     assert any(u.endswith("/api/semesters") for u in fetch_urls)
 
 

--- a/backend/tests/test_promotion_smoke.py
+++ b/backend/tests/test_promotion_smoke.py
@@ -1,0 +1,122 @@
+"""Post-deploy smoke checks for the promotion runner (#516).
+
+`run_checks` takes an injected fetcher, so these tests make no network calls.
+"""
+import json
+
+from promotion.smoke import CHECKS, Check, format_results, live_commit, run_checks
+
+API = "https://api.example.test"
+WEB = "https://example.test"
+
+HEALTH_BODY = json.dumps({"status": "ok", "service": "sapling-backend", "commit": "abc1234"})
+
+
+def fetcher(routes):
+    """Build a fetch(method, url) -> (status, body) from a {(method, url): (status, body)} map."""
+
+    def fetch(method, url):
+        return routes.get((method, url), (404, "not found"))
+
+    return fetch
+
+
+def test_check_passes_on_expected_status_and_body():
+    check = Check(name="health", target="api", path="/api/health", expect_status=(200,), expect_body='"status":"ok"')
+    fetch = fetcher({("GET", f"{API}/api/health"): (200, '{"status":"ok"}')})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is True
+    assert result.status == 200
+
+
+def test_check_fails_on_wrong_status():
+    check = Check(name="health", target="api", path="/api/health", expect_status=(200,))
+    fetch = fetcher({("GET", f"{API}/api/health"): (503, "down")})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is False
+    assert "503" in result.detail
+
+
+def test_check_fails_when_body_marker_missing():
+    check = Check(name="health", target="api", path="/api/health", expect_status=(200,), expect_body='"status":"ok"')
+    fetch = fetcher({("GET", f"{API}/api/health"): (200, '{"status":"degraded"}')})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is False
+    assert "missing" in result.detail
+
+
+def test_guarded_route_counts_401_as_mounted():
+    """A 401 proves the router is mounted; the pre-promotion failure mode was 404."""
+    check = Check(name="analytics", target="api", path="/api/admin/analytics/usage/summary", expect_status=(401, 403))
+    fetch = fetcher({("GET", f"{API}/api/admin/analytics/usage/summary"): (401, "")})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is True
+
+
+def test_guarded_route_fails_on_404():
+    check = Check(name="analytics", target="api", path="/api/admin/analytics/usage/summary", expect_status=(401, 403))
+    fetch = fetcher({("GET", f"{API}/api/admin/analytics/usage/summary"): (404, "")})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is False
+
+
+def test_web_target_uses_the_web_base():
+    check = Check(name="web root", target="web", path="/", expect_status=(200,))
+    fetch = fetcher({("GET", f"{WEB}/"): (200, "<html>")})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is True
+
+
+def test_unreachable_host_is_a_failure_not_a_crash():
+    def fetch(method, url):
+        return None, "connection refused"
+
+    [result] = run_checks(fetch, API, WEB, [Check(name="health", target="api", path="/api/health", expect_status=(200,))])
+    assert result.ok is False
+    assert result.status is None
+
+
+def test_default_checks_cover_the_promotion_surface():
+    paths = {c.path for c in CHECKS}
+    assert "/api/health" in paths
+    assert "/api/semesters" in paths
+    assert "/api/admin/analytics/usage/summary" in paths
+    assert "/api/auth/test-login" in paths
+    assert "/" in paths
+
+
+def test_default_checks_have_no_term_specific_assertions():
+    """#515's fall-2026 assertions were promotion-specific and would rot."""
+    for check in CHECKS:
+        assert "fall-2026" not in check.expect_body
+        assert "2026-05-18" not in check.expect_body
+
+
+def test_test_login_check_is_a_post_expecting_404():
+    [check] = [c for c in CHECKS if c.path == "/api/auth/test-login"]
+    assert check.method == "POST"
+    assert check.expect_status == (404,)
+
+
+def test_live_commit_reads_health():
+    fetch = fetcher({("GET", f"{API}/api/health"): (200, HEALTH_BODY)})
+    assert live_commit(fetch, API) == "abc1234"
+
+
+def test_live_commit_empty_when_unreachable():
+    def fetch(method, url):
+        return None, ""
+
+    assert live_commit(fetch, API) == ""
+
+
+def test_live_commit_empty_on_unparseable_body():
+    fetch = fetcher({("GET", f"{API}/api/health"): (200, "<html>502</html>")})
+    assert live_commit(fetch, API) == ""
+
+
+def test_format_results_marks_pass_and_fail():
+    check = Check(name="health", target="api", path="/api/health", expect_status=(200,))
+    fetch = fetcher({("GET", f"{API}/api/health"): (500, "boom")})
+    text = format_results(run_checks(fetch, API, WEB, [check]))
+    assert "FAIL" in text and "health" in text

--- a/backend/tests/test_promotion_snapshot.py
+++ b/backend/tests/test_promotion_snapshot.py
@@ -1,0 +1,106 @@
+"""Snapshot diffing for the promotion runner (#516).
+
+`diff` and `format_diff` are pure, so they need no database. `capture` is a thin
+psycopg shell exercised through a fake connection.
+"""
+from promotion.snapshot import capture, diff, format_diff
+
+
+class FakeCursor:
+    def __init__(self, script):
+        self._script = script
+        self._rows = []
+
+    def execute(self, sql, params=None):
+        for fragment, rows in self._script:
+            if fragment in " ".join(sql.split()):
+                self._rows = rows
+                return
+        raise AssertionError(f"unexpected SQL: {sql}")
+
+    def fetchone(self):
+        return self._rows[0]
+
+    def fetchall(self):
+        return self._rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeConn:
+    def __init__(self, script):
+        self._script = script
+        self.info = type("info", (), {"host": "aws-0-us-west-2.pooler.supabase.com"})()
+
+    def cursor(self):
+        return FakeCursor(self._script)
+
+
+def test_capture_collects_ledger_and_counts():
+    conn = FakeConn(
+        [
+            ("to_regclass", [(True,)]),
+            ("FROM schema_migrations", [("0001_a.sql",), ("0002_b.sql",)]),
+            ("information_schema.tables", [("users",), ("notes",)]),
+            # capture() quotes identifiers, so the fragment must too.
+            ('SELECT count(*) FROM public."users"', [(8,)]),
+            ('SELECT count(*) FROM public."notes"', [(0,)]),
+        ]
+    )
+    snap = capture(conn)
+    assert snap["ledger_exists"] is True
+    assert snap["ledger"] == ["0001_a.sql", "0002_b.sql"]
+    assert snap["tables"] == {"users": 8, "notes": 0}
+    assert snap["host"] == "aws-0-us-west-2.pooler.supabase.com"
+
+
+def test_capture_handles_missing_ledger():
+    conn = FakeConn(
+        [
+            ("to_regclass", [(False,)]),
+            ("information_schema.tables", [("users",)]),
+            ('SELECT count(*) FROM public."users"', [(3,)]),
+        ]
+    )
+    snap = capture(conn)
+    assert snap["ledger_exists"] is False
+    assert snap["ledger"] == []
+
+
+BEFORE = {"tables": {"users": 8, "terms": 4}, "ledger": ["0001_a.sql"]}
+AFTER = {"tables": {"users": 8, "terms": 3, "events": 0}, "ledger": ["0001_a.sql", "0002_b.sql"]}
+
+
+def test_diff_reports_new_tables():
+    assert diff(BEFORE, AFTER)["new_tables"] == ["events"]
+
+
+def test_diff_reports_dropped_tables():
+    assert diff(AFTER, BEFORE)["dropped_tables"] == ["events"]
+
+
+def test_diff_reports_row_count_changes():
+    assert diff(BEFORE, AFTER)["count_changes"] == {"terms": (4, 3)}
+
+
+def test_diff_reports_new_migrations():
+    assert diff(BEFORE, AFTER)["new_migrations"] == ["0002_b.sql"]
+
+
+def test_diff_of_identical_snapshots_is_empty():
+    d = diff(BEFORE, BEFORE)
+    assert d["new_tables"] == [] and d["dropped_tables"] == []
+    assert d["count_changes"] == {} and d["new_migrations"] == []
+
+
+def test_format_diff_mentions_every_change():
+    text = format_diff(diff(BEFORE, AFTER))
+    assert "events" in text and "terms" in text and "0002_b.sql" in text
+
+
+def test_format_diff_says_no_change_when_empty():
+    assert "no schema or row-count changes" in format_diff(diff(BEFORE, BEFORE))

--- a/docs/superpowers/plans/2026-08-02-staging-to-prod-promotion.md
+++ b/docs/superpowers/plans/2026-08-02-staging-to-prod-promotion.md
@@ -647,8 +647,9 @@ def test_capture_collects_ledger_and_counts():
             ("to_regclass", [(True,)]),
             ("FROM schema_migrations", [("0001_a.sql",), ("0002_b.sql",)]),
             ("information_schema.tables", [("users",), ("notes",)]),
-            ("SELECT count(*) FROM public.users", [(8,)]),
-            ("SELECT count(*) FROM public.notes", [(0,)]),
+            # capture() quotes identifiers, so the fragment must too.
+            ('SELECT count(*) FROM public."users"', [(8,)]),
+            ('SELECT count(*) FROM public."notes"', [(0,)]),
         ]
     )
     snap = capture(conn)
@@ -663,7 +664,7 @@ def test_capture_handles_missing_ledger():
         [
             ("to_regclass", [(False,)]),
             ("information_schema.tables", [("users",)]),
-            ("SELECT count(*) FROM public.users", [(3,)]),
+            ('SELECT count(*) FROM public."users"', [(3,)]),
         ]
     )
     snap = capture(conn)

--- a/docs/superpowers/plans/2026-08-02-staging-to-prod-promotion.md
+++ b/docs/superpowers/plans/2026-08-02-staging-to-prod-promotion.md
@@ -1775,9 +1775,11 @@ that shipped #515.
 - Production's `SUPABASE_DB_URL` in `backend/.env.production` must be the
   SESSION-mode pooler URI. Build it:
   `python scripts/pooler_url.py .env.production aws-0-us-west-2 --raw`
-- `STAGING_SUPABASE_DB_URL` should be set (staging is `aws-1-us-west-2`) so the
-  runner can refuse DDL that staging has never executed. Without it that guard
-  is inert.
+- `STAGING_SUPABASE_DB_URL` must be set (staging is on the `aws-1-us-west-2`
+  cluster) so the runner can refuse DDL that staging has never executed. If it
+  is unset and migrations are pending, preflight **blocks** with a
+  `staging-unknown` finding rather than guessing — `--skip-staging-check` is the
+  deliberate override.
 - `gh` must be authenticated.
 
 ## What it does
@@ -1789,10 +1791,15 @@ that shipped #515.
 4. **Snapshot** again and print the diff.
 5. **Pause** — the only prompt, at the only irreversible step.
 6. **Merge** `main` → `production`, retrying through the known `gh` 502.
-7. **Wait** until `/api/health` reports the promoted commit (10 min timeout).
+7. **Wait** until `/api/health` reports the merge commit now on
+   `origin/production` — not main's tip, which is never what gets deployed
+   (10 min timeout).
 8. **Smoke** the live surface.
 
 Exit codes: `0` success or nothing to promote, `1` failure, `2` you declined.
+
+Flags: `--verify-only` (stages 7-8 only), `--allow-destructive`,
+`--skip-staging-check`, `--yes`.
 
 ## The ordering you need to know about
 
@@ -1812,22 +1819,31 @@ prints the revert command; reverting is your call.
 
 ## Re-running
 
-Safe. Preflight finds nothing pending and the PR already `MERGED`, so a second
-run resumes at wait + smoke.
+Safe. Preflight is read-only and `db.migrate` skips what the ledger already
+records, so a re-run after a failure repeats no work.
+
+If the promotion already merged and you only want to re-check the live deploy —
+the deploy was slow, or smoke failed and you have since fixed something — use:
+
+```
+make promote ARGS="--verify-only"
+```
+
+That skips preflight, snapshots, migrate and the merge entirely, and runs only
+the deploy wait against `origin/production`'s tip followed by smoke. A plain
+re-run would instead report `nothing-to-promote` and exit 0 without re-checking
+anything, because by then there is genuinely nothing left to promote.
 ````
 
 - [ ] **Step 4: Document the command in CLAUDE.md**
 
-In `CLAUDE.md`, under the Database section of "Commands", append after the `db.seed_staging` block:
+In `CLAUDE.md`, under the Database section of "Commands", append after the `db.seed_staging` block a short prose line reading `Promotion (repo root; full runbook backend/promotion/README.md):` followed by a fenced block containing exactly these three lines:
 
-```
-Promotion (repo root; full runbook `backend/promotion/README.md`):
+    make promote                          # staging -> prod: preflight, migrate, confirm, merge, verify
+    make promote ARGS="--verify-only"     # re-check the live deploy only (wait + smoke)
+    make promote ARGS="--yes"             # skip the confirmation prompt (CI)
 
-```
-make promote                      # staging -> prod: preflight, migrate, confirm, merge, verify
-make promote ARGS="--yes"         # skip the confirmation prompt (CI)
-```
-```
+(The three command lines are shown indented here only so this brief does not nest code fences — in `CLAUDE.md` they go inside a normal triple-backtick block, matching the style of the surrounding Database and E2E command blocks.)
 
 - [ ] **Step 5: Delete the superseded artifacts**
 

--- a/docs/superpowers/plans/2026-08-02-staging-to-prod-promotion.md
+++ b/docs/superpowers/plans/2026-08-02-staging-to-prod-promotion.md
@@ -1112,8 +1112,13 @@ import pytest
 from promotion.runner import Options, Ports, run
 from promotion.preflight import Finding
 
-HEALTH_OLD = json.dumps({"status": "ok", "commit": "old1111"})
-HEALTH_NEW = json.dumps({"status": "ok", "commit": "new2222"})
+# Compact separators on purpose: FastAPI emits `{"status":"ok",...}` with no
+# spaces, and smoke's `api health` check looks for the literal `"status":"ok"`.
+# json.dumps' default `", "`/`": "` separators would not contain that substring,
+# so a faithful fake has to match the real wire format.
+COMPACT = (",", ":")
+HEALTH_OLD = json.dumps({"status": "ok", "commit": "old1111"}, separators=COMPACT)
+HEALTH_NEW = json.dumps({"status": "ok", "commit": "new2222"}, separators=COMPACT)
 
 
 class FakeGit:
@@ -1248,7 +1253,11 @@ def test_declining_the_prompt_stops_without_merging():
     kwargs = make_ports(confirm=lambda prompt: False)
     gh = kwargs["gh"]
     assert run(*build(kwargs)) == 2
-    assert gh.calls == []
+    # ensure_pr runs BEFORE the prompt on purpose — the prompt names the PR
+    # number, and an already-merged PR is how a re-run resumes. Declining must
+    # leave the PR open and unmerged, not uncreated.
+    assert "merge" not in gh.calls
+    assert gh.merged is False
 
 
 def test_declining_warns_that_migrations_already_applied():
@@ -1351,7 +1360,7 @@ def test_unknown_live_commit_degrades_instead_of_hanging():
     """No Railway env var: don't wait forever, warn and smoke anyway."""
     def fetch(method, url):
         if url.endswith("/api/health"):
-            return 200, json.dumps({"status": "ok", "commit": "unknown"})
+            return 200, json.dumps({"status": "ok", "commit": "unknown"}, separators=COMPACT)
         if url.endswith("/api/auth/test-login"):
             return 404, ""
         if "analytics" in url:
@@ -1495,6 +1504,11 @@ def run(ports: Ports, options: Options) -> int:
 
     # ---- Stage 6: wait for the deploy ---------------------------------
     waited = 0
+    # Advance by at least 1 per iteration. poll_interval is 0 in tests (so they
+    # don't actually sleep), and incrementing by it directly would leave `waited`
+    # pinned at 0 — an infinite loop on the very timeout path the tests exist to
+    # cover.
+    tick = max(options.poll_interval, 1)
     while waited < options.wait_timeout:
         live = smoke.live_commit(ports.fetch, options.api_base)
         if live == head[:7]:
@@ -1508,7 +1522,7 @@ def run(ports: Ports, options: Options) -> int:
             )
             break
         ports.sleep(options.poll_interval)
-        waited += options.poll_interval
+        waited += tick
     else:
         out(
             f"\nTIMEOUT: the deploy never reported {head[:7]} after "

--- a/docs/superpowers/plans/2026-08-02-staging-to-prod-promotion.md
+++ b/docs/superpowers/plans/2026-08-02-staging-to-prod-promotion.md
@@ -1,0 +1,1930 @@
+# Staging → Production Promotion Runner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hand-run staging→prod promotion sequence with `make promote` — a single command that preflights, migrates prod, pauses once for confirmation, merges `main`→`production`, waits for the deploy to actually report the promoted commit, and smokes it.
+
+**Architecture:** A `backend/promotion/` package of four single-responsibility units (`preflight`, `snapshot`, `smoke`, `runner`). Every unit splits pure logic from IO: the pure half takes plain data and is tested hermetically, the IO half is a thin shell. `runner` sequences the stages and owns the one confirmation prompt. A later `workflow_dispatch` wrapper can call `runner.run()` unchanged.
+
+**Tech Stack:** Python 3.12, psycopg 3 (already the migration runner's dependency), httpx 0.28 (already a backend dependency), `gh` CLI for the PR, pytest for tests.
+
+## Global Constraints
+
+- Tracking issue: **#516**. Reference it in commit messages.
+- New code lives under `backend/promotion/`; run everything from `backend/` with `venv/bin/python`.
+- `SUPABASE_DB_URL` for prod must be the **SESSION-mode pooler** URI (port 5432, user `postgres.<ref>`). The direct `db.<ref>.supabase.co` host is IPv6-only. Build it with `scripts/pooler_url.py`; production sits on the **`aws-0-us-west-2`** cluster, staging on **`aws-1-us-west-2`**.
+- **No new dependencies.** psycopg and httpx are already in `requirements.txt`.
+- All new tests must be hermetic — no network, no database, no prod credentials — and must pass in the default `python -m pytest tests/ -q` lane. Achieve this by injecting the IO callable, never by monkeypatching sockets.
+- Never edit an applied migration. This feature adds no migrations.
+- `ruff check .` must stay clean.
+- The runner must **never** auto-revert, auto-rollback, or run down migrations.
+
+---
+
+### Task 1: Surface the build commit on `/api/health`
+
+Without this the runner cannot distinguish "deploy hasn't landed yet" from "deploy landed and is broken".
+
+**Files:**
+- Modify: `backend/config.py` (append a function near the other env readers)
+- Modify: `backend/main.py:233-237` (the `health()` return dict)
+- Test: `backend/tests/test_health_build_commit.py` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `config.build_commit() -> str` — 7-char lowercase SHA, or the literal `"unknown"`. `/api/health` gains a `"commit"` key with that value.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_health_build_commit.py`:
+
+```python
+"""/api/health must report the deployed commit (#516).
+
+The promotion runner polls this to tell "not deployed yet" from "deployed and
+broken". A short SHA is no more sensitive than the model_mode already exposed.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from config import build_commit
+import main
+
+
+@pytest.fixture
+def client():
+    return TestClient(main.app)
+
+
+def test_build_commit_reads_railway_env(monkeypatch):
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "abc1234567890def")
+    assert build_commit() == "abc1234"
+
+
+def test_build_commit_is_unknown_when_unset(monkeypatch):
+    monkeypatch.delenv("RAILWAY_GIT_COMMIT_SHA", raising=False)
+    monkeypatch.delenv("GIT_COMMIT_SHA", raising=False)
+    assert build_commit() == "unknown"
+
+
+def test_build_commit_falls_back_to_generic_env(monkeypatch):
+    monkeypatch.delenv("RAILWAY_GIT_COMMIT_SHA", raising=False)
+    monkeypatch.setenv("GIT_COMMIT_SHA", "0f1e2d3c4b5a")
+    assert build_commit() == "0f1e2d3"
+
+
+def test_build_commit_ignores_blank_value(monkeypatch):
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "   ")
+    monkeypatch.delenv("GIT_COMMIT_SHA", raising=False)
+    assert build_commit() == "unknown"
+
+
+def test_health_reports_commit(client, monkeypatch):
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "deadbeefcafe")
+    body = client.get("/api/health").json()
+    assert body["status"] == "ok"
+    assert body["commit"] == "deadbee"
+
+
+def test_health_keeps_existing_keys(client):
+    body = client.get("/api/health").json()
+    assert body["service"] == "sapling-backend"
+    assert "model_mode" in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && venv/bin/python -m pytest tests/test_health_build_commit.py -v`
+Expected: FAIL with `ImportError: cannot import name 'build_commit' from 'config'`
+
+- [ ] **Step 3: Add `build_commit()` to config.py**
+
+Append to `backend/config.py`:
+
+```python
+def build_commit() -> str:
+    """Short git SHA of the running build, or "unknown".
+
+    The promotion runner (#516) polls /api/health until this matches the commit
+    it just promoted, which is what lets it distinguish "the deploy has not
+    landed yet" from "the deploy landed and the app is broken". Railway injects
+    RAILWAY_GIT_COMMIT_SHA; GIT_COMMIT_SHA is the generic fallback for any other
+    host. Local, Docker and E2E runs set neither and report "unknown", which the
+    runner degrades on rather than hanging.
+
+    Read at call time, not import time, so a test can set the env var.
+    """
+    raw = os.getenv("RAILWAY_GIT_COMMIT_SHA") or os.getenv("GIT_COMMIT_SHA") or ""
+    return raw.strip()[:7].lower() or "unknown"
+```
+
+- [ ] **Step 4: Add the key to the health response**
+
+In `backend/main.py`, change the body of `health()` (currently lines 233-237) to:
+
+```python
+    from agents._providers import _model_mode
+    from config import build_commit
+
+    return {
+        "status": "ok",
+        "service": "sapling-backend",
+        "model_mode": _model_mode(),
+        # The deployed commit, so a promotion can verify the code it merged is
+        # actually the code answering (#516). "unknown" off Railway.
+        "commit": build_commit(),
+    }
+```
+
+- [ ] **Step 5: Run the new tests and the full suite**
+
+Run: `cd backend && venv/bin/python -m pytest tests/test_health_build_commit.py -v && venv/bin/python -m pytest tests/ -q`
+Expected: new file PASSES; the full suite's pass count is unchanged apart from the additions. Read the pass/skip counts, not just the exit code.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/config.py backend/main.py backend/tests/test_health_build_commit.py
+git commit -m "feat(health): report the build commit so promotions can verify the deploy (#516)"
+```
+
+---
+
+### Task 2: `promotion/preflight.py` — the read-only guards
+
+**Files:**
+- Create: `backend/promotion/__init__.py`
+- Create: `backend/promotion/preflight.py`
+- Test: `backend/tests/test_promotion_preflight.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `Finding(kind: str, detail: str)` — frozen dataclass
+  - `project_ref(value: str) -> str`
+  - `ledger_diff(files: list[str], recorded: set[str]) -> tuple[list[str], list[str]]` returning `(pending, orphans)`
+  - `scan_destructive(paths: list[Path]) -> list[Finding]`
+  - `staging_gap(pending: list[str], staging_recorded: set[str]) -> list[str]`
+  - `evaluate(...) -> list[Finding]` — aggregates all guards into blocking findings
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_promotion_preflight.py`:
+
+```python
+"""Preflight guards for the prod promotion runner (#516).
+
+Every function here is pure — it takes plain data, so these tests need no
+database, no network and no credentials.
+"""
+from pathlib import Path
+
+from promotion.preflight import (
+    Finding,
+    evaluate,
+    ledger_diff,
+    project_ref,
+    scan_destructive,
+    staging_gap,
+)
+
+POOLER = "postgresql://postgres.abcdefghijklmnop:pw@aws-0-us-west-2.pooler.supabase.com:5432/postgres"
+DIRECT = "postgresql://postgres:pw@db.abcdefghijklmnop.supabase.co:5432/postgres"
+API = "https://abcdefghijklmnop.supabase.co"
+
+
+def test_project_ref_from_pooler_uri():
+    assert project_ref(POOLER) == "abcdefghijklmnop"
+
+
+def test_project_ref_from_direct_uri():
+    assert project_ref(DIRECT) == "abcdefghijklmnop"
+
+
+def test_project_ref_from_api_url():
+    assert project_ref(API) == "abcdefghijklmnop"
+
+
+def test_project_ref_unknown_shape_is_empty():
+    assert project_ref("postgresql://postgres:pw@127.0.0.1:54322/postgres") == ""
+
+
+def test_ledger_diff_reports_pending_in_file_order():
+    files = ["0001_a.sql", "0002_b.sql", "0003_c.sql"]
+    pending, orphans = ledger_diff(files, {"0001_a.sql"})
+    assert pending == ["0002_b.sql", "0003_c.sql"]
+    assert orphans == []
+
+
+def test_ledger_diff_reports_orphans():
+    pending, orphans = ledger_diff(["0001_a.sql"], {"0001_a.sql", "0099_ghost.sql"})
+    assert pending == []
+    assert orphans == ["0099_ghost.sql"]
+
+
+def test_staging_gap_flags_migrations_staging_never_ran():
+    assert staging_gap(["0002_b.sql", "0003_c.sql"], {"0002_b.sql"}) == ["0003_c.sql"]
+
+
+def test_staging_gap_empty_when_staging_is_ahead():
+    assert staging_gap(["0002_b.sql"], {"0002_b.sql", "0003_c.sql"}) == []
+
+
+def test_scan_destructive_flags_drop_table(tmp_path):
+    f = tmp_path / "0050_x.sql"
+    f.write_text("CREATE TABLE a (id int);\nDROP TABLE legacy_grades;\n")
+    findings = scan_destructive([f])
+    assert [x.kind for x in findings] == ["DROP TABLE"]
+    assert "0050_x.sql:2" in findings[0].detail
+
+
+def test_scan_destructive_flags_drop_column_and_truncate(tmp_path):
+    f = tmp_path / "0051_y.sql"
+    f.write_text("ALTER TABLE t DROP COLUMN old;\nTRUNCATE TABLE cache;\n")
+    assert {x.kind for x in scan_destructive([f])} == {"DROP COLUMN", "TRUNCATE"}
+
+
+def test_scan_destructive_flags_type_change(tmp_path):
+    f = tmp_path / "0052_z.sql"
+    f.write_text("ALTER TABLE t ALTER COLUMN amount TYPE numeric;\n")
+    assert [x.kind for x in scan_destructive([f])] == ["ALTER COLUMN ... TYPE"]
+
+
+def test_scan_destructive_ignores_line_comments(tmp_path):
+    """The repo's migrations explain themselves at length; a mention is not a DROP."""
+    f = tmp_path / "0053_c.sql"
+    f.write_text("-- this replaces the old DROP TABLE approach\nCREATE TABLE ok (id int);\n")
+    assert scan_destructive([f]) == []
+
+
+def test_scan_destructive_ignores_block_comments(tmp_path):
+    f = tmp_path / "0054_c.sql"
+    f.write_text("/*\n  We used to TRUNCATE here.\n*/\nCREATE TABLE ok (id int);\n")
+    assert scan_destructive([f]) == []
+
+
+def test_scan_destructive_clean_migration_passes(tmp_path):
+    f = tmp_path / "0055_ok.sql"
+    f.write_text("CREATE TABLE IF NOT EXISTS t (id int);\nCREATE INDEX ON t (id);\n")
+    assert scan_destructive([f]) == []
+
+
+def _evaluate(**over):
+    kwargs = dict(
+        db_url=POOLER,
+        supabase_url=API,
+        ledger_exists=True,
+        migration_files=["0001_a.sql", "0002_b.sql"],
+        recorded={"0001_a.sql"},
+        staging_recorded={"0001_a.sql", "0002_b.sql"},
+        destructive=[],
+        commits_ahead=3,
+        allow_destructive=False,
+        skip_staging_check=False,
+    )
+    kwargs.update(over)
+    return evaluate(**kwargs)
+
+
+def test_evaluate_clean_case_has_no_findings():
+    assert _evaluate() == []
+
+
+def test_evaluate_blocks_on_project_ref_mismatch():
+    findings = _evaluate(supabase_url="https://zzzzzzzzzzzzzzzz.supabase.co")
+    assert [f.kind for f in findings] == ["target-mismatch"]
+
+
+def test_evaluate_blocks_when_ledger_missing():
+    assert "no-ledger" in [f.kind for f in _evaluate(ledger_exists=False)]
+
+
+def test_evaluate_blocks_on_orphans():
+    findings = _evaluate(recorded={"0001_a.sql", "0099_ghost.sql"})
+    assert "orphan" in [f.kind for f in findings]
+
+
+def test_evaluate_blocks_when_staging_has_not_run_it():
+    findings = _evaluate(staging_recorded={"0001_a.sql"})
+    assert "staging-gap" in [f.kind for f in findings]
+
+
+def test_evaluate_staging_check_can_be_skipped():
+    findings = _evaluate(staging_recorded={"0001_a.sql"}, skip_staging_check=True)
+    assert "staging-gap" not in [f.kind for f in findings]
+
+
+def test_evaluate_blocks_on_destructive_ddl():
+    findings = _evaluate(destructive=[Finding("DROP TABLE", "0002_b.sql:4: DROP TABLE x;")])
+    assert "destructive" in [f.kind for f in findings]
+
+
+def test_evaluate_destructive_can_be_allowed():
+    findings = _evaluate(
+        destructive=[Finding("DROP TABLE", "0002_b.sql:4: DROP TABLE x;")],
+        allow_destructive=True,
+    )
+    assert "destructive" not in [f.kind for f in findings]
+
+
+def test_evaluate_reports_nothing_to_promote():
+    findings = _evaluate(commits_ahead=0)
+    assert [f.kind for f in findings] == ["nothing-to-promote"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && venv/bin/python -m pytest tests/test_promotion_preflight.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'promotion'`
+
+- [ ] **Step 3: Create the package marker**
+
+Create `backend/promotion/__init__.py`:
+
+```python
+"""Staging → production promotion runner (#516).
+
+Sequences the promotion that used to be a hand-run list of commands: preflight,
+snapshot, migrate, confirm, merge, wait for the deploy, smoke.
+
+Each module splits pure logic from IO so the logic is testable without a
+database or a network: `preflight` and `snapshot.diff` take plain data,
+`smoke.run_checks` takes an injected fetcher, and `runner` takes injected
+confirm/output callables.
+"""
+```
+
+- [ ] **Step 4: Implement preflight.py**
+
+Create `backend/promotion/preflight.py`:
+
+```python
+"""Read-only guards that must pass before production is touched (#516).
+
+Every check here runs BEFORE any mutation. The functions are pure: callers hand
+them already-fetched data (ledger rows, file lists, commit counts), which is
+what keeps them testable offline and keeps the IO in one place — the runner.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+# Line-oriented, deliberately. A migration that is destructive on one line and
+# harmless on the next should name the line, and the runner prints it verbatim
+# so the operator judges the actual statement rather than a filename.
+DESTRUCTIVE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("DROP TABLE", re.compile(r"\bDROP\s+TABLE\b", re.I)),
+    ("DROP COLUMN", re.compile(r"\bDROP\s+COLUMN\b", re.I)),
+    ("TRUNCATE", re.compile(r"\bTRUNCATE\b", re.I)),
+    ("ALTER COLUMN ... TYPE", re.compile(r"\bALTER\s+COLUMN\b.*\bTYPE\b", re.I)),
+]
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One blocking reason. `kind` is machine-readable, `detail` is for humans."""
+
+    kind: str
+    detail: str
+
+
+def project_ref(value: str) -> str:
+    """Supabase project ref from a DB URI or an API URL; "" if unrecognised.
+
+    Three shapes are in play. The session-mode pooler carries the ref in the
+    USERNAME (`postgres.<ref>@aws-0-...`) because the host is shared across
+    projects; the direct endpoint carries it in the host (`db.<ref>.supabase.co`);
+    the REST URL carries it as the leftmost label (`<ref>.supabase.co`).
+    """
+    parsed = urlparse(value)
+    user = parsed.username or ""
+    if user.startswith("postgres."):
+        return user.split(".", 1)[1]
+    host = parsed.hostname or ""
+    if host.startswith("db.") and host.endswith(".supabase.co"):
+        return host.split(".")[1]
+    if host.endswith(".supabase.co"):
+        return host.split(".")[0]
+    return ""
+
+
+def ledger_diff(files: list[str], recorded: set[str]) -> tuple[list[str], list[str]]:
+    """(pending, orphans) — pending keeps `files` order, orphans are sorted.
+
+    An orphan is a filename the ledger records that the repo does not have: that
+    environment ran SQL this repo has never seen. Applying more on top compounds
+    it, which is why the runner treats it as blocking.
+    """
+    pending = [f for f in files if f not in recorded]
+    orphans = sorted(recorded - set(files))
+    return pending, orphans
+
+
+def staging_gap(pending: list[str], staging_recorded: set[str]) -> list[str]:
+    """Pending-on-prod migrations staging has never executed.
+
+    Production must never be the first environment to run a piece of DDL.
+    """
+    return [f for f in pending if f not in staging_recorded]
+
+
+def _strip_comments(sql: str) -> str:
+    """Blank out `--` line comments and `/* */` blocks, preserving line numbers.
+
+    The migrations in this repo carry long explanatory headers that frequently
+    NAME destructive statements while doing nothing of the kind. Scanning raw
+    text would flag most of them.
+    """
+    without_blocks = re.sub(
+        r"/\*.*?\*/",
+        lambda m: re.sub(r"[^\n]", " ", m.group(0)),
+        sql,
+        flags=re.S,
+    )
+    return "\n".join(line.split("--", 1)[0] for line in without_blocks.splitlines())
+
+
+def scan_destructive(paths: list[Path]) -> list[Finding]:
+    """Destructive DDL in the given migration files.
+
+    This matters because the runner applies migrations BEFORE the code merges,
+    so between those stages the OLD production code runs against the NEW schema.
+    Additive DDL is harmless in that window; destructive DDL is not.
+    """
+    findings: list[Finding] = []
+    for path in paths:
+        raw_lines = path.read_text().splitlines()
+        scan_lines = _strip_comments("\n".join(raw_lines)).splitlines()
+        for lineno, line in enumerate(scan_lines, 1):
+            for label, pattern in DESTRUCTIVE_PATTERNS:
+                if pattern.search(line):
+                    original = raw_lines[lineno - 1].strip()
+                    findings.append(Finding(label, f"{path.name}:{lineno}: {original}"))
+    return findings
+
+
+def evaluate(
+    *,
+    db_url: str,
+    supabase_url: str,
+    ledger_exists: bool,
+    migration_files: list[str],
+    recorded: set[str],
+    staging_recorded: set[str],
+    destructive: list[Finding],
+    commits_ahead: int,
+    allow_destructive: bool,
+    skip_staging_check: bool,
+) -> list[Finding]:
+    """All blocking findings, in the order the operator should read them.
+
+    An empty list means preflight passed and the runner may proceed.
+    """
+    findings: list[Finding] = []
+
+    db_ref, api_ref = project_ref(db_url), project_ref(supabase_url)
+    if db_ref and api_ref and db_ref != api_ref:
+        findings.append(
+            Finding(
+                "target-mismatch",
+                f"SUPABASE_DB_URL points at project {db_ref} but SUPABASE_URL "
+                f"points at {api_ref}. The env file is mixed up — refusing to migrate.",
+            )
+        )
+
+    if not ledger_exists:
+        findings.append(
+            Finding(
+                "no-ledger",
+                "schema_migrations does not exist on this database. Applying now "
+                "would treat every migration as pending and fail recreating "
+                "existing objects. Reconcile with `python -m db.migrate --baseline` "
+                "against a verified-current schema first.",
+            )
+        )
+        # Everything downstream reads the ledger, so stop describing it.
+        return findings
+
+    pending, orphans = ledger_diff(migration_files, recorded)
+    for orphan in orphans:
+        findings.append(
+            Finding("orphan", f"recorded in the ledger but absent from the repo: {orphan}")
+        )
+
+    if not skip_staging_check:
+        for name in staging_gap(pending, staging_recorded):
+            findings.append(
+                Finding(
+                    "staging-gap",
+                    f"{name} is pending on production but staging has never run it. "
+                    "Production must not be the first environment to execute DDL. "
+                    "Let migrate-staging.yml apply it first, or pass --skip-staging-check.",
+                )
+            )
+
+    if destructive and not allow_destructive:
+        for finding in destructive:
+            findings.append(
+                Finding(
+                    "destructive",
+                    f"{finding.kind} in a pending migration — {finding.detail}. "
+                    "Migrations apply before the code merges, so the old production "
+                    "code would run against this schema. Pass --allow-destructive "
+                    "if that is genuinely safe here.",
+                )
+            )
+
+    if commits_ahead == 0 and not pending:
+        findings.append(
+            Finding("nothing-to-promote", "origin/main and origin/production are identical.")
+        )
+
+    return findings
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cd backend && venv/bin/python -m pytest tests/test_promotion_preflight.py -v`
+Expected: all PASS.
+
+- [ ] **Step 6: Sanity-check the scanner against real migrations**
+
+The scan must flag the known-destructive files and stay quiet on the additive ones. Run:
+
+```bash
+cd backend && venv/bin/python -c "
+from pathlib import Path
+from promotion.preflight import scan_destructive
+d = Path('db/migrations')
+for name in ['0013_drop_legacy_grade_tables.sql', '0021_gradebook.sql', '0030_documents_extracted_text.sql']:
+    print(name, '->', [f.kind for f in scan_destructive([d / name])])
+"
+```
+
+Expected: `0013_` and `0021_` report at least one kind; `0030_documents_extracted_text.sql` reports `[]`. If `0030_` reports a finding, the comment-stripping is wrong — fix it before moving on.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/promotion/__init__.py backend/promotion/preflight.py backend/tests/test_promotion_preflight.py
+git commit -m "feat(promotion): read-only preflight guards for prod promotion (#516)"
+```
+
+---
+
+### Task 3: `promotion/snapshot.py` — before/after evidence
+
+**Files:**
+- Create: `backend/promotion/snapshot.py`
+- Test: `backend/tests/test_promotion_snapshot.py`
+
+**Interfaces:**
+- Consumes: `promotion` package from Task 2.
+- Produces:
+  - `capture(conn) -> dict` with keys `host`, `ledger_exists`, `ledger` (`list[str]`), `tables` (`dict[str, int]`)
+  - `diff(before: dict, after: dict) -> dict` with keys `new_tables`, `dropped_tables`, `count_changes`, `new_migrations`
+  - `format_diff(d: dict) -> str`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_promotion_snapshot.py`:
+
+```python
+"""Snapshot diffing for the promotion runner (#516).
+
+`diff` and `format_diff` are pure, so they need no database. `capture` is a thin
+psycopg shell exercised through a fake connection.
+"""
+from promotion.snapshot import capture, diff, format_diff
+
+
+class FakeCursor:
+    def __init__(self, script):
+        self._script = script
+        self._rows = []
+
+    def execute(self, sql, params=None):
+        for fragment, rows in self._script:
+            if fragment in " ".join(sql.split()):
+                self._rows = rows
+                return
+        raise AssertionError(f"unexpected SQL: {sql}")
+
+    def fetchone(self):
+        return self._rows[0]
+
+    def fetchall(self):
+        return self._rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeConn:
+    def __init__(self, script):
+        self._script = script
+        self.info = type("info", (), {"host": "aws-0-us-west-2.pooler.supabase.com"})()
+
+    def cursor(self):
+        return FakeCursor(self._script)
+
+
+def test_capture_collects_ledger_and_counts():
+    conn = FakeConn(
+        [
+            ("to_regclass", [(True,)]),
+            ("FROM schema_migrations", [("0001_a.sql",), ("0002_b.sql",)]),
+            ("information_schema.tables", [("users",), ("notes",)]),
+            ("SELECT count(*) FROM public.users", [(8,)]),
+            ("SELECT count(*) FROM public.notes", [(0,)]),
+        ]
+    )
+    snap = capture(conn)
+    assert snap["ledger_exists"] is True
+    assert snap["ledger"] == ["0001_a.sql", "0002_b.sql"]
+    assert snap["tables"] == {"users": 8, "notes": 0}
+    assert snap["host"] == "aws-0-us-west-2.pooler.supabase.com"
+
+
+def test_capture_handles_missing_ledger():
+    conn = FakeConn(
+        [
+            ("to_regclass", [(False,)]),
+            ("information_schema.tables", [("users",)]),
+            ("SELECT count(*) FROM public.users", [(3,)]),
+        ]
+    )
+    snap = capture(conn)
+    assert snap["ledger_exists"] is False
+    assert snap["ledger"] == []
+
+
+BEFORE = {"tables": {"users": 8, "terms": 4}, "ledger": ["0001_a.sql"]}
+AFTER = {"tables": {"users": 8, "terms": 3, "events": 0}, "ledger": ["0001_a.sql", "0002_b.sql"]}
+
+
+def test_diff_reports_new_tables():
+    assert diff(BEFORE, AFTER)["new_tables"] == ["events"]
+
+
+def test_diff_reports_dropped_tables():
+    assert diff(AFTER, BEFORE)["dropped_tables"] == ["events"]
+
+
+def test_diff_reports_row_count_changes():
+    assert diff(BEFORE, AFTER)["count_changes"] == {"terms": (4, 3)}
+
+
+def test_diff_reports_new_migrations():
+    assert diff(BEFORE, AFTER)["new_migrations"] == ["0002_b.sql"]
+
+
+def test_diff_of_identical_snapshots_is_empty():
+    d = diff(BEFORE, BEFORE)
+    assert d["new_tables"] == [] and d["dropped_tables"] == []
+    assert d["count_changes"] == {} and d["new_migrations"] == []
+
+
+def test_format_diff_mentions_every_change():
+    text = format_diff(diff(BEFORE, AFTER))
+    assert "events" in text and "terms" in text and "0002_b.sql" in text
+
+
+def test_format_diff_says_no_change_when_empty():
+    assert "no schema or row-count changes" in format_diff(diff(BEFORE, BEFORE))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && venv/bin/python -m pytest tests/test_promotion_snapshot.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'promotion.snapshot'`
+
+- [ ] **Step 3: Implement snapshot.py**
+
+Create `backend/promotion/snapshot.py`:
+
+```python
+"""Before/after snapshots of the production database (#516).
+
+The point is evidence, not monitoring: capture once before migrating and once
+after, then diff, so the operator confirming the merge sees exactly what the
+migration did — and so a failed promotion has an artifact to reason about
+instead of terminal scrollback.
+
+SELECTs only. Nothing here writes.
+"""
+from __future__ import annotations
+
+LEDGER_EXISTS_SQL = "SELECT to_regclass('public.schema_migrations') IS NOT NULL"
+LEDGER_SQL = "SELECT filename FROM schema_migrations ORDER BY filename"
+TABLES_SQL = """
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+    ORDER BY table_name
+"""
+
+
+def capture(conn) -> dict:
+    """Ledger contents and per-table row counts for the connected database."""
+    snapshot: dict = {"host": getattr(conn.info, "host", "unknown")}
+
+    with conn.cursor() as cur:
+        cur.execute(LEDGER_EXISTS_SQL)
+        exists = bool(cur.fetchone()[0])
+        snapshot["ledger_exists"] = exists
+
+        ledger: list[str] = []
+        if exists:
+            cur.execute(LEDGER_SQL)
+            ledger = [row[0] for row in cur.fetchall()]
+        snapshot["ledger"] = ledger
+
+        cur.execute(TABLES_SQL)
+        names = [row[0] for row in cur.fetchall()]
+
+        counts: dict[str, int] = {}
+        for name in names:
+            # Identifier comes from information_schema, never from user input,
+            # and count(*) takes no bindable parameter for a table name.
+            cur.execute(f'SELECT count(*) FROM public."{name}"')
+            counts[name] = cur.fetchone()[0]
+        snapshot["tables"] = counts
+
+    return snapshot
+
+
+def diff(before: dict, after: dict) -> dict:
+    """What changed between two snapshots."""
+    b, a = before.get("tables", {}), after.get("tables", {})
+    return {
+        "new_tables": sorted(set(a) - set(b)),
+        "dropped_tables": sorted(set(b) - set(a)),
+        "count_changes": {k: (b[k], a[k]) for k in sorted(set(b) & set(a)) if b[k] != a[k]},
+        "new_migrations": [m for m in after.get("ledger", []) if m not in set(before.get("ledger", []))],
+    }
+
+
+def format_diff(d: dict) -> str:
+    """Human-readable diff for the confirmation prompt and the final report."""
+    lines: list[str] = []
+    if d["new_migrations"]:
+        lines.append(f"  migrations applied ({len(d['new_migrations'])}):")
+        lines += [f"    + {m}" for m in d["new_migrations"]]
+    if d["new_tables"]:
+        lines.append(f"  new tables: {', '.join(d['new_tables'])}")
+    if d["dropped_tables"]:
+        lines.append(f"  DROPPED tables: {', '.join(d['dropped_tables'])}")
+    if d["count_changes"]:
+        lines.append("  row-count changes:")
+        lines += [f"    {t}: {old} -> {new}" for t, (old, new) in d["count_changes"].items()]
+    return "\n".join(lines) if lines else "  no schema or row-count changes"
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd backend && venv/bin/python -m pytest tests/test_promotion_snapshot.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/promotion/snapshot.py backend/tests/test_promotion_snapshot.py
+git commit -m "feat(promotion): prod snapshot capture and diff (#516)"
+```
+
+---
+
+### Task 4: `promotion/smoke.py` — the durable post-deploy checks
+
+**Files:**
+- Create: `backend/promotion/smoke.py`
+- Test: `backend/tests/test_promotion_smoke.py`
+
+**Interfaces:**
+- Consumes: `promotion` package.
+- Produces:
+  - `Check(name, target, path, expect_status: tuple[int, ...], expect_body: str = "", method: str = "GET")` — frozen dataclass
+  - `CHECKS: list[Check]`
+  - `Result(check, ok: bool, status: int | None, detail: str)`
+  - `run_checks(fetch, api_base, web_base, checks=CHECKS) -> list[Result]` where `fetch(method, url) -> tuple[int | None, str]`
+  - `httpx_fetch(method, url) -> tuple[int | None, str]` — the real IO
+  - `format_results(results) -> str`
+  - `live_commit(fetch, api_base) -> str` — the deployed SHA from `/api/health`, `""` if unreachable
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_promotion_smoke.py`:
+
+```python
+"""Post-deploy smoke checks for the promotion runner (#516).
+
+`run_checks` takes an injected fetcher, so these tests make no network calls.
+"""
+import json
+
+from promotion.smoke import CHECKS, Check, format_results, live_commit, run_checks
+
+API = "https://api.example.test"
+WEB = "https://example.test"
+
+HEALTH_BODY = json.dumps({"status": "ok", "service": "sapling-backend", "commit": "abc1234"})
+
+
+def fetcher(routes):
+    """Build a fetch(method, url) -> (status, body) from a {(method, url): (status, body)} map."""
+
+    def fetch(method, url):
+        return routes.get((method, url), (404, "not found"))
+
+    return fetch
+
+
+def test_check_passes_on_expected_status_and_body():
+    check = Check(name="health", target="api", path="/api/health", expect_status=(200,), expect_body='"status":"ok"')
+    fetch = fetcher({("GET", f"{API}/api/health"): (200, '{"status":"ok"}')})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is True
+    assert result.status == 200
+
+
+def test_check_fails_on_wrong_status():
+    check = Check(name="health", target="api", path="/api/health", expect_status=(200,))
+    fetch = fetcher({("GET", f"{API}/api/health"): (503, "down")})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is False
+    assert "503" in result.detail
+
+
+def test_check_fails_when_body_marker_missing():
+    check = Check(name="health", target="api", path="/api/health", expect_status=(200,), expect_body='"status":"ok"')
+    fetch = fetcher({("GET", f"{API}/api/health"): (200, '{"status":"degraded"}')})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is False
+    assert "missing" in result.detail
+
+
+def test_guarded_route_counts_401_as_mounted():
+    """A 401 proves the router is mounted; the pre-promotion failure mode was 404."""
+    check = Check(name="analytics", target="api", path="/api/admin/analytics/usage/summary", expect_status=(401, 403))
+    fetch = fetcher({("GET", f"{API}/api/admin/analytics/usage/summary"): (401, "")})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is True
+
+
+def test_guarded_route_fails_on_404():
+    check = Check(name="analytics", target="api", path="/api/admin/analytics/usage/summary", expect_status=(401, 403))
+    fetch = fetcher({("GET", f"{API}/api/admin/analytics/usage/summary"): (404, "")})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is False
+
+
+def test_web_target_uses_the_web_base():
+    check = Check(name="web root", target="web", path="/", expect_status=(200,))
+    fetch = fetcher({("GET", f"{WEB}/"): (200, "<html>")})
+    [result] = run_checks(fetch, API, WEB, [check])
+    assert result.ok is True
+
+
+def test_unreachable_host_is_a_failure_not_a_crash():
+    def fetch(method, url):
+        return None, "connection refused"
+
+    [result] = run_checks(fetch, API, WEB, [Check(name="health", target="api", path="/api/health", expect_status=(200,))])
+    assert result.ok is False
+    assert result.status is None
+
+
+def test_default_checks_cover_the_promotion_surface():
+    paths = {c.path for c in CHECKS}
+    assert "/api/health" in paths
+    assert "/api/semesters" in paths
+    assert "/api/admin/analytics/usage/summary" in paths
+    assert "/api/auth/test-login" in paths
+    assert "/" in paths
+
+
+def test_default_checks_have_no_term_specific_assertions():
+    """#515's fall-2026 assertions were promotion-specific and would rot."""
+    for check in CHECKS:
+        assert "fall-2026" not in check.expect_body
+        assert "2026-05-18" not in check.expect_body
+
+
+def test_test_login_check_is_a_post_expecting_404():
+    [check] = [c for c in CHECKS if c.path == "/api/auth/test-login"]
+    assert check.method == "POST"
+    assert check.expect_status == (404,)
+
+
+def test_live_commit_reads_health():
+    fetch = fetcher({("GET", f"{API}/api/health"): (200, HEALTH_BODY)})
+    assert live_commit(fetch, API) == "abc1234"
+
+
+def test_live_commit_empty_when_unreachable():
+    def fetch(method, url):
+        return None, ""
+
+    assert live_commit(fetch, API) == ""
+
+
+def test_live_commit_empty_on_unparseable_body():
+    fetch = fetcher({("GET", f"{API}/api/health"): (200, "<html>502</html>")})
+    assert live_commit(fetch, API) == ""
+
+
+def test_format_results_marks_pass_and_fail():
+    check = Check(name="health", target="api", path="/api/health", expect_status=(200,))
+    fetch = fetcher({("GET", f"{API}/api/health"): (500, "boom")})
+    text = format_results(run_checks(fetch, API, WEB, [check]))
+    assert "FAIL" in text and "health" in text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && venv/bin/python -m pytest tests/test_promotion_smoke.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'promotion.smoke'`
+
+- [ ] **Step 3: Implement smoke.py**
+
+Create `backend/promotion/smoke.py`:
+
+```python
+"""Post-deploy smoke checks against the live production surface (#516).
+
+Unauthenticated surface only. A 401/403 on a guarded route is a PASS: it proves
+the router is MOUNTED, and the failure mode this catches is a 404 from code that
+never shipped.
+
+Checks are DATA, and the fetcher is injected, so the suite is testable without a
+network. Deliberately excluded: assertions about specific term data (#515 asserted
+`fall-2026` and a start date), which pass today and rot next term.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+DEFAULT_API = "https://api.saplinglearn.com"
+DEFAULT_WEB = "https://saplinglearn.com"
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    target: str  # "api" | "web"
+    path: str
+    expect_status: tuple[int, ...]
+    expect_body: str = ""
+    method: str = "GET"
+
+
+@dataclass
+class Result:
+    check: Check
+    ok: bool
+    status: int | None
+    detail: str
+
+
+CHECKS: list[Check] = [
+    Check("api health", "api", "/api/health", (200,), '"status":"ok"'),
+    # Mounted-not-404. These routers only exist in promoted code.
+    Check("academics mounted", "api", "/api/semesters", (200,)),
+    Check("notes mounted", "api", "/api/notes", (200, 401, 403, 405)),
+    Check("admin analytics mounted", "api", "/api/admin/analytics/usage/summary", (401, 403)),
+    Check("auth entrypoint", "api", "/api/auth/google", (200, 302, 307, 400, 401)),
+    # The local/test session minter must be OFF in production. POST specifically:
+    # a GET returns 405, which would mask a live endpoint.
+    Check("test-login disabled", "api", "/api/auth/test-login", (404,), method="POST"),
+    Check("web root", "web", "/", (200,), "<"),
+    # Proves the frontend worker's build-time BACKEND_URL is right; a wrong one 500s.
+    Check("web -> api proxy", "web", "/api/health", (200,), '"status":"ok"'),
+]
+
+
+def run_checks(fetch, api_base: str, web_base: str, checks: list[Check] | None = None) -> list[Result]:
+    """Run each check through `fetch(method, url) -> (status | None, body)`."""
+    results: list[Result] = []
+    for check in checks if checks is not None else CHECKS:
+        base = api_base if check.target == "api" else web_base
+        url = f"{base.rstrip('/')}{check.path}"
+        status, body = fetch(check.method, url)
+
+        if status is None:
+            results.append(Result(check, False, None, f"no response from {url}: {body[:120]}"))
+            continue
+        if status not in check.expect_status:
+            expected = "/".join(str(s) for s in check.expect_status)
+            results.append(Result(check, False, status, f"{url} -> {status}, expected {expected}"))
+            continue
+        if check.expect_body and check.expect_body not in body:
+            results.append(Result(check, False, status, f"{url} -> {status} but missing {check.expect_body!r}"))
+            continue
+        results.append(Result(check, True, status, f"{url} -> {status}"))
+    return results
+
+
+def live_commit(fetch, api_base: str) -> str:
+    """Deployed short SHA from /api/health, or "" if unreachable/unparseable."""
+    status, body = fetch("GET", f"{api_base.rstrip('/')}/api/health")
+    if status != 200:
+        return ""
+    try:
+        return str(json.loads(body).get("commit", ""))
+    except (ValueError, AttributeError):
+        return ""
+
+
+def format_results(results: list[Result]) -> str:
+    return "\n".join(
+        f"  {'PASS' if r.ok else 'FAIL'}  {r.check.name}  ({r.detail})" for r in results
+    )
+
+
+def httpx_fetch(method: str, url: str) -> tuple[int | None, str]:
+    """Real IO. Imported lazily so importing this module costs nothing."""
+    import httpx
+
+    try:
+        response = httpx.request(method, url, timeout=25.0, follow_redirects=False)
+        return response.status_code, response.text
+    except httpx.HTTPError as exc:  # DNS, TLS, timeout, refused
+        return None, str(exc)
+```
+
+- [ ] **Step 4: Run the tests and lint**
+
+Run: `cd backend && venv/bin/python -m pytest tests/test_promotion_smoke.py -v && venv/bin/ruff check promotion/`
+Expected: tests PASS, ruff clean. If ruff flags the unused `field` import, remove it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/promotion/smoke.py backend/tests/test_promotion_smoke.py
+git commit -m "feat(promotion): durable post-deploy smoke checks (#516)"
+```
+
+---
+
+### Task 5: `promotion/runner.py` — sequencing, the one prompt, the report
+
+**Files:**
+- Create: `backend/promotion/runner.py`
+- Create: `backend/promotion/__main__.py`
+- Test: `backend/tests/test_promotion_runner.py`
+
+**Interfaces:**
+- Consumes: `preflight.evaluate`, `snapshot.capture/diff/format_diff`, `smoke.run_checks/live_commit/format_results`, `db.migrate.run`.
+- Produces:
+  - `Ports` dataclass bundling every injected callable: `connect`, `git`, `gh`, `fetch`, `confirm`, `out`, `sleep`
+  - `Options` dataclass: `allow_destructive`, `skip_staging_check`, `api_base`, `web_base`, `wait_timeout`, `poll_interval`
+  - `run(ports: Ports, options: Options) -> int` — process exit code (0 success, 1 failure, 2 aborted by operator)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_promotion_runner.py`:
+
+```python
+"""Stage sequencing for the promotion runner (#516).
+
+Every port is injected, so the whole flow runs in-process with no database,
+no network, no git and no gh.
+"""
+import json
+
+import pytest
+
+from promotion.runner import Options, Ports, run
+from promotion.preflight import Finding
+
+HEALTH_OLD = json.dumps({"status": "ok", "commit": "old1111"})
+HEALTH_NEW = json.dumps({"status": "ok", "commit": "new2222"})
+
+
+class FakeGit:
+    def __init__(self, head="new2222", commits_ahead=3):
+        self.head = head
+        self.commits_ahead = commits_ahead
+        self.calls = []
+
+    def fetch(self):
+        self.calls.append("fetch")
+
+    def head_sha(self, ref):
+        self.calls.append(f"head:{ref}")
+        return self.head
+
+    def commits_ahead_of(self, base, head):
+        return self.commits_ahead
+
+
+class FakeGh:
+    def __init__(self):
+        self.merged = False
+        self.calls = []
+
+    def ensure_pr(self, base, head, title):
+        self.calls.append("ensure_pr")
+        return 999
+
+    def state(self, number):
+        return "MERGED" if self.merged else "OPEN"
+
+    def merge(self, number):
+        self.calls.append("merge")
+        self.merged = True
+
+
+def make_ports(**over):
+    """Happy path by default; override one port per test."""
+    fake_git, fake_gh = FakeGit(), FakeGh()
+    healths = [HEALTH_OLD, HEALTH_NEW, HEALTH_NEW, HEALTH_NEW, HEALTH_NEW]
+
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, healths.pop(0) if healths else HEALTH_NEW
+        if url.endswith("/api/auth/test-login"):
+            return 404, ""
+        if "analytics" in url:
+            return 401, ""
+        return 200, "<html>"
+
+    ports = dict(
+        connect=lambda: FakeConn(),
+        migrate=lambda conn: ["0002_b.sql"],
+        preflight_data=lambda conn: dict(
+            ledger_exists=True,
+            migration_files=["0001_a.sql", "0002_b.sql"],
+            recorded={"0001_a.sql"},
+            staging_recorded={"0001_a.sql", "0002_b.sql"},
+            destructive=[],
+            db_url="postgresql://postgres.ref1:p@aws-0-us-west-2.pooler.supabase.com:5432/postgres",
+            supabase_url="https://ref1.supabase.co",
+        ),
+        snapshots=[
+            {"tables": {"users": 8}, "ledger": ["0001_a.sql"]},
+            {"tables": {"users": 8, "events": 0}, "ledger": ["0001_a.sql", "0002_b.sql"]},
+        ],
+        git=fake_git,
+        gh=fake_gh,
+        fetch=fetch,
+        confirm=lambda prompt: True,
+        out=lambda line: None,
+        sleep=lambda seconds: None,
+    )
+    ports.update(over)
+    return ports
+
+
+class FakeConn:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def build(ports_kwargs, **option_over):
+    """Assemble Ports/Options from the dict make_ports returns."""
+    snapshots = list(ports_kwargs.pop("snapshots"))
+    preflight_data = ports_kwargs.pop("preflight_data")
+    migrate = ports_kwargs.pop("migrate")
+    ports = Ports(
+        connect=ports_kwargs["connect"],
+        preflight_data=preflight_data,
+        capture=lambda conn: snapshots.pop(0),
+        migrate=migrate,
+        git=ports_kwargs["git"],
+        gh=ports_kwargs["gh"],
+        fetch=ports_kwargs["fetch"],
+        confirm=ports_kwargs["confirm"],
+        out=ports_kwargs["out"],
+        sleep=ports_kwargs["sleep"],
+    )
+    options = Options(**{"wait_timeout": 5, "poll_interval": 0, **option_over})
+    return ports, options
+
+
+def test_happy_path_returns_zero_and_merges():
+    kwargs = make_ports()
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 0
+    assert "merge" in gh.calls
+
+
+def test_preflight_failure_aborts_before_migrating():
+    migrated = []
+    kwargs = make_ports(migrate=lambda conn: migrated.append(1) or [])
+    kwargs["preflight_data"] = lambda conn: dict(
+        ledger_exists=True,
+        migration_files=["0001_a.sql"],
+        recorded={"0001_a.sql", "0099_ghost.sql"},  # orphan
+        staging_recorded={"0001_a.sql"},
+        destructive=[],
+        db_url="postgresql://postgres.ref1:p@aws-0-us-west-2.pooler.supabase.com:5432/postgres",
+        supabase_url="https://ref1.supabase.co",
+    )
+    assert run(*build(kwargs)) == 1
+    assert migrated == []
+    assert kwargs["gh"].calls == []
+
+
+def test_declining_the_prompt_stops_without_merging():
+    kwargs = make_ports(confirm=lambda prompt: False)
+    gh = kwargs["gh"]
+    assert run(*build(kwargs)) == 2
+    assert gh.calls == []
+
+
+def test_declining_warns_that_migrations_already_applied():
+    lines = []
+    kwargs = make_ports(confirm=lambda prompt: False, out=lines.append)
+    run(*build(kwargs))
+    text = "\n".join(lines).lower()
+    assert "schema" in text and "ahead" in text
+
+
+def test_wait_timeout_does_not_run_smoke():
+    """A deploy that never lands must not be reported as a smoke failure."""
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, HEALTH_OLD  # never advances
+        raise AssertionError("smoke must not run after a wait timeout")
+
+    kwargs = make_ports(fetch=fetch)
+    assert run(*build(kwargs)) == 1
+
+
+def test_smoke_failure_returns_nonzero():
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, HEALTH_NEW
+        return 500, "boom"
+
+    kwargs = make_ports(fetch=fetch)
+    assert run(*build(kwargs)) == 1
+
+
+def test_smoke_failure_prints_the_revert_command():
+    lines = []
+
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, HEALTH_NEW
+        return 500, "boom"
+
+    kwargs = make_ports(fetch=fetch, out=lines.append)
+    run(*build(kwargs))
+    assert "git revert" in "\n".join(lines)
+
+
+def test_smoke_failure_does_not_revert_anything():
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, HEALTH_NEW
+        return 500, "boom"
+
+    kwargs = make_ports(fetch=fetch)
+    gh = kwargs["gh"]
+    run(*build(kwargs))
+    assert "revert" not in " ".join(gh.calls)
+
+
+def test_merge_retries_through_a_transient_failure():
+    """The known gh squash-merge 502: error raised, but the PR does merge."""
+
+    class FlakyGh(FakeGh):
+        def __init__(self):
+            super().__init__()
+            self.attempts = 0
+
+        def merge(self, number):
+            self.attempts += 1
+            self.merged = True  # it landed despite the error
+            if self.attempts == 1:
+                raise RuntimeError("HTTP 502")
+
+    kwargs = make_ports(gh=FlakyGh())
+    assert run(*build(kwargs)) == 0
+
+
+def test_nothing_to_promote_exits_clean():
+    kwargs = make_ports()
+    kwargs["git"].commits_ahead = 0
+    kwargs["preflight_data"] = lambda conn: dict(
+        ledger_exists=True,
+        migration_files=["0001_a.sql"],
+        recorded={"0001_a.sql"},
+        staging_recorded={"0001_a.sql"},
+        destructive=[],
+        db_url="postgresql://postgres.ref1:p@aws-0-us-west-2.pooler.supabase.com:5432/postgres",
+        supabase_url="https://ref1.supabase.co",
+    )
+    assert run(*build(kwargs)) == 0
+
+
+def test_already_merged_pr_resumes_at_wait_and_smoke():
+    """Re-running after a failure must not re-merge."""
+    kwargs = make_ports()
+    gh = kwargs["gh"]
+    gh.merged = True
+    assert run(*build(kwargs)) == 0
+    assert "merge" not in gh.calls
+
+
+def test_unknown_live_commit_degrades_instead_of_hanging():
+    """No Railway env var: don't wait forever, warn and smoke anyway."""
+    def fetch(method, url):
+        if url.endswith("/api/health"):
+            return 200, json.dumps({"status": "ok", "commit": "unknown"})
+        if url.endswith("/api/auth/test-login"):
+            return 404, ""
+        if "analytics" in url:
+            return 401, ""
+        return 200, "<html>"
+
+    lines = []
+    kwargs = make_ports(fetch=fetch, out=lines.append)
+    assert run(*build(kwargs)) == 0
+    assert "unknown" in "\n".join(lines).lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && venv/bin/python -m pytest tests/test_promotion_runner.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'promotion.runner'`
+
+- [ ] **Step 3: Implement runner.py**
+
+Create `backend/promotion/runner.py`:
+
+```python
+"""Stage sequencing for the staging -> production promotion (#516).
+
+Ordering is DB-first: migrations apply BEFORE the code merges, which is what the
+destructive-DDL guard in preflight exists to protect. Between the migrate stage
+and the merge, the OLD production code runs against the NEW schema.
+
+Every side effect is an injected port, so the whole sequence is testable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from promotion import preflight, smoke, snapshot
+
+EXIT_OK, EXIT_FAIL, EXIT_ABORTED = 0, 1, 2
+
+
+@dataclass
+class Ports:
+    connect: Callable[[], Any]
+    preflight_data: Callable[[Any], dict]
+    capture: Callable[[Any], dict]
+    migrate: Callable[[Any], list[str]]
+    git: Any
+    gh: Any
+    fetch: Callable[[str, str], tuple[int | None, str]]
+    confirm: Callable[[str], bool]
+    out: Callable[[str], None]
+    sleep: Callable[[float], None]
+
+
+@dataclass
+class Options:
+    allow_destructive: bool = False
+    skip_staging_check: bool = False
+    api_base: str = smoke.DEFAULT_API
+    web_base: str = smoke.DEFAULT_WEB
+    wait_timeout: int = 600
+    poll_interval: int = 10
+
+
+def run(ports: Ports, options: Options) -> int:
+    out = ports.out
+
+    # ---- Stage 1: preflight (read-only) --------------------------------
+    ports.git.fetch()
+    head = ports.git.head_sha("origin/main")
+    commits_ahead = ports.git.commits_ahead_of("origin/production", "origin/main")
+
+    with ports.connect() as conn:
+        data = ports.preflight_data(conn)
+        findings = preflight.evaluate(
+            commits_ahead=commits_ahead,
+            allow_destructive=options.allow_destructive,
+            skip_staging_check=options.skip_staging_check,
+            **data,
+        )
+
+        if findings:
+            blocking = [f for f in findings if f.kind != "nothing-to-promote"]
+            for finding in findings:
+                out(f"  [{finding.kind}] {finding.detail}")
+            if not blocking:
+                out("Nothing to promote — production already matches main.")
+                return EXIT_OK
+            out("\nPREFLIGHT FAILED — production was not touched.")
+            return EXIT_FAIL
+
+        pending, _ = preflight.ledger_diff(data["migration_files"], data["recorded"])
+        out(f"Preflight OK. {commits_ahead} commit(s) to promote, {len(pending)} migration(s) pending.")
+
+        # ---- Stage 2-4: snapshot, migrate, snapshot --------------------
+        before = ports.capture(conn)
+        if pending:
+            applied = ports.migrate(conn)
+            out(f"Applied {len(applied)} migration(s).")
+        after = ports.capture(conn)
+
+    changes = snapshot.diff(before, after)
+    out("\nDatabase changes:")
+    out(snapshot.format_diff(changes))
+
+    # ---- The one pause ------------------------------------------------
+    number = ports.gh.ensure_pr("production", "main", f"Promote staging to production — {commits_ahead} commits")
+    already_merged = ports.gh.state(number) == "MERGED"
+
+    if not already_merged:
+        prompt = (
+            f"\nMerge PR #{number} ({commits_ahead} commits, "
+            f"{len(changes['new_migrations'])} migrations applied) into production?"
+        )
+        if not ports.confirm(prompt):
+            out(
+                "\nABORTED before the merge.\n"
+                "  NOTE: the migrations above are ALREADY APPLIED. Production's "
+                "schema is now AHEAD of production's code.\n"
+                "  Re-run to resume at the merge, or revert deliberately."
+            )
+            return EXIT_ABORTED
+
+        # The squash-merge 502 wedge: gh can error while the merge lands. Never
+        # trust the first failure — re-read the PR state.
+        for attempt in range(5):
+            try:
+                ports.gh.merge(number)
+            except Exception as exc:  # noqa: BLE001 — any gh failure gets re-checked
+                out(f"  merge attempt {attempt + 1} errored ({exc}); re-checking PR state")
+            if ports.gh.state(number) == "MERGED":
+                break
+            ports.sleep(options.poll_interval)
+        else:
+            out(f"\nPR #{number} never reported MERGED. Production code unchanged.")
+            return EXIT_FAIL
+    else:
+        out(f"PR #{number} is already merged — resuming at the deploy wait.")
+
+    out(f"Merged. Waiting for the deploy to report {head[:7]}.")
+
+    # ---- Stage 6: wait for the deploy ---------------------------------
+    waited = 0
+    while waited < options.wait_timeout:
+        live = smoke.live_commit(ports.fetch, options.api_base)
+        if live == head[:7]:
+            out(f"  deploy is live ({live}).")
+            break
+        if live == "unknown":
+            out(
+                "  WARNING: /api/health reports commit 'unknown' — the host is not "
+                "injecting a commit SHA, so the deploy cannot be confirmed. "
+                "Proceeding to smoke anyway."
+            )
+            break
+        ports.sleep(options.poll_interval)
+        waited += options.poll_interval
+    else:
+        out(
+            f"\nTIMEOUT: the deploy never reported {head[:7]} after "
+            f"{options.wait_timeout}s. NOT running smoke — a deploy failure must "
+            "not look like a smoke failure. Check the Railway build."
+        )
+        return EXIT_FAIL
+
+    # ---- Stage 7: smoke ------------------------------------------------
+    results = smoke.run_checks(ports.fetch, options.api_base, options.web_base)
+    out("\nSmoke:")
+    out(smoke.format_results(results))
+
+    if any(not r.ok for r in results):
+        out(
+            "\nSMOKE FAILED. Production was NOT reverted — the applied migrations "
+            "cannot be rolled back, so reverting the code would leave old code "
+            "against a newer schema.\n"
+            "  To revert deliberately:\n"
+            "    git checkout production && git revert -m 1 HEAD && git push origin production"
+        )
+        return EXIT_FAIL
+
+    out("\nPROMOTION COMPLETE — all smoke checks passed.")
+    return EXIT_OK
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd backend && venv/bin/python -m pytest tests/test_promotion_runner.py -v`
+Expected: all PASS. If `test_nothing_to_promote_exits_clean` fails, check that `evaluate` only emits `nothing-to-promote` when there are also no pending migrations.
+
+- [ ] **Step 5: Implement the CLI entry point**
+
+Create `backend/promotion/__main__.py`:
+
+```python
+"""`python -m promotion` — the real ports wired to the real world (#516).
+
+Run from backend/ with production's env loaded:
+
+    venv/bin/dotenv -f .env.production run -- venv/bin/python -m promotion
+
+Flags:
+    --allow-destructive      proceed despite destructive DDL in pending migrations
+    --skip-staging-check     proceed despite migrations staging has never run
+    --yes                    answer the confirmation prompt automatically (CI)
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import psycopg
+
+from db import migrate as db_migrate
+from promotion import preflight, smoke, snapshot
+from promotion.runner import Options, Ports, run
+
+
+class Git:
+    def fetch(self) -> None:
+        subprocess.run(["git", "fetch", "origin", "--quiet"], check=True)
+
+    def head_sha(self, ref: str) -> str:
+        return subprocess.run(
+            ["git", "rev-parse", ref], check=True, capture_output=True, text=True
+        ).stdout.strip()
+
+    def commits_ahead_of(self, base: str, head: str) -> int:
+        result = subprocess.run(
+            ["git", "rev-list", "--count", f"{base}..{head}"],
+            check=True, capture_output=True, text=True,
+        )
+        return int(result.stdout.strip())
+
+
+class Gh:
+    def ensure_pr(self, base: str, head: str, title: str) -> int:
+        existing = subprocess.run(
+            ["gh", "pr", "list", "--base", base, "--head", head, "--state", "all",
+             "--limit", "1", "--json", "number,state", "--jq", ".[0].number // empty"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        if existing:
+            return int(existing)
+        subprocess.run(
+            ["gh", "pr", "create", "--base", base, "--head", head,
+             "--title", title, "--body", "Automated promotion (#516)."],
+            check=True, capture_output=True, text=True,
+        )
+        return self.ensure_pr(base, head, title)
+
+    def state(self, number: int) -> str:
+        return subprocess.run(
+            ["gh", "pr", "view", str(number), "--json", "state", "--jq", ".state"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+    def merge(self, number: int) -> None:
+        subprocess.run(["gh", "pr", "merge", str(number), "--merge"],
+                       check=True, capture_output=True, text=True)
+
+
+def _staging_recorded() -> set[str]:
+    """Staging's ledger, so preflight can refuse DDL staging never ran."""
+    url = os.environ.get("STAGING_SUPABASE_DB_URL", "").strip()
+    if not url:
+        return set()
+    with psycopg.connect(url) as conn, conn.cursor() as cur:
+        cur.execute("SELECT filename FROM schema_migrations")
+        return {row[0] for row in cur.fetchall()}
+
+
+def _preflight_data(conn) -> dict:
+    files = [p.name for p in db_migrate.discover_migrations(db_migrate.MIGRATIONS_DIR)]
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass('public.schema_migrations') IS NOT NULL")
+        exists = bool(cur.fetchone()[0])
+        recorded: set[str] = set()
+        if exists:
+            cur.execute("SELECT filename FROM schema_migrations")
+            recorded = {row[0] for row in cur.fetchall()}
+
+    pending, _ = preflight.ledger_diff(files, recorded)
+    pending_paths = [db_migrate.MIGRATIONS_DIR / name for name in pending]
+    return {
+        "db_url": os.environ.get("SUPABASE_DB_URL", ""),
+        "supabase_url": os.environ.get("SUPABASE_URL", ""),
+        "ledger_exists": exists,
+        "migration_files": files,
+        "recorded": recorded,
+        "staging_recorded": _staging_recorded(),
+        "destructive": preflight.scan_destructive(pending_paths),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="promotion")
+    parser.add_argument("--allow-destructive", action="store_true")
+    parser.add_argument("--skip-staging-check", action="store_true")
+    parser.add_argument("--yes", action="store_true")
+    args = parser.parse_args()
+
+    db_url = os.environ.get("SUPABASE_DB_URL", "").strip()
+    if not db_url:
+        print(
+            "ERROR: SUPABASE_DB_URL is not set. Run under production's env:\n"
+            "  venv/bin/dotenv -f .env.production run -- venv/bin/python -m promotion\n"
+            "It must be the SESSION-mode pooler URI (port 5432, user postgres.<ref>); "
+            "production is on the aws-0-us-west-2 cluster. Build it with "
+            "`python scripts/pooler_url.py .env.production aws-0-us-west-2 --raw`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    def confirm(prompt: str) -> bool:
+        if args.yes:
+            return True
+        return input(f"{prompt} [y/N] ").strip().lower() in {"y", "yes"}
+
+    ports = Ports(
+        connect=lambda: psycopg.connect(db_url),
+        preflight_data=_preflight_data,
+        capture=snapshot.capture,
+        migrate=lambda conn: db_migrate.run(conn),
+        git=Git(),
+        gh=Gh(),
+        fetch=smoke.httpx_fetch,
+        confirm=confirm,
+        out=print,
+        sleep=time.sleep,
+    )
+    return run(ports, Options(
+        allow_destructive=args.allow_destructive,
+        skip_staging_check=args.skip_staging_check,
+    ))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 6: Verify the CLI refuses to run without credentials**
+
+Run: `cd backend && env -u SUPABASE_DB_URL venv/bin/python -m promotion`
+Expected: exits 1 with the pooler instructions. **It must not connect to anything.**
+
+- [ ] **Step 7: Run the full backend suite**
+
+Run: `cd backend && venv/bin/python -m pytest tests/ -q && venv/bin/ruff check .`
+Expected: green; read the pass/skip counts. `ruff` clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/promotion/runner.py backend/promotion/__main__.py backend/tests/test_promotion_runner.py
+git commit -m "feat(promotion): stage sequencing, confirmation gate and CLI (#516)"
+```
+
+---
+
+### Task 6: `make promote`, the runbook, and artifact cleanup
+
+**Files:**
+- Modify: `Makefile` (add target + `.PHONY`)
+- Create: `backend/promotion/README.md`
+- Modify: `CLAUDE.md` (Commands section)
+- Delete: `backend/prod_snapshot.py`, `backend/prod_db_check.py`, `backend/smoke_prod_app.sh`, `backend/smoke_prod_promotion.sh`, `backend/prod_snapshot_*.json`
+
+**Do NOT delete** `backend/apply_graph_edges_fix.py` or `backend/graph_edges_fix.sql`. Those are a separate production reconciliation (the `graph_edges` table missing from 0023), unrelated to promotion. Ruled out of scope by the human partner during pre-flight.
+
+**Interfaces:**
+- Consumes: `python -m promotion` from Task 5.
+- Produces: `make promote`.
+
+- [ ] **Step 1: Add the Makefile target**
+
+In `Makefile`, change the `.PHONY` line to include `promote` and append:
+
+```makefile
+# Staging -> production promotion (#516): preflight, migrate prod, confirm,
+# merge main->production, wait for the deploy, smoke. One prompt, at the merge.
+# See backend/promotion/README.md.
+promote:
+	cd backend && venv/bin/dotenv -f .env.production run -- venv/bin/python -m promotion $(ARGS)
+```
+
+- [ ] **Step 2: Verify the target reaches the CLI**
+
+Run: `make promote ARGS="--help"`
+Expected: argparse usage listing `--allow-destructive`, `--skip-staging-check`, `--yes`.
+
+- [ ] **Step 3: Write the runbook**
+
+Create `backend/promotion/README.md`:
+
+````markdown
+# Promotion runbook
+
+`make promote` — staging (`main`) to production. Replaces the hand-run sequence
+that shipped #515.
+
+## Before you run it
+
+- Production's `SUPABASE_DB_URL` in `backend/.env.production` must be the
+  SESSION-mode pooler URI. Build it:
+  `python scripts/pooler_url.py .env.production aws-0-us-west-2 --raw`
+- `STAGING_SUPABASE_DB_URL` should be set (staging is `aws-1-us-west-2`) so the
+  runner can refuse DDL that staging has never executed. Without it that guard
+  is inert.
+- `gh` must be authenticated.
+
+## What it does
+
+1. **Preflight** (read-only): target-identity, ledger exists, no orphans,
+   staging-ran-it-first, no destructive DDL, something to promote.
+2. **Snapshot** production.
+3. **Migrate** production (`db.migrate`).
+4. **Snapshot** again and print the diff.
+5. **Pause** — the only prompt, at the only irreversible step.
+6. **Merge** `main` → `production`, retrying through the known `gh` 502.
+7. **Wait** until `/api/health` reports the promoted commit (10 min timeout).
+8. **Smoke** the live surface.
+
+Exit codes: `0` success or nothing to promote, `1` failure, `2` you declined.
+
+## The ordering you need to know about
+
+Migrations apply **before** the code merges. Between stages 3 and 6 the OLD
+production code runs against the NEW schema. Additive DDL is fine there;
+destructive DDL is not, which is why preflight blocks on it and
+`--allow-destructive` is an explicit decision.
+
+**If you answer `n` at the prompt, the migrations are already applied.**
+Production's schema will be ahead of its code. Re-running resumes at the merge.
+
+## When smoke fails
+
+Nothing is reverted, deliberately: the migrations cannot be rolled back, so
+reverting the code would leave old code against a newer schema. The runner
+prints the revert command; reverting is your call.
+
+## Re-running
+
+Safe. Preflight finds nothing pending and the PR already `MERGED`, so a second
+run resumes at wait + smoke.
+````
+
+- [ ] **Step 4: Document the command in CLAUDE.md**
+
+In `CLAUDE.md`, under the Database section of "Commands", append after the `db.seed_staging` block:
+
+```
+Promotion (repo root; full runbook `backend/promotion/README.md`):
+
+```
+make promote                      # staging -> prod: preflight, migrate, confirm, merge, verify
+make promote ARGS="--yes"         # skip the confirmation prompt (CI)
+```
+```
+
+- [ ] **Step 5: Delete the superseded artifacts**
+
+These are untracked working files from the #515 promotion, now replaced by the package. Confirm each is untracked before deleting, so nothing tracked is lost:
+
+```bash
+cd /home/andresl/Projects/sapling
+git status --porcelain backend/prod_snapshot.py backend/prod_db_check.py \
+  backend/smoke_prod_app.sh backend/smoke_prod_promotion.sh backend/prod_snapshot_*.json
+```
+
+Expected: every line starts with `??` (untracked). Then:
+
+```bash
+rm -f backend/prod_snapshot.py backend/prod_db_check.py \
+      backend/smoke_prod_app.sh backend/smoke_prod_promotion.sh \
+      backend/prod_snapshot_*.json
+```
+
+`backend/apply_graph_edges_fix.py` and `backend/graph_edges_fix.sql` must survive this step untouched.
+
+- [ ] **Step 6: Confirm the suite and lint are still green**
+
+Run: `cd backend && venv/bin/python -m pytest tests/ -q && venv/bin/ruff check .`
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Makefile backend/promotion/README.md CLAUDE.md
+git commit -m "feat(promotion): make promote target, runbook, and #515 artifact cleanup (#516)"
+```
+
+---
+
+### Task 7: Rehearse against production read-only, then open the PR
+
+The runner has never touched a real database. Prove the read-only half works before anyone trusts the write half.
+
+**Files:** none modified.
+
+**Interfaces:** consumes everything above.
+
+> **Steps 1 and 2 are run by the controller session, NOT a subagent.** Ruled during pre-flight: production credentials and the live connection stay under direct supervision. A subagent executing this task performs Steps 3 and 4 only, after the controller reports the rehearsal results.
+
+- [ ] **Step 1: Verify preflight against live production without mutating it** *(controller)*
+
+Production is currently level with `main` (#515 merged today), so preflight should report `nothing-to-promote` and stop — which exercises the connection, the ledger read and the guards without applying anything.
+
+Run:
+
+```bash
+cd backend && venv/bin/dotenv -f .env.production run -- venv/bin/python -m promotion
+```
+
+Expected: connects, reports `[nothing-to-promote] origin/main and origin/production are identical.`, exits 0. **It must not reach the confirmation prompt.**
+
+If it reports `target-mismatch`, the `.env.production` `SUPABASE_DB_URL` is the direct IPv6-only host or points at the wrong project — fix it with `scripts/pooler_url.py` before continuing.
+
+- [ ] **Step 2: Verify the smoke checks pass against live production** *(controller)*
+
+Run:
+
+```bash
+cd backend && venv/bin/python -c "
+from promotion.smoke import CHECKS, httpx_fetch, run_checks, format_results, DEFAULT_API, DEFAULT_WEB
+results = run_checks(httpx_fetch, DEFAULT_API, DEFAULT_WEB)
+print(format_results(results))
+raise SystemExit(0 if all(r.ok for r in results) else 1)
+"
+```
+
+Expected: every check PASSes against the current production deploy. A failure here is a real finding about production, not a bug in the checks — investigate before proceeding.
+
+Note: `api health` will report `commit` as `unknown` until the Task 1 change is deployed. That is expected and does not fail this check.
+
+- [ ] **Step 3: Push the branch and open the PR**
+
+```bash
+git push -u origin feat/516-promotion-runner
+gh pr create --title "feat(promotion): one-command staging→prod promotion runner (#516)" \
+  --body "Closes #516.
+
+Replaces the hand-run promotion sequence from #515 with \`make promote\`.
+
+- \`backend/promotion/\` — preflight guards, snapshot/diff, durable smoke checks, stage runner
+- \`/api/health\` now reports the build commit so the deploy wait is deterministic
+- deletes the untracked #515 working artifacts the package supersedes
+
+All new tests are hermetic (injected IO — no network, no DB, no prod credentials).
+Rehearsed read-only against live production: preflight correctly reports
+nothing-to-promote, and the smoke checks pass against the current deploy.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 4: Run `/code-review` on the PR before merging**
+
+Per the repo's gate, code review runs on the PR before it merges — not as a wrap-up afterwards.
+
+---
+
+## Self-Review
+
+**Spec coverage** — every acceptance item in #516 maps to a task:
+
+| #516 acceptance item | Task |
+|---|---|
+| `backend/promotion/` package, four units | 2, 3, 4, 5 |
+| `make promote` + `python -m promotion` | 5 (CLI), 6 (Makefile) |
+| Six preflight guards, each hermetically tested | 2 |
+| `/api/health` build commit + tested `unknown` fallback | 1 |
+| Committed smoke checks, promotion-specific assertions removed | 4 (incl. an explicit test that `fall-2026` is absent) |
+| Single prompt; declining prints "schema ahead of code" | 5 |
+| Smoke failure reports, exits non-zero, touches nothing | 5 |
+| Untracked `prod_*`/`smoke_prod_*` artifacts absorbed or deleted | 6 |
+| Runbook replacing tribal knowledge | 6 |
+
+**Type consistency** — `Finding(kind, detail)` is constructed identically in `preflight` and asserted in both preflight and runner tests. `fetch(method, url) -> (status | None, body)` has the same signature in `smoke.run_checks`, `smoke.live_commit`, `smoke.httpx_fetch` and the runner's `Ports.fetch`. `capture(conn) -> dict` returns the `tables`/`ledger` keys that `diff` reads. `db_migrate.run(conn)` matches the real signature at `backend/db/migrate.py:132`.
+
+**Known follow-up, deliberately out of scope:** the `workflow_dispatch` wrapper. `runner.run(ports, options)` takes every side effect as a port, so the wrapper supplies a non-interactive `confirm` and CI secrets without touching the runner.

--- a/docs/superpowers/plans/2026-08-02-staging-to-prod-promotion.md
+++ b/docs/superpowers/plans/2026-08-02-staging-to-prod-promotion.md
@@ -328,8 +328,14 @@ def test_evaluate_destructive_can_be_allowed():
 
 
 def test_evaluate_reports_nothing_to_promote():
-    findings = _evaluate(commits_ahead=0)
+    findings = _evaluate(commits_ahead=0, recorded={"0001_a.sql", "0002_b.sql"})
     assert [f.kind for f in findings] == ["nothing-to-promote"]
+
+
+def test_evaluate_allows_a_migration_only_promotion():
+    """Code is level but the schema is behind — that is still work to do."""
+    findings = _evaluate(commits_ahead=0)  # default fixture leaves 0002_b.sql pending
+    assert findings == []
 ```
 
 - [ ] **Step 2: Run test to verify it fails**


### PR DESCRIPTION
Closes #516.

Replaces the hand-run promotion sequence from #515 with `make promote`.

## What lands

- **`backend/promotion/`** — four single-responsibility units plus a runner:
  - `preflight.py` — read-only guards: target identity, ledger exists, no orphans, staging-ran-it-first, no destructive DDL, something to promote
  - `snapshot.py` — before/after prod capture + diff (SELECT-only)
  - `smoke.py` — durable post-deploy checks as data, injected fetcher
  - `runner.py` / `__main__.py` — stage sequencing, the single confirmation prompt, real ports
- **`/api/health` reports the build commit** (`config.build_commit()`), so the deploy wait is deterministic instead of a sleep
- **`make promote`** + runbook at `backend/promotion/README.md` + CLAUDE.md entry
- **Deletes the untracked #515 working artifacts** the package supersedes (`prod_snapshot.py`, `prod_db_check.py`, `smoke_prod_*.sh`, `prod_snapshot_*.json`)

## Design decisions

- **DB-first ordering.** Migrations apply before the code merges, so in that window production's OLD code runs against the NEW schema. That is exactly why the destructive-DDL guard exists, and why `--allow-destructive` is an explicit decision rather than a default.
- **One human confirmation, at the merge.** Declining leaves the migrations applied and says so loudly — production's schema is then ahead of its code, and re-running resumes.
- **Never auto-reverts.** Applied migrations cannot be rolled back, so reverting the code would leave old code against a newer schema. On smoke failure it reports and exits non-zero; the revert is the operator's call.
- **A 401/403 on a guarded smoke route is a PASS** — it proves the router is mounted. The failure mode being caught is a 404.
- **Term-specific assertions deliberately excluded** from the smoke checks (#515's hand-written version asserted `fall-2026` and a start date; those pass today and rot next term).

## Verification

All new tests are hermetic — every side effect is an injected port, so the full promotion sequence runs in-process with no database, network, subprocess or `gh`. Suite: **1638 passed, 38 skipped**; `ruff check .` fully clean.

Rehearsed **read-only against live production**:

```
target host        : aws-0-us-west-2.pooler.supabase.com:5432
db project ref     : jxqcmjqtjlpuxfrxmrdv   (matches api ref)
commits to promote : 0
ledger             : 49 on disk / 49 recorded, no pending, no orphans
findings           : [nothing-to-promote]
smoke              : 8/8 PASS against api.saplinglearn.com + saplinglearn.com
```

## Review history worth knowing

The branch went through per-task review plus a whole-branch review. Two Critical defects were caught before merge, both in the original plan rather than the implementation:

1. **The confirmation gate would have been bypassed on the first real run.** `ensure_pr` queried `--state all`, which returns PR #515 (MERGED) — the runner would have read that as "already merged", skipped both the prompt and the merge, and exited 1 blaming the deploy, after having already migrated production.
2. **Every *successful* promotion would have reported as a failure.** The deploy wait compared `/api/health` against `origin/main`'s tip, but `gh pr merge --merge` creates a merge commit on `production`, which is what gets deployed. Those SHAs can never match.

Beyond those, five separate defects were of one kind: **the tool printing something that could be false about production state** — claiming "production code unchanged" when a 502'd merge may have landed, claiming "partially migrated" when zero migrations landed, and handing the operator a `git revert -m 1 HEAD` recipe on a path where nothing was merged (which would have reverted an unrelated, working deploy). Each is now framed as an observation or scoped to the path where it is true.

## Known and deferred

- The same generic revert recipe is reachable under `--verify-only`; that path predates this work and merges nothing either way.
- "production and main are level" is true for `main → production` only; production may carry extra commits.
- `capture()` does `count(*)` per table — twice per promotion, fine at current prod size.
- `_strip_comments` splits on the first `--` without respecting string literals; no current migration contains such a literal, and the guard backstops human review rather than replacing it.

## Follow-up (not this PR)

A `workflow_dispatch` wrapper with a protected `production` environment. `runner.run(ports, options)` takes every side effect as a port, so the wrapper supplies a non-interactive `confirm` and CI secrets without touching the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a streamlined staging-to-production promotion workflow via `make promote`.
  - Added preflight checks for migration drift, staging gaps, destructive changes, and target mismatches.
  - Added database snapshots, deployment verification, smoke tests, verification-only runs, and configurable confirmations.
  - Health responses now report the deployed commit identifier.

- **Documentation**
  - Added promotion setup guidance, runbook instructions, safety requirements, and troubleshooting details.

- **Bug Fixes**
  - Improved failure reporting, retry handling, and safeguards against unsafe or misleading promotion outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->