### PR TITLE
fix(gradescope): staging serves the whole feature at a doubled prefix; restore the working route

### DIFF
--- a/backend/models/gradescope.py
+++ b/backend/models/gradescope.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 GradescopeAuthMode = Literal["password", "cookies"]
 

--- a/backend/routes/gradescope.py
+++ b/backend/routes/gradescope.py
@@ -1,233 +1,618 @@
-"""backend/routes/gradescope.py
+"""
+backend/routes/gradescope.py
 
-Matches the contract already defined in frontend/src/lib/api.ts exactly:
-URLs, param placement (user_id as query param, like the rest of this
-app's routes — e.g. calendar/status/{userId}), and response shapes.
+Per-user Gradescope sync. Stores email/password encrypted at rest, logs in
+fresh on each call (no persisted session), and upserts grades into the
+existing assignments table keyed on `gradescope_assignment_id`.
 
-⚠️ STORAGE PLACEHOLDER: `_load_credential_row` / `_save_credential_row` /
-`_delete_credential_row` / `_update_sync_metadata` and the
-gradescope_links row helpers are stubbed against a guessed
-`db.connection.table(...)` PostgREST-style helper. Replace with your real
-data-access call.
-
-Deliberately NOT implemented: POST /api/gradescope/credentials/bu-sso.
-frontend/src/lib/api.ts already calls this (connectGradescopeViaBuSso) but
-I'm not building server-side automation of a university SSO/Duo login —
-see conversation for why. Point that button at something else, or remove
-it from api.ts / the UI.
+Endpoints (mounted under /api/gradescope):
+- POST   /credentials                  Test login then save encrypted creds
+- DELETE /credentials                  Remove creds
+- GET    /status                       Has creds? last_synced_at?
+- GET    /courses                      List the user's Gradescope student courses
+- GET    /links                        List sapling-course -> gradescope-course mappings
+- POST   /link                         Create/update a mapping
+- DELETE /link/{sapling_course_id}     Remove a mapping
+- POST   /sync/{sapling_course_id}     Pull assignments, upsert grades
 """
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
+import uuid
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, Literal
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
+from gradescopeapi.classes.connection import GSConnection
+from pydantic import BaseModel, Field
 
-from models.gradescope import (
-    GradescopeCourse,
-    GradescopeCredentialsIn,
-    GradescopeLink,
-    GradescopeLinkIn,
-    GradescopeStatus,
-    GradescopeSyncResult,
+from db.connection import table
+from services import gradescope_service
+from services.academics import (
+    enrollment_id_for,
+    offering_course_id,
+    user_enrollment_ids,
+    user_offering_ids_for_course,
 )
-from services import gradescope_service as gs
-from services.gradescope_sync_service import (
-    GradescopeSyncError,
-    build_credential_row,
-    list_courses_for_linking,
-    sync_course,
-)
+from services.auth_guard import require_self
+from services.encryption import encrypt, decrypt, encrypt_if_present
+from services.request_limits import check_rate_limit
 
 logger = logging.getLogger(__name__)
-
-router = APIRouter(prefix="/api/gradescope", tags=["gradescope"])
-
-
-# ────────────────────────────────────────────────────────────────────────────
-# TODO(wire-me): replace with your real table access
-# ────────────────────────────────────────────────────────────────────────────
-
-def _load_credential_row(user_id: str) -> Optional[dict[str, Any]]:
-    from db.connection import table  # type: ignore[import-not-found]
-
-    rows = table("gradescope_credentials").select("*").eq("user_id", user_id).execute()
-    data = getattr(rows, "data", None) or []
-    return data[0] if data else None
+router = APIRouter()
 
 
-def _save_credential_row(user_id: str, row: dict[str, Any]) -> None:
-    from db.connection import table  # type: ignore[import-not-found]
-
-    payload = {**row, "user_id": user_id, "updated_at": datetime.now(timezone.utc).isoformat()}
-    table("gradescope_credentials").upsert(payload, on_conflict="user_id").execute()
+# ── Body models ────────────────────────────────────────────────────────────
 
 
-def _delete_credential_row(user_id: str) -> None:
-    from db.connection import table  # type: ignore[import-not-found]
-
-    table("gradescope_credentials").delete().eq("user_id", user_id).execute()
+AuthMode = Literal["password", "cookies"]
 
 
-def _update_sync_metadata(
-    user_id: str, sapling_course_id: str, *, last_error: Optional[str]
-) -> None:
-    from db.connection import table  # type: ignore[import-not-found]
+class CredentialsBody(BaseModel):
+    """Either {auth_mode: 'password', email, password} OR
+    {auth_mode: 'cookies', gradescope_session, signed_token?}."""
 
-    now = datetime.now(timezone.utc).isoformat()
-    table("gradescope_credentials").update({"last_error": last_error}).eq(
-        "user_id", user_id
-    ).execute()
-    table("gradescope_links").update({"last_synced_at": now}).eq(
-        "user_id", user_id
-    ).eq("sapling_course_id", sapling_course_id).execute()
+    user_id: str
+    auth_mode: AuthMode = "password"
+    # password mode
+    email: str | None = None
+    password: str | None = None
+    # cookies mode
+    gradescope_session: str | None = None
+    signed_token: str | None = None
 
 
-def _load_link(user_id: str, sapling_course_id: str) -> Optional[dict[str, Any]]:
-    from db.connection import table  # type: ignore[import-not-found]
+class BuSsoBody(BaseModel):
+    """Live BU SSO + Duo flow. Username + password are used in-memory only;
+    we never persist them. The resulting session cookies are persisted as
+    if the user had pasted them themselves (auth_mode='cookies')."""
 
-    rows = (
-        table("gradescope_links")
-        .select("*")
-        .eq("user_id", user_id)
-        .eq("sapling_course_id", sapling_course_id)
-        .execute()
+    user_id: str
+    bu_username: str = Field(min_length=1)
+    bu_password: str = Field(min_length=1)
+    # Caps the time the headless browser spends parked on the Duo iframe
+    # waiting for the user's tap. Frontend should match this on its
+    # request-timeout side.
+    duo_timeout_seconds: int = Field(default=120, ge=15, le=300)
+
+
+class LinkBody(BaseModel):
+    user_id: str
+    sapling_course_id: str
+    gradescope_course_id: str
+
+
+class SyncResult(BaseModel):
+    inserted: int
+    updated: int
+    skipped: int
+    failed: int
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+class StoredCreds(BaseModel):
+    auth_mode: AuthMode
+    email: str | None = None
+    password: str | None = None
+    gradescope_session: str | None = None
+    signed_token: str | None = None
+
+
+def _load_creds(user_id: str) -> StoredCreds | None:
+    """Fetch and decrypt stored Gradescope credentials for user_id. Returns None if none saved."""
+    rows = table("gradescope_credentials").select(
+        "auth_mode,email_encrypted,password_encrypted,cookies_encrypted",
+        filters={"user_id": f"eq.{user_id}"},
+        limit=1,
     )
-    data = getattr(rows, "data", None) or []
-    return data[0] if data else None
+    if not rows:
+        return None
+    row = rows[0]
+    mode: AuthMode = row.get("auth_mode") or "password"
+    try:
+        if mode == "password":
+            return StoredCreds(
+                auth_mode="password",
+                email=decrypt(row["email_encrypted"]) if row.get("email_encrypted") else None,
+                password=decrypt(row["password_encrypted"]) if row.get("password_encrypted") else None,
+            )
+        else:  # cookies
+            raw = decrypt(row["cookies_encrypted"]) if row.get("cookies_encrypted") else None
+            payload = json.loads(raw) if raw else {}
+            return StoredCreds(
+                auth_mode="cookies",
+                gradescope_session=payload.get("_gradescope_session"),
+                signed_token=payload.get("signed_token"),
+            )
+    except Exception:
+        logger.exception("Failed to decrypt Gradescope creds for user_id=%s", user_id)
+        raise HTTPException(
+            status_code=500, detail="Stored credentials could not be read."
+        )
 
 
-def _list_links(user_id: str) -> list[dict[str, Any]]:
-    from db.connection import table  # type: ignore[import-not-found]
-
-    rows = table("gradescope_links").select("*").eq("user_id", user_id).execute()
-    return getattr(rows, "data", None) or []
-
-
-def _save_link(user_id: str, sapling_course_id: str, gradescope_course_id: str) -> dict[str, Any]:
-    from db.connection import table  # type: ignore[import-not-found]
-
-    payload = {
-        "user_id": user_id,
-        "sapling_course_id": sapling_course_id,
-        "gradescope_course_id": gradescope_course_id,
-    }
-    result = table("gradescope_links").upsert(
-        payload, on_conflict="user_id,sapling_course_id"
-    ).execute()
-    data = getattr(result, "data", None) or []
-    return data[0] if data else payload
+def _establish_connection(creds: StoredCreds) -> GSConnection:
+    """Re-establish an authenticated Gradescope session from stored creds.
+    Picks the right login path based on the user's chosen mode."""
+    if creds.auth_mode == "password":
+        if not creds.email or not creds.password:
+            raise HTTPException(
+                status_code=500, detail="Password-mode creds missing email/password"
+            )
+        return gradescope_service.login(creds.email, creds.password)
+    else:
+        return gradescope_service.login_with_cookies(
+            signed_token=creds.signed_token,
+            gradescope_session=creds.gradescope_session,
+        )
 
 
-def _delete_link(user_id: str, sapling_course_id: str) -> None:
-    from db.connection import table  # type: ignore[import-not-found]
+def _enrollment_for(user_id: str, sapling_course_id: str) -> str | None:
+    """Resolve (user, abstract course) → the user's enrollment id, or None.
 
-    table("gradescope_links").delete().eq("user_id", user_id).eq(
-        "sapling_course_id", sapling_course_id
-    ).execute()
+    Doubles as the ownership check this module used to do against
+    `user_courses` — a table that stopped existing when 0020 renamed it to
+    `enrollments` (offering-keyed). No enrollment means the user isn't in the
+    course, which is the same 404 the old check produced.
+
+    Gradescope links key on `enrollment_id` (0027), not the abstract course:
+    grades land on enrollment-scoped `assignments` (0021), so a link has to
+    name the specific class instance the grades belong to — otherwise a retake
+    gives two enrollments and the sync cannot tell which term's assignments to
+    write. The HTTP boundary still speaks `course_id` per the repo convention;
+    resolution happens here.
+    """
+    return enrollment_id_for(user_id, sapling_course_id)
 
 
-# ────────────────────────────────────────────────────────────────────────────
-# Routes — URLs/params match frontend/src/lib/api.ts exactly
-# ────────────────────────────────────────────────────────────────────────────
+def _all_enrollments_for(user_id: str, sapling_course_id: str) -> list[str]:
+    """EVERY enrollment the user holds in this abstract course, not just the
+    term-preferred one.
 
-@router.get("/status", response_model=GradescopeStatus)
-def get_status(user_id: str):
-    row = _load_credential_row(user_id)
-    if row is None:
-        return GradescopeStatus(has_credentials=False)
-    return GradescopeStatus(
-        has_credentials=True,
-        auth_mode=row.get("auth_mode"),
-        last_synced_at=row.get("last_synced_at"),
-        credentials_updated_at=row.get("updated_at"),
+    `enrollment_id_for` re-derives a single enrollment from the current term on
+    each call, which is right for CREATING a link but wrong for finding one
+    that already exists: a retake gives two enrollments, and a link made in
+    Fall must still be findable, deletable and syncable once Spring is the
+    current term. Resolving by heuristic there produced duplicate links, a
+    delete that reported success while removing nothing, and a sync that 400'd
+    "no link" for a course `GET /links` was still listing (#265 review).
+    """
+    offering_ids = set(user_offering_ids_for_course(user_id, sapling_course_id))
+    if not offering_ids:
+        return []
+    return [
+        e["id"]
+        for e in user_enrollment_ids(user_id)
+        if e.get("offering_id") in offering_ids
+    ]
+
+
+def _enforce_gs_rate_limit(user_id: str, action: str, *, limit: int, window_sec: int) -> None:
+    """Per-user sliding-window guard for the live-scrape / headless-browser
+    endpoints. Each of these drives a real login + scrape against Gradescope
+    (and bu-sso launches a Chromium that blocks a worker thread up to ~300s),
+    so without a cap an authenticated user could exhaust workers or get the
+    app's IP throttled/banned by Gradescope.
+    """
+    retry = check_rate_limit(
+        f"gradescope:{action}:{user_id}", limit=limit, window_sec=window_sec
     )
+    if retry is not None:
+        # main.py's HTTPException handler forwards exc.headers as of #544, so
+        # the budget rides in a real Retry-After. It stays in the detail
+        # string too — clients that only surface the message keep working.
+        raise HTTPException(
+            status_code=429,
+            detail=f"Too many Gradescope {action} requests. Retry in {retry}s.",
+            headers={"Retry-After": str(retry)},
+        )
+
+
+# ── Credentials CRUD ───────────────────────────────────────────────────────
 
 
 @router.post("/credentials")
-def save_credentials(body: GradescopeCredentialsIn):
-    try:
-        body.validate_mode()
-    except ValueError as e:
-        raise HTTPException(status_code=422, detail=str(e)) from e
+def save_credentials(body: CredentialsBody, request: Request):
+    """Test the login first, then encrypt-and-save. Never persist creds
+    that don't authenticate — the user sees a clean error instead.
 
-    # Verify the credentials actually work before storing them, so a typo
-    # doesn't sit silently until the next sync attempt fails.
-    try:
-        if body.auth_mode == "password":
-            gs.login(body.email, body.password)
-        else:
-            gs.login_with_cookies(body.signed_token, body.gradescope_session)
-    except gs.GradescopeAuthError as e:
-        raise HTTPException(status_code=401, detail=str(e)) from e
+    Two modes:
+      - 'password': test login(email, password). For accounts with a
+        Gradescope-side password.
+      - 'cookies':  test login_with_cookies(signed_token, _gradescope_session).
+        For SSO-only accounts (BU/Shibboleth/Duo), where the user pastes
+        their browser session cookies.
+    """
+    require_self(body.user_id, request)
+    # Each save tests a live login against Gradescope before persisting.
+    _enforce_gs_rate_limit(body.user_id, "credential", limit=10, window_sec=300)
 
-    row = build_credential_row(
-        auth_mode=body.auth_mode,
-        email=body.email,
-        password=body.password,
-        gradescope_session=body.gradescope_session,
-        signed_token=body.signed_token,
+    if body.auth_mode == "password":
+        if not body.email or not body.password:
+            raise HTTPException(
+                status_code=400, detail="email and password are required for password mode"
+            )
+        try:
+            gradescope_service.login(body.email, body.password)
+        except gradescope_service.GradescopeAuthError as e:
+            raise HTTPException(status_code=401, detail=str(e))
+        payload: dict[str, Any] = {
+            "user_id": body.user_id,
+            "auth_mode": "password",
+            "email_encrypted": encrypt(body.email),
+            "password_encrypted": encrypt(body.password),
+            "cookies_encrypted": None,
+        }
+    else:  # cookies
+        if not body.gradescope_session:
+            raise HTTPException(
+                status_code=400,
+                detail="_gradescope_session cookie is required for cookies mode",
+            )
+        try:
+            gradescope_service.login_with_cookies(
+                signed_token=body.signed_token,
+                gradescope_session=body.gradescope_session,
+            )
+        except gradescope_service.GradescopeAuthError as e:
+            raise HTTPException(status_code=401, detail=str(e))
+        cookie_blob = json.dumps(
+            {
+                "_gradescope_session": body.gradescope_session,
+                "signed_token": body.signed_token or None,
+            }
+        )
+        payload = {
+            "user_id": body.user_id,
+            "auth_mode": "cookies",
+            "email_encrypted": None,
+            "password_encrypted": None,
+            "cookies_encrypted": encrypt(cookie_blob),
+        }
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    payload["updated_at"] = now_iso
+    table("gradescope_credentials").upsert(payload, on_conflict="user_id")
+    return {"ok": True}
+
+
+@router.post("/credentials/bu-sso")
+async def save_credentials_via_bu_sso(body: BuSsoBody, request: Request):
+    """Live BU SSO via Playwright. Drives a headless Chromium through
+    Gradescope → School Credentials → BU WebLogin → Duo. Blocks the
+    request until the user taps Duo on their phone (or times out), then
+    persists the resulting session cookies as auth_mode='cookies'.
+
+    BU password is held in memory for the duration of the request only;
+    we never write it to disk. The frontend should configure a request
+    timeout slightly longer than `duo_timeout_seconds` so the spinner can
+    sit while we wait for the tap.
+    """
+    require_self(body.user_id, request)
+    # Strictest cap: each call launches a Chromium that pins a worker thread for
+    # up to duo_timeout_seconds and fires a Duo push at the user's phone.
+    _enforce_gs_rate_limit(body.user_id, "bu-sso", limit=3, window_sec=600)
+
+    try:
+        # sync_playwright wants its own event loop; run the whole flow in
+        # a worker thread so FastAPI's loop stays free and Playwright
+        # doesn't fight Windows's SelectorEventLoop. ~30s–125s blocking
+        # call (mostly idle while we wait on Duo).
+        cookies = await asyncio.to_thread(
+            gradescope_service.login_via_bu_sso,
+            body.bu_username,
+            body.bu_password,
+            body.duo_timeout_seconds,
+        )
+    except gradescope_service.GradescopeDuoTimeout as e:
+        # 408 reads more honestly than 401 here — the credentials may be
+        # fine, the user just didn't tap in time.
+        raise HTTPException(status_code=408, detail=str(e) or "Duo push timed out.")
+    except gradescope_service.GradescopeAuthError as e:
+        raise HTTPException(status_code=401, detail=str(e) or "Gradescope auth failed.")
+    except Exception as e:
+        # Never let a blank `crashed:` reach the client again — surface
+        # type, message, and a request id so the user can paste a useful
+        # error.
+        logger.exception("Unexpected error in BU SSO flow")
+        msg = str(e) or repr(e) or "no message"
+        raise HTTPException(
+            status_code=500,
+            detail=f"SSO flow crashed: {type(e).__name__}: {msg}",
+        )
+
+    cookie_blob = json.dumps({
+        "_gradescope_session": cookies.get("_gradescope_session"),
+        "signed_token": cookies.get("signed_token") or None,
+    })
+    now_iso = datetime.now(timezone.utc).isoformat()
+    table("gradescope_credentials").upsert(
+        {
+            "user_id": body.user_id,
+            "auth_mode": "cookies",
+            "email_encrypted": None,
+            "password_encrypted": None,
+            "cookies_encrypted": encrypt(cookie_blob),
+            "updated_at": now_iso,
+        },
+        on_conflict="user_id",
     )
-    _save_credential_row(body.user_id, row)
     return {"ok": True}
 
 
 @router.delete("/credentials")
-def delete_credentials(user_id: str):
-    _delete_credential_row(user_id)
+def delete_credentials(user_id: str, request: Request):
+    """Remove stored Gradescope credentials for user_id."""
+    require_self(user_id, request)
+    table("gradescope_credentials").delete(filters={"user_id": f"eq.{user_id}"})
     return {"ok": True}
+
+
+@router.get("/status")
+def get_status(user_id: str, request: Request):
+    """Return whether the user has saved credentials and when they last synced."""
+    require_self(user_id, request)
+    rows = table("gradescope_credentials").select(
+        "auth_mode,last_synced_at,updated_at",
+        filters={"user_id": f"eq.{user_id}"},
+        limit=1,
+    )
+    if not rows:
+        return {"has_credentials": False, "auth_mode": None, "last_synced_at": None}
+    return {
+        "has_credentials": True,
+        "auth_mode": rows[0].get("auth_mode") or "password",
+        "last_synced_at": rows[0].get("last_synced_at"),
+        "credentials_updated_at": rows[0].get("updated_at"),
+    }
+
+
+# ── Course listing + linking ───────────────────────────────────────────────
 
 
 @router.get("/courses")
-def list_courses(user_id: str):
-    row = _load_credential_row(user_id)
-    if row is None:
-        raise HTTPException(status_code=400, detail="Gradescope isn't connected yet.")
+def list_gradescope_courses(user_id: str, request: Request):
+    """Hit Gradescope live with the saved creds, list student-role courses."""
+    require_self(user_id, request)
+    _enforce_gs_rate_limit(user_id, "courses", limit=10, window_sec=300)
+    creds = _load_creds(user_id)
+    if not creds:
+        raise HTTPException(status_code=404, detail="No Gradescope credentials saved")
     try:
-        raw_courses = list_courses_for_linking(row)
-    except gs.GradescopeAuthError as e:
-        raise HTTPException(status_code=401, detail=str(e)) from e
-    except gs.GradescopeFetchError as e:
-        raise HTTPException(status_code=502, detail=str(e)) from e
-    return {"courses": [GradescopeCourse(**c) for c in raw_courses]}
+        conn = _establish_connection(creds)
+        courses = gradescope_service.list_student_courses(conn)
+    except gradescope_service.GradescopeAuthError as e:
+        raise HTTPException(status_code=401, detail=str(e))
+    except gradescope_service.GradescopeFetchError as e:
+        raise HTTPException(status_code=502, detail=str(e))
+    return {"courses": courses}
 
 
 @router.get("/links")
-def list_links(user_id: str):
-    return {"links": [GradescopeLink(**link) for link in _list_links(user_id)]}
+def list_links(user_id: str, request: Request):
+    """List all sapling-course → gradescope-course mappings for user_id.
+
+    The table keys on `enrollment_id` (0027) while the API keeps the abstract
+    `sapling_course_id`, so each row is mapped back out to its course before it
+    leaves — the frontend contract is unchanged.
+    """
+    require_self(user_id, request)
+    enrollments = user_enrollment_ids(user_id)
+    if not enrollments:
+        return {"links": []}
+
+    course_by_enrollment = {
+        e["id"]: offering_course_id(e.get("offering_id")) for e in enrollments
+    }
+    rows = table("gradescope_course_links").select(
+        "id,enrollment_id,gradescope_course_id,last_synced_at",
+        filters={"enrollment_id": f"in.({','.join(course_by_enrollment)})"},
+    )
+    links = [
+        {
+            "id": r["id"],
+            "sapling_course_id": course_by_enrollment[r.get("enrollment_id")],
+            "gradescope_course_id": r.get("gradescope_course_id"),
+            "last_synced_at": r.get("last_synced_at"),
+        }
+        for r in rows
+        # Drop rather than answer sapling_course_id: null — an offering whose
+        # course can't be resolved has no id the client could act on, and a
+        # null there reads as a real link the UI can't do anything with.
+        if course_by_enrollment.get(r.get("enrollment_id"))
+    ]
+    return {"links": links}
 
 
 @router.post("/link")
-def link_course(body: GradescopeLinkIn):
-    link = _save_link(body.user_id, body.sapling_course_id, body.gradescope_course_id)
-    return {"link": GradescopeLink(**link) if link else None}
+def upsert_link(body: LinkBody, request: Request):
+    """Create or replace the link between a Sapling course and a Gradescope course."""
+    require_self(body.user_id, request)
+    enrollment_id = _enrollment_for(body.user_id, body.sapling_course_id)
+    if not enrollment_id:
+        raise HTTPException(status_code=404, detail="Sapling course not found for user")
+
+    # Manual upsert. The delete spans EVERY enrollment the user holds in this
+    # course, not just the one we're about to write: otherwise re-linking after
+    # a term rollover leaves the old term's row in place and the course ends up
+    # with two links (#265 review).
+    all_enrollments = _all_enrollments_for(body.user_id, body.sapling_course_id)
+    if all_enrollments:
+        table("gradescope_course_links").delete(
+            filters={"enrollment_id": f"in.({','.join(all_enrollments)})"}
+        )
+    inserted = table("gradescope_course_links").insert({
+        "enrollment_id": enrollment_id,
+        "gradescope_course_id": body.gradescope_course_id,
+    })
+    link = dict(inserted[0]) if inserted else None
+    if link is not None:
+        # Answer in the API's vocabulary, not the table's.
+        link["sapling_course_id"] = body.sapling_course_id
+    return {"link": link}
 
 
 @router.delete("/link/{sapling_course_id}")
-def unlink_course(sapling_course_id: str, user_id: str):
-    _delete_link(user_id, sapling_course_id)
+def remove_link(sapling_course_id: str, user_id: str, request: Request):
+    """Remove the Gradescope link for a Sapling course."""
+    require_self(user_id, request)
+    # Across ALL the user's enrollments in the course: a link created under a
+    # previous term must still be removable once the term has rolled over.
+    # Resolving the single term-preferred enrollment here deleted nothing while
+    # still answering ok:true (#265 review).
+    all_enrollments = _all_enrollments_for(user_id, sapling_course_id)
+    if not all_enrollments:
+        # Nothing resolvable to delete; stay idempotent rather than 404 on a
+        # remove, matching the previous behaviour of a no-match delete.
+        return {"ok": True}
+    table("gradescope_course_links").delete(
+        filters={"enrollment_id": f"in.({','.join(all_enrollments)})"}
+    )
     return {"ok": True}
 
 
-@router.post("/sync/{sapling_course_id}", response_model=GradescopeSyncResult)
-def sync(sapling_course_id: str, user_id: str):
-    credential_row = _load_credential_row(user_id)
-    if credential_row is None:
-        raise HTTPException(status_code=400, detail="Gradescope isn't connected yet.")
+# ── Sync ───────────────────────────────────────────────────────────────────
 
-    link = _load_link(user_id, sapling_course_id)
-    if link is None:
+
+def _due_to_date_string(iso: str | None) -> str | None:
+    """Sapling stores due_date as a date string (YYYY-MM-DD). Gradescope
+    gives us a full ISO timestamp; pull just the date portion."""
+    if not iso:
+        return None
+    try:
+        return iso.split("T")[0] if "T" in iso else iso
+    except Exception:
+        return None
+
+
+@router.post("/sync/{sapling_course_id}")
+def sync_course(sapling_course_id: str, user_id: str, request: Request) -> dict[str, Any]:
+    """Pull assignments from the linked Gradescope course and upsert into the Sapling gradebook."""
+    require_self(user_id, request)
+    _enforce_gs_rate_limit(user_id, "sync", limit=10, window_sec=300)
+    all_enrollments = _all_enrollments_for(user_id, sapling_course_id)
+    if not all_enrollments:
+        raise HTTPException(status_code=404, detail="Sapling course not found for user")
+
+    # Find the link across every enrollment in the course, then key the whole
+    # sync on THAT row's enrollment — not on a re-derived term guess. The
+    # grades belong to the class instance the link was made against, and after
+    # a term rollover the heuristic points at a different one (#265 review).
+    link_rows = table("gradescope_course_links").select(
+        "id,enrollment_id,gradescope_course_id",
+        filters={"enrollment_id": f"in.({','.join(all_enrollments)})"},
+        limit=1,
+    )
+    if not link_rows:
         raise HTTPException(
             status_code=400,
-            detail="This course isn't linked to a Gradescope course yet.",
+            detail="No Gradescope course is linked to this Sapling course",
         )
+    gs_course_id = link_rows[0]["gradescope_course_id"]
+    enrollment_id = link_rows[0]["enrollment_id"]
+
+    creds = _load_creds(user_id)
+    if not creds:
+        raise HTTPException(status_code=404, detail="No Gradescope credentials saved")
 
     try:
-        result = sync_course(credential_row, link)
-    except (gs.GradescopeAuthError, gs.GradescopeFetchError, GradescopeSyncError) as e:
-        _update_sync_metadata(user_id, sapling_course_id, last_error=str(e))
-        raise HTTPException(status_code=502, detail=str(e)) from e
+        conn = _establish_connection(creds)
+        gs_assignments = gradescope_service.list_assignments(conn, gs_course_id)
+    except gradescope_service.GradescopeAuthError as e:
+        raise HTTPException(status_code=401, detail=str(e))
+    except gradescope_service.GradescopeFetchError as e:
+        raise HTTPException(status_code=502, detail=str(e))
 
-    _update_sync_metadata(user_id, sapling_course_id, last_error=None)
-    return result
+    # Load existing assignments keyed by gradescope_assignment_id so we
+    # know whether each incoming one is an insert or an update.
+    existing = table("assignments").select(
+        "id,gradescope_assignment_id",
+        filters={"enrollment_id": f"eq.{enrollment_id}"},
+    )
+    by_gs_id: dict[str, str] = {
+        r["gradescope_assignment_id"]: r["id"]
+        for r in existing
+        if r.get("gradescope_assignment_id")
+    }
+
+    # Build a normalized category-name → id map for auto-matching new assignments.
+    # A new assignment whose title contains a category name (e.g. "Homework 3"
+    # contains "homework") is automatically categorized; otherwise category_id
+    # stays None and the user can link it manually.
+    # 0021 renamed course_categories -> gradebook_categories, enrollment-keyed.
+    cats = table("gradebook_categories").select(
+        "id,name",
+        filters={"enrollment_id": f"eq.{enrollment_id}"},
+    )
+    cats_by_name: dict[str, str] = {
+        c["name"].lower().strip(): c["id"]
+        for c in cats
+        if c.get("name") and c.get("id")
+    }
+
+    def _infer_category_id(title: str) -> str | None:
+        t = title.lower()
+        for name, cat_id in cats_by_name.items():
+            if name in t:
+                return cat_id
+        return None
+
+    inserted = updated = skipped = failed = 0
+    for a in gs_assignments:
+        gs_id = a.get("id")
+        if not gs_id:
+            skipped += 1
+            continue
+        title = a.get("name") or "(untitled)"
+        due_date = _due_to_date_string(a.get("due_date"))
+        points_earned = a.get("points_earned")
+        points_possible = a.get("points_possible")
+
+        record_write: dict[str, Any] = {
+            "title": title,
+            "due_date": due_date,
+            "source": "gradescope",
+            "gradescope_assignment_id": gs_id,
+        }
+        # Only include grade fields when Gradescope returned a value —
+        # absent grades (None) must not overwrite previously synced data.
+        if points_earned is not None:
+            record_write["points_earned"] = encrypt_if_present(points_earned)
+        if points_possible is not None:
+            record_write["points_possible"] = encrypt_if_present(points_possible)
+        try:
+            if gs_id in by_gs_id:
+                table("assignments").update(
+                    record_write,
+                    filters={"id": f"eq.{by_gs_id[gs_id]}"},
+                )
+                updated += 1
+            else:
+                table("assignments").insert({
+                    "id": str(uuid.uuid4()),
+                    "enrollment_id": enrollment_id,
+                    "category_id": _infer_category_id(title),
+                    **record_write,
+                })
+                inserted += 1
+        except Exception:
+            logger.exception("Failed to upsert Gradescope assignment %s", gs_id)
+            failed += 1
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    table("gradescope_credentials").update(
+        {"last_synced_at": now_iso},
+        filters={"user_id": f"eq.{user_id}"},
+    )
+    table("gradescope_course_links").update(
+        {"last_synced_at": now_iso},
+        filters={"enrollment_id": f"eq.{enrollment_id}"},
+    )
+
+    return SyncResult(
+        inserted=inserted, updated=updated, skipped=skipped, failed=failed
+    ).model_dump()

--- a/backend/services/gradescope_service.py
+++ b/backend/services/gradescope_service.py
@@ -1,18 +1,8 @@
 """backend/services/gradescope_service.py
 
-Thin wrapper around the unofficial `gradescopeapi` package. Logs a student
-into Gradescope and surfaces just what the gradebook needs: courses +
-assignments-with-grades.
-
-Two supported ways to authenticate:
-
-1. `login(email, password)` — direct Gradescope accounts (schools that
-   don't route through an SSO/Shibboleth identity provider).
-2. `login_with_cookies(...)` — for SSO schools. The student logs into
-   Gradescope normally in their own browser (2FA and all), then copies
-   the resulting session cookie into Sapling. Nothing here automates or
-   drives that login — it only validates and reuses a cookie the user
-   already produced themselves.
+Thin wrapper around the unofficial `gradescopeapi` package. Logs in with a
+student's Gradescope email/password and surfaces just the bits the
+gradebook needs: courses + assignments-with-grades.
 
 Caveats worth being honest about:
 - Gradescope has no official public API. `gradescopeapi` scrapes the web
@@ -22,14 +12,13 @@ Caveats worth being honest about:
   we log in for the duration of the request, and let the connection go
   out of scope. Per-user credentials are encrypted at rest by the route
   layer using `services.encryption`.
-- Session cookies (from `login_with_cookies`) are short-lived — Gradescope
-  expires them periodically, so an SSO user will need to re-paste a fresh
-  cookie from time to time rather than getting a truly "forever" sync.
 """
 
 from __future__ import annotations
 
 import logging
+import re
+import time
 from typing import Any
 
 import requests
@@ -48,6 +37,30 @@ except ImportError:  # pragma: no cover - depends on env
 
 logger = logging.getLogger(__name__)
 
+# Playwright is optional — only the BU SSO flow needs it. Deployments
+# without a Chromium binary (e.g. CF Workers) can still use the other
+# auth modes; we surface a clean ImportError-style message instead of
+# crashing at import time.
+#
+# Using the SYNC API on purpose: Playwright's async API requires the
+# host loop to be ProactorEventLoop on Windows, but uvicorn under FastAPI
+# on Windows can be Selector — they conflict at subprocess launch. The
+# sync API runs Playwright in its own greenlet-driven loop and is the
+# documented pattern for FastAPI + Windows. We call it from the route via
+# asyncio.to_thread so the FastAPI event loop stays unblocked.
+try:
+    from playwright.sync_api import (  # type: ignore[import-not-found]
+        sync_playwright,
+        TimeoutError as PlaywrightTimeoutError,
+        Locator,
+        Page,
+    )
+    PLAYWRIGHT_AVAILABLE = True
+except ImportError:  # pragma: no cover - depends on env
+    PLAYWRIGHT_AVAILABLE = False
+    Locator = Any  # type: ignore[misc,assignment]
+    Page = Any  # type: ignore[misc,assignment]
+
 
 class GradescopeAuthError(Exception):
     """Raised when login fails (invalid creds, captcha, blocked, etc.)."""
@@ -56,6 +69,10 @@ class GradescopeAuthError(Exception):
 class GradescopeFetchError(Exception):
     """Raised when a downstream scrape fails (page format changed, course
     inaccessible, network glitch, etc.)."""
+
+
+class GradescopeDuoTimeout(GradescopeAuthError):
+    """Raised when the user didn't tap their Duo push within the deadline."""
 
 
 # Look like a recent desktop Chrome. The library's default `python-requests`
@@ -89,13 +106,13 @@ def login_with_cookies(
     signed_token: str | None,
     gradescope_session: str | None,
 ) -> GSConnection:
-    """Build a logged-in GSConnection from cookies the user already has.
+    """Build a logged-in GSConnection from pasted browser cookies.
 
-    For SSO accounts (Shibboleth-style schools) we don't drive any login
-    flow — the user signs in normally in their own browser, copies the
-    session cookie from DevTools, and pastes it here. We validate by
-    hitting /account; anything other than a 200 on a non-/login URL means
-    the cookie is stale or wrong.
+    For SSO accounts (BU, other Shibboleth schools) we can't post the
+    /login form — Duo 2FA stops us. Instead the user signs in normally in
+    their browser, copies the session cookies from DevTools, and pastes
+    them here. We validate by hitting /account; anything other than a
+    200 on a non-/login URL means the cookies are stale or wrong.
 
     `gradescope_session` is required (the actual session cookie).
     `signed_token` is the "remember me" cookie — optional, present on
@@ -130,7 +147,7 @@ def login_with_cookies(
 
     if r.status_code != 200 or "/login" in (r.url or ""):
         raise GradescopeAuthError(
-            "Session cookie is invalid or expired. Re-copy it from your browser."
+            "Session cookies are invalid or expired. Re-copy them from your browser."
         )
 
     # Pick up X-CSRF-Token for any later POSTs the library makes.
@@ -147,7 +164,7 @@ def login_with_cookies(
 
 
 def login(email: str, password: str) -> GSConnection:
-    """Authenticate with Gradescope directly. Returns a logged-in GSConnection.
+    """Authenticate with Gradescope. Returns a logged-in GSConnection.
 
     Reimplemented here instead of calling gradescopeapi's built-in login
     because that version has two bugs:
@@ -163,10 +180,6 @@ def login(email: str, password: str) -> GSConnection:
     handed back to a real `GSConnection` so the rest of the library
     (`account.get_courses()`, `account.get_assignments()`, etc.) continues
     to work as designed.
-
-    Note: this only works for direct Gradescope accounts. Schools that
-    require SSO (Shibboleth-style) will fail here with an in-page error —
-    use `login_with_cookies` for those instead.
     """
     _require_gradescopeapi()
     base_url = DEFAULT_GRADESCOPE_BASE_URL
@@ -311,3 +324,345 @@ def list_assignments(conn: GSConnection, course_id: str) -> list[dict[str, Any]]
             }
         )
     return out
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# BU SSO via Playwright
+# ────────────────────────────────────────────────────────────────────────────
+# Drive a headless Chromium through Gradescope's "School Credentials" entry
+# → Boston University → Shibboleth WebLogin → Duo. We hold open until the
+# page redirects back to gradescope.com (which happens only after the user
+# taps Approve on their phone), then harvest the session cookies. BU
+# password lives in-memory for the duration of the request and is never
+# persisted; only the resulting cookies are stored.
+#
+# Selectors are best-effort and may need tuning after a real run — BU's
+# Shibboleth template and Gradescope's IdP picker both change occasionally.
+# Each step tries multiple fallback selectors before failing.
+
+# Gradescope's normal login page. The school picker is hidden behind a
+# "School Credentials" button on this page — we click it first, then the
+# typeahead appears.
+_GRADESCOPE_LOGIN = "https://www.gradescope.com/login"
+_BU_SCHOOL_NAME = "Boston University"
+
+# "School Credentials" entry button on /login. The text varies a little
+# between Gradescope rev'd (sometimes "Sign in with school credentials").
+_SCHOOL_CREDS_BUTTON_SELECTORS = [
+    "a:has-text('School Credentials')",
+    "button:has-text('School Credentials')",
+    "a:has-text('school credentials')",
+    "a:has-text('Sign in with school')",
+    "a[href*='saml']",
+]
+
+# Typeahead input on the school picker page. Multiple candidates because
+# the picker's markup changes more often than the rest of the flow.
+_BU_IDP_SEARCH_SELECTORS = [
+    "input[placeholder*='school' i]",
+    "input[placeholder*='institution' i]",
+    "input[placeholder*='search' i]",
+    "input[name*='school' i]",
+    "input[name*='institution' i]",
+    "input[type='search']",
+    # last-resort: any visible text-ish input
+    "input:not([type='hidden']):not([type='password']):not([type='submit'])",
+]
+_SHIB_USERNAME_SELECTORS = [
+    "input[name='j_username']",
+    "input#username",
+    "input[name='username']",
+]
+_SHIB_PASSWORD_SELECTORS = [
+    "input[name='j_password']",
+    "input#password",
+    "input[name='password']",
+]
+_SHIB_SUBMIT_SELECTORS = [
+    "button[name='_eventId_proceed']",
+    "button:has-text('Continue')",
+    "button:has-text('Login')",
+    "button[type='submit']",
+    "input[type='submit']",
+]
+
+# Post-Duo continuation buttons. Shibboleth's "Trust this browser?" page
+# and SAML POST-back pages tend to render one of these. Order matters —
+# the more specific the label, the earlier we try. "No"-prefixed labels
+# are intentionally absent.
+_POST_DUO_BUTTON_LABELS = [
+    r"^yes,?\s*trust",      # "Yes, trust browser"
+    r"trust\s*browser",
+    r"^yes,?\s*this is",    # "Yes, this is my device"
+    r"^remember\s*me",
+    r"^continue$",
+    r"^proceed$",
+    r"^submit$",
+]
+# Fallback selectors when get_by_role doesn't find a button.
+_POST_DUO_FALLBACK_SELECTORS = [
+    "input[type='submit'][value*='Continue' i]",
+    "input[type='submit'][value*='Trust' i]",
+    "input[type='submit'][value*='Submit' i]",
+    "a:has-text('Continue')",
+]
+
+
+def _dump_page_state(page: "Page") -> str:
+    """Build a short diagnostic string for error messages when a selector
+    step fails. Includes URL, page title, and a summary of every input
+    element on the page so we can adjust selectors without guessing."""
+    try:
+        url = page.url
+    except Exception:
+        url = "<unknown>"
+    try:
+        title = page.title()
+    except Exception:
+        title = "<unknown>"
+    try:
+        inputs = page.eval_on_selector_all(
+            "input, button, a",
+            """els => els.slice(0, 40).map(e => {
+                if (e.tagName === 'INPUT') {
+                    return `input[name='${e.name||''}' type='${e.type||''}' placeholder='${e.placeholder||''}' id='${e.id||''}']`;
+                }
+                if (e.tagName === 'BUTTON') {
+                    return `button[text='${(e.innerText||'').slice(0, 40)}' name='${e.name||''}']`;
+                }
+                if (e.tagName === 'A') {
+                    return `a[text='${(e.innerText||'').slice(0, 40)}' href='${(e.href||'').slice(0, 60)}']`;
+                }
+                return e.tagName;
+            })""",
+        )
+        elements_str = "; ".join(inputs)
+    except Exception as ex:
+        elements_str = f"<eval failed: {ex}>"
+    return f"page={url} title={title!r} elements=[{elements_str}]"
+
+
+def _first_visible(page: "Page", selectors: list[str], timeout_ms: int) -> "Locator":
+    """Return the first selector in `selectors` that resolves to a visible
+    element within `timeout_ms` per selector. Raises GradescopeAuthError
+    if none match — that's how we know BU/Shibboleth markup drifted."""
+    for sel in selectors:
+        try:
+            loc = page.locator(sel).first
+            loc.wait_for(state="visible", timeout=timeout_ms)
+            return loc
+        except PlaywrightTimeoutError:
+            continue
+    raise GradescopeAuthError(
+        f"Couldn't find any of these elements on the page: {selectors}. "
+        "BU/Shibboleth markup may have changed."
+    )
+
+
+def login_via_bu_sso(
+    bu_username: str,
+    bu_password: str,
+    duo_timeout_seconds: int = 120,
+) -> dict[str, str]:
+    """Run a full BU-SSO + Duo dance and return the resulting Gradescope
+    cookies. Caller is responsible for storing them. Synchronous so it can
+    be invoked from a worker thread via asyncio.to_thread without
+    bumping into Windows event-loop quirks.
+
+    Raises:
+        GradescopeAuthError      — bad creds, missing selectors, Duo denied
+        GradescopeDuoTimeout     — Duo push not approved within deadline
+    """
+    if not PLAYWRIGHT_AVAILABLE:
+        raise GradescopeAuthError(
+            "Playwright is not installed on the backend. Run "
+            "`pip install playwright && playwright install chromium`."
+        )
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        try:
+            context = browser.new_context(
+                user_agent=_BROWSER_HEADERS["User-Agent"],
+                viewport={"width": 1280, "height": 800},
+                locale="en-US",
+            )
+            # Knock out a couple of the most obvious headless tells. Real
+            # anti-bot evasion is its own discipline; this is the floor.
+            context.add_init_script(
+                "Object.defineProperty(navigator, 'webdriver', { get: () => undefined });"
+            )
+            page = context.new_page()
+
+            # Step 1: Land on Gradescope's login page. wait_until='commit'
+            # returns as soon as the navigation commits, ~1s faster than
+            # 'domcontentloaded'. The selector waits below will block on
+            # whatever element we need anyway.
+            try:
+                page.goto(_GRADESCOPE_LOGIN, timeout=20000, wait_until="commit")
+            except PlaywrightTimeoutError as e:
+                raise GradescopeAuthError(f"Couldn't reach Gradescope: {e}") from e
+
+            # Step 2: Click "School Credentials" to reveal the IdP picker.
+            try:
+                school_btn = _first_visible(
+                    page, _SCHOOL_CREDS_BUTTON_SELECTORS, 6000
+                )
+                school_btn.click()
+            except GradescopeAuthError as e:
+                raise GradescopeAuthError(
+                    f"Couldn't find the 'School Credentials' button on /login. "
+                    f"{_dump_page_state(page)}. Original: {e}"
+                ) from e
+
+            # Step 3: Type "Boston University" into the school search.
+            # Skipping wait_for_load_state — the selector wait below
+            # already blocks until the search input is visible.
+            try:
+                search = _first_visible(page, _BU_IDP_SEARCH_SELECTORS, 8000)
+                search.fill(_BU_SCHOOL_NAME)
+                bu_option = page.get_by_text(_BU_SCHOOL_NAME, exact=False).first
+                bu_option.wait_for(state="visible", timeout=5000)
+                bu_option.click()
+            except (PlaywrightTimeoutError, GradescopeAuthError) as e:
+                raise GradescopeAuthError(
+                    f"Couldn't pick Boston University from Gradescope's school picker. "
+                    f"{_dump_page_state(page)}. Original: {e}"
+                ) from e
+
+            # Step 4: Wait for redirect to shib.bu.edu (just URL — don't
+            # block on load state, since the selector wait below handles
+            # readiness).
+            try:
+                page.wait_for_url("**shib.bu.edu/**", timeout=15000)
+            except PlaywrightTimeoutError as e:
+                raise GradescopeAuthError(
+                    f"Didn't land on BU's WebLogin (currently at {page.url}): {e}"
+                ) from e
+
+            # Step 5: Fill BU username + password, click Continue. Trimmed
+            # per-selector timeouts — these elements appear within the
+            # first DOM commit, so 5s is plenty.
+            username_field = _first_visible(page, _SHIB_USERNAME_SELECTORS, 5000)
+            username_field.fill(bu_username)
+            password_field = _first_visible(page, _SHIB_PASSWORD_SELECTORS, 3000)
+            password_field.fill(bu_password)
+            submit = _first_visible(page, _SHIB_SUBMIT_SELECTORS, 3000)
+            # NOTE: from here until the Duo push lands on the user's phone,
+            # latency is out of our hands (BU → Duo servers → APNs/FCM).
+            submit.click()
+
+            # Step 5: Wait for the redirect chain to end on gradescope.com,
+            # clicking through any post-Duo interstitials along the way.
+            #
+            # The flow after Continue is usually:
+            #   submit -> Duo iframe -> (user taps Approve on phone) ->
+            #   "Trust this browser?" page -> SAML POST -> gradescope.com
+            #
+            # Those middle steps need clicks. We poll every ~1.5s, check if
+            # we've landed on Gradescope, and otherwise look for known
+            # continuation buttons ("Yes, trust browser", "Continue",
+            # "Submit") and click whichever is visible.
+            deadline = time.monotonic() + duo_timeout_seconds
+            last_diag_url = ""
+            while time.monotonic() < deadline:
+                current_url = page.url or ""
+                if "gradescope.com" in current_url and "/login" not in current_url:
+                    break
+                # Try to click through any visible continuation button.
+                # Order matters: most-specific labels first so we don't
+                # mis-click a "No" when "Yes, trust browser" exists.
+                for label_pat in _POST_DUO_BUTTON_LABELS:
+                    try:
+                        btn = page.get_by_role(
+                            "button", name=re.compile(label_pat, re.I)
+                        ).first
+                        btn.click(timeout=600)
+                        break
+                    except PlaywrightTimeoutError:
+                        continue
+                    except Exception:
+                        continue
+                else:
+                    # No button clicked this iteration. Also try inputs of
+                    # type=submit and bare <a> "Continue" links.
+                    for sel in _POST_DUO_FALLBACK_SELECTORS:
+                        try:
+                            page.locator(sel).first.click(timeout=600)
+                            break
+                        except Exception:
+                            continue
+                last_diag_url = current_url
+                page.wait_for_timeout(1500)
+            else:
+                # Loop ran out the clock without breaking on success.
+                body_text = ""
+                try:
+                    body_text = page.locator("body").inner_text(timeout=3000)
+                except Exception as exc:
+                    # Non-fatal: fall back to empty body text for the
+                    # diagnostic keyword checks below.
+                    logger.debug("Could not read page body text for SSO diagnostics", exc_info=exc)
+                lowered = body_text.lower()
+                url = page.url or last_diag_url
+                if "shib.bu.edu" in url:
+                    if any(k in lowered for k in ("login failed", "incorrect", "invalid")):
+                        raise GradescopeAuthError(
+                            "BU login failed — username or password is incorrect."
+                        )
+                    if any(k in lowered for k in ("denied", "rejected", "declined")):
+                        raise GradescopeAuthError(
+                            "Duo push was denied. Try again and tap Approve."
+                        )
+                    if "captcha" in lowered:
+                        raise GradescopeAuthError(
+                            "BU WebLogin asked for a CAPTCHA — the automated flow "
+                            "can't solve those. Use cookie paste instead."
+                        )
+                    raise GradescopeDuoTimeout(
+                        f"Stuck on Shibboleth after Duo for {duo_timeout_seconds}s. "
+                        f"{_dump_page_state(page)}"
+                    )
+                raise GradescopeAuthError(
+                    f"SSO ended at an unexpected URL: {url}. {_dump_page_state(page)}"
+                )
+
+            # Step 6: Tiny settle so cookies are committed by the browser
+            # before we read them. domcontentloaded fires fast and is
+            # enough — networkidle waits for trailing analytics calls,
+            # which we don't care about.
+            try:
+                page.wait_for_load_state("domcontentloaded", timeout=4000)
+            except PlaywrightTimeoutError:
+                # Intentional non-fatal: the settle is best-effort; continue
+                # to the cookie-harvest checks even if the load state lags.
+                logger.debug("Timed out waiting for domcontentloaded; continuing with cookie harvest checks.")
+
+            if "/login" in (page.url or ""):
+                raise GradescopeAuthError(
+                    "Reached Gradescope but it bounced us back to /login — "
+                    "SAML assertion may have been rejected."
+                )
+
+            # Step 7: Harvest the Gradescope session cookies.
+            all_cookies = context.cookies()
+            gs_cookies = {
+                c["name"]: c["value"]
+                for c in all_cookies
+                if "gradescope.com" in (c.get("domain") or "")
+            }
+            if "_gradescope_session" not in gs_cookies:
+                raise GradescopeAuthError(
+                    "Couldn't find a Gradescope session cookie after SSO. "
+                    f"Found: {list(gs_cookies.keys())}"
+                )
+
+            return {
+                "_gradescope_session": gs_cookies["_gradescope_session"],
+                "signed_token": gs_cookies.get("signed_token", "") or "",
+            }
+        finally:
+            try:
+                browser.close()
+            except Exception as _close_err:
+                logger.debug("browser.close() failed: %s", _close_err)

--- a/frontend/src/components/settings/GradescopeConnect.tsx
+++ b/frontend/src/components/settings/GradescopeConnect.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   getGradescopeStatus,
   saveGradescopeCredentials,
@@ -47,7 +47,14 @@ export function GradescopeConnect({
   const [error, setError] = useState<string | null>(null);
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
 
-  async function refreshAll() {
+  // useCallback, not a plain function declaration: the mount effect below has
+  // to list refreshAll as a dependency (react-hooks/exhaustive-deps is an
+  // error in this repo, and it fails the lint step before tsc/vitest ever
+  // run). A fresh function identity every render would make that effect
+  // re-fire on every render and loop the status/courses/links fetches.
+  // Keying on userId also fixes a real bug the empty dep array hid: switching
+  // user without unmounting kept the previous account's Gradescope state.
+  const refreshAll = useCallback(async () => {
     const s = await getGradescopeStatus(userId);
     setStatus(s);
     if (s.has_credentials) {
@@ -58,11 +65,11 @@ export function GradescopeConnect({
       setGsCourses(coursesRes.courses);
       setLinks(linksRes.links);
     }
-  }
+  }, [userId]);
 
   useEffect(() => {
     refreshAll().catch((e) => setError((e as Error).message));
-  }, []);
+  }, [refreshAll]);
 
   async function handleConnect() {
     setBusy(true);


### PR DESCRIPTION
## The `Backend (pytest)` job has not actually run on `staging` since 2026-07-10

`ruff` runs **before** `pytest` in the backend job, and `82787ca` left an unused-import error behind — so the suite has been skipped, not passing, ever since. Turning the lint step green (see below) makes it run again, and it comes back red on 5 tests in `tests/test_gradescope.py`.

## What `82787ca` actually shipped

That commit replaced the finished Gradescope integration with a `TODO(wire-me)` scaffold (649 lines of `routes/gradescope.py`, mostly deletions; 413 more from `services/gradescope_service.py`) and did **not** update `tests/test_gradescope.py`. The scaffold is broken three independent ways:

**1. Every endpoint is unreachable.** The router declares its own prefix *and* `main.py` adds the same one:

```python
# routes/gradescope.py:50
router = APIRouter(prefix="/api/gradescope", tags=["gradescope"])
# main.py:167
app.include_router(gradescope.router,  prefix="/api/gradescope")
```

Dumping the live route table confirms it:

```
['POST'] /api/gradescope/api/gradescope/credentials
['GET']  /api/gradescope/api/gradescope/courses
['POST'] /api/gradescope/api/gradescope/sync/{sapling_course_id}
```

The whole feature 404s on staging today. Some tests "passed" only because they assert `404`.

**2. It calls a database client that does not exist.** The scaffold uses supabase-py chaining:

```python
table("gradescope_credentials").select("*").eq("user_id", user_id).execute()
```

but this repo's `db/connection.py` is PostgREST-style — `select(columns, filters=...)`, `update(data, filters)`, `delete(filters)`, `upsert(data, on_conflict)`. There is no `.eq()` and no `.execute()`, so every handler would `AttributeError` even if it were reachable.

**3. No rate limiting and no `/credentials/bu-sso`**, both of which `tests/test_gradescope.py` requires (10/5min on courses and sync, 3/10min on bu-sso, per-user).

## The fix

The tests were right; the route was wrong. This restores `routes/gradescope.py` and `services/gradescope_service.py` from `main` — the version that matches **this branch's own test file**, matches **this branch's `db/connection.py`**, and is what production runs. `models/gradescope.py` and `services/gradescope_sync_service.py` from `82787ca` are left in place.

Also clears the two lint errors that gate the suite:
- `models/gradescope.py` — unused `pydantic.Field` import.
- `settings/GradescopeConnect.tsx` — `react-hooks/exhaustive-deps` error, fixed with `useCallback` keyed on `userId` rather than a suppression. That also fixes a real bug the empty dep array hid: switching user without unmounting kept the previous account's Gradescope state.

## Verification

- `ruff check .` → clean (was 1 error)
- `npx eslint` on the component → clean (was 1 error); `npx tsc --noEmit` clean
- `tests/test_gradescope.py`: **25 passed** (was 5 failed / 20 passed)
- Full hermetic backend suite: **1035 passed, 23 skipped**
- Route table now mounts 9 endpoints at a single `/api/gradescope/...` prefix, including `credentials/bu-sso`

## Context

`staging` is **239 commits behind `main`** and carries exactly one commit `main` does not — `82787ca`, the one above. Worth deciding separately whether staging should simply be brought up to `main` rather than maintained as a fork; this PR only repairs the breakage. It also unblocks #535, whose backend job fails on these same 5 tests.
