### PR TITLE
feat(quiz): attempt lifecycle — mastery snapshot, derived status + TTL sweep, resume, paginated history (#542)

### DIFF
--- a/backend/db/connection.py
+++ b/backend/db/connection.py
@@ -82,9 +82,20 @@ class SupabaseTable:
         r.raise_for_status()
         return r.json()
 
-    def update(self, data: dict, filters: dict) -> list:
-        r = _client.patch(self.url, params=filters, json=data)
+    def update(self, data: dict, filters: dict, *, prefer_return_minimal: bool = False) -> list:
+        """PATCH matching rows; returns the updated rows.
+
+        `prefer_return_minimal=True` overrides the client-wide
+        `Prefer: return=representation` for writes whose result nobody
+        reads — a background sweep over many rows would otherwise drag
+        every updated row (including large encrypted columns) back over
+        the wire. Returns [] in that mode.
+        """
+        headers = {"Prefer": "return=minimal"} if prefer_return_minimal else None
+        r = _client.patch(self.url, params=filters, json=data, headers=headers)
         r.raise_for_status()
+        if prefer_return_minimal:
+            return []
         return r.json()
 
     def upsert(self, data, on_conflict: str = "id") -> list:

--- a/backend/db/migrations/20260813013547_quiz_attempts_lifecycle.sql
+++ b/backend/db/migrations/20260813013547_quiz_attempts_lifecycle.sql
@@ -10,7 +10,15 @@
 -- timestamps that define it. The lazy per-user sweep (routes/quiz.py) stamps
 -- abandoned_at on in-progress attempts older than the documented TTL.
 
+-- IF NOT EXISTS per the repo's idempotent-DDL rule: a migration that half
+-- applied must be re-runnable without hand-editing the ledger.
 ALTER TABLE quiz_attempts
-    ADD COLUMN mastery_before DOUBLE PRECISION,
-    ADD COLUMN mastery_after  DOUBLE PRECISION,
-    ADD COLUMN abandoned_at   TIMESTAMPTZ;
+    ADD COLUMN IF NOT EXISTS mastery_before DOUBLE PRECISION,
+    ADD COLUMN IF NOT EXISTS mastery_after  DOUBLE PRECISION,
+    ADD COLUMN IF NOT EXISTS abandoned_at   TIMESTAMPTZ;
+
+-- Partial index for the lazy abandon sweep + the history read, both of
+-- which filter on (user_id, completed_at IS NULL, abandoned_at IS NULL).
+CREATE INDEX IF NOT EXISTS idx_quiz_attempts_user_open
+    ON quiz_attempts(user_id, created_at)
+    WHERE completed_at IS NULL AND abandoned_at IS NULL;

--- a/backend/db/migrations/20260813013547_quiz_attempts_lifecycle.sql
+++ b/backend/db/migrations/20260813013547_quiz_attempts_lifecycle.sql
@@ -1,0 +1,16 @@
+-- #542 D1/D2: attempt lifecycle columns.
+--
+-- mastery_before/after: without them a replayed or audited submit can't
+-- reconstruct what the student saw, and no history UI can show progression
+-- (plaintext analytics scalars, same rationale as score/total in #521).
+--
+-- abandoned_at: the "abandoned" half of the derived status. Status is NEVER
+-- stored — it is derived at read time (completed_at → completed,
+-- abandoned_at → abandoned, else in_progress), so it cannot drift from the
+-- timestamps that define it. The lazy per-user sweep (routes/quiz.py) stamps
+-- abandoned_at on in-progress attempts older than the documented TTL.
+
+ALTER TABLE quiz_attempts
+    ADD COLUMN mastery_before DOUBLE PRECISION,
+    ADD COLUMN mastery_after  DOUBLE PRECISION,
+    ADD COLUMN abandoned_at   TIMESTAMPTZ;

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 
@@ -24,6 +24,7 @@ from services import events_service
 from services.auth_guard import require_self
 from services.quiz_config import (
     CONCRETE_DIFFICULTIES,
+    QUIZ_ATTEMPT_ABANDON_TTL_HOURS,
     REQUESTED_DIFFICULTIES,
     quiz_config_payload,
 )
@@ -76,6 +77,50 @@ _OPTION_LABELS = ["A", "B", "C", "D", "E", "F"]
 # the config tuple so a difficulty added there can't be silently dropped by
 # _resolved_difficulty's counting.
 _DIFFICULTY_RANK = {d: i for i, d in enumerate(CONCRETE_DIFFICULTIES)}
+
+
+def _abandon_cutoff() -> datetime:
+    return datetime.now(timezone.utc) - timedelta(
+        hours=QUIZ_ATTEMPT_ABANDON_TTL_HOURS
+    )
+
+
+def _attempt_status(attempt: dict) -> str:
+    """#542 D2: status is DERIVED from the timestamps, never stored, so it
+    can't drift. An in-progress row past the TTL reads as abandoned even
+    before the lazy sweep has stamped abandoned_at."""
+    if attempt.get("completed_at"):
+        return "completed"
+    if attempt.get("abandoned_at"):
+        return "abandoned"
+    created = attempt.get("created_at")
+    if created:
+        try:
+            created_dt = datetime.fromisoformat(str(created).replace("Z", "+00:00"))
+        except ValueError:
+            created_dt = None
+        if created_dt and created_dt < _abandon_cutoff():
+            return "abandoned"
+    return "in_progress"
+
+
+def _sweep_abandoned(user_id: str) -> None:
+    """Stamp abandoned_at on this user's stale in-progress attempts (#542
+    D2). Conditional-update filters arbitrate — same idiom as the submit
+    claim — and runs lazily on the read paths (history/resume), so no
+    scheduler is needed. Best-effort: a failure never breaks the read."""
+    try:
+        table("quiz_attempts").update(
+            {"abandoned_at": datetime.now(timezone.utc).isoformat()},
+            filters={
+                "user_id": f"eq.{user_id}",
+                "completed_at": "is.null",
+                "abandoned_at": "is.null",
+                "created_at": f"lt.{_abandon_cutoff().isoformat()}",
+            },
+        )
+    except Exception:
+        logger.exception("quiz: abandon sweep failed user=%s", user_id)
 
 
 def _strip_answer_key(wire_questions: list[dict]) -> list[dict]:
@@ -483,6 +528,104 @@ async def generate_quiz(body: GenerateQuizBody, request: Request):
     }
 
 
+@router.get("/attempts")
+def list_attempts(
+    request: Request,
+    user_id: str,
+    limit: int = 20,
+    offset: int = 0,
+):
+    """#542 D4: paginated attempt history for the signed-in user — the
+    plaintext scalars (#521/#527) finally get their reader. No question
+    payloads here (and therefore no answer keys)."""
+    require_self(user_id, request)
+    limit = max(1, min(limit, 100))
+    offset = max(0, offset)
+    # Lazy lifecycle sweep (#542 D2) — the read paths keep statuses honest.
+    _sweep_abandoned(user_id)
+
+    rows, total = table("quiz_attempts").select_with_count(
+        "id,concept_node_id,difficulty,score,total,mastery_before,"
+        "mastery_after,completed_at,abandoned_at,created_at",
+        filters={"user_id": f"eq.{user_id}"},
+        order="created_at.desc",
+        limit=limit,
+        offset=offset,
+    )
+    rows = rows or []
+
+    node_ids = sorted({r["concept_node_id"] for r in rows if r.get("concept_node_id")})
+    nodes: dict[str, dict] = {}
+    if node_ids:
+        node_rows = table("graph_nodes").select(
+            "id,concept_name,course_id",
+            filters={"id": f"in.({','.join(node_ids)})", "user_id": f"eq.{user_id}"},
+        ) or []
+        nodes = {n["id"]: n for n in node_rows}
+
+    attempts = []
+    for r in rows:
+        node = nodes.get(r.get("concept_node_id")) or {}
+        before, after = r.get("mastery_before"), r.get("mastery_after")
+        delta = round(after - before, 4) if before is not None and after is not None else None
+        attempts.append({
+            "quiz_id": r["id"],
+            "status": _attempt_status(r),
+            "concept_node_id": r.get("concept_node_id"),
+            "concept_name": node.get("concept_name"),
+            "course_id": node.get("course_id"),
+            "score": r.get("score"),
+            "total": r.get("total"),
+            "difficulty": r.get("difficulty"),
+            "mastery_before": before,
+            "mastery_after": after,
+            "mastery_delta": delta,
+            "created_at": r.get("created_at"),
+            "completed_at": r.get("completed_at"),
+        })
+    return {"total": total, "attempts": attempts, "limit": limit, "offset": offset}
+
+
+@router.get("/attempts/{attempt_id}")
+def get_attempt(attempt_id: str, request: Request):
+    """#542 D2: resume state for one attempt — enough to rebuild an
+    in-progress quiz client-side: questions WITHOUT the answer key, plus
+    the responses already recorded through /answer."""
+    attempt_rows = table("quiz_attempts").select(
+        "*", filters={"id": f"eq.{attempt_id}"}
+    )
+    if not attempt_rows:
+        raise QuizAPIError(
+            status_code=404,
+            code=QuizErrorCode.QUIZ_ATTEMPT_NOT_FOUND,
+            message="We couldn't find that quiz.",
+        )
+    attempt = attempt_rows[0]
+    require_self(attempt["user_id"], request)
+    _sweep_abandoned(attempt["user_id"])
+
+    questions = decrypt_json_column(attempt["questions_json"]) or []
+    responses = table("quiz_responses").select(
+        "question_index,selected_index,is_correct,time_ms,confidence,answered_at",
+        filters={"attempt_id": f"eq.{attempt_id}"},
+        order="question_index.asc",
+    ) or []
+    return {
+        "quiz_id": attempt["id"],
+        "status": _attempt_status(attempt),
+        "difficulty": attempt.get("difficulty"),
+        "concept_node_id": attempt.get("concept_node_id"),
+        "questions": _strip_answer_key(questions),
+        "responses": responses,
+        "score": attempt.get("score"),
+        "total": attempt.get("total"),
+        "mastery_before": attempt.get("mastery_before"),
+        "mastery_after": attempt.get("mastery_after"),
+        "created_at": attempt.get("created_at"),
+        "completed_at": attempt.get("completed_at"),
+    }
+
+
 @router.post("/attempts/{attempt_id}/answer")
 def answer_question(attempt_id: str, body: AnswerQuestionBody, request: Request):
     """#541 C1: grade one question server-side and record the response.
@@ -766,6 +909,11 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
             # not the raw request — the attempt's stored answers must agree
             # with the score computed from them.
             "answers_json": encrypt_json(graded_answers),
+            # #542 D1: the mastery snapshot — without it a replayed/audited
+            # submit can't reconstruct what the student saw, and history
+            # can't show progression. Plaintext scalars (#521 rationale).
+            "mastery_before": mastery_before,
+            "mastery_after": mastery_after,
             # completed_at was already stamped by the atomic claim above.
         },
         filters={"id": f"eq.{body.quiz_id}"},

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -79,59 +79,143 @@ _OPTION_LABELS = ["A", "B", "C", "D", "E", "F"]
 _DIFFICULTY_RANK = {d: i for i, d in enumerate(CONCRETE_DIFFICULTIES)}
 
 
+# PostgREST passes `offset` to Postgres as a bigint; anything past this is
+# a client bug, and an empty page is a better answer than a 500.
+_MAX_HISTORY_OFFSET = 1_000_000
+
+
 def _abandon_cutoff() -> datetime:
     return datetime.now(timezone.utc) - timedelta(
         hours=QUIZ_ATTEMPT_ABANDON_TTL_HOURS
     )
 
 
-def _attempt_status(attempt: dict) -> str:
+def _parse_ts(value) -> datetime | None:
+    """Parse a stored timestamp to an AWARE datetime, or None.
+
+    Naive values (an out-of-band write, a hand-edited row) are assumed UTC
+    rather than left naive: comparing a naive datetime against an aware one
+    raises TypeError, which `except ValueError` around the parse does not
+    catch — it would 500 both read endpoints.
+    """
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _attempt_status(attempt: dict, last_activity_at=None) -> str:
     """#542 D2: status is DERIVED from the timestamps, never stored, so it
     can't drift. An in-progress row past the TTL reads as abandoned even
-    before the lazy sweep has stamped abandoned_at."""
+    before the lazy sweep has stamped abandoned_at.
+
+    `last_activity_at` is the newest recorded answer (quiz_responses):
+    a quiz generated days ago but answered minutes ago is being WORKED ON,
+    not abandoned — keying the TTL on created_at alone would strand the
+    responses already recorded against it.
+    """
     if attempt.get("completed_at"):
         return "completed"
     if attempt.get("abandoned_at"):
         return "abandoned"
-    created = attempt.get("created_at")
-    if created:
-        try:
-            created_dt = datetime.fromisoformat(str(created).replace("Z", "+00:00"))
-        except ValueError:
-            created_dt = None
-        if created_dt and created_dt < _abandon_cutoff():
-            return "abandoned"
+    cutoff = _abandon_cutoff()
+    latest = max(
+        (t for t in (_parse_ts(attempt.get("created_at")),
+                     _parse_ts(last_activity_at)) if t is not None),
+        default=None,
+    )
+    if latest is not None and latest < cutoff:
+        return "abandoned"
     return "in_progress"
 
 
-def _sweep_abandoned(user_id: str) -> None:
+def _refuse_if_abandoned(attempt: dict) -> None:
+    """409 on an attempt that's been swept as abandoned (#542 D2).
+
+    Checks the STAMP, not the derived TTL: a student mid-quiz whose
+    attempt merely crossed the age cutoff keeps working (their answers
+    refresh the activity clock — see _attempt_status), but once the sweep
+    has actually marked it, the attempt is closed.
+    """
+    if attempt.get("abandoned_at"):
+        raise QuizAPIError(
+            status_code=409,
+            code=QuizErrorCode.QUIZ_ATTEMPT_ABANDONED,
+            message="This quiz expired. Start a new one when you're ready.",
+        )
+
+
+def _sweep_abandoned(user_id: str, *, active_attempt_ids: set[str] | None = None) -> None:
     """Stamp abandoned_at on this user's stale in-progress attempts (#542
     D2). Conditional-update filters arbitrate — same idiom as the submit
-    claim — and runs lazily on the read paths (history/resume), so no
-    scheduler is needed. Best-effort: a failure never breaks the read."""
+    claim — and it runs lazily on the read paths, so no scheduler is
+    needed. Best-effort: a failure never breaks the read.
+
+    `active_attempt_ids` are attempts with recent recorded answers, which
+    must survive the sweep even though they were created before the
+    cutoff — the student is mid-quiz.
+    """
+    filters = {
+        "user_id": f"eq.{user_id}",
+        "completed_at": "is.null",
+        "abandoned_at": "is.null",
+        "created_at": f"lt.{_abandon_cutoff().isoformat()}",
+    }
+    if active_attempt_ids:
+        filters["id"] = f"not.in.({','.join(sorted(active_attempt_ids))})"
     try:
         table("quiz_attempts").update(
             {"abandoned_at": datetime.now(timezone.utc).isoformat()},
-            filters={
-                "user_id": f"eq.{user_id}",
-                "completed_at": "is.null",
-                "abandoned_at": "is.null",
-                "created_at": f"lt.{_abandon_cutoff().isoformat()}",
-            },
+            filters=filters,
+            # The sweep is a side effect of a READ; without this PostgREST's
+            # global Prefer: return=representation drags every swept row
+            # back in full — including the encrypted questions_json /
+            # answers_json blobs — on each history page load.
+            prefer_return_minimal=True,
         )
     except Exception:
         logger.exception("quiz: abandon sweep failed user=%s", user_id)
 
 
+# The keys a keyless (student-facing) question may carry. An ALLOWLIST,
+# not a denylist: `explanation` states the correct answer in prose, and a
+# stored row from an older shape can hold the answer under any key at all
+# (the rich seed has {"q":..., "a":...}). Anything not listed here never
+# reaches a client that hasn't answered yet.
+_KEYLESS_QUESTION_KEYS = ("id", "question", "concept_tested", "difficulty")
+_KEYLESS_OPTION_KEYS = ("label", "text")
+
+
+def _is_wire_question(q) -> bool:
+    """True if this stored question is in the current wire shape, so
+    _strip_answer_key can be trusted to remove everything sensitive."""
+    return (
+        isinstance(q, dict)
+        and isinstance(q.get("options"), list)
+        and bool(q.get("options"))
+        and all(isinstance(o, dict) and "label" in o for o in q["options"])
+    )
+
+
 def _strip_answer_key(wire_questions: list[dict]) -> list[dict]:
-    """Deep-enough copy of the wire questions without per-option `correct`
-    booleans (#541 C3). Storage always keeps the key — grading is
-    server-side; only the RESPONSE is stripped."""
+    """The student-facing view of a question: no per-option `correct`
+    booleans and no `explanation` (#541 C3, tightened in #542 review).
+
+    Built by allowlist, so a question shape this function doesn't
+    recognise can't leak an answer through an unexpected key. Callers must
+    gate on _is_wire_question first — an unrecognised shape has no safe
+    keyless projection at all.
+    """
     stripped = []
     for q in wire_questions:
-        q2 = dict(q)
+        q2 = {k: q[k] for k in _KEYLESS_QUESTION_KEYS if k in q}
         q2["options"] = [
-            {k: v for k, v in o.items() if k != "correct"}
+            {k: o[k] for k in _KEYLESS_OPTION_KEYS if k in o}
             for o in q.get("options", [])
         ]
         stripped.append(q2)
@@ -540,7 +624,10 @@ def list_attempts(
     payloads here (and therefore no answer keys)."""
     require_self(user_id, request)
     limit = max(1, min(limit, 100))
-    offset = max(0, offset)
+    # Clamp BOTH ends: an unbounded offset is stringified into PostgREST's
+    # offset param and Postgres rejects it as bigint-out-of-range — a 500
+    # where an empty page is the honest answer.
+    offset = max(0, min(offset, _MAX_HISTORY_OFFSET))
     # Lazy lifecycle sweep (#542 D2) — the read paths keep statuses honest.
     _sweep_abandoned(user_id)
 
@@ -548,7 +635,11 @@ def list_attempts(
         "id,concept_node_id,difficulty,score,total,mastery_before,"
         "mastery_after,completed_at,abandoned_at,created_at",
         filters={"user_id": f"eq.{user_id}"},
-        order="created_at.desc",
+        # `id` is the unique tiebreaker: without it two attempts sharing a
+        # created_at have undefined relative order across the separate
+        # queries serving page N and N+1, so a row can repeat or vanish.
+        # Same idiom as routes/gamification.py's xp_events paging.
+        order="created_at.desc,id.desc",
         limit=limit,
         offset=offset,
     )
@@ -602,20 +693,48 @@ def get_attempt(attempt_id: str, request: Request):
         )
     attempt = attempt_rows[0]
     require_self(attempt["user_id"], request)
-    _sweep_abandoned(attempt["user_id"])
 
-    questions = decrypt_json_column(attempt["questions_json"]) or []
     responses = table("quiz_responses").select(
         "question_index,selected_index,is_correct,time_ms,confidence,answered_at",
         filters={"attempt_id": f"eq.{attempt_id}"},
         order="question_index.asc",
     ) or []
+    last_activity = max(
+        (r.get("answered_at") for r in responses if r.get("answered_at")),
+        default=None,
+    )
+    status = _attempt_status(attempt, last_activity_at=last_activity)
+    # Answering keeps an attempt alive, so exempt it from the sweep.
+    _sweep_abandoned(
+        attempt["user_id"],
+        active_attempt_ids={attempt_id} if status == "in_progress" else None,
+    )
+
+    questions = decrypt_json_column(attempt["questions_json"]) or []
+    if questions and not all(_is_wire_question(q) for q in questions):
+        # A stored shape this code doesn't recognise has no safe keyless
+        # projection — passing it through would ship whatever key it holds
+        # (legacy rows store the answer under `a`). Refuse the resume.
+        logger.warning(
+            "quiz: attempt %s stores questions in an unrecognised shape; "
+            "refusing to resume", attempt_id,
+        )
+        raise QuizAPIError(
+            status_code=409,
+            code=QuizErrorCode.QUIZ_ATTEMPT_NOT_RESUMABLE,
+            message="This quiz can't be resumed. Start a new one.",
+        )
+    # Only an in-progress attempt hands back questions: a completed or
+    # abandoned one would otherwise let a client keep answering (the write
+    # paths refuse it, but there's no reason to ship the payload at all).
+    resumable = status == "in_progress"
     return {
         "quiz_id": attempt["id"],
-        "status": _attempt_status(attempt),
+        "status": status,
+        "resumable": resumable,
         "difficulty": attempt.get("difficulty"),
         "concept_node_id": attempt.get("concept_node_id"),
-        "questions": _strip_answer_key(questions),
+        "questions": _strip_answer_key(questions) if resumable else [],
         "responses": responses,
         "score": attempt.get("score"),
         "total": attempt.get("total"),
@@ -652,6 +771,7 @@ def answer_question(attempt_id: str, body: AnswerQuestionBody, request: Request)
             code=QuizErrorCode.QUIZ_ATTEMPT_ALREADY_COMPLETED,
             message="This quiz has already been submitted.",
         )
+    _refuse_if_abandoned(attempt)
 
     questions = decrypt_json_column(attempt["questions_json"]) or []
     if body.question_index >= len(questions):
@@ -775,6 +895,9 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
             code=QuizErrorCode.QUIZ_ATTEMPT_ALREADY_COMPLETED,
             message="This quiz has already been submitted.",
         )
+    # An abandoned attempt must not pay out mastery, XP or achievements —
+    # otherwise the TTL is a label and the sweep enforces nothing.
+    _refuse_if_abandoned(attempt)
     # The read above is only the fast path — two CONCURRENT submits (a
     # double-click on the final submit) would both pass it. The atomic claim
     # below (conditional update on completed_at IS NULL, PR #464 review) is
@@ -886,7 +1009,7 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
     # bumps times_studied/last_studied_at, records the event (now in
     # node_mastery_events), and updates the streak. We don't touch graph_nodes
     # or node_mastery_events directly — that's the graph slice's territory.
-    apply_graph_update(
+    applied = apply_graph_update(
         user_id,
         {
             "updated_nodes": [
@@ -900,6 +1023,18 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
         },
         course_id=node.get("course_id"),
     )
+    # #542 D1 (review): persist what the GRAPH actually wrote, not what we
+    # predicted. apply_graph_update owns the write — it resolves the node by
+    # normalized concept name and clamps the result — so its reported
+    # before/after is the only value that can't disagree with graph_nodes.
+    # Falls back to the local computation if the call returned nothing
+    # recognisable (it degrades rather than raising).
+    for change in applied or []:
+        if isinstance(change, dict) and change.get("after") is not None:
+            mastery_before = change.get("before", mastery_before)
+            mastery_after = change["after"]
+            mastery_delta = mastery_after - mastery_before
+            break
 
     table("quiz_attempts").update(
         {

--- a/backend/services/achievement_service.py
+++ b/backend/services/achievement_service.py
@@ -56,11 +56,18 @@ def _get_user_stat(user_id: str, trigger_type: str) -> int:
         return _count_rows("documents", {"user_id": f"eq.{user_id}"})
 
     if trigger_type == "quizzes_completed":
-        # #542 D3: completed attempts only — generate writes the attempt row
-        # BEFORE the student answers anything, so an unfiltered count let
-        # "generate and close the tab" advance quizzes_10.
+        # #542 D3: really-finished attempts only. Two filters, because
+        # neither alone is sufficient: generate writes the attempt row
+        # BEFORE the student answers anything (so an unfiltered count let
+        # "generate and close the tab" advance quizzes_10), and submit's
+        # atomic claim stamps completed_at BEFORE grading (so a submit that
+        # dies between the claim and the score write would still count).
+        # A persisted score is the evidence a quiz was graded — the same
+        # signal agents/tools/quiz_history.py treats as completion.
         return _count_rows("quiz_attempts", {
-            "user_id": f"eq.{user_id}", "completed_at": "not.is.null",
+            "user_id": f"eq.{user_id}",
+            "completed_at": "not.is.null",
+            "score": "not.is.null",
         })
 
     if trigger_type == "rooms_joined":

--- a/backend/services/achievement_service.py
+++ b/backend/services/achievement_service.py
@@ -56,7 +56,12 @@ def _get_user_stat(user_id: str, trigger_type: str) -> int:
         return _count_rows("documents", {"user_id": f"eq.{user_id}"})
 
     if trigger_type == "quizzes_completed":
-        return _count_rows("quiz_attempts", {"user_id": f"eq.{user_id}"})
+        # #542 D3: completed attempts only — generate writes the attempt row
+        # BEFORE the student answers anything, so an unfiltered count let
+        # "generate and close the tab" advance quizzes_10.
+        return _count_rows("quiz_attempts", {
+            "user_id": f"eq.{user_id}", "completed_at": "not.is.null",
+        })
 
     if trigger_type == "rooms_joined":
         return _count_rows("room_members", {"user_id": f"eq.{user_id}"})

--- a/backend/services/quiz_config.py
+++ b/backend/services/quiz_config.py
@@ -42,6 +42,14 @@ REQUESTED_DIFFICULTIES = CONCRETE_DIFFICULTIES + ("adaptive",)
 # short-answer grading.
 QUIZ_QUESTION_TYPES = ("multiple_choice",)
 
+# #542 D2: an in-progress attempt older than this is considered abandoned
+# (derived status + the lazy per-user sweep that stamps abandoned_at).
+# 24h: a quiz is a single sitting — anything paused across a day is not
+# coming back, and the resume endpoint stops offering it. Deliberately
+# generous vs. a session-length TTL so a student who steps away mid-quiz
+# for hours can still resume.
+QUIZ_ATTEMPT_ABANDON_TTL_HOURS = 24
+
 
 def quiz_config_payload() -> dict:
     """The GET /api/quiz/config response body."""

--- a/backend/services/quiz_errors.py
+++ b/backend/services/quiz_errors.py
@@ -34,6 +34,13 @@ class QuizErrorCode(str, Enum):
     QUIZ_CONCEPT_NOT_FOUND = "QUIZ_CONCEPT_NOT_FOUND"
     QUIZ_ATTEMPT_NOT_FOUND = "QUIZ_ATTEMPT_NOT_FOUND"
     QUIZ_ATTEMPT_ALREADY_COMPLETED = "QUIZ_ATTEMPT_ALREADY_COMPLETED"
+    # #542 D2: the attempt was swept as abandoned (past the TTL with no
+    # activity). Distinct from "already completed" — the student never
+    # finished it, and the client should offer a fresh quiz, not a resume.
+    QUIZ_ATTEMPT_ABANDONED = "QUIZ_ATTEMPT_ABANDONED"
+    # #542 review: the stored questions aren't in a shape we can safely
+    # show without the answer key, so this attempt cannot be resumed.
+    QUIZ_ATTEMPT_NOT_RESUMABLE = "QUIZ_ATTEMPT_NOT_RESUMABLE"
     # #541 C1: the answer endpoint got an index that doesn't exist on this
     # attempt (question_index past the quiz, selected_index past the options).
     QUIZ_QUESTION_INVALID = "QUIZ_QUESTION_INVALID"

--- a/backend/tests/integration/test_quiz_lifecycle_db.py
+++ b/backend/tests/integration/test_quiz_lifecycle_db.py
@@ -52,6 +52,45 @@ def test_lifecycle_columns_exist_and_round_trip(db_conn):
     assert row["abandoned_at"] is None
 
 
+def test_resume_and_history_refuse_another_students_attempt(
+    db_conn, authed_client, other_user_client
+):
+    """IDOR negatives the hermetic lane structurally cannot provide: its
+    conftest stubs require_self to a no-op, so only this lane (real HMAC
+    sessions, real rows) can prove the new GETs are owner-scoped."""
+    import uuid
+
+    from db.connection import table
+
+    attempt_id = str(uuid.uuid4())
+    table("quiz_attempts").insert({
+        "id": attempt_id,
+        "user_id": USER,                       # owned by rich-user-active
+        "concept_node_id": _node_id(db_conn),
+        "difficulty": "easy",
+        "questions_json": [],
+    })
+
+    # The owner can read it…
+    mine = authed_client.get(f"/api/quiz/attempts/{attempt_id}")
+    assert mine.status_code == 200
+
+    # …a different signed-in student cannot.
+    theirs = other_user_client.get(f"/api/quiz/attempts/{attempt_id}")
+    assert theirs.status_code in (403, 404), (
+        f"another student read attempt {attempt_id} (status {theirs.status_code})"
+    )
+    assert attempt_id not in theirs.text
+
+    # History is scoped by the SESSION, not the query param: asking for
+    # someone else's user_id must not return their attempts.
+    cross = other_user_client.get(
+        "/api/quiz/attempts", params={"user_id": USER}
+    )
+    assert cross.status_code in (403, 404)
+    assert attempt_id not in cross.text
+
+
 def test_sweep_marks_only_stale_unfinished_attempts(db_conn):
     """The conditional update must touch the stale in-progress row and
     leave the fresh one and the completed one alone."""

--- a/backend/tests/integration/test_quiz_lifecycle_db.py
+++ b/backend/tests/integration/test_quiz_lifecycle_db.py
@@ -1,0 +1,97 @@
+"""#542 real-DB half: attempt lifecycle columns against local Supabase.
+
+The mastery snapshot and abandonment sweep are pure DB behaviour — a
+mocked table() would happily accept columns the migration never added
+(the #265 schema/code-drift class). #397 seam: writes through the app
+layer, raw reads via psycopg.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+USER = "rich-user-active"
+
+
+def _node_id(db_conn) -> str:
+    row = db_conn.execute(
+        "SELECT id FROM graph_nodes WHERE user_id = %s ORDER BY id LIMIT 1",
+        (USER,),
+    ).fetchone()
+    assert row is not None
+    return row["id"]
+
+
+def test_lifecycle_columns_exist_and_round_trip(db_conn):
+    """mastery_before/after/abandoned_at must be real columns the app can
+    write — the exact drift a MagicMock suite cannot see."""
+    import uuid
+
+    from db.connection import table
+
+    attempt_id = str(uuid.uuid4())
+    table("quiz_attempts").insert({
+        "id": attempt_id,
+        "user_id": USER,
+        "concept_node_id": _node_id(db_conn),
+        "difficulty": "medium",
+        "questions_json": [],
+    })
+    table("quiz_attempts").update(
+        {"mastery_before": 0.25, "mastery_after": 0.34},
+        filters={"id": f"eq.{attempt_id}"},
+    )
+    row = db_conn.execute(
+        "SELECT mastery_before, mastery_after, abandoned_at "
+        "FROM quiz_attempts WHERE id = %s",
+        (attempt_id,),
+    ).fetchone()
+    assert row["mastery_before"] == pytest.approx(0.25)
+    assert row["mastery_after"] == pytest.approx(0.34)
+    assert row["abandoned_at"] is None
+
+
+def test_sweep_marks_only_stale_unfinished_attempts(db_conn):
+    """The conditional update must touch the stale in-progress row and
+    leave the fresh one and the completed one alone."""
+    import uuid
+
+    from db.connection import table
+    from routes.quiz import _sweep_abandoned
+    from services.quiz_config import QUIZ_ATTEMPT_ABANDON_TTL_HOURS
+
+    node_id = _node_id(db_conn)
+    stale_id, fresh_id, done_id = (str(uuid.uuid4()) for _ in range(3))
+    now = datetime.now(timezone.utc)
+    long_ago = (now - timedelta(hours=QUIZ_ATTEMPT_ABANDON_TTL_HOURS + 2)).isoformat()
+
+    for attempt_id, created_at, completed_at in (
+        (stale_id, long_ago, None),
+        (fresh_id, now.isoformat(), None),
+        (done_id, long_ago, now.isoformat()),
+    ):
+        payload = {
+            "id": attempt_id,
+            "user_id": USER,
+            "concept_node_id": node_id,
+            "difficulty": "easy",
+            "questions_json": [],
+            "created_at": created_at,
+        }
+        if completed_at:
+            payload["completed_at"] = completed_at
+        table("quiz_attempts").insert(payload)
+
+    _sweep_abandoned(USER)
+
+    rows = {
+        r["id"]: r
+        for r in db_conn.execute(
+            "SELECT id, abandoned_at FROM quiz_attempts WHERE id = ANY(%s)",
+            ([stale_id, fresh_id, done_id],),
+        ).fetchall()
+    }
+    assert rows[stale_id]["abandoned_at"] is not None, "stale in-progress attempt not swept"
+    assert rows[fresh_id]["abandoned_at"] is None, "a fresh attempt must stay resumable"
+    assert rows[done_id]["abandoned_at"] is None, "a completed attempt is never abandoned"

--- a/backend/tests/test_quiz_lifecycle_d.py
+++ b/backend/tests/test_quiz_lifecycle_d.py
@@ -113,6 +113,58 @@ class TestMasterySnapshotPersisted:
         assert row["mastery_before"] == 0.5
         assert row["mastery_after"] == r.json()["mastery_after"]
 
+    def test_snapshot_records_what_the_graph_actually_wrote(self):
+        """apply_graph_update owns the write (it clamps and resolves by
+        concept name); persisting submit's local prediction instead would
+        let history show progression the graph never took."""
+        update_calls: list = []
+
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                mock.select.return_value = [_attempt_row()]
+
+                def _update(data, filters=None, **kw):
+                    update_calls.append(data)
+                    return [{"id": "quiz1"}]
+                mock.update.side_effect = _update
+            elif name == "graph_nodes":
+                mock.select.return_value = [{
+                    "mastery_score": 0.5,
+                    "concept_name": "Loops",
+                    "course_id": "course1",
+                }]
+            else:
+                mock.select.return_value = []
+                mock.update.return_value = []
+            return mock
+
+        # The graph clamped to 0.9 rather than the 0.53 submit predicted.
+        applied = MagicMock(return_value=[
+            {"concept": "Loops", "before": 0.5, "after": 0.9},
+        ])
+        with (
+            patch("routes.quiz.table", side_effect=factory),
+            patch("routes.quiz.apply_graph_update", new=applied),
+            patch("routes.quiz.get_quiz_context", return_value={}),
+            patch(
+                "routes.quiz.quiz_context_agent.run",
+                new=AsyncMock(return_value=SimpleNamespace(
+                    output=SimpleNamespace(model_dump=lambda: {})
+                )),
+            ),
+            patch("routes.quiz.save_quiz_context"),
+        ):
+            r = client.post("/api/quiz/submit", json={
+                "quiz_id": "quiz1",
+                "answers": [{"question_id": 1, "selected_label": "B"}],
+            })
+
+        assert r.status_code == 200
+        stored = [d for d in update_calls if "score" in d][0]
+        assert stored["mastery_after"] == 0.9
+        assert r.json()["mastery_after"] == 0.9
+
 
 # ── D2: derived status + resume ─────────────────────────────────────────────
 
@@ -130,6 +182,46 @@ class TestAttemptResume:
             return mock
 
         return factory
+
+    def test_resume_never_ships_the_explanation(self):
+        """The explanation names the correct option in prose ("B is
+        right."), so shipping it on resume hands over the answer key in a
+        different field — the exact hole C3/D2 exist to close."""
+        with patch("routes.quiz.table",
+                   side_effect=self._factory(_attempt_row())):
+            r = client.get("/api/quiz/attempts/quiz1")
+        assert r.status_code == 200
+        body = r.text
+        assert "B is right." not in body
+        for q in r.json()["questions"]:
+            assert "explanation" not in q
+
+    def test_resume_refuses_unrecognised_stored_shapes(self):
+        """_strip_answer_key only understands the current wire shape. A
+        legacy/foreign row (e.g. the seed's {"q":..., "a": "Av = λv"})
+        must NOT be passed through with its answer intact and an empty
+        options list — refuse the resume instead."""
+        legacy = _attempt_row(questions_json=[
+            {"q": "What defines an eigenvalue?", "a": "Av = lambda v"},
+        ])
+        with patch("routes.quiz.table", side_effect=self._factory(legacy)):
+            r = client.get("/api/quiz/attempts/quiz1")
+        assert r.status_code == 409
+        assert r.json()["error"]["code"] == "QUIZ_ATTEMPT_NOT_RESUMABLE"
+        assert "Av = lambda v" not in r.text
+
+    def test_abandoned_attempt_is_not_resumable(self):
+        """A swept attempt must stop being offered — the config comment
+        promises exactly this, and serving its questions while /answer and
+        /submit still accept them makes the TTL enforce nothing."""
+        abandoned = _attempt_row(abandoned_at="2026-08-12T01:00:00+00:00")
+        with patch("routes.quiz.table", side_effect=self._factory(abandoned)):
+            r = client.get("/api/quiz/attempts/quiz1")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "abandoned"
+        assert data["questions"] == [], "an abandoned attempt must not serve questions"
+        assert data["resumable"] is False
 
     def test_resume_returns_keyless_questions_and_responses(self):
         responses = [{
@@ -171,6 +263,58 @@ class TestAttemptResume:
         assert r.json()["error"]["code"] == "QUIZ_ATTEMPT_NOT_FOUND"
 
 
+class TestAbandonedIsEnforced:
+    """The abandoned state has to bite on the WRITE paths too, or it's a
+    label: /answer and /submit both accepted swept attempts and paid out
+    mastery, XP and achievements."""
+
+    def _factory(self, attempt, responses=None):
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                mock.select.return_value = [attempt]
+                mock.update.return_value = []
+            elif name == "quiz_responses":
+                mock.select.return_value = responses or []
+            elif name == "graph_nodes":
+                mock.select.return_value = [{
+                    "mastery_score": 0.5, "concept_name": "Loops",
+                    "course_id": "course1",
+                }]
+            else:
+                mock.select.return_value = []
+                mock.update.return_value = []
+            return mock
+
+        return factory
+
+    def test_answer_on_an_abandoned_attempt_409s(self):
+        abandoned = _attempt_row(abandoned_at="2026-08-12T01:00:00+00:00")
+        with patch("routes.quiz.table", side_effect=self._factory(abandoned)):
+            r = client.post("/api/quiz/attempts/quiz1/answer", json={
+                "question_index": 0, "selected_index": 1,
+            })
+        assert r.status_code == 409
+        assert r.json()["error"]["code"] == "QUIZ_ATTEMPT_ABANDONED"
+
+    def test_submit_of_an_abandoned_attempt_409s_and_writes_nothing(self):
+        abandoned = _attempt_row(abandoned_at="2026-08-12T01:00:00+00:00")
+        apply_mock = MagicMock()
+        with (
+            patch("routes.quiz.table", side_effect=self._factory(abandoned)),
+            patch("routes.quiz.apply_graph_update", new=apply_mock),
+            patch("routes.quiz.get_quiz_context", return_value={}),
+            patch("routes.quiz.save_quiz_context"),
+        ):
+            r = client.post("/api/quiz/submit", json={
+                "quiz_id": "quiz1",
+                "answers": [{"question_id": 1, "selected_label": "B"}],
+            })
+        assert r.status_code == 409
+        assert r.json()["error"]["code"] == "QUIZ_ATTEMPT_ABANDONED"
+        apply_mock.assert_not_called()
+
+
 # ── D2: lazy TTL sweep ──────────────────────────────────────────────────────
 
 
@@ -186,8 +330,8 @@ class TestAbandonSweep:
         def factory(name):
             mock = MagicMock()
             if name == "quiz_attempts":
-                def _update(data, filters=None):
-                    update_calls.append((data, filters))
+                def _update(data, filters=None, *, prefer_return_minimal=False):
+                    update_calls.append((data, filters, prefer_return_minimal))
                     return []
                 mock.update.side_effect = _update
             return mock
@@ -196,8 +340,11 @@ class TestAbandonSweep:
             _sweep_abandoned("user_andres")
 
         assert len(update_calls) == 1
-        data, filters = update_calls[0]
+        data, filters, minimal = update_calls[0]
         assert "abandoned_at" in data
+        # A write triggered by a GET must not drag every swept row (with
+        # its encrypted blobs) back over the wire.
+        assert minimal is True
         assert filters["user_id"] == "eq.user_andres"
         assert filters["completed_at"] == "is.null"
         assert filters["abandoned_at"] == "is.null"
@@ -209,12 +356,48 @@ class TestAbandonSweep:
         )
         assert abs((cutoff - expected).total_seconds()) < 60
 
+    def test_recent_answer_activity_keeps_an_attempt_alive(self):
+        """An attempt generated long ago but answered minutes ago is being
+        worked on — sweeping it by created_at alone would strand the
+        responses already recorded against it."""
+        from routes.quiz import _attempt_status
+
+        old_attempt = _attempt_row(
+            created_at=(datetime.now(timezone.utc) - timedelta(days=3)).isoformat()
+        )
+        assert _attempt_status(old_attempt) == "abandoned"
+        assert _attempt_status(
+            old_attempt,
+            last_activity_at=(
+                datetime.now(timezone.utc) - timedelta(minutes=2)
+            ).isoformat(),
+        ) == "in_progress"
+
+    def test_naive_created_at_does_not_explode(self):
+        """A timezone-naive timestamp (out-of-band write) parses fine and
+        then raises TypeError on the aware comparison — past the
+        ValueError guard."""
+        from routes.quiz import _attempt_status
+
+        naive = _attempt_row(created_at="2020-01-01T00:00:00")
+        assert _attempt_status(naive) in {"abandoned", "in_progress"}
+
+    def test_unparseable_created_at_does_not_explode(self):
+        from routes.quiz import _attempt_status
+
+        assert _attempt_status(_attempt_row(created_at="not-a-date")) == "in_progress"
+
 
 # ── D3: achievements count completed attempts only ──────────────────────────
 
 
 class TestAchievementCountsCompletedOnly:
-    def test_quizzes_completed_stat_filters_on_completed_at(self):
+    def test_quizzes_completed_stat_requires_a_recorded_score(self):
+        """completed_at is stamped by the atomic claim BEFORE grading, so
+        filtering on it alone still counts attempts that were never scored
+        (e.g. the graph read 404s after the claim). The evidence a quiz was
+        really finished is a persisted score — the same signal
+        agents/tools/quiz_history.py treats as completion."""
         from services import achievement_service
 
         captured = {}
@@ -233,8 +416,12 @@ class TestAchievementCountsCompletedOnly:
             achievement_service.get_user_stat("u1", "quizzes_completed")
 
         assert captured["table"] == "quiz_attempts"
-        assert captured["filters"]["completed_at"] == "not.is.null", (
+        filters = captured["filters"]
+        assert filters["completed_at"] == "not.is.null", (
             "an abandoned generate must not advance quizzes_10 (#542 D3)"
+        )
+        assert filters["score"] == "not.is.null", (
+            "a claimed-but-never-graded attempt must not advance quizzes_10"
         )
 
 
@@ -252,10 +439,15 @@ class TestAttemptHistory:
                          created_at="2026-08-11T00:00:00+00:00"),
         ]
 
+        selected = {}
+
         def factory(name):
             mock = MagicMock()
             if name == "quiz_attempts":
-                mock.select_with_count.return_value = (attempts, 2)
+                def _swc(columns="*", filters=None, order=None, limit=None, offset=None):
+                    selected["columns"] = columns
+                    return attempts, 2
+                mock.select_with_count.side_effect = _swc
                 mock.update.return_value = []
             elif name == "graph_nodes":
                 mock.select.return_value = [{
@@ -285,4 +477,58 @@ class TestAttemptHistory:
         assert second["status"] == "abandoned"
         assert second["mastery_delta"] is None
         # No question payloads (and therefore no keys) on the history list.
+        # Asserted against the SELECTED COLUMNS, not the mocked rows: the
+        # rows above happen to carry questions_json, so `"questions" not in
+        # first` alone would pass even if the route echoed them.
         assert "questions" not in first
+        assert "questions_json" not in first
+        assert "questions_json" not in selected["columns"], (
+            "history must not even fetch the question payloads"
+        )
+
+    def test_offset_is_clamped_at_the_top(self):
+        """An arbitrarily large offset is stringified into PostgREST's
+        offset param and Postgres rejects it as bigint-out-of-range —
+        a 500 where an empty page is the honest answer."""
+        captured = {}
+
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                def _swc(columns="*", filters=None, order=None, limit=None, offset=None):
+                    captured["offset"] = offset
+                    return [], 0
+                mock.select_with_count.side_effect = _swc
+                mock.update.return_value = []
+            else:
+                mock.select.return_value = []
+            return mock
+
+        with patch("routes.quiz.table", side_effect=factory):
+            r = client.get("/api/quiz/attempts", params={
+                "user_id": "user_andres", "offset": 99999999999999999999,
+            })
+        assert r.status_code == 200
+        assert captured["offset"] < 2**31
+
+    def test_pagination_order_has_a_unique_tiebreaker(self):
+        """Rows sharing a created_at need a stable secondary sort or they
+        can repeat/vanish across page boundaries (the created_at,id
+        precedent in gamification.py)."""
+        captured = {}
+
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                def _swc(columns="*", filters=None, order=None, limit=None, offset=None):
+                    captured["order"] = order
+                    return [], 0
+                mock.select_with_count.side_effect = _swc
+                mock.update.return_value = []
+            else:
+                mock.select.return_value = []
+            return mock
+
+        with patch("routes.quiz.table", side_effect=factory):
+            client.get("/api/quiz/attempts", params={"user_id": "user_andres"})
+        assert "id" in captured["order"]

--- a/backend/tests/test_quiz_lifecycle_d.py
+++ b/backend/tests/test_quiz_lifecycle_d.py
@@ -1,0 +1,288 @@
+"""
+Workstream D of the pre-revamp quiz repair batch (#542, epic #537):
+attempt lifecycle.
+
+- D1: submit persists mastery_before / mastery_after on the attempt row.
+- D2: status is DERIVED (completed_at → completed, abandoned_at →
+  abandoned, else in_progress); a lazy per-user TTL sweep stamps
+  abandoned_at; GET /api/quiz/attempts/{id} returns resume state —
+  questions WITHOUT the answer key, plus recorded responses.
+- D3: the quizzes_completed achievement stat counts completed attempts
+  only (an abandoned generate no longer advances quizzes_10).
+- D4: GET /api/quiz/attempts — paginated history for the signed-in user.
+"""
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+QUESTIONS = [
+    {
+        "id": 1,
+        "question": "Q1?",
+        "options": [
+            {"label": "A", "text": "a1", "correct": False},
+            {"label": "B", "text": "b1", "correct": True},
+        ],
+        "explanation": "B is right.",
+        "concept_tested": "Loops",
+        "difficulty": "medium",
+    },
+]
+
+
+def _recent() -> str:
+    """A created_at inside the abandon TTL — relative, so the suite doesn't
+    rot as wall-clock time passes the fixture date."""
+    return (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+
+
+def _attempt_row(**overrides) -> dict:
+    row = {
+        "id": "quiz1",
+        "user_id": "user_andres",
+        "concept_node_id": "node1",
+        "difficulty": "medium",
+        "questions_json": QUESTIONS,
+        "score": None,
+        "total": None,
+        "completed_at": None,
+        "abandoned_at": None,
+        "mastery_before": None,
+        "mastery_after": None,
+        "created_at": _recent(),
+    }
+    row.update(overrides)
+    return row
+
+
+# ── D1: mastery snapshot persisted at submit ────────────────────────────────
+
+
+class TestMasterySnapshotPersisted:
+    def test_submit_writes_mastery_before_and_after(self):
+        update_calls: list = []
+
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                mock.select.return_value = [_attempt_row()]
+
+                def _update(data, filters=None):
+                    update_calls.append(data)
+                    return [{"id": "quiz1"}]
+                mock.update.side_effect = _update
+            elif name == "graph_nodes":
+                mock.select.return_value = [{
+                    "mastery_score": 0.5,
+                    "concept_name": "Loops",
+                    "course_id": "course1",
+                }]
+            else:
+                mock.select.return_value = []
+                mock.update.return_value = []
+            return mock
+
+        with (
+            patch("routes.quiz.table", side_effect=factory),
+            patch("routes.quiz.apply_graph_update"),
+            patch("routes.quiz.get_quiz_context", return_value={}),
+            patch(
+                "routes.quiz.quiz_context_agent.run",
+                new=AsyncMock(return_value=SimpleNamespace(
+                    output=SimpleNamespace(model_dump=lambda: {})
+                )),
+            ),
+            patch("routes.quiz.save_quiz_context"),
+        ):
+            r = client.post("/api/quiz/submit", json={
+                "quiz_id": "quiz1",
+                "answers": [{"question_id": 1, "selected_label": "B"}],
+            })
+
+        assert r.status_code == 200
+        final = [d for d in update_calls if "score" in d]
+        assert len(final) == 1
+        row = final[0]
+        assert row["mastery_before"] == 0.5
+        assert row["mastery_after"] == r.json()["mastery_after"]
+
+
+# ── D2: derived status + resume ─────────────────────────────────────────────
+
+
+class TestAttemptResume:
+    def _factory(self, attempt, responses=None):
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                mock.select.return_value = [attempt] if attempt else []
+            elif name == "quiz_responses":
+                mock.select.return_value = responses or []
+            else:
+                mock.select.return_value = []
+            return mock
+
+        return factory
+
+    def test_resume_returns_keyless_questions_and_responses(self):
+        responses = [{
+            "attempt_id": "quiz1", "question_index": 0,
+            "selected_index": 1, "is_correct": True,
+            "time_ms": 900, "confidence": None,
+            "answered_at": "2026-08-12T00:01:00+00:00",
+        }]
+        with patch("routes.quiz.table",
+                   side_effect=self._factory(_attempt_row(), responses)):
+            r = client.get("/api/quiz/attempts/quiz1")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "in_progress"
+        assert data["quiz_id"] == "quiz1"
+        # The key must never ride along on a resume payload.
+        for q in data["questions"]:
+            assert all("correct" not in o for o in q["options"])
+        assert data["responses"][0]["question_index"] == 0
+        assert data["responses"][0]["is_correct"] is True
+
+    def test_status_derivations(self):
+        cases = [
+            (_attempt_row(completed_at="2026-08-12T01:00:00+00:00",
+                          score=1, total=1), "completed"),
+            (_attempt_row(abandoned_at="2026-08-12T01:00:00+00:00"), "abandoned"),
+            (_attempt_row(), "in_progress"),
+        ]
+        for attempt, expected in cases:
+            with patch("routes.quiz.table", side_effect=self._factory(attempt)):
+                r = client.get("/api/quiz/attempts/quiz1")
+            assert r.status_code == 200
+            assert r.json()["status"] == expected
+
+    def test_unknown_attempt_404s(self):
+        with patch("routes.quiz.table", side_effect=self._factory(None)):
+            r = client.get("/api/quiz/attempts/nope")
+        assert r.status_code == 404
+        assert r.json()["error"]["code"] == "QUIZ_ATTEMPT_NOT_FOUND"
+
+
+# ── D2: lazy TTL sweep ──────────────────────────────────────────────────────
+
+
+class TestAbandonSweep:
+    def test_sweep_marks_stale_in_progress_attempts(self):
+        """The per-user sweep stamps abandoned_at on in-progress rows older
+        than the TTL — conditional update filters arbitrate, not app code."""
+        from routes.quiz import _sweep_abandoned
+        from services.quiz_config import QUIZ_ATTEMPT_ABANDON_TTL_HOURS
+
+        update_calls = []
+
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                def _update(data, filters=None):
+                    update_calls.append((data, filters))
+                    return []
+                mock.update.side_effect = _update
+            return mock
+
+        with patch("routes.quiz.table", side_effect=factory):
+            _sweep_abandoned("user_andres")
+
+        assert len(update_calls) == 1
+        data, filters = update_calls[0]
+        assert "abandoned_at" in data
+        assert filters["user_id"] == "eq.user_andres"
+        assert filters["completed_at"] == "is.null"
+        assert filters["abandoned_at"] == "is.null"
+        cutoff_expr = filters["created_at"]
+        assert cutoff_expr.startswith("lt.")
+        cutoff = datetime.fromisoformat(cutoff_expr[3:])
+        expected = datetime.now(timezone.utc) - timedelta(
+            hours=QUIZ_ATTEMPT_ABANDON_TTL_HOURS
+        )
+        assert abs((cutoff - expected).total_seconds()) < 60
+
+
+# ── D3: achievements count completed attempts only ──────────────────────────
+
+
+class TestAchievementCountsCompletedOnly:
+    def test_quizzes_completed_stat_filters_on_completed_at(self):
+        from services import achievement_service
+
+        captured = {}
+
+        def _fake_table(name):
+            mock = MagicMock()
+
+            def _select(columns="*", filters=None, **kw):
+                captured["table"] = name
+                captured["filters"] = filters
+                return []
+            mock.select.side_effect = _select
+            return mock
+
+        with patch("services.achievement_service.table", side_effect=_fake_table):
+            achievement_service.get_user_stat("u1", "quizzes_completed")
+
+        assert captured["table"] == "quiz_attempts"
+        assert captured["filters"]["completed_at"] == "not.is.null", (
+            "an abandoned generate must not advance quizzes_10 (#542 D3)"
+        )
+
+
+# ── D4: paginated history ───────────────────────────────────────────────────
+
+
+class TestAttemptHistory:
+    def test_history_lists_the_sessions_users_attempts(self):
+        attempts = [
+            _attempt_row(id="q-new", completed_at="2026-08-12T02:00:00+00:00",
+                         score=2, total=3, mastery_before=0.5,
+                         mastery_after=0.55,
+                         created_at="2026-08-12T01:59:00+00:00"),
+            _attempt_row(id="q-old", abandoned_at="2026-08-11T00:10:00+00:00",
+                         created_at="2026-08-11T00:00:00+00:00"),
+        ]
+
+        def factory(name):
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                mock.select_with_count.return_value = (attempts, 2)
+                mock.update.return_value = []
+            elif name == "graph_nodes":
+                mock.select.return_value = [{
+                    "id": "node1", "concept_name": "Loops",
+                    "course_id": "course1",
+                }]
+            else:
+                mock.select.return_value = []
+            return mock
+
+        with patch("routes.quiz.table", side_effect=factory):
+            r = client.get("/api/quiz/attempts", params={"user_id": "user_andres"})
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 2
+        first = data["attempts"][0]
+        assert first["quiz_id"] == "q-new"
+        assert first["status"] == "completed"
+        assert first["concept_name"] == "Loops"
+        assert first["course_id"] == "course1"
+        assert first["score"] == 2
+        assert first["total"] == 3
+        assert first["difficulty"] == "medium"
+        assert first["mastery_delta"] == 0.05
+        assert first["created_at"] == attempts[0]["created_at"]
+        second = data["attempts"][1]
+        assert second["status"] == "abandoned"
+        assert second["mastery_delta"] is None
+        # No question payloads (and therefore no keys) on the history list.
+        assert "questions" not in first


### PR DESCRIPTION
Closes #542. Workstream D of the pre-revamp quiz repair batch (epic #537). The attempt lifecycle leaked orphans and leaked the answer key; the plaintext scalars kept for analytics in #521/#527 had no reader at all.

## What

**D1 — mastery snapshot persisted.** `mastery_before` / `mastery_after` land on the attempt row at submit (migration `20260813013547`, plaintext scalars per the #521 rationale). Without them a replayed or audited submit can't reconstruct what the student saw — the reason the #129 replay guard had to 409 instead of replaying the original 200.

**D2 — explicit status, derived not stored.** `completed_at` → `completed`, `abandoned_at` → `abandoned`, else `in_progress`; an in-progress row past `QUIZ_ATTEMPT_ABANDON_TTL_HOURS` (24h, documented: a quiz is one sitting, but generous enough that stepping away for hours still resumes) reads as abandoned even before it's stamped. A lazy per-user sweep on the read paths stamps `abandoned_at` via conditional-update filters — same idiom as the submit claim, no scheduler. `GET /api/quiz/attempts/{id}` returns resume state: questions **without** the answer key plus the responses recorded through `/answer`.

**D3 — achievements count completed attempts only.** `generate` writes the attempt row before the student answers anything, so the unfiltered count let "generate and close the tab" advance `quizzes_10`.

**Blast radius (measured on staging, 2026-08-12):** 1 user, 2 attempts, **0 completed**, `quizzes_10` (threshold 10) **never granted**. Nobody loses a badge; one user's progress number drops 2 → 0. The achievement system is idempotent on `(user_id, achievement_id)` and grants are never revoked by this change — a recount can only withhold a badge not yet earned, and any already-granted badge stays. Prod recheck before merge is noted below.

**D4 — `GET /api/quiz/attempts`.** Paginated history for the signed-in user: concept, course, score, total, difficulty, mastery delta, dates. No question payloads, so no keys.

## Wire-contract notes

All three endpoints are additive; no existing response shape changes. `submit` gains two persisted columns (response unchanged). No client code depends on the new routes yet — they exist for the #537 flow.

## Verification

- Hermetic suite: **1949 passed** (7 new lifecycle tests, written first, watched fail).
- Real-DB integration tests: lifecycle columns round-trip; the sweep touches the stale in-progress attempt and leaves a fresh one and a completed one alone (mocked tables can't see either).
- Full local cycle under the stack lock: Playwright → oracles → integration → teardown.
- `ruff check` clean. Migration applied to staging ahead of merge.

**Prod check before promoting:** re-run the D3 blast-radius query against production (`SELECT count(*) FILTER (WHERE completed_at IS NULL) FROM quiz_attempts` + granted `quizzes_completed` badges). Staging is clean; prod was not re-queried after this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quiz attempt history with pagination.
  * Added the ability to resume eligible in-progress quiz attempts.
  * Added automatic handling of stale attempts after 24 hours of inactivity.
  * Added clearer statuses and error messages for abandoned or non-resumable attempts.
  * Improved quiz completion tracking to count only fully completed and scored attempts.

* **Bug Fixes**
  * Prevented answers and submissions from being added to abandoned attempts.
  * Protected answer keys from appearing in resume and history responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->