### PR TITLE
feat(quiz): mastery-model seam, honest delivered counts, wire validation, concurrency tests (#543)

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -63,6 +63,18 @@ ORCHESTRATOR_LIMITS = UsageLimits(
     total_tokens_limit=100_000,
 )
 
+# #543 E2: the quiz generation top-up runs a SECOND agent call in the same
+# request. Reusing ORCHESTRATOR_LIMITS would hand it a fresh full budget,
+# silently doubling the per-request cost backstop that limit exists to be.
+# The retry only rewrites a handful of questions and already has the
+# concept context in its prompt, so a fraction of the budget is enough —
+# and it keeps one request's worst case close to the intended ceiling.
+TOPUP_LIMITS = UsageLimits(
+    request_limit=4,
+    tool_calls_limit=4,
+    total_tokens_limit=40_000,
+)
+
 # The chat tutor's own ceiling (#149): its tool surface grew to seven
 # (two graph readers joined the five ADR-0015 tools), so a legitimately
 # tool-heavy turn — a couple of reads plus graph writes — needs more

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -25,7 +25,10 @@ from services.auth_guard import require_self
 from services.quiz_config import (
     CONCRETE_DIFFICULTIES,
     QUIZ_ATTEMPT_ABANDON_TTL_HOURS,
+    QUIZ_TOPUP_DROP_RATIO,
+    QUIZ_TOPUP_MAX_RETRIES,
     REQUESTED_DIFFICULTIES,
+    mastery_after,
     quiz_config_payload,
 )
 from services.quiz_errors import QuizAPIError, QuizErrorCode
@@ -241,6 +244,42 @@ def _resolved_difficulty(wire_questions: list[dict]) -> str:
     return max(counts, key=lambda d: (counts[d], _DIFFICULTY_RANK[d]))
 
 
+# The wire contract every emitted question must satisfy (#543 E3). The
+# agent schema already pins 4 options, but the route is the boundary the
+# stored questions_json and every grading path trust, so it validates
+# rather than assuming.
+_MIN_OPTIONS = 2
+
+
+def _validate_wire_question(wire: dict) -> bool:
+    """True if this wire question is answerable and gradable.
+
+    Rejects: fewer than two options, duplicate option text (the student
+    can pick "the same" answer and be wrong), and anything other than
+    exactly one correct option (zero = ungradable free point per #129,
+    two = the grader's first-match wins silently).
+    """
+    options = wire.get("options") or []
+    qid = wire.get("id")
+    if len(options) < _MIN_OPTIONS:
+        logger.warning(
+            "quiz: dropping question id=%s — only %d option(s)", qid, len(options)
+        )
+        return False
+    texts = [str(o.get("text", "")).strip().casefold() for o in options]
+    if len(set(texts)) != len(texts):
+        logger.warning("quiz: dropping question id=%s — duplicate option text", qid)
+        return False
+    n_correct = sum(1 for o in options if o.get("correct"))
+    if n_correct != 1:
+        logger.warning(
+            "quiz: dropping question id=%s — %d correct options (need exactly 1)",
+            qid, n_correct,
+        )
+        return False
+    return True
+
+
 def _agent_question_to_wire(q: QuizQuestion, qid: int) -> dict | None:
     """Map an agent QuizQuestion to the legacy wire-format dict, or
     return None if the question violates the contract.
@@ -285,6 +324,8 @@ def _agent_question_to_wire(q: QuizQuestion, qid: int) -> dict | None:
             "options (n_options=%d, canonical_len=%d, fp=%s)",
             qid, len(q.options), len(canonical_only), fp,
         )
+        return None
+    if not _validate_wire_question({"id": qid, "options": options}):
         return None
     return {
         "id": qid,
@@ -462,19 +503,65 @@ async def _quiz_via_agent(
     run_kwargs: dict = {"deps": deps, "usage_limits": ORCHESTRATOR_LIMITS}
     if model_override is not None:
         run_kwargs["model"] = model_override
-    result = record_agent_usage(
-        await quiz_agent.run(user_message, **run_kwargs),
-        feature="quiz", task="quiz", user_id=deps.user_id,
-    )
-    quiz: Quiz = result.output
-    # Filter out questions where the agent's correct_answer didn't match
-    # any option verbatim — _agent_question_to_wire returns None for those.
-    # Re-number the survivors so question IDs stay 1-based and contiguous.
+
+    async def _run(message: str) -> Quiz:
+        result = record_agent_usage(
+            await quiz_agent.run(message, **run_kwargs),
+            feature="quiz", task="quiz", user_id=deps.user_id,
+        )
+        return result.output
+
+    # Filter out questions the agent got wrong (correct_answer not among
+    # the options, duplicate/insufficient options, no single correct
+    # answer) and duplicate stems within this attempt —
+    # _agent_question_to_wire returns None for the former,
+    # _validate_wire_question backs it. Survivors are re-numbered so
+    # question ids stay 1-based and contiguous.
     wire_questions: list[dict] = []
-    for q in quiz.questions:
-        mapped = _agent_question_to_wire(q, len(wire_questions) + 1)
-        if mapped is not None:
-            wire_questions.append(mapped)
+    seen_stems: set[str] = set()
+
+    def _absorb(quiz: Quiz) -> None:
+        for q in quiz.questions:
+            stem = q.question.strip().casefold()
+            if stem in seen_stems:
+                logger.warning(
+                    "quiz: dropping duplicate question stem (len=%d)", len(stem)
+                )
+                continue
+            mapped = _agent_question_to_wire(q, len(wire_questions) + 1)
+            if mapped is not None:
+                seen_stems.add(stem)
+                wire_questions.append(mapped)
+
+    _absorb(await _run(user_message))
+
+    # #543 E2: one bounded top-up when drift cost us a big share of the
+    # quiz. Bounded because a retry loop against a drifting model burns
+    # tokens without converging — a slightly short quiz beats a slow one.
+    missing = num_questions - len(wire_questions)
+    if wire_questions and missing > 0 and missing >= num_questions * QUIZ_TOPUP_DROP_RATIO:
+        for _ in range(QUIZ_TOPUP_MAX_RETRIES):
+            logger.info(
+                "quiz: topping up after drift (have=%d, requested=%d)",
+                len(wire_questions), num_questions,
+            )
+            topup_msg = (
+                f"{user_message}\n\n[TOP-UP] Several questions were rejected for "
+                f"format errors. Generate {missing} MORE questions on the same "
+                f"concept, different from the ones already asked. Remember: "
+                f"correct_answer must appear VERBATIM in options."
+            )
+            try:
+                _absorb(await _run(topup_msg))
+            except Exception:
+                # A failed top-up must not lose the questions we already
+                # have — serve the short quiz with an honest count.
+                logger.exception("quiz: top-up run failed; serving what we have")
+                break
+            missing = num_questions - len(wire_questions)
+            if missing <= 0:
+                break
+
     if not wire_questions:
         # All questions dropped — raise so generate_quiz's bare-Exception
         # catch degrades to HTTP 502 (the raw-Gemini legacy fallback was
@@ -482,7 +569,8 @@ async def _quiz_via_agent(
         raise RuntimeError(
             "quiz_agent produced no valid questions after wire-format validation"
         )
-    return wire_questions
+    # Never serve more than asked for (a generous top-up run can overshoot).
+    return wire_questions[:num_questions]
 
 @router.get("/config")
 def quiz_config():
@@ -609,6 +697,12 @@ async def generate_quiz(body: GenerateQuizBody, request: Request):
         "questions": response_questions,
         "requested_difficulty": body.difficulty,
         "resolved_difficulty": _resolved_difficulty(questions),
+        # #543 E2: never silently short-change a quiz. Drift (and the
+        # bounded top-up) can leave fewer questions than asked for; the
+        # client can now say so instead of pretending this is what was
+        # requested.
+        "requested_count": body.num_questions,
+        "delivered_count": len(questions),
     }
 
 
@@ -992,8 +1086,11 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
         )
     node = node_rows[0]
     mastery_before = node["mastery_score"]
-    mastery_after = max(0.0, min(1.0, mastery_before + (score * 0.03) - ((total - score) * 0.02)))
-    mastery_delta = mastery_after - mastery_before
+    # #543 E1: the model is a named seam now (services/quiz_config.py).
+    # The numbers are unchanged — see docs/quiz-mastery-model.md for the
+    # options the revamp gets to choose from.
+    mastery_score_after = mastery_after(mastery_before, score=score, total=total)
+    mastery_delta = mastery_score_after - mastery_before
 
     score_ratio = score / total if total > 0 else 0.0
     if score_ratio >= 0.7:
@@ -1032,8 +1129,10 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
     for change in applied or []:
         if isinstance(change, dict) and change.get("after") is not None:
             mastery_before = change.get("before", mastery_before)
-            mastery_after = change["after"]
-            mastery_delta = mastery_after - mastery_before
+            # NB: mastery_after is the imported model function (#543 E1);
+            # the value lives in mastery_score_after.
+            mastery_score_after = change["after"]
+            mastery_delta = mastery_score_after - mastery_before
             break
 
     table("quiz_attempts").update(
@@ -1048,7 +1147,7 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
             # submit can't reconstruct what the student saw, and history
             # can't show progression. Plaintext scalars (#521 rationale).
             "mastery_before": mastery_before,
-            "mastery_after": mastery_after,
+            "mastery_after": mastery_score_after,
             # completed_at was already stamped by the atomic claim above.
         },
         filters={"id": f"eq.{body.quiz_id}"},
@@ -1152,6 +1251,6 @@ def submit_quiz(body: SubmitQuizBody, background_tasks: BackgroundTasks, request
         "score": score,
         "total": total,
         "mastery_before": mastery_before,
-        "mastery_after": mastery_after,
+        "mastery_after": mastery_score_after,
         "results": results,
     }

--- a/backend/routes/quiz.py
+++ b/backend/routes/quiz.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 from pydantic_ai.exceptions import UsageLimitExceeded, UnexpectedModelBehavior
 
 import config
-from agents import ORCHESTRATOR_LIMITS
+from agents import ORCHESTRATOR_LIMITS, TOPUP_LIMITS
 from agents._providers import UnregisteredHandlerError
 from agents.quiz import quiz_agent, Quiz, QuizQuestion
 from agents.deps import SaplingDeps
@@ -266,7 +266,12 @@ def _validate_wire_question(wire: dict) -> bool:
             "quiz: dropping question id=%s — only %d option(s)", qid, len(options)
         )
         return False
-    texts = [str(o.get("text", "")).strip().casefold() for o in options]
+    # Compare exactly as GRADING does (_agent_question_to_wire matches
+    # correct_answer with `text.strip() == canonical`): case-sensitively.
+    # Casefolding here would reject items whose options differ only by
+    # case — `list` vs `List` is a real question, and one this route
+    # graded correctly before the check existed.
+    texts = [str(o.get("text", "")).strip() for o in options]
     if len(set(texts)) != len(texts):
         logger.warning("quiz: dropping question id=%s — duplicate option text", qid)
         return False
@@ -500,13 +505,13 @@ async def _quiz_via_agent(
         user_message = routing_msg
 
     model_override = _resolve_model_pref(model_pref)
-    run_kwargs: dict = {"deps": deps, "usage_limits": ORCHESTRATOR_LIMITS}
+    run_kwargs: dict = {"deps": deps}
     if model_override is not None:
         run_kwargs["model"] = model_override
 
-    async def _run(message: str) -> Quiz:
+    async def _run(message: str, limits) -> Quiz:
         result = record_agent_usage(
-            await quiz_agent.run(message, **run_kwargs),
+            await quiz_agent.run(message, usage_limits=limits, **run_kwargs),
             feature="quiz", task="quiz", user_id=deps.user_id,
         )
         return result.output
@@ -517,49 +522,78 @@ async def _quiz_via_agent(
     # _agent_question_to_wire returns None for the former,
     # _validate_wire_question backs it. Survivors are re-numbered so
     # question ids stay 1-based and contiguous.
+    #
+    # `dropped` counts questions we REJECTED, which is a different thing
+    # from "fewer than requested": the Quiz schema lets a run return any
+    # count, and the E2E seam always returns 3 no matter what was asked.
+    # Keying the top-up on under-delivery therefore fired a second full
+    # generation on perfectly good responses.
     wire_questions: list[dict] = []
     seen_stems: set[str] = set()
+    dropped = 0
 
     def _absorb(quiz: Quiz) -> None:
+        nonlocal dropped
         for q in quiz.questions:
             stem = q.question.strip().casefold()
             if stem in seen_stems:
                 logger.warning(
                     "quiz: dropping duplicate question stem (len=%d)", len(stem)
                 )
+                dropped += 1
                 continue
             mapped = _agent_question_to_wire(q, len(wire_questions) + 1)
-            if mapped is not None:
-                seen_stems.add(stem)
-                wire_questions.append(mapped)
+            if mapped is None:
+                dropped += 1
+                continue
+            seen_stems.add(stem)
+            wire_questions.append(mapped)
 
-    _absorb(await _run(user_message))
+    _absorb(await _run(user_message, ORCHESTRATOR_LIMITS))
 
-    # #543 E2: one bounded top-up when drift cost us a big share of the
-    # quiz. Bounded because a retry loop against a drifting model burns
-    # tokens without converging — a slightly short quiz beats a slow one.
-    missing = num_questions - len(wire_questions)
-    if wire_questions and missing > 0 and missing >= num_questions * QUIZ_TOPUP_DROP_RATIO:
+    # #543 E2: one bounded top-up when DRIFT cost us a big share of the
+    # quiz. Gated on questions actually dropped (never on a clean short
+    # response), and it runs for total drift too — that's the case a
+    # retry most obviously helps, and the old `wire_questions and` guard
+    # made it the only case that never retried. Bounded because a retry
+    # loop against a drifting model burns tokens without converging.
+    if dropped and dropped >= num_questions * QUIZ_TOPUP_DROP_RATIO:
         for _ in range(QUIZ_TOPUP_MAX_RETRIES):
+            missing = max(1, num_questions - len(wire_questions))
             logger.info(
-                "quiz: topping up after drift (have=%d, requested=%d)",
-                len(wire_questions), num_questions,
+                "quiz: topping up after drift (have=%d, dropped=%d, requested=%d)",
+                len(wire_questions), dropped, num_questions,
             )
+            # Name the stems to avoid: "different from the ones already
+            # asked" is unactionable otherwise, and a deterministic model
+            # re-emits the same questions, which the dedupe above then
+            # discards — a full generation for nothing.
+            already = "\n".join(f"- {q['question']}" for q in wire_questions)
             topup_msg = (
-                f"{user_message}\n\n[TOP-UP] Several questions were rejected for "
+                f"{user_message}\n\n[TOP-UP] Some questions were rejected for "
                 f"format errors. Generate {missing} MORE questions on the same "
-                f"concept, different from the ones already asked. Remember: "
-                f"correct_answer must appear VERBATIM in options."
+                f"concept. Remember: correct_answer must appear VERBATIM in "
+                f"options."
             )
+            if already:
+                topup_msg += (
+                    f"\n\nDo NOT repeat any of these questions, which are "
+                    f"already in the quiz:\n{already}"
+                )
             try:
-                _absorb(await _run(topup_msg))
-            except Exception:
-                # A failed top-up must not lose the questions we already
-                # have — serve the short quiz with an honest count.
-                logger.exception("quiz: top-up run failed; serving what we have")
+                _absorb(await _run(topup_msg, TOPUP_LIMITS))
+            except Exception as e:
+                # The request deliberately SUCCEEDS from here — serve the
+                # short quiz with an honest count. No traceback: the E2E
+                # logscan oracle reports those as findings, and this path
+                # is a handled degradation, not a bug (same rule the
+                # quiz_context seam skip follows).
+                logger.warning(
+                    "quiz: top-up run failed (%s: %s); serving what we have",
+                    type(e).__name__, e,
+                )
                 break
-            missing = num_questions - len(wire_questions)
-            if missing <= 0:
+            if len(wire_questions) >= num_questions:
                 break
 
     if not wire_questions:

--- a/backend/services/quiz_config.py
+++ b/backend/services/quiz_config.py
@@ -42,6 +42,54 @@ REQUESTED_DIFFICULTIES = CONCRETE_DIFFICULTIES + ("adaptive",)
 # short-answer grading.
 QUIZ_QUESTION_TYPES = ("multiple_choice",)
 
+# ── Mastery model (#543 E1) ─────────────────────────────────────────────────
+#
+# How one quiz moves a concept's mastery score:
+#
+#     after = clamp01(before + correct*MASTERY_DELTA_PER_CORRECT
+#                            - wrong*MASTERY_DELTA_PER_WRONG)
+#
+# The pedagogy these numbers encode: mastery is earned faster than it is
+# lost (0.03 vs 0.02), so a student who mostly succeeds trends upward even
+# with occasional misses, and a bad quiz dents progress without erasing it.
+# ~17 consecutive correct answers take a concept from 0 to mastered, which
+# is roughly three or four full quizzes — slow enough that the tier means
+# something, fast enough to be visible within a study session.
+#
+# THE OPEN QUESTION (deliberately NOT answered here — see
+# docs/quiz-mastery-model.md): the delta is per-ITEM and flat, so a
+# 10-question hard quiz moves mastery 3.3x as much as a 3-question easy
+# one, and a hard item counts exactly as much as an easy one. Scaling by
+# difficulty and/or normalizing by quiz length are both defensible; each
+# changes the numbers the #393 E2E journey pins (+0.09 for 3/3). #543
+# lands this seam ONLY — the revamp (#537) decides the model, and any
+# change ships in the same commit as the journey update.
+MASTERY_DELTA_PER_CORRECT = 0.03
+MASTERY_DELTA_PER_WRONG = 0.02
+
+
+def mastery_after(before: float, *, score: int, total: int) -> float:
+    """The post-quiz mastery score, clamped to [0, 1]."""
+    wrong = max(0, total - score)
+    raw = (
+        before
+        + score * MASTERY_DELTA_PER_CORRECT
+        - wrong * MASTERY_DELTA_PER_WRONG
+    )
+    return max(0.0, min(1.0, raw))
+
+
+# ── Generation honesty (#543 E2) ────────────────────────────────────────────
+#
+# Questions whose correct_answer doesn't match an option verbatim are
+# dropped (routes/quiz.py::_agent_question_to_wire). If enough of a quiz
+# drops, one bounded top-up run refills it — bounded because a retry loop
+# on a drifting model burns tokens without converging, and a slightly
+# short quiz beats a slow one.
+QUIZ_TOPUP_DROP_RATIO = 0.34   # >1/3 of the requested count lost → top up
+QUIZ_TOPUP_MAX_RETRIES = 1
+
+
 # #542 D2: an in-progress attempt older than this is considered abandoned
 # (derived status + the lazy per-user sweep that stamps abandoned_at).
 # 24h: a quiz is a single sitting — anything paused across a day is not

--- a/backend/tests/test_quiz_routes.py
+++ b/backend/tests/test_quiz_routes.py
@@ -952,7 +952,12 @@ class TestQuizAgentDegrade:
                 "use_shared_context": False,
             })
         assert r.status_code == 502
-        agent_run_mock.assert_called_once()  # the agent path was actually tried
+        # The agent path was actually tried — twice, because #543 E2 gives
+        # total drift the same bounded top-up as partial drift (it used to
+        # be the ONE case that never retried, which is backwards: a
+        # transient formatting slip is exactly what one retry clears).
+        # Still exactly one retry, then 502.
+        assert agent_run_mock.call_count == 2
 
 
 # ── Wire-format contract: pinned by tests so silent drift can't recur ───────

--- a/backend/tests/test_quiz_scoring_e.py
+++ b/backend/tests/test_quiz_scoring_e.py
@@ -1,0 +1,373 @@
+"""
+Workstream E of the pre-revamp quiz repair batch (#543, epic #537):
+scoring and generation correctness.
+
+- E1: the mastery-delta constants live in a named config with a
+  pedagogy docstring. THE NUMBERS DO NOT CHANGE in this PR — the seam
+  lands, the revamp decides. The #393 journey's pinned +0.09 must stay
+  exactly reproducible.
+- E2: generation never silently short-changes a quiz — the response
+  reports requested_count vs delivered_count, and a high drop rate
+  triggers one bounded top-up retry. All-dropped stays a 502.
+- E3: wire-format validation — at least 2 options, no duplicate option
+  text, exactly one correct option, no duplicate question stems.
+- E4: concurrency — double-submit, double-answer on one index,
+  generate-while-generating for the same concept.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from agents.quiz import Quiz, QuizQuestion
+
+client = TestClient(app)
+
+
+def _q(question="Q?", options=("a", "b", "c", "d"), correct="a", difficulty="easy"):
+    return QuizQuestion(
+        question=question,
+        type="multiple_choice",
+        difficulty=difficulty,
+        options=list(options),
+        correct_answer=correct,
+        explanation="x",
+        concept="Loops",
+    )
+
+
+def _generate_factory():
+    def factory(name):
+        mock = MagicMock()
+        if name == "graph_nodes":
+            mock.select.return_value = [{
+                "id": "node1",
+                "course_id": "course1",
+                "concept_name": "Loops",
+                "mastery_score": 0.5,
+            }]
+        elif name == "quiz_attempts":
+            mock.insert.return_value = [{"id": "quiz-generated"}]
+        else:
+            mock.select.return_value = []
+            mock.insert.return_value = []
+        return mock
+
+    return factory
+
+
+def _generate(num_questions=3):
+    return client.post("/api/quiz/generate", json={
+        "user_id": "user_andres",
+        "concept_node_id": "node1",
+        "num_questions": num_questions,
+        "difficulty": "easy",
+        "use_shared_context": False,
+    })
+
+
+# ── E1: mastery model is a configurable seam (behaviour unchanged) ──────────
+
+
+class TestMasteryModelSeam:
+    def test_constants_are_named_and_unchanged(self):
+        from services.quiz_config import (
+            MASTERY_DELTA_PER_CORRECT,
+            MASTERY_DELTA_PER_WRONG,
+        )
+
+        # Pinned: #543 lands the seam only. Changing these changes the
+        # #393 journey's asserted +0.09 and must be a deliberate, separate
+        # decision (see docs/quiz-mastery-model.md).
+        assert MASTERY_DELTA_PER_CORRECT == 0.03
+        assert MASTERY_DELTA_PER_WRONG == 0.02
+
+    def test_mastery_delta_matches_the_pinned_journey_value(self):
+        from services.quiz_config import mastery_after
+
+        # frontend/e2e/quiz.spec.ts: 3 correct of 3 → +0.09 exactly.
+        assert mastery_after(0.25, score=3, total=3) == pytest.approx(0.34)
+        assert mastery_after(0.25, score=3, total=3) - 0.25 == pytest.approx(0.09)
+
+    def test_clamped_to_unit_interval(self):
+        from services.quiz_config import mastery_after
+
+        assert mastery_after(0.99, score=5, total=5) == 1.0
+        assert mastery_after(0.01, score=0, total=5) == 0.0
+
+    def test_wrong_answers_subtract(self):
+        from services.quiz_config import mastery_after
+
+        # 2 correct (+0.06), 3 wrong (-0.06) → net zero.
+        assert mastery_after(0.5, score=2, total=5) == pytest.approx(0.5)
+
+    def test_options_writeup_exists(self):
+        """E1 asks for the trade-offs to be written down for the revamp,
+        not decided here."""
+        from pathlib import Path
+
+        doc = Path(__file__).resolve().parents[2] / "docs" / "quiz-mastery-model.md"
+        assert doc.exists(), "the mastery-model options write-up is missing"
+        text = doc.read_text()
+        assert "0.03" in text and "0.02" in text
+        assert "#393" in text, "the write-up must flag the pinned journey value"
+
+
+# ── E2: honest counts + bounded top-up ──────────────────────────────────────
+
+
+class TestDeliveredCount:
+    def test_response_reports_requested_and_delivered(self):
+        good = Quiz(questions=[_q(f"Q{i}?") for i in range(3)])
+        with (
+            patch("routes.quiz.table", side_effect=_generate_factory()),
+            patch("routes.quiz.quiz_agent.run",
+                  new=AsyncMock(return_value=SimpleNamespace(output=good))),
+        ):
+            r = _generate(num_questions=3)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["requested_count"] == 3
+        assert data["delivered_count"] == 3
+
+    def test_drops_are_reported_not_hidden(self):
+        """Two of three questions drift (correct_answer not among options).
+        The client must be able to say something honest instead of silently
+        receiving a shorter quiz."""
+        drifted = Quiz(questions=[
+            _q("Q1?"),
+            _q("Q2?", correct="NOT-AN-OPTION"),
+            _q("Q3?", correct="NOT-AN-OPTION"),
+        ])
+        topped_up = Quiz(questions=[_q("Q4?"), _q("Q5?")])
+        run = AsyncMock(side_effect=[
+            SimpleNamespace(output=drifted),
+            SimpleNamespace(output=topped_up),
+        ])
+        with (
+            patch("routes.quiz.table", side_effect=_generate_factory()),
+            patch("routes.quiz.quiz_agent.run", new=run),
+        ):
+            r = _generate(num_questions=3)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["requested_count"] == 3
+        # One survivor + two from the single top-up run.
+        assert data["delivered_count"] == 3
+        assert len(data["questions"]) == 3
+        # Ids stay 1-based and contiguous across the top-up boundary.
+        assert [q["id"] for q in data["questions"]] == [1, 2, 3]
+        assert run.call_count == 2, "exactly one bounded top-up retry"
+
+    def test_top_up_is_bounded_to_one_retry(self):
+        """If the top-up also drifts, we serve what we have — never loop."""
+        drifted = Quiz(questions=[
+            _q("Q1?"),
+            _q("Q2?", correct="NOPE"),
+            _q("Q3?", correct="NOPE"),
+        ])
+        also_drifted = Quiz(questions=[_q("Q4?", correct="NOPE")])
+        run = AsyncMock(side_effect=[
+            SimpleNamespace(output=drifted),
+            SimpleNamespace(output=also_drifted),
+        ])
+        with (
+            patch("routes.quiz.table", side_effect=_generate_factory()),
+            patch("routes.quiz.quiz_agent.run", new=run),
+        ):
+            r = _generate(num_questions=3)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["delivered_count"] == 1
+        assert data["requested_count"] == 3
+        assert run.call_count == 2
+
+    def test_no_top_up_when_the_drop_rate_is_low(self):
+        """One drop out of five isn't worth a second LLM call."""
+        mostly_good = Quiz(questions=[
+            _q("Q1?"), _q("Q2?"), _q("Q3?"), _q("Q4?"),
+            _q("Q5?", correct="NOPE"),
+        ])
+        run = AsyncMock(return_value=SimpleNamespace(output=mostly_good))
+        with (
+            patch("routes.quiz.table", side_effect=_generate_factory()),
+            patch("routes.quiz.quiz_agent.run", new=run),
+        ):
+            r = _generate(num_questions=5)
+        assert r.status_code == 200
+        assert r.json()["delivered_count"] == 4
+        assert run.call_count == 1
+
+    def test_all_dropped_still_502s(self):
+        nothing_valid = Quiz(questions=[
+            _q("Q1?", correct="NOPE"), _q("Q2?", correct="NOPE"),
+        ])
+        run = AsyncMock(return_value=SimpleNamespace(output=nothing_valid))
+        with (
+            patch("routes.quiz.table", side_effect=_generate_factory()),
+            patch("routes.quiz.quiz_agent.run", new=run),
+        ):
+            r = _generate(num_questions=2)
+        assert r.status_code == 502
+        assert r.json()["error"]["code"] == "QUIZ_GENERATION_FAILED"
+
+
+# ── E3: wire-format validation ──────────────────────────────────────────────
+
+
+class TestWireValidation:
+    def test_duplicate_option_text_is_dropped(self):
+        """Two identical options make the item unanswerable — the student
+        can pick the 'same' answer and be wrong."""
+        from routes.quiz import _agent_question_to_wire
+
+        q = _q(options=("a", "a", "b", "c"), correct="b")
+        assert _agent_question_to_wire(q, 1) is None
+
+    def test_too_few_options_is_dropped(self):
+        from routes.quiz import _validate_wire_question
+
+        wire = {
+            "id": 1,
+            "question": "Q?",
+            "options": [{"label": "A", "text": "a", "correct": True}],
+            "explanation": "x",
+        }
+        assert _validate_wire_question(wire) is False
+
+    def test_exactly_one_correct_option_required(self):
+        from routes.quiz import _validate_wire_question
+
+        two_correct = {
+            "id": 1,
+            "question": "Q?",
+            "options": [
+                {"label": "A", "text": "a", "correct": True},
+                {"label": "B", "text": "b", "correct": True},
+            ],
+            "explanation": "x",
+        }
+        none_correct = {
+            "id": 2,
+            "question": "Q?",
+            "options": [
+                {"label": "A", "text": "a", "correct": False},
+                {"label": "B", "text": "b", "correct": False},
+            ],
+            "explanation": "x",
+        }
+        assert _validate_wire_question(two_correct) is False
+        assert _validate_wire_question(none_correct) is False
+
+    def test_duplicate_stems_within_one_attempt_are_dropped(self):
+        """The same question twice is padding, not a quiz."""
+        dupes = Quiz(questions=[
+            _q("What is a loop?"),
+            _q("What is a loop?", options=("w", "x", "y", "z"), correct="w"),
+            _q("What is recursion?", options=("1", "2", "3", "4"), correct="1"),
+        ])
+        run = AsyncMock(return_value=SimpleNamespace(output=dupes))
+        with (
+            patch("routes.quiz.table", side_effect=_generate_factory()),
+            patch("routes.quiz.quiz_agent.run", new=run),
+        ):
+            r = _generate(num_questions=3)
+        assert r.status_code == 200
+        stems = [q["question"] for q in r.json()["questions"]]
+        assert len(stems) == len(set(stems)), "duplicate stems reached the client"
+        assert len(stems) == 2
+
+
+# ── E4: concurrency ─────────────────────────────────────────────────────────
+
+
+class TestConcurrency:
+    def test_double_answer_on_one_index_records_once(self):
+        """The UNIQUE arbitrates: the loser's insert raises, the route
+        re-reads and returns the winner rather than 500ing."""
+        rows: list[dict] = []
+
+        class _Responses:
+            def select(self, columns="*", filters=None, order=None, **_):
+                if not rows:
+                    return []
+                return [dict(rows[0])]
+
+            def insert(self, payload):
+                if rows:
+                    raise RuntimeError("duplicate key (23505)")
+                rows.append(dict(payload))
+                return [dict(payload)]
+
+        responses = _Responses()
+
+        def factory(name):
+            if name == "quiz_responses":
+                return responses
+            mock = MagicMock()
+            if name == "quiz_attempts":
+                mock.select.return_value = [{
+                    "id": "quiz1",
+                    "user_id": "user_andres",
+                    "concept_node_id": "node1",
+                    "difficulty": "medium",
+                    "completed_at": None,
+                    "questions_json": [{
+                        "id": 1,
+                        "question": "Q1?",
+                        "options": [
+                            {"label": "A", "text": "a", "correct": False},
+                            {"label": "B", "text": "b", "correct": True},
+                        ],
+                        "explanation": "B.",
+                    }],
+                }]
+            else:
+                mock.select.return_value = []
+            return mock
+
+        payload = {"question_index": 0, "selected_index": 1}
+        with patch("routes.quiz.table", side_effect=factory):
+            first = client.post("/api/quiz/attempts/quiz1/answer", json=payload)
+            second = client.post("/api/quiz/attempts/quiz1/answer", json=payload)
+
+        assert first.status_code == 200 and second.status_code == 200
+        assert first.json()["recorded"] is True
+        assert second.json()["recorded"] is False
+        assert len(rows) == 1
+
+    def test_concurrent_generate_for_one_concept_creates_distinct_attempts(self):
+        """Two generates for the same concept must not collide on an id or
+        overwrite each other's attempt row."""
+        inserted: list[dict] = []
+
+        def factory(name):
+            mock = MagicMock()
+            if name == "graph_nodes":
+                mock.select.return_value = [{
+                    "id": "node1", "course_id": "course1",
+                    "concept_name": "Loops", "mastery_score": 0.5,
+                }]
+            elif name == "quiz_attempts":
+                def _insert(payload):
+                    inserted.append(payload)
+                    return [{"id": payload["id"]}]
+                mock.insert.side_effect = _insert
+            else:
+                mock.select.return_value = []
+            return mock
+
+        good = Quiz(questions=[_q()])
+        with (
+            patch("routes.quiz.table", side_effect=factory),
+            patch("routes.quiz.quiz_agent.run",
+                  new=AsyncMock(return_value=SimpleNamespace(output=good))),
+        ):
+            r1 = _generate(num_questions=1)
+            r2 = _generate(num_questions=1)
+
+        assert r1.status_code == 200 and r2.status_code == 200
+        assert r1.json()["quiz_id"] != r2.json()["quiz_id"]
+        assert len({row["id"] for row in inserted}) == 2

--- a/backend/tests/test_quiz_scoring_e.py
+++ b/backend/tests/test_quiz_scoring_e.py
@@ -200,7 +200,100 @@ class TestDeliveredCount:
         assert r.json()["delivered_count"] == 4
         assert run.call_count == 1
 
-    def test_all_dropped_still_502s(self):
+    def test_no_top_up_when_the_agent_simply_returns_fewer(self):
+        """A short-but-clean generation is NOT a drift failure. The agent's
+        schema lets it return any count (the E2E seam always returns 3
+        while the UI asks for 5), so keying the retry on requested-minus-
+        delivered fires a second full generation on ordinary requests —
+        doubling latency and tokens for nothing."""
+        short_but_clean = Quiz(questions=[_q("Q1?"), _q("Q2?"), _q("Q3?")])
+        run = AsyncMock(return_value=SimpleNamespace(output=short_but_clean))
+        with (
+            patch("routes.quiz.table", side_effect=_generate_factory()),
+            patch("routes.quiz.quiz_agent.run", new=run),
+        ):
+            r = _generate(num_questions=5)
+        assert r.status_code == 200
+        assert r.json()["delivered_count"] == 3
+        assert run.call_count == 1, (
+            "nothing was dropped — a top-up here is pure waste"
+        )
+
+    def test_top_up_prompt_lists_the_stems_already_asked(self):
+        """'different from the ones already asked' is unactionable unless
+        the model is told what they were — otherwise a deterministic model
+        regenerates the same stems and the dedupe discards the whole run."""
+        drifted = Quiz(questions=[
+            _q("What is a loop?"),
+            _q("Q2?", correct="NOPE"),
+            _q("Q3?", correct="NOPE"),
+        ])
+        topped = Quiz(questions=[_q("What is recursion?", options=("w", "x", "y", "z"), correct="w")])
+        run = AsyncMock(side_effect=[
+            SimpleNamespace(output=drifted),
+            SimpleNamespace(output=topped),
+        ])
+        with (
+            patch("routes.quiz.table", side_effect=_generate_factory()),
+            patch("routes.quiz.quiz_agent.run", new=run),
+        ):
+            r = _generate(num_questions=3)
+        assert r.status_code == 200
+        assert run.call_count == 2
+        topup_msg = run.call_args_list[1][0][0]
+        assert "What is a loop?" in topup_msg, (
+            "the top-up must name the stems it has to avoid"
+        )
+
+    def test_top_up_gets_its_own_bounded_budget(self):
+        """Reusing the first run's usage_limits hands the retry a fresh
+        ORCHESTRATOR_LIMITS, doubling the per-request cost ceiling."""
+        from agents import ORCHESTRATOR_LIMITS
+
+        drifted = Quiz(questions=[
+            _q("Q1?"), _q("Q2?", correct="NOPE"), _q("Q3?", correct="NOPE"),
+        ])
+        topped = Quiz(questions=[_q("Q4?"), _q("Q5?")])
+        run = AsyncMock(side_effect=[
+            SimpleNamespace(output=drifted),
+            SimpleNamespace(output=topped),
+        ])
+        with (
+            patch("routes.quiz.table", side_effect=_generate_factory()),
+            patch("routes.quiz.quiz_agent.run", new=run),
+        ):
+            _generate(num_questions=3)
+        first_limits = run.call_args_list[0].kwargs["usage_limits"]
+        topup_limits = run.call_args_list[1].kwargs["usage_limits"]
+        assert first_limits is ORCHESTRATOR_LIMITS
+        assert topup_limits is not ORCHESTRATOR_LIMITS
+        assert (
+            topup_limits.total_tokens_limit
+            < ORCHESTRATOR_LIMITS.total_tokens_limit
+        ), "the retry must not double the request's cost backstop"
+
+    def test_total_drift_gets_the_retry_too(self):
+        """Total drift is the case a retry most obviously helps — a
+        `wire_questions and ...` guard made it the ONE case that never
+        retried, sending the student straight to a 502."""
+        nothing_valid = Quiz(questions=[
+            _q("Q1?", correct="NOPE"), _q("Q2?", correct="NOPE"),
+        ])
+        recovered = Quiz(questions=[_q("Q3?"), _q("Q4?")])
+        run = AsyncMock(side_effect=[
+            SimpleNamespace(output=nothing_valid),
+            SimpleNamespace(output=recovered),
+        ])
+        with (
+            patch("routes.quiz.table", side_effect=_generate_factory()),
+            patch("routes.quiz.quiz_agent.run", new=run),
+        ):
+            r = _generate(num_questions=2)
+        assert r.status_code == 200
+        assert r.json()["delivered_count"] == 2
+        assert run.call_count == 2
+
+    def test_all_dropped_after_the_retry_still_502s(self):
         nothing_valid = Quiz(questions=[
             _q("Q1?", correct="NOPE"), _q("Q2?", correct="NOPE"),
         ])
@@ -212,6 +305,30 @@ class TestDeliveredCount:
             r = _generate(num_questions=2)
         assert r.status_code == 502
         assert r.json()["error"]["code"] == "QUIZ_GENERATION_FAILED"
+        assert run.call_count == 2, "one bounded retry, then give up"
+
+    def test_failed_top_up_logs_without_a_traceback(self, caplog):
+        """The recovery path deliberately SUCCEEDS, so it must not emit a
+        traceback — the E2E logscan oracle reports those as findings (same
+        rule the quiz_context handler follows)."""
+        drifted = Quiz(questions=[
+            _q("Q1?"), _q("Q2?", correct="NOPE"), _q("Q3?", correct="NOPE"),
+        ])
+        run = AsyncMock(side_effect=[
+            SimpleNamespace(output=drifted),
+            RuntimeError("top-up blew up"),
+        ])
+        with (
+            patch("routes.quiz.table", side_effect=_generate_factory()),
+            patch("routes.quiz.quiz_agent.run", new=run),
+        ):
+            with caplog.at_level("WARNING", logger="routes.quiz"):
+                r = _generate(num_questions=3)
+        assert r.status_code == 200
+        assert r.json()["delivered_count"] == 1
+        topup_logs = [rec for rec in caplog.records if "top-up" in rec.message]
+        assert topup_logs
+        assert all(not rec.exc_info for rec in topup_logs)
 
 
 # ── E3: wire-format validation ──────────────────────────────────────────────
@@ -225,6 +342,20 @@ class TestWireValidation:
 
         q = _q(options=("a", "a", "b", "c"), correct="b")
         assert _agent_question_to_wire(q, 1) is None
+
+    def test_case_distinct_options_are_kept(self):
+        """Grading matches correct_answer case-SENSITIVELY, so options that
+        differ only by case are distinct and gradable — a concept quiz on
+        `list` vs `List` is a real question, not a malformed one. The
+        duplicate check must use the same comparison grading does."""
+        from routes.quiz import _agent_question_to_wire
+
+        q = _q(options=("list", "List", "tuple", "Tuple"), correct="List")
+        wire = _agent_question_to_wire(q, 1)
+        assert wire is not None
+        correct = [o for o in wire["options"] if o["correct"]]
+        assert len(correct) == 1
+        assert correct[0]["text"] == "List"
 
     def test_too_few_options_is_dropped(self):
         from routes.quiz import _validate_wire_question
@@ -285,19 +416,36 @@ class TestWireValidation:
 
 class TestConcurrency:
     def test_double_answer_on_one_index_records_once(self):
-        """The UNIQUE arbitrates: the loser's insert raises, the route
-        re-reads and returns the winner rather than 500ing."""
+        """The real race: BOTH requests see an empty table (the pre-read
+        happens before either insert), so the second insert is the one the
+        UNIQUE rejects. The route must re-read and return the winner
+        rather than 500ing.
+
+        The fake models that interleaving directly — its select returns
+        empty until an insert has actually landed AND the caller has been
+        through its pre-read once, which is what makes the second insert
+        collide instead of being short-circuited by the existing-row
+        branch."""
         rows: list[dict] = []
+        state = {"selects": 0, "insert_attempts": 0}
 
         class _Responses:
             def select(self, columns="*", filters=None, order=None, **_):
-                if not rows:
+                state["selects"] += 1
+                # First TWO reads see nothing: both requests raced past
+                # the idempotency pre-read before either wrote.
+                if state["selects"] <= 2:
                     return []
-                return [dict(rows[0])]
+                return [dict(r) for r in rows]
 
             def insert(self, payload):
-                if rows:
-                    raise RuntimeError("duplicate key (23505)")
+                state["insert_attempts"] += 1
+                for r in rows:
+                    if r["question_index"] == payload["question_index"]:
+                        raise RuntimeError(
+                            'duplicate key value violates unique constraint '
+                            '"quiz_responses_attempt_question_key" (23505)'
+                        )
                 rows.append(dict(payload))
                 return [dict(payload)]
 
@@ -337,6 +485,12 @@ class TestConcurrency:
         assert first.json()["recorded"] is True
         assert second.json()["recorded"] is False
         assert len(rows) == 1
+        # The point of the test: the loser really did attempt an insert and
+        # got the UNIQUE violation, rather than being filtered by the
+        # pre-read (which would leave the race handler unexercised).
+        assert state["insert_attempts"] == 2
+        # Both answers graded identically off the winning row.
+        assert second.json()["is_correct"] == first.json()["is_correct"]
 
     def test_concurrent_generate_for_one_concept_creates_distinct_attempts(self):
         """Two generates for the same concept must not collide on an id or

--- a/docs/quiz-mastery-model.md
+++ b/docs/quiz-mastery-model.md
@@ -1,0 +1,63 @@
+# Quiz mastery model — options for the revamp
+
+**Status:** open question, deliberately undecided. #543 landed the seam
+(`services/quiz_config.py::mastery_after` + the two named constants) with the
+numbers **unchanged**; the #537 revamp decides the model.
+
+## What ships today
+
+```
+after = clamp01(before + correct × 0.03 − wrong × 0.02)
+```
+
+Flat, per-item, difficulty-blind, length-blind. Earning is faster than losing
+(0.03 vs 0.02), so a mostly-succeeding student trends upward and a bad quiz
+dents progress without erasing it. From 0, about 17 consecutive correct answers
+reach mastered (`mastery_tier` thresholds live in `config.py::get_mastery_tier`)
+— roughly three or four full quizzes.
+
+## What's hard to defend
+
+1. **Length dominates.** A 10-question quiz moves mastery 3.3× as much as a
+   3-question one, purely because it has more items. A student can farm mastery
+   by always picking the longest quiz.
+2. **Difficulty is free.** A correct *hard* answer and a correct *easy* answer
+   move the score identically, even though the quiz agent deliberately varies
+   difficulty by mastery (`agents/quiz.py` adaptive rules). The signal the agent
+   works to produce is discarded at scoring time.
+3. **Adaptive mode is unpriced.** Since #540 the agent may choose the mix
+   itself; "adaptive" quizzes have no defined difficulty for scoring purposes.
+
+## Options
+
+**A. Keep flat per-item (status quo).** Simplest, already shipped, and the only
+option that needs no journey change. Accepts the length and difficulty issues.
+
+**B. Normalize by quiz length.** `delta = (accuracy − passing_threshold) × step`,
+so a quiz is worth a fixed amount regardless of item count. Removes the
+farm-by-length incentive; makes a 3-question quiz as consequential as a 10, which
+may over-weight small samples.
+
+**C. Weight per item by difficulty.** e.g. easy ×0.6, medium ×1.0, hard ×1.5 on
+both the credit and the penalty. Uses the agent's difficulty signal; needs a
+defined weight for items generated in adaptive mode (the per-question difficulty
+is concrete even there, so this is workable).
+
+**D. B + C combined.** Length-normalized and difficulty-weighted. Most defensible
+pedagogically, most disruptive to existing numbers, and the hardest to explain in
+a UI ("why did I only gain 0.02?").
+
+**E. Replace the linear model.** Something with diminishing returns near the
+ceiling (mastery is harder to gain at 0.9 than at 0.3) — e.g. move a fraction of
+the remaining distance. Realistic, but no longer readable as "+0.03 per right
+answer" in the results screen.
+
+## Constraint on whoever decides
+
+The `#393` journey in `frontend/e2e/quiz.spec.ts` pins **+0.09** for a 3-of-3
+quiz (3 × 0.03), asserted
+three ways: the UI's before→after, `graph_nodes.mastery_score`, and the
+`node_mastery_events.delta` sign. Any change to the model **must** update that
+journey in the same commit, with a comment saying why — see the working
+agreement in the #537 batch brief. `backend/tests/test_quiz_scoring_e.py`
+also pins the constants; that's the tripwire, not an obstacle.

--- a/frontend/src/components/QuizPanel.test.tsx
+++ b/frontend/src/components/QuizPanel.test.tsx
@@ -186,3 +186,34 @@ describe("QuizPanel — config-driven selectors (#540 A2)", () => {
     );
   });
 });
+
+describe("QuizPanel — short-quiz honesty (#543 E2)", () => {
+  it("warns when generation delivered fewer questions than requested", async () => {
+    mockGenerateQuiz.mockResolvedValue({
+      quiz_id: "quiz-1",
+      questions: [QUESTION],
+      requested_count: 5,
+      delivered_count: 1,
+    });
+    renderPanel();
+
+    fireEvent.click(screen.getByTestId("quiz-start"));
+    expect(await screen.findByTestId("quiz-answer-options")).toBeInTheDocument();
+    await waitFor(() => expect(toast.warn).toHaveBeenCalledTimes(1));
+    expect(String(toast.warn.mock.calls[0][0])).toContain("1 of 5");
+  });
+
+  it("stays quiet when the full quiz was delivered", async () => {
+    mockGenerateQuiz.mockResolvedValue({
+      quiz_id: "quiz-1",
+      questions: [QUESTION],
+      requested_count: 1,
+      delivered_count: 1,
+    });
+    renderPanel();
+
+    fireEvent.click(screen.getByTestId("quiz-start"));
+    expect(await screen.findByTestId("quiz-answer-options")).toBeInTheDocument();
+    expect(toast.warn).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/QuizPanel.tsx
+++ b/frontend/src/components/QuizPanel.tsx
@@ -165,6 +165,14 @@ export function QuizPanel({ userId, concepts, courses, initialConceptId, onExit 
         toast.warn("No questions were generated — try another concept or difficulty.");
         return;
       }
+      // #543 E2: say so when generation delivered fewer questions than
+      // asked, rather than quietly handing over a shorter quiz.
+      const requested = res.requested_count ?? Number(count);
+      if (res.delivered_count != null && res.delivered_count < requested) {
+        toast.warn(
+          `We could only build ${res.delivered_count} of ${requested} questions for this concept.`,
+        );
+      }
       setQuizId(res.quiz_id);
       setQuestions(nextQuestions);
       // #540 A1: what generation actually chose — shown when the student

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -441,7 +441,7 @@ export interface QuizConfig {
 export const fetchQuizConfig = () => fetchJSON<QuizConfig>('/api/quiz/config');
 
 export const generateQuiz = (userId: string, conceptNodeId: string, numQuestions: number, difficulty: string, useSharedContext = true) =>
-  fetchJSON<{ quiz_id: string; questions: any[]; requested_difficulty?: string; resolved_difficulty?: string }>('/api/quiz/generate', {
+  fetchJSON<{ quiz_id: string; questions: any[]; requested_difficulty?: string; resolved_difficulty?: string; requested_count?: number; delivered_count?: number }>('/api/quiz/generate', {
     method: 'POST',
     body: JSON.stringify({ user_id: userId, concept_node_id: conceptNodeId, num_questions: numQuestions, difficulty, use_shared_context: useSharedContext }),
   });


### PR DESCRIPTION
Closes #543. Workstream E of the pre-revamp quiz repair batch (epic #537).

## What

**E1 — the mastery model is a seam, not a magic number.** `MASTERY_DELTA_PER_CORRECT` / `_PER_WRONG` and `mastery_after()` live in `services/quiz_config.py` with the pedagogy written down. **The numbers do not change**: the `#393` journey's `+0.09` is byte-identical and now pinned by a unit test as well.

The trade-offs the revamp gets to decide are written up in `docs/quiz-mastery-model.md`: length dominates (a 10-question quiz moves mastery 3.3× a 3-question one, purely for having more items), difficulty is free (the agent varies difficulty by mastery and scoring discards that signal), and adaptive mode is unpriced. Options A–E are laid out with the constraint that any change must update the `#393` journey in the same commit.

**E2 — generation stops silently short-changing quizzes.** The response reports `requested_count` and `delivered_count`. Losing more than a third of the requested questions to drift triggers **one** bounded top-up run (a retry loop against a drifting model burns tokens without converging; a slightly short quiz beats a slow one). A failed top-up serves what we have rather than losing it; all-dropped still 502s.

**E3 — wire-format validation at the route boundary.** At least two options, no duplicate option text (a student can otherwise pick "the same" answer and be wrong), exactly one correct option (zero is the #129 free point, two means the grader's first match wins silently), and no duplicate question stems within one attempt.

**E4 — concurrency tests.** Double-answer on one index (the UNIQUE arbitrates; the loser re-reads instead of 500ing) and generate-while-generating for one concept (distinct attempt rows). Double-submit was already pinned by #464's tests.

## Note on the rebase

Rebasing onto the merged #550 surfaced a real shadowing bug: D's post-`apply_graph_update` block assigned a local `mastery_after`, which shadows E's imported `mastery_after()` model function — `UnboundLocalError` on every submit. Caught by 24 existing tests, fixed here (the value lives in `mastery_score_after`).

## Verification

- Hermetic suite: **1976 passed** (16 new tests, written first, watched fail).
- Full local cycle under the stack lock on the stacked branch: Playwright → oracles → integration → teardown.
- `ruff check` clean. No migration in this workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
