### PR TITLE
fix(api): stop otel turning every 405 into a 500 (unblocks 5 PRs)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,6 +28,7 @@ from routes.admin_analytics import router as admin_analytics_router
 from routes.newsletter import router as newsletter_router
 from services import quiz_config, quiz_errors
 from services.logfire_scrubber import EXTRA_PATTERNS, scrub_value
+from services import otel_fastapi_compat
 from services.request_context import RequestIDMiddleware, current_request_id
 from services.storage_service import (
     ALLOWED_CONTENT_TYPES,
@@ -146,6 +147,11 @@ app = FastAPI(title="Sapling API", version="1.0.0", lifespan=_lifespan)
 # _drop_request_arguments; request/response headers are not captured
 # (capture_headers=False); and the separate arguments/endpoint spans are off
 # (extra_spans=False). No student content leaves the process on request spans.
+# Must run BEFORE instrument_fastapi: on FastAPI >= 0.138 the otel route
+# resolver raises AttributeError on any wrong-method request, turning every
+# 405 into a 500. See services/otel_fastapi_compat.py for the full analysis.
+otel_fastapi_compat.install_route_details_guard()
+
 logfire.instrument_fastapi(
     app,
     capture_headers=False,

--- a/backend/services/otel_fastapi_compat.py
+++ b/backend/services/otel_fastapi_compat.py
@@ -1,0 +1,107 @@
+"""Compatibility guard for otel FastAPI instrumentation on FastAPI >= 0.138.
+
+The bug
+-------
+`opentelemetry.instrumentation.fastapi._get_route_details(scope)` walks
+`app.routes` looking for the route a request matched, and reads `.path` off
+each candidate:
+
+    if match == Match.FULL:
+        try:
+            route = starlette_route.path
+        except AttributeError:
+            # routes added via host routing won't have a path attribute
+            route = scope.get("path")
+        break
+    if match == Match.PARTIAL:
+        route = starlette_route.path      # <-- no guard
+
+From FastAPI 0.138, `app.include_router(...)` leaves `_IncludedRouter`
+objects in `app.routes`, and those have no `.path`. The FULL branch already
+tolerates a path-less route; the PARTIAL branch does not.
+
+A PARTIAL match is precisely what a **wrong-method request** produces — the
+path matches, the method does not. So every 405 raised `AttributeError` out
+of the instrumentation middleware instead of returning 405.
+
+That is not a test-only concern: staging and production install the same
+hash-pinned lock (fastapi 0.138.0, opentelemetry-instrumentation-fastapi
+0.63b1), so a 405 on the deployed API became a 500.
+
+Why patch rather than upgrade
+-----------------------------
+There is nothing to upgrade to: the unguarded line is present in every
+released `opentelemetry-instrumentation-fastapi` through 0.65b0 (checked
+against the published wheels). Pinning FastAPI back below 0.138 to dodge it
+would trade a one-line shim for a framework downgrade.
+
+Why this was invisible locally
+------------------------------
+The dev venv runs older resolved dependencies than `requirements.lock`
+(fastapi 0.136 / starlette 1.0 at the time of writing), and pre-0.138
+FastAPI puts no `_IncludedRouter` in `app.routes`. The full suite was green
+locally and red in CI on exactly one test. Reproduced at the locked versions
+in a scratch environment before fixing.
+
+Remove this module when a released otel version guards the PARTIAL branch;
+`tests/test_otel_fastapi_compat.py` pins the behaviour until then.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+def _guard(original: Callable) -> Callable:
+    """Wrap otel's route resolver so a path-less route degrades instead of raising.
+
+    Only `AttributeError` is absorbed, and the fallback (`scope["path"]`) is
+    the one otel's own FULL-match branch already uses for host-routed routes
+    — this applies an existing behaviour to the branch that missed it rather
+    than inventing a new one. Any other exception is a real defect and stays
+    visible.
+    """
+
+    def _get_route_details_guarded(scope):
+        try:
+            return original(scope)
+        except AttributeError:
+            # A route object with no `.path` (FastAPI >= 0.138's
+            # `_IncludedRouter`). The concrete path is a worse span name than
+            # the route template, but it is vastly better than a 500.
+            return scope.get("path")
+
+    _get_route_details_guarded._sapling_guarded = True  # type: ignore[attr-defined]
+    _get_route_details_guarded._sapling_original = original  # type: ignore[attr-defined]
+    return _get_route_details_guarded
+
+
+def install_route_details_guard() -> bool:
+    """Install the guard. Idempotent; returns True if it is in place.
+
+    Never raises: this runs at import time in `main.py`, and a failure to
+    install observability compatibility must not stop the app from booting.
+    """
+    try:
+        import opentelemetry.instrumentation.fastapi as otel_fastapi
+    except Exception:  # pragma: no cover - otel is a hard dep in practice
+        logger.debug("otel fastapi instrumentation not importable; guard skipped")
+        return False
+
+    current = getattr(otel_fastapi, "_get_route_details", None)
+    if current is None:  # pragma: no cover - upstream renamed it
+        logger.warning(
+            "otel fastapi: _get_route_details is gone; the 405 guard no longer "
+            "applies — re-check whether the upstream bug is fixed"
+        )
+        return False
+    if getattr(current, "_sapling_guarded", False):
+        # Already wrapped. Wrapping again would stack a redundant layer per
+        # import, which matters in test runs that re-import main.
+        return True
+
+    otel_fastapi._get_route_details = _guard(current)
+    return True

--- a/backend/tests/test_otel_fastapi_compat.py
+++ b/backend/tests/test_otel_fastapi_compat.py
@@ -1,0 +1,87 @@
+"""The 405 crash: FastAPI 0.138 + opentelemetry-instrumentation-fastapi.
+
+`app.include_router(...)` puts `_IncludedRouter` objects in `app.routes` from
+FastAPI 0.138 onward. otel's route-detail resolver reads `.path` off each
+candidate route; the FULL-match branch guards that read with
+`except AttributeError`, but the PARTIAL-match branch does not — and a
+PARTIAL match is exactly what a wrong-method request produces.
+
+So every 405 raised `AttributeError` out of the instrumentation middleware
+instead of returning 405. Not a test-only problem: it is what the deployed
+app does, since staging/prod install the same hash-pinned lock.
+
+Verified against the LOCKED versions (fastapi 0.138.0, starlette 1.3.1,
+opentelemetry-instrumentation-fastapi 0.63b1) in a scratch env, because the
+dev venv runs older deps and cannot reproduce it. Present in every released
+otel version through 0.65b0, so there is nothing to upgrade to.
+"""
+
+from services import otel_fastapi_compat as compat
+
+
+def test_guard_is_installed_at_import_time():
+    """main.py installs it before instrumenting; importing the app is enough."""
+    import main  # noqa: F401
+
+    import opentelemetry.instrumentation.fastapi as otel_fastapi
+
+    assert getattr(otel_fastapi._get_route_details, "_sapling_guarded", False)
+
+
+def test_guard_falls_back_to_the_scope_path_on_attribute_error():
+    """The fallback is the SAME one otel's FULL-match branch already uses for
+    host-routed routes — this is not inventing a new behaviour, it is
+    applying the existing one to the branch that was missed."""
+    calls = []
+
+    def _boom(scope):
+        calls.append(scope)
+        raise AttributeError("'_IncludedRouter' object has no attribute 'path'")
+
+    guarded = compat._guard(_boom)
+    assert guarded({"path": "/api/quiz/submit"}) == "/api/quiz/submit"
+    assert len(calls) == 1
+
+
+def test_guard_passes_through_a_normal_resolution():
+    guarded = compat._guard(lambda scope: "/api/quiz/{quiz_id}")
+    assert guarded({"path": "/api/quiz/abc"}) == "/api/quiz/{quiz_id}"
+
+
+def test_guard_does_not_swallow_other_errors():
+    """Only AttributeError. A KeyError or TypeError from the resolver is a
+    real defect and must stay visible."""
+    def _boom(scope):
+        raise KeyError("something else")
+
+    guarded = compat._guard(_boom)
+    try:
+        guarded({"path": "/x"})
+    except KeyError:
+        return
+    raise AssertionError("KeyError should propagate")
+
+
+def test_install_is_idempotent():
+    """Called at import; a second call must not wrap the wrapper (which would
+    stack a fallback layer per import in test runs)."""
+    import opentelemetry.instrumentation.fastapi as otel_fastapi
+
+    compat.install_route_details_guard()
+    first = otel_fastapi._get_route_details
+    compat.install_route_details_guard()
+    assert otel_fastapi._get_route_details is first
+
+
+def test_method_not_allowed_returns_405_not_a_crash():
+    """End-to-end at whatever versions are installed. Under the locked
+    fastapi this fails without the guard; under older fastapi it passes
+    either way — which is precisely why CI caught it and the dev venv did
+    not."""
+    from fastapi.testclient import TestClient
+
+    from main import app
+
+    client = TestClient(app)
+    r = client.get("/api/quiz/submit")  # POST-only route
+    assert r.status_code == 405


### PR DESCRIPTION
## Why this is separate

`Backend (pytest)` has been red **on `main`** since the FastAPI 0.138 lock, on one test:

```
FAILED tests/test_quiz_preflight_a.py::TestQuizErrorEnvelope::test_method_not_allowed_gets_generic_code
AttributeError: '_IncludedRouter' object has no attribute 'path'
opentelemetry/instrumentation/fastapi/__init__.py:495
```

**This is not test-only.** otel's `_get_route_details` guards its FULL-match `.path` read with `except AttributeError`, but its PARTIAL-match branch does not — and a PARTIAL match is exactly a wrong-method request. The error escapes the middleware, so **every 405 returns 500**. Staging and production install the same lock, so that is live behaviour today.

There is nothing to upgrade to: the unguarded line is present in every released `opentelemetry-instrumentation-fastapi` through 0.65b0. `services/otel_fastapi_compat.py` wraps the resolver, absorbing only `AttributeError` and falling back to `scope["path"]` — which is otel's own FULL-branch fallback.

## Why now

This one failure is blocking the CI of **five** open PRs, none of which touch routing or quiz:

| PR | |
|---|---|
| #562 | fix(tutor): stop the tutor repeating itself |
| #536 | fix(learn): add a concept back after deleting it |
| #535 | feat(landing): port the v5 marketing landing |
| #512 | feat(academics): per-section Fall 2026 offerings |
| #507 | feat(documents): file-level dedup |

Their `pull_request` runs check out a merge of head + base, so landing this on `main` turns all five green without touching their branches.

## Relationship to #563

The three files here are lifted **verbatim** from #563, which diagnosed the bug and already carries the fix. `backend/main.py` is byte-identical to that branch's version, so #563 still auto-merges cleanly after this lands — both sides hold the same content. #563 keeps the credit for the diagnosis; this just unblocks the queue ahead of it.

## Verification

- `ruff check .` clean
- Full hermetic suite: **1970 passed, 56 skipped**
- `test_otel_fastapi_compat.py` + `test_quiz_preflight_a.py`: 27 passed
